### PR TITLE
fix: webhook signature verification timing-safety and comment encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,6 +1330,7 @@ dependencies = [
  "serde_json",
  "serde_yml",
  "sha2",
+ "subtle",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,9 @@ tower-http = { version = "0.5", features = ["trace"] }
 # HMAC for webhook signature verification
 hmac = "0.12"
 
+# Constant-time comparison for timing-safe signature verification
+subtle = "2"
+
 # Async combinators (FuturesUnordered for concurrent routing)
 futures = "0.3"
 


### PR DESCRIPTION
## Summary
- Fixed timing-unsafe HMAC verification by using constant-time comparison (`subtle::ConstantTimeEq`)
- Fixed comment body newlines by using `--raw-field` instead of `--field` for gh CLI
- Fixed webhook event IDs to use actual GitHub comment/review IDs instead of synthesized timestamps
- Fixed webhook health check to properly handle HTTP client builder errors

## Test plan
- [x] All 276 tests pass
- [x] Code compiles without warnings

Closes #167