### PR TITLE
feat: task delegation — agent spawns subtasks

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -192,6 +192,45 @@ impl ExternalBackend for GitHubBackend {
             .collect())
     }
 
+    async fn create_sub_task(
+        &self,
+        parent_id: &ExternalId,
+        title: &str,
+        body: &str,
+        labels: &[String],
+    ) -> anyhow::Result<ExternalId> {
+        // Add parent label for metadata
+        let mut all_labels = labels.to_vec();
+        all_labels.push(format!("parent:{}", parent_id.0));
+
+        // Create the child issue
+        let child_issue = self
+            .gh
+            .create_issue(&self.repo, title, body, &all_labels)
+            .await?;
+
+        let child_id = ExternalId(child_issue.number.to_string());
+
+        // Try to establish native sub-issue relationship via GraphQL
+        if let (Some(child_node_id), Ok(parent_issue)) = (
+            child_issue.node_id,
+            self.gh.get_issue(&self.repo, &parent_id.0).await,
+        ) {
+            if let Some(parent_node_id) = parent_issue.node_id {
+                if let Err(e) = self.gh.add_sub_issue(&parent_node_id, &child_node_id).await {
+                    tracing::warn!(
+                        parent = parent_id.0,
+                        child = child_id.0,
+                        err = %e,
+                        "failed to add native sub-issue link (parent label still set)"
+                    );
+                }
+            }
+        }
+
+        Ok(child_id)
+    }
+
     async fn has_open_issue_with_title(&self, title: &str, label: &str) -> anyhow::Result<bool> {
         let issues = self.gh.list_issues(&self.repo, label).await?;
         Ok(issues.iter().any(|i| i.title == title))

--- a/src/engine/runner/agent.rs
+++ b/src/engine/runner/agent.rs
@@ -250,15 +250,43 @@ Your final output MUST be a JSON object with these fields:
   "remaining": ["list of remaining items"],
   "files_changed": ["list of files modified"],
   "blockers": ["list of blockers, empty if none"],
-  "reason": "reason if blocked or needs_review, empty string otherwise"
+  "reason": "reason if blocked or needs_review, empty string otherwise",
+  "delegations": [{"title": "...", "body": "...", "labels": ["..."]}]
 }
 ```
+
+Note: `delegations` is optional — only include it when delegating subtasks.
 
 Status rules:
 - **done**: all work is committed, pushed, PR created, and tests pass. You must have produced a visible result (committed code, posted a comment, or completed the requested action). Pure research with no output is `in_progress`.
 - **in_progress**: partial work was committed but more remains.
-- **blocked**: waiting on dependencies or missing information.
+- **blocked**: waiting on dependencies, missing information, or delegated subtasks.
 - **needs_review**: encountered errors you cannot resolve.
+
+## Task Delegation
+
+If a task is too complex for a single agent, you can delegate subtasks. Include a `delegations` array in your response:
+
+```json
+{
+  "status": "blocked",
+  "summary": "Decomposed into subtasks",
+  "accomplished": ["Analyzed requirements"],
+  "remaining": ["Waiting on subtasks"],
+  "delegations": [
+    {"title": "Subtask title", "body": "Detailed description of the subtask", "labels": ["label1"]},
+    {"title": "Another subtask", "body": "Description", "labels": ["label2"]}
+  ]
+}
+```
+
+Delegation rules:
+- Set status to `blocked` when delegating — you will be re-run after all subtasks complete.
+- Each delegation becomes a separate GitHub issue routed to an agent independently.
+- Provide clear, detailed descriptions in `body` so the subtask agent has full context.
+- Only delegate when the task genuinely requires parallel workstreams or different expertise.
+- Do not delegate trivial work — just do it yourself.
+- Labels are optional — the orchestrator will route each subtask automatically.
 
 ## Visibility
 

--- a/src/github/cli.rs
+++ b/src/github/cli.rs
@@ -479,6 +479,26 @@ impl GhCli {
         }
     }
 
+    /// Add a sub-issue relationship using the GitHub GraphQL API.
+    pub async fn add_sub_issue(
+        &self,
+        parent_node_id: &str,
+        child_node_id: &str,
+    ) -> anyhow::Result<()> {
+        let query = format!(
+            r#"mutation {{
+                addSubIssue(input: {{issueId: "{}", subIssueId: "{}"}}) {{
+                    issue {{ number }}
+                    subIssue {{ number }}
+                }}
+            }}"#,
+            parent_node_id, child_node_id
+        );
+
+        self.graphql(&query).await?;
+        Ok(())
+    }
+
     pub async fn get_sub_issues(&self, repo: &str, number: &str) -> anyhow::Result<Vec<u64>> {
         // Parse owner and repo from "owner/repo" format
         let parts: Vec<&str> = repo.split('/').collect();


### PR DESCRIPTION
## Summary

- Add `Delegation` struct and `delegations` field to `AgentResponse` in `parser.rs`
- Add `create_sub_task()` to `ExternalBackend` trait with default `parent:{id}` label implementation
- Implement `create_sub_task` in GitHub backend with native sub-issue linking via GraphQL `addSubIssue` mutation
- Add `process_delegations()` to `TaskRunner` — creates child GitHub issues and blocks parent
- Integrate delegation processing in `run_with_context()` after agent response
- Add delegation instructions and output format to agent system prompt

## Flow

1. Agent returns `status:blocked` with `delegations[]`
2. Engine creates child GitHub issues with `parent:{id}` label + native sub-issue link
3. Parent marked `status:blocked`
4. Children are routed and dispatched normally
5. Phase 4 unblock: when all children are `done`, parent returns to `status:new`
6. Original agent re-runs with previous context

## Test plan

- [x] All 279 existing tests pass
- [x] New parser tests: `parse_with_delegations`, `parse_delegations_empty_by_default`, `parse_delegations_without_labels`
- [ ] Manual: create a task that triggers delegation and verify child issues are created
- [ ] Manual: verify Phase 4 unblock works when all children complete

Closes #152