### PR TITLE
feat: orch project add — auto-clone GitHub repos as bare clones

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -584,9 +584,7 @@ mod tests {
     fn permission_rules_default_disallows_rm() {
         let rules = PermissionRules::default();
         assert!(rules.disallowed_tools.contains(&"Bash(rm *)".to_string()));
-        assert!(rules
-            .disallowed_tools
-            .contains(&"Bash(rm -*)".to_string()));
+        assert!(rules.disallowed_tools.contains(&"Bash(rm -*)".to_string()));
     }
 
     #[test]
@@ -732,12 +730,30 @@ mod tests {
         let cmd = claude.build_command(None, "", "/tmp/sys.md", "/tmp/msg.md", &perms);
 
         // Each blocked path should generate 4 disallowed tool patterns
-        assert!(cmd.contains("Bash(cd /home/user/project*)"), "missing Bash(cd) for first path");
-        assert!(cmd.contains("Read(/home/user/project/*)"), "missing Read for first path");
-        assert!(cmd.contains("Write(/home/user/project/*)"), "missing Write for first path");
-        assert!(cmd.contains("Edit(/home/user/project/*)"), "missing Edit for first path");
-        assert!(cmd.contains("Bash(cd /opt/other*)"), "missing Bash(cd) for second path");
-        assert!(cmd.contains("Read(/opt/other/*)"), "missing Read for second path");
+        assert!(
+            cmd.contains("Bash(cd /home/user/project*)"),
+            "missing Bash(cd) for first path"
+        );
+        assert!(
+            cmd.contains("Read(/home/user/project/*)"),
+            "missing Read for first path"
+        );
+        assert!(
+            cmd.contains("Write(/home/user/project/*)"),
+            "missing Write for first path"
+        );
+        assert!(
+            cmd.contains("Edit(/home/user/project/*)"),
+            "missing Edit for first path"
+        );
+        assert!(
+            cmd.contains("Bash(cd /opt/other*)"),
+            "missing Bash(cd) for second path"
+        );
+        assert!(
+            cmd.contains("Read(/opt/other/*)"),
+            "missing Read for second path"
+        );
     }
 
     /// Test that blocked paths don't affect Codex (it uses sandbox isolation).
@@ -847,7 +863,10 @@ mod tests {
                 cmd.contains("--permission-mode acceptEdits"),
                 "{agent}: expected acceptEdits"
             );
-            assert!(cmd.contains("Bash(rm *)"), "{agent}: expected rm disallowed");
+            assert!(
+                cmd.contains("Bash(rm *)"),
+                "{agent}: expected rm disallowed"
+            );
             assert!(
                 cmd.contains("Read(/blocked/*)"),
                 "{agent}: expected blocked path Read"
@@ -873,13 +892,8 @@ mod tests {
         // Verify each agent can build a command from the config-loaded rules
         for agent_name in &["claude", "codex", "opencode", "kimi", "minimax"] {
             let runner = get_runner(agent_name);
-            let cmd = runner.build_command(
-                None,
-                "timeout 1800",
-                "/tmp/sys.md",
-                "/tmp/msg.md",
-                &perms,
-            );
+            let cmd =
+                runner.build_command(None, "timeout 1800", "/tmp/sys.md", "/tmp/msg.md", &perms);
             assert!(
                 !cmd.is_empty(),
                 "{agent_name}: build_command returned empty string"
@@ -903,13 +917,7 @@ mod tests {
         let perms = PermissionRules::from_config();
 
         let claude = get_runner("claude");
-        let cmd = claude.build_command(
-            None,
-            "",
-            "/tmp/sys.md",
-            "/tmp/msg.md",
-            &perms,
-        );
+        let cmd = claude.build_command(None, "", "/tmp/sys.md", "/tmp/msg.md", &perms);
 
         if perms.autonomous {
             assert!(
@@ -924,13 +932,7 @@ mod tests {
         }
 
         let codex = get_runner("codex");
-        let cmd = codex.build_command(
-            None,
-            "",
-            "/tmp/sys.md",
-            "/tmp/msg.md",
-            &perms,
-        );
+        let cmd = codex.build_command(None, "", "/tmp/sys.md", "/tmp/msg.md", &perms);
 
         if perms.autonomous {
             assert!(cmd.contains("--ask-for-approval never"));

--- a/src/home.rs
+++ b/src/home.rs
@@ -101,7 +101,6 @@ pub fn contexts_dir() -> anyhow::Result<PathBuf> {
 }
 
 /// Get the path to the projects directory (~/.orch/projects/).
-#[allow(dead_code)]
 pub fn projects_dir() -> anyhow::Result<PathBuf> {
     let dir = orch_home()?.join("projects");
     std::fs::create_dir_all(&dir)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,9 +271,9 @@ enum BoardAction {
 
 #[derive(Subcommand)]
 enum ProjectAction {
-    /// Add a project path to the global registry
+    /// Add a project to the global registry (local path or GitHub slug)
     Add {
-        /// Path to the project directory
+        /// Local path, GitHub slug (owner/repo), or GitHub URL
         #[arg(default_value = ".")]
         path: String,
     },


### PR DESCRIPTION
## Summary

- Add GitHub slug and URL detection to `orch project add` — when given `owner/repo` or `https://github.com/owner/repo`, auto-clones as a bare repo to `~/.orch/projects/{owner}/{repo}.git`
- Creates `.orch.yml` inside the bare clone with `gh.repo` configured
- Registers the bare clone path in the global `config.yml` projects list
- Idempotent: if the bare clone already exists, just registers it without re-cloning
- Local path behavior unchanged — still works for `.`, relative, and absolute paths

## Test plan

- [x] 10 unit tests for `parse_github_slug()` covering slugs, HTTPS URLs, `.git` suffix, trailing slashes, absolute/relative/tilde paths, single words, and multi-segment paths
- [x] Full test suite passes (261 tests, 0 failures)
- [ ] Manual: `orch project add gabrielkoerich/some-repo` clones to `~/.orch/projects/gabrielkoerich/some-repo.git`
- [ ] Manual: `orch project add https://github.com/owner/repo` works identically
- [ ] Manual: Re-running the same command is idempotent
- [ ] Manual: `orch project add /local/path` still works as before

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)