### PR TITLE
Implement task delegation processing in engine

### DIFF
--- a/src/engine/runner/agent.rs
+++ b/src/engine/runner/agent.rs
@@ -270,7 +270,7 @@ Your final output MUST be a JSON object with these fields:
   "files_changed": ["list of files modified"],
   "blockers": ["list of blockers, empty if none"],
   "reason": "reason if blocked or needs_review, empty string otherwise",
-  "delegations": [{"title": "...", "body": "...", "labels": ["..."]}]
+  "delegations": [{"title": "...", "body": "...", "labels": ["..."], "suggested_agent": "codex"}]
 }
 ```
 
@@ -293,7 +293,7 @@ If a task is too complex for a single agent, you can delegate subtasks. Include 
   "accomplished": ["Analyzed requirements"],
   "remaining": ["Waiting on subtasks"],
   "delegations": [
-    {"title": "Subtask title", "body": "Detailed description of the subtask", "labels": ["label1"]},
+    {"title": "Subtask title", "body": "Detailed description of the subtask", "labels": ["label1"], "suggested_agent": "codex"},
     {"title": "Another subtask", "body": "Description", "labels": ["label2"]}
   ]
 }
@@ -306,6 +306,7 @@ Delegation rules:
 - Only delegate when the task genuinely requires parallel workstreams or different expertise.
 - Do not delegate trivial work — just do it yourself.
 - Labels are optional — the orchestrator will route each subtask automatically.
+- `suggested_agent` is optional — use when a specific agent is best suited for a subtask.
 
 ## Visibility
 

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -363,7 +363,12 @@ impl TaskRunner {
                         "error": parsed.response.error,
                         "learnings": parsed.response.learnings,
                         "delegations": parsed.response.delegations.iter()
-                            .map(|d| serde_json::json!({"title": d.title, "body": d.body}))
+                            .map(|d| serde_json::json!({
+                                "title": d.title,
+                                "body": d.body,
+                                "labels": d.labels,
+                                "suggested_agent": d.suggested_agent,
+                            }))
                             .collect::<Vec<_>>(),
                     })
                 }
@@ -1024,6 +1029,9 @@ impl TaskRunner {
             // Build labels: status:new + any labels from the delegation
             let mut labels = delegation.labels.clone();
             labels.push("status:new".to_string());
+            if let Some(agent) = delegation.suggested_agent.as_ref() {
+                labels.push(format!("agent:{agent}"));
+            }
 
             // Build child body with delegation reference
             let child_body = format!(
@@ -1036,6 +1044,10 @@ impl TaskRunner {
                 .await
             {
                 Ok(child_id) => {
+                    let _ = sidecar::set(
+                        &child_id.0,
+                        &[format!("parent_id={}", parent_id.0)],
+                    );
                     tracing::info!(
                         parent = parent_id.0,
                         child = child_id.0,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -43,6 +43,8 @@ pub struct Delegation {
     pub body: String,
     #[serde(default)]
     pub labels: Vec<String>,
+    #[serde(default)]
+    pub suggested_agent: Option<String>,
 }
 
 /// Parse an agent response from a file path (or stdin if "-").


### PR DESCRIPTION
## Summary

Extends delegation processing with `suggested_agent` support so agents can hint which agent should handle each subtask. Also fixes `result.json` to include `labels` and `suggested_agent` in delegation entries, and records `parent_id` in the child task's sidecar.

## Changes

- **`src/parser.rs`**: Added `suggested_agent: Option<String>` field to `Delegation` struct
- **`src/engine/runner/agent.rs`**: Updated agent prompt to show `suggested_agent` in delegation format examples and added rule explaining when to use it
- **`src/engine/runner/mod.rs`**: 
  - Include `labels` and `suggested_agent` in `result.json` delegation entries
  - Push `agent:{agent}` label onto child task when `suggested_agent` is set, so the router honors the hint
  - Store `parent_id` in child task sidecar for traceability

Closes #178