### PR TITLE
fix: flatten nested .orchestrator/.orchestrator to .orchestrator/state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ orch task unblock all
 
 ## Logs
 
-- Service log: `~/.orchestrator/.orchestrator/orch.log`
+- Service log: `~/.orchestrator/state/orch.log`
 - Brew stdout: `/opt/homebrew/var/log/orch.log` (startup messages only)
 - Brew stderr: `/opt/homebrew/var/log/orch.error.log`
 
@@ -143,7 +143,7 @@ Override the router by adding labels to tasks:
 
 ### RouteResult Struct
 
-Routing results are stored in the sidecar file (`~/.orchestrator/.orchestrator/{task_id}.json`):
+Routing results are stored in the sidecar file (`~/.orchestrator/state/{task_id}.json`):
 
 ```rust
 pub struct RouteResult {
@@ -194,7 +194,7 @@ The routing prompt template is at `prompts/route.md`. It includes:
     owner/repo.git       #   each has .orchestrator.yml inside
   worktrees/             # agent worktrees (all projects)
     repo/branch/         #   created by the runner, one per task
-  .orchestrator/         # runtime state (logs, prompts, pid, locks)
+  state/                 # runtime state (logs, prompts, pid, locks)
 ```
 
 - **User-managed projects** (e.g. `~/Projects/foo`): user clones, runs `orch init`. Project dir stays where the user put it.

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -110,12 +110,12 @@ orch agents                 # list available agents and their status
 
 | Log | Location |
 |-----|----------|
-| Server log | `~/.orchestrator/.orchestrator/orchestrator.log` |
-| Server archive | `~/.orchestrator/.orchestrator/orchestrator.archive.log` |
-| Jobs log | `~/.orchestrator/.orchestrator/jobs.log` |
-| Per-task output | `~/.orchestrator/.orchestrator/output-{id}.json` |
-| Per-task tools | `~/.orchestrator/.orchestrator/tools-{id}.json` |
-| Per-task prompts | `~/.orchestrator/.orchestrator/prompt-{id}.md` |
+| Server log | `~/.orchestrator/state/orchestrator.log` |
+| Server archive | `~/.orchestrator/state/orchestrator.archive.log` |
+| Jobs log | `~/.orchestrator/state/jobs.log` |
+| Per-task output | `~/.orchestrator/state/output-{id}.json` |
+| Per-task tools | `~/.orchestrator/state/tools-{id}.json` |
+| Per-task prompts | `~/.orchestrator/state/prompt-{id}.md` |
 | Task context | `~/.orchestrator/contexts/task-{id}.md` |
 | Brew stdout | `/opt/homebrew/var/log/orchestrator.log` |
 | Brew stderr | `/opt/homebrew/var/log/orchestrator.error.log` |

--- a/src/engine/runner/agent.rs
+++ b/src/engine/runner/agent.rs
@@ -3,6 +3,7 @@
 //! Supports Claude, Codex, OpenCode (plus Kimi/MiniMax as Claude aliases).
 //! Generates a runner shell script that tmux executes — agents need a real terminal.
 
+use crate::sidecar;
 use crate::tmux::TmuxManager;
 use std::path::PathBuf;
 
@@ -41,10 +42,12 @@ pub struct AgentInvocation {
 ///
 /// The script sets up environment, runs the agent, captures output and exit code.
 pub fn build_runner_script(inv: &AgentInvocation) -> String {
-    let state_dir = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".orchestrator")
-        .join(".orchestrator");
+    let state_dir = sidecar::state_dir().unwrap_or_else(|_| {
+        dirs::home_dir()
+            .unwrap_or_default()
+            .join(".orchestrator")
+            .join("state")
+    });
 
     let sys_file = state_dir.join(format!("prompt-{}-sys.txt", inv.task_id));
     let msg_file = state_dir.join(format!("prompt-{}-msg.txt", inv.task_id));
@@ -178,11 +181,7 @@ pub async fn spawn_in_tmux(tmux: &TmuxManager, inv: &AgentInvocation) -> anyhow:
     let script_content = build_runner_script(inv);
 
     // Write runner script
-    let state_dir = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".orchestrator")
-        .join(".orchestrator");
-    std::fs::create_dir_all(&state_dir)?;
+    let state_dir = sidecar::state_dir()?;
 
     let script_path = state_dir.join(format!("runner-{}.sh", inv.task_id));
     std::fs::write(&script_path, &script_content)?;

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -226,9 +226,13 @@ impl TaskRunner {
             }
         }
 
-        // Read exit code
-        let state_dir = self.orch_home.join(".orchestrator");
-        let status_file = state_dir.join(format!("exit-{task_id}.txt"));
+        // Read exit code (check new state dir, fall back to legacy)
+        let status_file =
+            sidecar::state_file(&format!("exit-{task_id}.txt")).unwrap_or_else(|_| {
+                self.orch_home
+                    .join("state")
+                    .join(format!("exit-{task_id}.txt"))
+            });
         let exit_code: i32 = std::fs::read_to_string(&status_file)
             .ok()
             .and_then(|s| s.trim().parse().ok())

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -28,13 +28,9 @@ pub enum RunResult {
 
 /// Collect and classify the agent's response.
 pub fn collect_response(task_id: &str, exit_code: i32, output_file: &Path) -> RunResult {
-    let state_dir = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".orchestrator")
-        .join(".orchestrator");
-
-    // Read stderr
-    let stderr_path = state_dir.join(format!("stderr-{task_id}.txt"));
+    // Read stderr (check new state dir, fall back to legacy)
+    let stderr_path = sidecar::state_file(&format!("stderr-{task_id}.txt"))
+        .unwrap_or_else(|_| PathBuf::from(format!("/tmp/stderr-{task_id}.txt")));
     let stderr = std::fs::read_to_string(&stderr_path).unwrap_or_default();
 
     // Read response from output file
@@ -128,15 +124,19 @@ fn read_output_file(task_id: &str, primary_path: &Path) -> String {
     }
 
     // Fallback locations
-    let state_dir = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".orchestrator")
-        .join(".orchestrator");
+    let state_dir = sidecar::state_dir().unwrap_or_else(|_| PathBuf::from("/tmp"));
 
-    let fallbacks = [
+    let mut fallbacks = vec![
         PathBuf::from(format!("/tmp/output-{task_id}.json")),
         state_dir.join(format!("output-{task_id}.json")),
     ];
+
+    // Also check legacy location
+    if let Ok(legacy_path) = sidecar::state_file(&format!("output-{task_id}.json")) {
+        if !fallbacks.contains(&legacy_path) {
+            fallbacks.push(legacy_path);
+        }
+    }
 
     for path in &fallbacks {
         if let Ok(content) = std::fs::read_to_string(path) {


### PR DESCRIPTION
## Summary

- Replaces confusing nested `~/.orchestrator/.orchestrator/` directory with `~/.orchestrator/state/` for all runtime state files
- Adds `state_dir()` and `state_file()` public helpers to `sidecar.rs` with backward-compatible fallback to legacy paths
- Updates all 5 consumer modules: `engine/runner/agent.rs`, `engine/runner/response.rs`, `engine/runner/mod.rs`, `cli/service.rs`
- Updates documentation in `AGENTS.md` and `docs/content/cli.md`

## Test plan

- [x] All 105 tests pass (`cargo test`)
- [x] No clippy warnings (`cargo clippy`)
- [x] Code formatted (`cargo fmt`)
- [x] Backward compat: `state_file()` checks new path first, falls back to legacy `~/.orchestrator/.orchestrator/` for reads

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)