### PR TITLE
chore: clean up dead code and update PLAN.md

### DIFF
--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -179,11 +179,9 @@ pub trait ExternalBackend: Send + Sync {
     /// Add metadata labels / tags (additive — does not remove existing labels).
     /// The GitHub backend uses POST /repos/{repo}/issues/{number}/labels,
     /// which appends to the existing label set.
-    #[allow(dead_code)]
     async fn set_labels(&self, id: &ExternalId, labels: &[String]) -> anyhow::Result<()>;
 
     /// Remove a label / tag.
-    #[allow(dead_code)]
     async fn remove_label(&self, id: &ExternalId, label: &str) -> anyhow::Result<()>;
 
     /// Get sub-issues (children) of a task.

--- a/src/engine/runner/agent.rs
+++ b/src/engine/runner/agent.rs
@@ -7,7 +7,6 @@ use crate::tmux::TmuxManager;
 use std::path::PathBuf;
 
 /// Agent invocation configuration.
-#[allow(dead_code)]
 pub struct AgentInvocation {
     /// Agent name (claude, codex, opencode, kimi, minimax)
     pub agent: String,
@@ -21,9 +20,11 @@ pub struct AgentInvocation {
     pub agent_message: String,
     /// Task ID
     pub task_id: String,
-    /// Branch name
+    /// Branch name (reserved for sandbox isolation, not yet wired into the runner script).
+    #[allow(dead_code)]
     pub branch: String,
-    /// Main project directory (for sandbox)
+    /// Main project directory (reserved for sandbox isolation, not yet wired into the runner script).
+    #[allow(dead_code)]
     pub main_project_dir: PathBuf,
     /// Disallowed tools pattern
     pub disallowed_tools: Vec<String>,

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -100,7 +100,6 @@ impl PermissionRules {
 /// Parsed response from an agent, including metadata extracted from the
 /// agent-specific output envelope.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct ParsedResponse {
     /// Normalized task response (status, summary, accomplished, etc.)
     pub response: AgentResponse,
@@ -111,16 +110,17 @@ pub struct ParsedResponse {
     /// Wall-clock duration in milliseconds (if reported by the agent).
     pub duration_ms: Option<u64>,
     /// Permission denials encountered during execution.
+    #[allow(dead_code)]
     pub permission_denials: Vec<String>,
 }
 
 /// Agent-specific error with enough detail for autonomous recovery.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum AgentError {
     /// Rate/usage limit — reroute to different agent, cooldown current.
     RateLimit {
         message: String,
+        #[allow(dead_code)]
         retry_after: Option<Duration>,
     },
     /// Auth/billing/API key error — switch agent entirely.
@@ -130,6 +130,7 @@ pub enum AgentError {
     /// Context window exceeded — truncate and retry, then switch agent.
     ContextOverflow {
         message: String,
+        #[allow(dead_code)]
         max_tokens: Option<u64>,
     },
     /// Agent timed out — retry once, then switch agent.
@@ -211,12 +212,13 @@ fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> usize {
 ///
 /// Each agent implements this to handle its specific CLI invocation,
 /// output parsing, and error classification.
-#[allow(dead_code)]
 pub trait AgentRunner: Send + Sync {
     /// Agent name (e.g., "claude", "codex", "opencode").
+    #[allow(dead_code)]
     fn name(&self) -> &str;
 
     /// Check if this agent's binary is available on the system.
+    #[allow(dead_code)]
     fn is_available(&self) -> bool;
 
     /// Build the CLI command string for the runner shell script.

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -550,7 +550,6 @@ impl GhHttp {
     }
 
     /// List comments on an issue.
-    #[allow(dead_code)]
     pub async fn list_comments(
         &self,
         repo: &str,

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -29,7 +29,6 @@ pub struct GitHubUser {
     pub login: String,
 }
 
-#[allow(dead_code)] // used by list_comments and list_recent_comments
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitHubComment {
     pub id: u64,


### PR DESCRIPTION
## Summary

- Removed `#[allow(dead_code)]` from `AgentInvocation`, `ParsedResponse`, `AgentError`, and `AgentRunner` — these are actively used by agent runner implementations (codex, claude, opencode)
- Moved field-level annotations to specific unused fields (`branch`, `main_project_dir` in `AgentInvocation`; `permission_denials` in `ParsedResponse`; `retry_after`/`max_tokens` in `AgentError` variants; `name`/`is_available` on `AgentRunner` trait methods)
- Deleted legacy dead code: `RunResult` enum, `collect_response` fn, and `snippet` fn from `response.rs` (replaced by the `AgentError`-based failover system; -142 lines)
- Removed incorrect `#[allow(dead_code)]` from `ExternalBackend::set_labels` and `remove_label` (both called in CLI, engine dispatch, and runner)
- Removed `#[allow(dead_code)]` from `GhHttp::list_comments` (called from `engine/mod.rs`) and `GitHubComment` struct (used by http.rs and engine)
- Updated `PLAN.md`: reflect native reqwest HTTP migration, add `http.rs`/`backoff.rs` to module structure, mark `cli.rs` as legacy fallback, add recently completed items to Phase 5

## Test plan

- [x] `cargo check` — zero warnings
- [x] `cargo test` — 389 tests pass, 0 failures

Closes #211