### PR TITLE
fix: agent data pipeline loses file changes and uses stale git refs

### DIFF
--- a/src/engine/runner/context.rs
+++ b/src/engine/runner/context.rs
@@ -172,7 +172,7 @@ pub async fn build_repo_tree(project_dir: &Path) -> String {
 /// Build git diff from base branch (only for retries).
 pub async fn build_git_diff(project_dir: &Path, default_branch: &str) -> String {
     let output = Command::new("git")
-        .args(["diff", default_branch])
+        .args(["diff", &format!("origin/{default_branch}")])
         .current_dir(project_dir)
         .output_with_context()
         .await;

--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -429,7 +429,7 @@ async fn has_unpushed_commits(dir: &Path, branch: &str, default_branch: &str) ->
     } else {
         // Compare against default branch (passed in, NOT detected from
         // current HEAD — in a worktree HEAD is the feature branch itself)
-        format!("{default_branch}..HEAD")
+        format!("origin/{default_branch}..HEAD")
     };
 
     tracing::debug!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -125,7 +125,14 @@ fn map_generic_response(val: &serde_json::Value) -> anyhow::Result<AgentResponse
 
     let accomplished = extract_string_array(obj.get("accomplished"));
     let remaining = extract_string_array(obj.get("remaining"));
-    let files = extract_string_array(obj.get("files"));
+    let files = {
+        let f = extract_string_array(obj.get("files"));
+        if !f.is_empty() {
+            f
+        } else {
+            extract_string_array(obj.get("files_changed"))
+        }
+    };
     let error = obj.get("error").and_then(|v| v.as_str()).map(String::from);
     let learnings = extract_string_array(obj.get("learnings"));
 


### PR DESCRIPTION
## Summary

Clean compile. All three fixes are in place:

1. **`src/parser.rs`** — `files` now falls back to `files_changed` when `files` is absent/empty, so agents following the prompt literally no longer have their file list silently dropped.

2. **`src/engine/runner/context.rs:175`** — `build_git_diff` now diffs against `origin/{default_branch}` (fresh remote ref) instead of the potentially-stale local branch.

3. **`src/engine/runner/git_ops.rs:432`** — `has_unpushed_commits` fallback now compares `origin/{default_branch}..HEAD`, preventing false negatives that would skip PR creation.

---
*Task #278 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch)*