### PR TITLE
bug: orch --version always shows 0.1.0 regardless of release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
   # Cross-compile build jobs for macOS targets
   build-macos:
-    needs: [test, secrets]
+    needs: [test, secrets, check-release]
     if: github.ref == 'refs/heads/main'
     strategy:
       matrix:
@@ -100,6 +100,8 @@ jobs:
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
+        env:
+          ORCH_BUILD_VERSION: ${{ needs.check-release.outputs.version }}
 
       - name: Package binary
         run: |

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,32 @@
+fn main() {
+    // Version priority:
+    // 1. ORCH_BUILD_VERSION env var (set by CI to the computed release version, e.g. "v0.5.7")
+    // 2. git describe --tags --abbrev=0 (last tag, for local dev builds when tags exist)
+    // 3. CARGO_PKG_VERSION from Cargo.toml (hardcoded fallback)
+    let version = std::env::var("ORCH_BUILD_VERSION")
+        .map(|v| v.trim_start_matches('v').to_string())
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(git_tag_version)
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+
+    println!("cargo:rustc-env=ORCH_VERSION={version}");
+    println!("cargo:rerun-if-env-changed=ORCH_BUILD_VERSION");
+}
+
+fn git_tag_version() -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["describe", "--tags", "--abbrev=0"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let tag = String::from_utf8(output.stdout).ok()?;
+    let version = tag.trim().trim_start_matches('v').to_string();
+    if version.is_empty() {
+        None
+    } else {
+        Some(version)
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,9 +15,7 @@ use tokio::sync::broadcast;
 
 /// Print version information.
 pub fn version() {
-    let pkg_version = env!("CARGO_PKG_VERSION");
-    let git_desc = option_env!("ORCH_GIT_DESCRIBE").unwrap_or("unknown");
-    println!("orch {pkg_version} ({git_desc})");
+    println!("orch {}", env!("ORCH_VERSION"));
 }
 
 /// Initialize orchestrator for a project.

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ fn ensure_path() {
 }
 
 #[derive(Parser)]
-#[command(name = "orch", version, about = "Orch — The Agent Orchestrator")]
+#[command(name = "orch", version = env!("ORCH_VERSION"), about = "Orch — The Agent Orchestrator")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -400,7 +400,7 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::Serve => {
-            tracing::info!(version = env!("CARGO_PKG_VERSION"), "starting orch serve");
+            tracing::info!(version = env!("ORCH_VERSION"), "starting orch serve");
             engine::serve().await?;
         }
         Commands::Version => {


### PR DESCRIPTION
## Summary

Clean. Here's a summary of the fix:

## Changes

**`build.rs`** (new file) — Injects `ORCH_VERSION` at compile time:
1. Reads `ORCH_BUILD_VERSION` env var (set by CI to the computed release tag, e.g. `v0.5.7`)
2. Falls back to `git describe --tags --abbrev=0` (works in local dev when tags exist)
3. Falls back to `CARGO_PKG_VERSION` from Cargo.toml

**`src/main.rs`** — Uses `env!("ORCH_VERSION")` in both the clap `--version` flag and the serve startup log

**`src/cli/mod.rs`** — `version()` simplified to use `env!("ORCH_VERSION")`, removing the dead `ORCH_GIT_DESCRIBE` reference

**`.github/workflows/release.yml`** — `build-macos` now depends on `check-release` (so the version is known before compiling) and passes `ORCH_BUILD_VERSION: ${{ needs.check-release.outputs.version }}` as an env var to `cargo build`. This ensures the binary embedded version matches the tag created in the `release` job.

---
*Task #294 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch)*