### PR TITLE
detect_default_branch returns current branch (HEAD), not repo default branch

### DIFF
--- a/src/engine/runner/worktree.rs
+++ b/src/engine/runner/worktree.rs
@@ -60,13 +60,17 @@ pub fn branch_name(task_id: &str, title: &str) -> String {
 /// Detect the default branch of a repository.
 pub async fn detect_default_branch(project_dir: &Path) -> String {
     let output = Command::new("git")
-        .args(["symbolic-ref", "--short", "HEAD"])
+        .args(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
         .current_dir(project_dir)
         .output_with_context()
         .await;
 
     match output {
-        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        Ok(o) if o.status.success() => {
+            let branch = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            // strip "origin/" prefix if present
+            branch.strip_prefix("origin/").unwrap_or(&branch).to_string()
+        }
         _ => "main".to_string(),
     }
 }

--- a/src/engine/runner/worktree.rs
+++ b/src/engine/runner/worktree.rs
@@ -69,7 +69,10 @@ pub async fn detect_default_branch(project_dir: &Path) -> String {
         Ok(o) if o.status.success() => {
             let branch = String::from_utf8_lossy(&o.stdout).trim().to_string();
             // strip "origin/" prefix if present
-            branch.strip_prefix("origin/").unwrap_or(&branch).to_string()
+            branch
+                .strip_prefix("origin/")
+                .unwrap_or(&branch)
+                .to_string()
         }
         _ => "main".to_string(),
     }


### PR DESCRIPTION
## Summary

Excellent! The fix has been successfully implemented. Here's a summary of what was done:

## Summary

I've successfully fixed the `detect_default_branch()` function in `src/engine/runner/worktree.rs` (lines 61-75).

### The Problem
The function was using `git symbolic-ref --short HEAD` which returns the **current** checked-out branch instead of the repository's default branch. This caused:
- Incorrect diffs when agents run in worktrees on feature branches
- PRs targeting the wrong branch
- Failures when HEAD is on a non-main branch

### The Solution
Changed the command to `git symbolic-ref --short refs/remotes/origin/HEAD` which:
- Returns the repository's actual default branch (main, master, etc.) regardless of the current checkout state
- Works correctly even when running from within a worktree
- Properly handles the `origin/` prefix by stripping it

### Changes Made
- ✅ Updated the git command to query the remote default branch reference
- ✅ Added logic to strip the "origin/" prefix from the output
- ✅ Maintained backward compatibility with fallback to "main"
- ✅ Project builds successfully (no compilation errors)
- ✅ Committed with message: "fix: detect_default_branch returns repo default, not current branch"

The fix ensures agents will now use the correct base branch for diffs and PR creation, improving task success rates.

---
*Task #234 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch)*