### PR TITLE
test: add opencode permission fixtures, fix clippy

### DIFF
--- a/src/engine/runner/agents/claude.rs
+++ b/src/engine/runner/agents/claude.rs
@@ -207,15 +207,13 @@ impl AgentRunner for ClaudeRunner {
                 &permissions.allowed_edit_paths,
             );
             format!("--allowedTools '{}'", tools.join(","))
+        } else if !permissions.disallowed_tools.is_empty() {
+            format!(
+                "--disallowedTools '{}'",
+                permissions.disallowed_tools.join(",")
+            )
         } else {
-            if !permissions.disallowed_tools.is_empty() {
-                format!(
-                    "--disallowedTools '{}'",
-                    permissions.disallowed_tools.join(",")
-                )
-            } else {
-                String::new()
-            }
+            String::new()
         };
 
         format!(

--- a/tests/fixtures/opencode_permission_denied.jsonl
+++ b/tests/fixtures/opencode_permission_denied.jsonl
@@ -1,0 +1,3 @@
+{"type":"step_start","timestamp":1706300000,"part":{"type":"step-start","snapshot":"Starting task..."}}
+{"type":"text","timestamp":1706300001,"part":{"type":"text","text":"I need to run cargo test to verify the changes."}}
+{"type":"error","timestamp":1706300002,"error":{"name":"PermissionError","data":{"message":"user rejected permission for tool bash: cargo test"}}}

--- a/tests/fixtures/opencode_rate_limit.jsonl
+++ b/tests/fixtures/opencode_rate_limit.jsonl
@@ -1,0 +1,2 @@
+{"type":"step_start","timestamp":1706300000,"part":{"type":"step-start","snapshot":"Starting task..."}}
+{"type":"error","timestamp":1706300001,"message":"rate limit exceeded: too many requests, please try again later"}

--- a/tests/integration_agents.rs
+++ b/tests/integration_agents.rs
@@ -189,15 +189,7 @@ fn codex_responds_with_ndjson() {
     }
 
     let output = agent_cmd("codex")
-        .args([
-            "--ask-for-approval",
-            "never",
-            "--sandbox",
-            "workspace-write",
-            "exec",
-            "--json",
-            SIMPLE_PROMPT,
-        ])
+        .args(["--full-auto", "exec", "--json", SIMPLE_PROMPT])
         .output()
         .expect("failed to execute codex");
 
@@ -258,15 +250,7 @@ fn codex_stdin_pipe_mode() {
 
     // Test piped stdin — matches real task invocation: cat msg | codex ... exec --json -
     let output = agent_cmd("codex")
-        .args([
-            "--ask-for-approval",
-            "never",
-            "--sandbox",
-            "workspace-write",
-            "exec",
-            "--json",
-            "-",
-        ])
+        .args(["--full-auto", "exec", "--json", "-"])
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())


### PR DESCRIPTION
## Summary

- Add opencode permission denied detection (`user rejected permission` pattern)
- Add fixture tests for permission denied and rate limit errors
- Test `translate_permissions_to_opencode` with full 22-tool config list
- Fix clippy `collapsible_else_if` warning in claude.rs
- Update codex integration tests to use `--full-auto` flag

Follow-up to the allowed_tools/permissions work on main.

## Test plan

- [x] `cargo test` — 380 tests pass
- [x] `cargo clippy` — clean, no warnings
- [x] `cargo fmt` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)