### PR TITLE
ci: add cargo-llvm-cov coverage tracking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
       - name: Cache cargo
         uses: actions/cache@v4
         with:
@@ -39,8 +42,14 @@ jobs:
       - name: Clippy
         run: cargo clippy -- -D warnings
 
-      - name: Run tests
-        run: cargo test
+      - name: Run tests with coverage
+        run: cargo llvm-cov --lcov --output-path lcov.info
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: lcov.info
 
   secrets:
     runs-on: ubuntu-latest

--- a/PLAN.md
+++ b/PLAN.md
@@ -1295,6 +1295,7 @@ Benefits: per-repo isolation (no issue number collisions), per-attempt separatio
 | `axum` | Webhook HTTP server | In use |
 | `teloxide` | Telegram bot | Future (Phase 3) |
 | `serenity` | Discord bot | Future (Phase 3) |
+| `cargo-llvm-cov` | Coverage tracking in CI | CI tooling |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `cargo-llvm-cov` to the CI pipeline to track code coverage across all 392 unit tests. This provides visibility into which code paths are exercised by the test suite, enabling safer refactoring of large files.

## Changes

- Install `cargo-llvm-cov` tool in the CI job via GitHub Actions
- Replace `cargo test` with `cargo llvm-cov --lcov --output-path lcov.info`
- Upload `lcov.info` as a CI artifact on every push and PR (LCOV format)
- Update `PLAN.md` to document `cargo-llvm-cov` as CI tooling

## Test Results

- ✅ All 392 unit tests pass with coverage tracking enabled
- ✅ No regressions from baseline test suite

## Context

With active refactoring in progress (#228, #257) and more planned, coverage data becomes critical for:
- Confirming coverage didn't drop during refactoring
- Identifying code paths that lack test coverage
- Guiding test development for complex components

The ~20% performance overhead from `cargo-llvm-cov` is acceptable for a full test run (~1.5s baseline → ~1.8s with coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)