### PR TITLE
fix: guard empty branch names + morning review 2026-03-01

### DIFF
--- a/docs/content/posts/morning-review-2026-03-01.md
+++ b/docs/content/posts/morning-review-2026-03-01.md
@@ -1,0 +1,59 @@
++++
+title = "Morning Review — 2026-03-01"
+date = 2026-03-01
+description = "System health check, empty branch guard fix, task status update"
+[taxonomies]
+tags = ["morning-review", "maintenance"]
++++
+
+## Overview
+
+Second morning review of the day. The system is running well — 30+ commits landed in the last 24 hours with major fixes to jobs resolution, review workflow, and PR lifecycle. The engine is healthy, dispatching tasks, running reviews, and merging PRs autonomously.
+
+## Evening Retro Carry-Forward (from #226)
+
+| Priority | Status |
+|----------|--------|
+| Verify brew deployment of fixes | Brew service running (PID 52623), error log still shows old crash-loop messages — PR #233 not yet deployed |
+| Check tasks #223, #224, #225 | #224 merged via auto-review. #223 failed PR (no commits on branch). #225 in_review |
+| Fix #227 (stale tmux sessions) | Still open/routed, not yet picked up |
+
+## System Health
+
+**Tests**: 389 passed, 0 failed, 2 ignored (unit). 9 integration tests ignored (expected — require live agents).
+
+**Engine**: Actively dispatching. Tasks #234 completed and PR #238 created. Task #232 dispatched. Task #237 in progress. Review agents running.
+
+**Logs** (20,307 lines in `orch.log`):
+- ~3,479 WARN/ERROR entries (most are old health-check failures from Feb 27)
+- 4 transient GitHub API timeouts at 20:13 UTC (recovered automatically)
+- Codex agent exit-code-2 failures on tasks #230, #231, #232, #234 — all recovered by re-routing to claude
+- Review agent parse error on task #225 (NDJSON response from opencode review agent)
+- CI rerun-failed-jobs 403 on tasks #232, #234 (workflow already completed, not retriable)
+
+**Error log**: 651 lines, all "no valid projects configured" crash-loop messages from before the fix in PR #233. Will clear once brew binary is upgraded.
+
+## Fix Applied: Empty Branch Name Guard
+
+**Root cause**: Recurring `[branch ""]` corruption in `.git/config` blocks all `gh` CLI commands. The `gh issue develop` command writes a `gh-merge-base` config entry for the branch name — if the branch name is empty, it creates `[branch ""]` which is invalid git config.
+
+**Fix**: Added empty-string guards to `link_issue_to_branch()` and `push_branch()` in `src/engine/runner/git_ops.rs`. These prevent `gh issue develop` and `git push` from running with empty branch names. The worktree setup already validates branch names, but this provides defense-in-depth.
+
+**Fixed twice this session**: The entry reappeared between fixes, confirming the engine is actively creating it during task dispatch.
+
+## Open Issues Summary
+
+| Issue | Title | Status | Notes |
+|-------|-------|--------|-------|
+| #234 | detect_default_branch returns HEAD | in_review (PR #238) | Fix landed, awaiting merge |
+| #232 | GhHttp::list_comments no pagination | in_progress | Agent working on it |
+| #231 | Runner bypasses build_full_context | routed | Memory system dead code — high impact |
+| #230 | Break tick() into named phases | routed | Refactoring task |
+| #228 | Decompose engine/mod.rs | in_progress | Large refactor |
+| #227 | TmuxManager kill stale sessions | routed | From evening retro |
+
+## Recommendations
+
+1. **Deploy PR #233** (crash-loop backoff) via `brew upgrade orch` — clears the 651 error-log spam
+2. **Prioritize #231** (build_full_context bypass) — memory/context is completely dead code, agents have no memory across retries
+3. **Monitor #234 merge** — fixes wrong base branch in worktrees, high impact on PR quality

--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -94,6 +94,11 @@ pub async fn push_branch(dir: &Path, branch: &str, default_branch: &str) -> anyh
         branch
     };
 
+    // Guard against empty branch names (prevents git config corruption)
+    if branch_to_push.is_empty() {
+        anyhow::bail!("cannot push: branch name is empty");
+    }
+
     // Skip push for main/master
     if branch_to_push == "main" || branch_to_push == "master" {
         return Ok(false);
@@ -230,6 +235,11 @@ pub async fn create_pr_if_needed(
 /// This creates the "Development" sidebar link in GitHub.
 /// Failures are logged but not fatal — the PR is still created.
 async fn link_issue_to_branch(dir: &Path, task_id: &str, branch: &str) {
+    if branch.is_empty() {
+        tracing::warn!(task_id, "skipping link_issue_to_branch: empty branch name");
+        return;
+    }
+
     let result = Command::new("gh")
         .args(["issue", "develop", task_id, "--name", branch])
         .current_dir(dir)


### PR DESCRIPTION
## Summary

- Add empty-string guards to `link_issue_to_branch()` and `push_branch()` in `src/engine/runner/git_ops.rs` to prevent recurring git config corruption from `gh issue develop` with empty branch names
- Add morning review post documenting system health, task status, and recommendations

### Root cause
`gh issue develop --name ""` creates a `[branch ""]` entry in `.git/config` with `gh-merge-base = main`. This is invalid git config that breaks all `gh` CLI commands. The entry was recreated 3 times during this session by the running engine.

### Defense-in-depth
- `link_issue_to_branch()`: skip and warn if branch name is empty
- `push_branch()`: bail with error if branch name is empty
- Existing validation in `setup_worktree()` at line 177 already catches empty names at creation time

Closes #235

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — 389 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)