### PR TITLE
GhHttp::list_comments does not paginate, breaking review lifecycle on busy PRs

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -592,8 +592,7 @@ impl GhHttp {
         number: &str,
     ) -> anyhow::Result<Vec<GitHubComment>> {
         let url = format!("{GITHUB_API}/repos/{repo}/issues/{number}/comments");
-        self.get_all_pages(&url, &[("per_page", "100")])
-            .await
+        self.get_all_pages(&url, &[("per_page", "100")]).await
     }
 
     /// Check if a PR with the given branch was merged.
@@ -672,8 +671,7 @@ impl GhHttp {
         pr_number: u64,
     ) -> anyhow::Result<Vec<GitHubReview>> {
         let url = format!("{GITHUB_API}/repos/{repo}/pulls/{pr_number}/reviews");
-        self.get_all_pages(&url, &[("per_page", "100")])
-            .await
+        self.get_all_pages(&url, &[("per_page", "100")]).await
     }
 
     /// Get review comments for a specific PR review.

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -591,10 +591,9 @@ impl GhHttp {
         repo: &str,
         number: &str,
     ) -> anyhow::Result<Vec<GitHubComment>> {
-        self.get_json(&format!(
-            "{GITHUB_API}/repos/{repo}/issues/{number}/comments"
-        ))
-        .await
+        let url = format!("{GITHUB_API}/repos/{repo}/issues/{number}/comments");
+        self.get_all_pages(&url, &[("per_page", "100")])
+            .await
     }
 
     /// Check if a PR with the given branch was merged.
@@ -672,10 +671,9 @@ impl GhHttp {
         repo: &str,
         pr_number: u64,
     ) -> anyhow::Result<Vec<GitHubReview>> {
-        self.get_json(&format!(
-            "{GITHUB_API}/repos/{repo}/pulls/{pr_number}/reviews"
-        ))
-        .await
+        let url = format!("{GITHUB_API}/repos/{repo}/pulls/{pr_number}/reviews");
+        self.get_all_pages(&url, &[("per_page", "100")])
+            .await
     }
 
     /// Get review comments for a specific PR review.


### PR DESCRIPTION
## Summary

## ✅ Fix Complete

I've successfully fixed the GitHub HTTP pagination issue in task #232. Here's what was changed:

### Changes Made

**File: `src/github/http.rs`**

1. **`list_comments()` (lines 589-597)** — Now uses `get_all_pages()` instead of single-page `get_json()`
2. **`get_pr_reviews()` (lines 670-677)** — Now uses `get_all_pages()` instead of single-page `get_json()`

Both methods now fetch all pages with `per_page=100`, ensuring no results are truncated.

### Why This Matters

- **Before**: PRs/issues with >30 comments would have later comments silently truncated
- **Impact**: `get_automated_review_status()` couldn't find review comments on page 2+, causing tasks to hang in `in_review` state indefinitely
- **After**: All comments across all pages are fetched, fixing the review lifecycle for busy PRs

### Testing

✅ Code compiles successfully  
✅ All 389 unit tests pass  
✅ Commit created: `80ef9de`

The fix follows the existing pattern used in similar paginated methods like `get_mentions()` in the same file.

---
*Task #232 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch)*