### PR TITLE
Integrated security module into response posting flow - scans and redacts secrets before posting to GitHub

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -18,6 +18,7 @@ pub mod worktree;
 use crate::backends::{ExternalBackend, ExternalId, ExternalTask, Status};
 use crate::config;
 use crate::engine::router::{get_route_result, RouteResult};
+use crate::security;
 use crate::sidecar;
 use crate::tmux::TmuxManager;
 use response::RunResult;
@@ -454,14 +455,29 @@ impl TaskRunner {
         };
         backend.update_status(&task.id, new_status).await?;
 
-        // Post comment
+        // Post comment (scan for secrets before posting to GitHub)
         let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
-        let comment = if !summary.is_empty() {
+        let raw_comment = if !summary.is_empty() {
             format!("[{now}] {status}: {summary}")
         } else if !last_error.is_empty() {
             format!("[{now}] {status}: {last_error}")
         } else {
             format!("[{now}] {status}")
+        };
+
+        // Scan for leaked secrets and redact if needed
+        let comment = if security::has_leaks(&raw_comment) {
+            let leaks = security::scan(&raw_comment);
+            let rules: Vec<&str> = leaks.iter().map(|l| l.rule).collect();
+            let warning = format!(
+                "\n\n> ⚠️ **Security Notice**: {} potential secret(s) detected and redacted: {}",
+                leaks.len(),
+                rules.join(", ")
+            );
+            let redacted = security::redact(&raw_comment);
+            format!("{redacted}{warning}")
+        } else {
+            raw_comment
         };
         backend.post_comment(&task.id, &comment).await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod engine;
 mod github;
 mod parser;
 #[allow(dead_code)] // security module ready for use, not integrated yet
-mod security;
+pub mod security;
 mod sidecar;
 mod template;
 mod tmux;


### PR DESCRIPTION
## Summary

Integrated security module into response posting flow - scans and redacts secrets before posting to GitHub

### What was done

- Made security module public in main.rs
- Added security import to runner/mod.rs
- Integrated security::has_leaks() scan before posting comments
- Added security::redact() to sanitize leaked secrets
- Added warning notice when secrets are detected and redacted
- All 105 tests pass
- No clippy warnings

### Remaining

- Approve git push to publish changes

### Files changed

- `src/main.rs`
- `src/engine/runner/mod.rs`

Closes #71

---
*Created by minimax[bot] via [Orchestrator](https://github.com/gabrielkoerich/orchestrator)*