### PR TITLE
feat(ci): add Rust cache to CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,21 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: stable
           components: clippy, rustfmt
+          cache: false
+          rustflags: ""
 
-      - name: Cache cargo
-        uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          prefix-key: "v1-rust"
+          cache-all-crates: true
 
       - name: Check formatting
         run: cargo fmt -- --check
@@ -47,8 +44,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: false
+          rustflags: ""
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust"
+          cache-all-crates: true
 
       - name: Build orch-core
         run: cargo build --release


### PR DESCRIPTION
## Summary
- Replace `dtolnay/rust-toolchain@stable` with `actions-rust-lang/setup-rust-toolchain@v1` in both `rust` and `bats` jobs
- Replace manual `actions/cache@v4` with `Swatinem/rust-cache@v2` for smarter Rust-specific caching
- Add `Swatinem/rust-cache@v2` to the `bats` job (previously had no caching at all)

Closes #60

## Test plan
- [ ] Verify the `rust` job passes with the new toolchain setup and cache
- [ ] Verify the `bats` job passes with the new toolchain setup and cache
- [ ] Confirm cache hits on subsequent runs speed up CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)