### PR TITLE
fix: remove unnecessary #[allow(dead_code)] attributes

### DIFF
--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -295,7 +295,6 @@ pub fn get_reroute_chain(task_id: &str) -> String {
 }
 
 /// Update the reroute chain in sidecar.
-#[allow(dead_code)]
 pub fn update_reroute_chain(task_id: &str, current_agent: &str, existing_chain: &str) -> String {
     let mut chain = existing_chain.to_string();
     if chain.is_empty() {

--- a/src/engine/runner/worktree.rs
+++ b/src/engine/runner/worktree.rs
@@ -284,7 +284,6 @@ pub async fn setup_worktree(
 }
 
 /// Find an existing worktree by task ID prefix.
-#[allow(dead_code)]
 fn find_existing_worktree(worktrees_base: &Path, task_id: &str) -> Option<PathBuf> {
     let prefix = format!("gh-task-{task_id}-");
 


### PR DESCRIPTION
## Summary

Removed unnecessary `#[allow(dead_code)]` attributes from functions that are actually being called.

## Changes

### src/engine/runner/response.rs
- Removed `#[allow(dead_code)]` from `update_reroute_chain` (line 298)
- This function is called at src/engine/runner/mod.rs:316

### src/engine/runner/worktree.rs  
- Removed `#[allow(dead_code)]` from `find_existing_worktree` (line 287)
- This function is called at line 143

## What was NOT changed

The following `#[allow(dead_code)]` attributes were intentionally kept:
- **src/engine/tasks.rs** - Methods are part of TaskManager API but not currently used from TaskManager (uses backend directly)
- **src/db.rs** - Methods are used in tests and internal_tasks module (which has module-level #![allow(dead_code)])
- **src/main.rs** - Channels and security modules (documented as scaffolding for future features)
- **src/tmux.rs** - API completeness

Closes #101