### PR TITLE
Approved PRs with merge conflicts are stuck: review_open_prs doesn't detect CONFLICTING state

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1805,6 +1805,29 @@ async fn review_open_prs(
                     tracing::warn!(task_id, err = %e, "failed to update task status to done");
                 }
             } else {
+                // Check if PR has merge conflicts before attempting auto-merge
+                let pr_details = gh.get_pr(repo, pr_number).await;
+                let is_conflicting = pr_details
+                    .as_ref()
+                    .map(|pr| pr.mergeable == Some(false))
+                    .unwrap_or(false);
+
+                if is_conflicting {
+                    tracing::info!(
+                        task_id,
+                        pr_number,
+                        "PR approved but has merge conflicts — re-dispatching agent to rebase"
+                    );
+                    // Reset review_started flag so agent can be re-dispatched
+                    if let Err(e) = sidecar::set(task_id, &["review_started=".to_string()]) {
+                        tracing::warn!(task_id, err = %e, "failed to reset review_started flag");
+                    }
+                    if let Err(e) = backend.update_status(&task.id, Status::Routed).await {
+                        tracing::warn!(task_id, err = %e, "failed to re-route conflicting PR");
+                    }
+                    continue;
+                }
+
                 tracing::info!(
                     task_id,
                     pr_number,

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -6,7 +6,9 @@
 //! Auth: reads token from `gh auth token` once at startup, falls back to
 //! `GITHUB_TOKEN` / `GH_TOKEN` env vars.
 
-use super::types::{GitHubComment, GitHubIssue, GitHubReview, GitHubReviewComment};
+use super::types::{
+    GitHubComment, GitHubIssue, GitHubPullRequest, GitHubReview, GitHubReviewComment,
+};
 use reqwest::{header, Client, Response, StatusCode};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -662,6 +664,13 @@ impl GhHttp {
             .and_then(|n| n.as_u64())
             .ok_or_else(|| anyhow::anyhow!("PR missing number field"))
             .map(Some)
+    }
+
+    /// Get PR details by PR number.
+    /// Returns the full PR object including the `mergeable` field.
+    pub async fn get_pr(&self, repo: &str, pr_number: u64) -> anyhow::Result<GitHubPullRequest> {
+        let url = format!("{GITHUB_API}/repos/{repo}/pulls/{pr_number}");
+        self.get_json(&url).await
     }
 
     /// Get reviews for a PR.

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -29,6 +29,30 @@ pub struct GitHubUser {
     pub login: String,
 }
 
+/// Pull request details from the GitHub API.
+/// The `mergeable` field indicates if the PR can be merged:
+/// - `true` - PR can be merged
+/// - `false` - PR has merge conflicts (CONFLICTING)
+/// - `null` - GitHub is still computing mergeability
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubPullRequest {
+    pub number: u64,
+    pub title: String,
+    pub body: Option<String>,
+    pub state: String,
+    pub head: GitHubBranchRef,
+    pub base: GitHubBranchRef,
+    pub mergeable: Option<bool>,
+    pub merged: Option<bool>,
+    pub html_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubBranchRef {
+    pub ref_field: String,
+    pub sha: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitHubComment {
     pub id: u64,


### PR DESCRIPTION
## Summary

The clippy warnings are pre-existing and not related to my changes. The implementation is complete.

## Summary

I've implemented the fix for detecting CONFLICTING PRs in `review_open_prs`:

### Changes Made:

1. **`src/github/types.rs`** - Added two new structs:
   - `GitHubPullRequest` - Contains PR details including the `mergeable` field which can be:
     - `Some(true)` - PR can be merged
     - `Some(false)` - PR has merge conflicts (CONFLICTING)
     - `None` - GitHub is still computing mergeability
   - `GitHubBranchRef` - For the `head` and `base` branch references

2. **`src/github/http.rs`** - Added `get_pr` method:
   - Fetches full PR details from `GET /repos/{owner}/{repo}/pulls/{pr_number}`
   - Returns `GitHubPullRequest` with the `mergeable` field

3. **`src/engine/mod.rs`** - Updated `review_open_prs`:
   - Before attempting auto-merge on approved PRs, checks if `mergeable == Some(false)`
   - If conflicting, resets the `review_started` sidecar flag and re-routes the task to `Status::Routed`
   - This causes the agent to be re-dispatched, where it will rebase on main and resolve the conflict

### How it fixes the bug:

When a review agent approves a PR and GitHub auto-merge is enabled, if new commits land on `main` that create a merge conflict:
1. GitHub cancels auto-merge automatically
2. On the next `review_open_prs` sync tick, the engine detects `mergeable: false`
3. The task is re-routed, causing the agent to re-dispatch
4. The agent rebases on main, resolves conflicts, and pushes the updated branch
5. GitHub auto-merge can then proceed normally

---
*Task #254 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch)*