### PR TITLE
feat: wire router into engine dispatch loop

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -25,7 +25,7 @@ use crate::channels::capture::CaptureService;
 use crate::channels::transport::Transport;
 use crate::channels::ChannelRegistry;
 use crate::db::{Db, TaskStatus};
-use crate::engine::router::{get_route_result, RouteResult};
+use crate::engine::router::{get_route_result, RouteResult, Router};
 use crate::sidecar;
 use crate::tmux::TmuxManager;
 use anyhow::Context;
@@ -102,6 +102,15 @@ pub async fn serve() -> anyhow::Result<()> {
     // Task runner (delegates to run_task.sh)
     let runner = Arc::new(TaskRunner::new(repo.clone()));
 
+    // Agent router (selects agent + model per task)
+    let router = Arc::new(Router::from_config());
+    tracing::info!(
+        mode = %router.config.mode,
+        agents = ?router.available_agents,
+        fallback = %router.config.fallback_executor,
+        "router initialized"
+    );
+
     // Jobs path
     let orch_home = dirs::home_dir().unwrap_or_default().join(".orchestrator");
     let jobs_path = orch_home.join("jobs.yml");
@@ -137,6 +146,7 @@ pub async fn serve() -> anyhow::Result<()> {
                     &config,
                     &jobs_path,
                     &db,
+                    &router,
                 ).await {
                     tracing::error!(?e, "tick failed");
                 }
@@ -192,6 +202,7 @@ async fn tick(
     config: &EngineConfig,
     jobs_path: &std::path::PathBuf,
     db: &Arc<Db>,
+    router: &Router,
 ) -> anyhow::Result<()> {
     // Phase 1: Check active tmux sessions for completions
     let session_snapshot = tmux.snapshot().await;
@@ -256,13 +267,56 @@ async fn tick(
         }
     }
 
-    // Phase 3: Dispatch new/routed tasks
-    let mut new_tasks = backend.list_by_status(Status::New).await?;
-    let routed_tasks = backend.list_by_status(Status::Routed).await?;
-    new_tasks.extend(routed_tasks);
+    // Phase 3a: Route new tasks
+    let new_tasks = backend.list_by_status(Status::New).await?;
+    let routable: Vec<&ExternalTask> = new_tasks
+        .iter()
+        .filter(|t| !t.labels.iter().any(|l| l == "no-agent"))
+        .collect();
 
-    // Filter out no-agent tasks
-    let dispatchable: Vec<&ExternalTask> = new_tasks
+    for task in routable {
+        match router.route(task).await {
+            Ok(result) => {
+                // Store route result in sidecar
+                if let Err(e) = router.store_route_result(&task.id.0, &result) {
+                    tracing::warn!(task_id = task.id.0, ?e, "failed to store route result");
+                }
+
+                // Add agent and complexity labels for visibility
+                let labels = vec![
+                    format!("agent:{}", result.agent),
+                    format!("complexity:{}", result.complexity),
+                ];
+                if let Err(e) = backend.set_labels(&task.id, &labels).await {
+                    tracing::warn!(task_id = task.id.0, ?e, "failed to set routing labels");
+                }
+
+                // Transition to routed
+                if let Err(e) = backend.update_status(&task.id, Status::Routed).await {
+                    tracing::warn!(task_id = task.id.0, ?e, "failed to set status:routed");
+                }
+
+                if let Some(ref warning) = result.warning {
+                    tracing::warn!(task_id = task.id.0, warning, "routing sanity warning");
+                }
+
+                tracing::info!(
+                    task_id = task.id.0,
+                    agent = %result.agent,
+                    complexity = %result.complexity,
+                    reason = %result.reason,
+                    "task routed"
+                );
+            }
+            Err(e) => {
+                tracing::error!(task_id = task.id.0, ?e, "routing failed, skipping task");
+            }
+        }
+    }
+
+    // Phase 3b: Dispatch routed tasks
+    let routed_tasks = backend.list_by_status(Status::Routed).await?;
+    let dispatchable: Vec<&ExternalTask> = routed_tasks
         .iter()
         .filter(|t| !t.labels.iter().any(|l| l == "no-agent"))
         .collect();
@@ -288,8 +342,6 @@ async fn tick(
         };
 
         // Mark in_progress BEFORE spawning to prevent double dispatch.
-        // If two ticks overlap, the second tick's list_by_status("new") won't
-        // include this task because it's already in_progress.
         let task_id = task.id.0.clone();
         if let Err(e) = backend.update_status(&task.id, Status::InProgress).await {
             tracing::error!(task_id, ?e, "failed to set in_progress, skipping dispatch");
@@ -307,7 +359,7 @@ async fn tick(
         let capture = capture.clone();
         let task_id_for_cleanup = task_id.clone();
 
-        // Load routing result from sidecar
+        // Load routing result from sidecar (stored during Phase 3a)
         let route_result = get_route_result(&task_id).ok();
 
         tokio::spawn(async move {
@@ -326,7 +378,6 @@ async fn tick(
                 }
                 Err(e) => {
                     tracing::error!(task_id, ?e, "task runner failed");
-                    // Post error comment
                     let _ = backend
                         .post_comment(
                             &crate::backends::ExternalId(task_id.clone()),

--- a/src/engine/router.rs
+++ b/src/engine/router.rs
@@ -11,8 +11,6 @@
 //! 4. Parse LLM response (JSON with agent, model, reason, profile)
 //! 5. Fallback to configured default agent if LLM fails
 
-#![allow(dead_code)]
-
 use crate::backends::ExternalTask;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;


### PR DESCRIPTION
## Summary
- Integrates the existing `Router` module into the engine tick loop, completing the agent selection feature
- Splits Phase 3 into **3a (routing)** and **3b (dispatch)**: new tasks are routed first (label → round-robin → LLM → fallback), then routed tasks are dispatched
- Route results are stored in sidecar and `agent:`/`complexity:` labels are added to issues for visibility
- Removes `#![allow(dead_code)]` from `router.rs` since the module is now actively called

## Test plan
- [x] `cargo build` — clean
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt -- --check` — formatted
- [x] `cargo test` — all 85 tests pass

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)