### PR TITLE
fix(ci): replace deprecated macos-13 with macos-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
             os: macos-latest
             arch: arm64
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
             arch: x86_64
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Summary
- Replace `macos-13` runner with `macos-latest` for x86_64 cross-compilation
- `macos-13` is deprecated ("macos-13-us-default not supported")
- Both arm64 and x86_64 targets now build on `macos-latest` using Rust cross-compilation

## Test plan
- [x] CI should pass with both macOS targets building on `macos-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)