### PR TITLE
chore: document retained unused router functions

### DIFF
--- a/src/engine/router.rs
+++ b/src/engine/router.rs
@@ -724,7 +724,12 @@ impl Router {
     }
 
     /// Route using round-robin algorithm (task-ID based, stateless).
-    /// Kept for backward compatibility; prefer `route_round_robin_stateful`.
+    ///
+    /// Kept for backward compatibility and unit tests. The project prefers
+    /// the stateful `route_round_robin_stateful` (which persists an index),
+    /// but this stateless modulo-based implementation is intentionally
+    /// retained to allow deterministic selection based on task ID and for
+    /// existing tests that exercise the legacy behavior.
     #[allow(dead_code)]
     fn route_round_robin(&self, task: &ExternalTask) -> anyhow::Result<RouteResult> {
         let agents = &self.available_agents;
@@ -1284,6 +1289,9 @@ impl Router {
     }
 
     /// Get a snapshot of current agent weights for logging.
+    ///
+    /// Public helper kept for debugging and observability (useful when
+    /// inspecting router state from integration tests or admin tooling).
     #[allow(dead_code)]
     pub fn weight_snapshot(&self) -> Vec<(String, f64, u32)> {
         self.weights.snapshot()
@@ -1305,6 +1313,8 @@ impl Router {
 
     /// Route multiple tasks concurrently using FuturesUnordered.
     /// Returns results in completion order (not input order).
+    ///
+    /// Retained as a convenience for batch-processing callers and tests.
     #[allow(dead_code)]
     pub async fn route_batch(
         self: &Arc<Self>,

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -13,6 +13,12 @@ use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
 
 /// Classification of agent execution result (legacy, used in tests).
+///
+/// This enum is kept for backwards compatibility with older call sites and
+/// unit tests that inspect detailed execution outcomes. Newer code prefers
+/// `WeightSignal` and the parsing helpers above, but removing this enum would
+/// require updating multiple modules and tests, so it remains intentionally
+/// available.
 #[allow(dead_code)]
 pub enum RunResult {
     /// Agent completed successfully with a parsed response.
@@ -31,8 +37,8 @@ pub enum RunResult {
 
 /// Outcome signal for the engine to update router weights.
 ///
-/// Returned by the task runner so the engine can feed rate limit
-/// and success signals back to the router's weighted round-robin.
+/// Returned by the task runner so the engine can feed rate limit and
+/// success signals back to the router's weighted round-robin implementation.
 #[derive(Debug, Clone)]
 pub enum WeightSignal {
     /// Agent completed a task successfully.

--- a/src/github/cli.rs
+++ b/src/github/cli.rs
@@ -156,7 +156,10 @@ impl GhCli {
     ///
     /// Uses `--input -` with a JSON payload — the `-f labels[]=` form doesn't
     /// map correctly to the GitHub JSON API.
-    #[allow(dead_code)] // available for backends, not all paths used yet
+    ///
+    /// Kept as a public helper for backends and integration tests that need to
+    /// programmatically append labels. Intentionally retained for API parity
+    /// with the original shell helper.
     pub async fn add_labels(
         &self,
         repo: &str,
@@ -252,7 +255,6 @@ impl GhCli {
     ///
     /// Returns Ok if the label was removed or didn't exist (404).
     /// Propagates all other errors to prevent silent state corruption.
-    #[allow(dead_code)]
     pub async fn remove_label(&self, repo: &str, number: &str, label: &str) -> anyhow::Result<()> {
         let encoded = urlencoding::encode(label);
         let endpoint = format!("repos/{repo}/issues/{number}/labels/{encoded}");


### PR DESCRIPTION
Closes #177\n\nDocument retained unused router functions and helpers. Removed a few unnecessary #[allow(dead_code)] annotations and added comments explaining why certain functions are preserved for backward compatibility and tests.\n\nWorktree: /Users/gb/.orchestrator/worktrees/orch/gh-task-177-dead-code-unused-router-functions-marked