### PR TITLE
fix: use is_ascii_alphanumeric() in branch_name() to prevent panic on non-ASCII titles

### DIFF
--- a/src/engine/runner/worktree.rs
+++ b/src/engine/runner/worktree.rs
@@ -27,7 +27,7 @@ pub fn branch_name(task_id: &str, title: &str) -> String {
     let raw: String = title
         .to_lowercase()
         .chars()
-        .map(|c| if c.is_alphanumeric() { c } else { '-' })
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
         .collect();
 
     // Collapse consecutive dashes and trim
@@ -413,6 +413,33 @@ mod tests {
         let name = branch_name("10", "--- ??? ---");
         assert_eq!(name, "gh-task-10");
         assert!(!name.is_empty());
+    }
+
+    #[test]
+    fn branch_name_chinese_chars_no_panic() {
+        // Non-ASCII alphanumeric chars must not be kept in the slug — byte-offset
+        // truncation at &slug[..40] would panic if a multi-byte char straddles byte 40.
+        let name = branch_name("265", "implement 用户认证 user auth");
+        assert!(name.starts_with("gh-task-265-"));
+        assert!(!name.is_empty());
+        let slug = name.strip_prefix("gh-task-265-").unwrap();
+        assert!(slug.len() <= 40, "slug too long: {}", slug.len());
+        assert!(slug.is_ascii(), "slug contains non-ASCII: {slug}");
+    }
+
+    #[test]
+    fn branch_name_emoji_no_panic() {
+        let name = branch_name("265", "fix 🚀 deployment pipeline 🔥");
+        assert!(name.starts_with("gh-task-265-"));
+        let slug = name.strip_prefix("gh-task-265-").unwrap();
+        assert!(slug.is_ascii(), "slug contains non-ASCII: {slug}");
+    }
+
+    #[test]
+    fn branch_name_all_non_ascii_falls_back_to_task_id() {
+        // Title with only non-ASCII chars → empty slug → task-id only fallback
+        let name = branch_name("265", "用户认证 실행 тест");
+        assert_eq!(name, "gh-task-265");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes a panic in `branch_name()` (`src/engine/runner/worktree.rs:30`) where `&slug[..40]` would panic if byte offset 40 fell inside a multi-byte Unicode character
- Root cause: `c.is_alphanumeric()` is Unicode-aware and kept non-ASCII chars (Chinese, Japanese, emoji, accented letters) in the slug, making it unsafe to truncate by byte offset
- Fix: change to `c.is_ascii_alphanumeric()` — one character change that ensures the slug only ever contains ASCII, making `&slug[..40]` always safe
- Added 3 regression tests covering Chinese characters, emoji, and all-non-ASCII titles

## Test plan

- [x] `cargo test branch_name` — all 9 tests pass (6 existing + 3 new)
- [x] `branch_name_chinese_chars_no_panic` — verifies slug is ASCII-only with Chinese title
- [x] `branch_name_emoji_no_panic` — verifies slug is ASCII-only with emoji title
- [x] `branch_name_all_non_ascii_falls_back_to_task_id` — verifies all-non-ASCII title falls back to `gh-task-{id}`

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)