### PR TITLE
chore: set version to 0.1.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,7 +1310,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orch"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orch"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 description = "Orch — The Agent Orchestrator (Rust core)"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version from `0.1.0` to `0.1.0-alpha.1` for pre-release testing
- All major features implemented, needs real-world testing before stable

## Current state
- Engine, runner, CLI, channels, metrics, routing — all working
- 150+ tests passing
- CI pipeline with cross-compile for macOS arm64 + x86_64

🤖 Generated with [Claude Code](https://claude.com/claude-code)