### PR TITLE
fix: log error when rerun_failed_jobs fails instead of silently discarding

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2145,8 +2145,19 @@ async fn auto_merge_pr(
                     if let Ok(Some((run_id, _, _))) =
                         gh.get_latest_run_for_branch(repo, branch).await
                     {
-                        let _ = gh.rerun_failed_jobs(repo, run_id).await;
-                        tracing::info!(task_id = task.id.0, run_id, "re-triggered failed CI jobs");
+                        match gh.rerun_failed_jobs(repo, run_id).await {
+                            Ok(()) => tracing::info!(
+                                task_id = task.id.0,
+                                run_id,
+                                "re-triggered failed CI jobs"
+                            ),
+                            Err(e) => tracing::warn!(
+                                task_id = task.id.0,
+                                run_id,
+                                error = %e,
+                                "failed to re-trigger CI jobs"
+                            ),
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

- Fix silent error discard in `auto_merge_pr` when `rerun_failed_jobs` fails
- Previously `let _ = gh.rerun_failed_jobs(...)` discarded the error result and always logged "re-triggered failed CI jobs" regardless of success or failure
- Now properly matches on `Ok`/`Err` and logs warnings when the rerun fails

## Test plan

- [x] All 364 tests pass
- [x] `cargo fmt --check` passes
- [x] Logic change is minimal and targeted

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)