### PR TITLE
fix: template render_template leaks all env vars including secrets into agent prompts

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,5 @@
 use regex::Regex;
 use std::collections::HashMap;
-use std::env;
 use std::fs;
 use std::io::{self, Write};
 use std::sync::LazyLock;
@@ -73,7 +72,7 @@ pub fn render_template(template_path: &str, extra_vars: &[String]) -> Result<Str
     let data =
         fs::read_to_string(template_path).map_err(|e| format!("failed to read template: {}", e))?;
 
-    let mut vars: HashMap<String, String> = env::vars().collect();
+    let mut vars: HashMap<String, String> = HashMap::new();
 
     for var in extra_vars {
         if let Some((key, value)) = var.split_once('=') {
@@ -82,6 +81,44 @@ pub fn render_template(template_path: &str, extra_vars: &[String]) -> Result<Str
     }
 
     render_template_with_vars(&data, &vars)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn render_template_does_not_leak_env_vars() {
+        // Set a sensitive env var that must NOT appear in the rendered output
+        unsafe {
+            std::env::set_var("ORCH_TEST_SECRET_TOKEN", "should-not-appear");
+        }
+
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "hello world").unwrap();
+
+        let result = render_template(f.path().to_str().unwrap(), &[]).unwrap();
+        assert!(
+            !result.contains("should-not-appear"),
+            "env var leaked into rendered template"
+        );
+
+        unsafe {
+            std::env::remove_var("ORCH_TEST_SECRET_TOKEN");
+        }
+    }
+
+    #[test]
+    fn render_template_uses_explicit_vars() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "value={{{{MY_VAR}}}}").unwrap();
+
+        let result =
+            render_template(f.path().to_str().unwrap(), &["MY_VAR=hello".to_string()]).unwrap();
+        assert_eq!(result.trim(), "value=hello");
+    }
 }
 
 pub fn render_and_print(template_path: &str, extra_vars: &[String]) -> io::Result<()> {


### PR DESCRIPTION
## Summary

The fix is complete. Here's a summary of what was done:

**Root cause:** `render_template()` called `env::vars().collect()` at line 76, making all process environment variables (including secrets from `$HOME/.private`) available for template substitution.

**Fix:** Replaced `env::vars().collect()` with `HashMap::new()` — an empty map. Template variables are only populated from explicitly passed `extra_vars` (`KEY=value` pairs). This is safe because:
- All agent prompt variables (`TASK_ID`, `TASK_TITLE`, `GIT_DIFF`, etc.) are already passed explicitly by the callers in `agent.rs` via `render_template_str`
- The `render_template` / `render_and_print` path (used by the `orch template` CLI command) only uses what the user explicitly provides on the command line
- No template file uses any system env var names

**Also removed** the now-unused `use std::env;` import.

**Tests added:**
- `render_template_does_not_leak_env_vars` — sets a fake secret env var and asserts it never appears in rendered output
- `render_template_uses_explicit_vars` — confirms explicit `KEY=value` args still work correctly

---
*Task #241 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch)*