### PR TITLE
fix: opencode review agent fails to parse NDJSON as ReviewResponse (#292)

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -548,7 +548,7 @@ pub(crate) async fn review_and_merge(
         }
     }
 
-    // 9. Read and parse response using the same pipeline as normal tasks
+    // 9. Read and parse response
     let raw_output = runner::response::read_output_file(&review_task_id, &output_file, repo);
     let agent_runner = runner::agents::get_runner(&review_agent);
 
@@ -560,27 +560,60 @@ pub(crate) async fn review_and_merge(
 
     let stderr = std::fs::read_to_string(review_attempt_dir.join("stderr.txt")).unwrap_or_default();
 
-    // Use agent-specific parsing (handles envelope, is_error, auth, rate limit)
-    let parse_result = if exit_code == 0 && !raw_output.is_empty() {
-        agent_runner.parse_response(&raw_output)
-    } else {
-        Err(agent_runner.classify_error(exit_code, &raw_output, &stderr))
-    };
+    // Abort on hard agent errors (non-zero exit, rate limit, auth, etc.)
+    if exit_code != 0 || raw_output.is_empty() {
+        let err = agent_runner.classify_error(exit_code, &raw_output, &stderr);
+        tracing::error!(task_id = task.id.0, error = %err, "review agent failed");
+        return Ok(ReviewDecision::Failed(format!("agent error: {err}")));
+    }
 
-    let parsed = match parse_result {
-        Ok(p) => p,
+    // Stage 1: strip the agent-specific output envelope to get the review text.
+    //
+    // For opencode this unwraps the NDJSON stream; for claude/kimi it unwraps
+    // the JSON content envelope. When parsing fails (e.g. opencode emits NDJSON
+    // with no "text" events due to a format change) or the summary is empty
+    // (the agent put a ReviewResponse JSON where AgentResponse.summary was
+    // expected), fall back to the raw output and let Stage 2 handle it.
+    let text_for_review = match agent_runner.parse_response(&raw_output) {
+        Ok(p) if !p.response.summary.is_empty() => p.response.summary,
+        Ok(_) => {
+            // Envelope parsed but summary is empty — the agent likely
+            // output a ReviewResponse JSON directly (no AgentResponse wrapper).
+            tracing::debug!(
+                task_id = task.id.0,
+                agent = %review_agent,
+                "review agent: empty summary after parse, falling back to raw output"
+            );
+            raw_output.clone()
+        }
+        Err(runner::agents::AgentError::InvalidResponse { .. }) => {
+            // Unparseable envelope (e.g. opencode NDJSON format change).
+            // Fall back; parse_review_from_output handles NDJSON directly.
+            tracing::warn!(
+                task_id = task.id.0,
+                agent = %review_agent,
+                "review agent: envelope parse failed (InvalidResponse), falling back to raw output"
+            );
+            raw_output.clone()
+        }
         Err(e) => {
-            tracing::error!(task_id = task.id.0, error = %e, "review agent error: {}", e);
+            // Hard error — rate limit, auth, model unavailable, etc.
+            tracing::error!(task_id = task.id.0, error = %e, "review agent error");
             return Ok(ReviewDecision::Failed(format!("agent error: {e}")));
         }
     };
 
-    // The agent's summary contains the review JSON (or markdown with JSON block)
-    let review_text = &parsed.response.summary;
-    let review_response = match runner::response::parse_review_response(review_text) {
+    // Stage 2: parse the ReviewResponse from the extracted text.
+    // parse_review_from_output handles JSON, markdown code blocks, and NDJSON.
+    let review_response = match runner::response::parse_review_from_output(&text_for_review) {
         Ok(r) => r,
         Err(e) => {
-            tracing::error!(task_id = task.id.0, error = %e, review_text = %review_text, "failed to parse review response");
+            tracing::error!(
+                task_id = task.id.0,
+                error = %e,
+                output = %text_for_review.chars().take(300).collect::<String>(),
+                "failed to parse review response"
+            );
             return Ok(ReviewDecision::Failed(format!("parse error: {e}")));
         }
     };

--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -64,6 +64,10 @@ impl OpenCodeRunner {
     /// JSON response. If the concatenated text doesn't parse as JSON,
     /// tries each text event individually (newest first) since earlier
     /// events are often progress messages.
+    ///
+    /// Handles two text event formats emitted by different opencode versions:
+    /// - Format 1 (current): `{"type":"text","part":{"type":"text","text":"..."}}`
+    /// - Format 2 (newer):   `{"type":"text","text":"..."}`
     fn extract_text(&self, events: &[serde_json::Value]) -> Option<String> {
         let mut texts = Vec::new();
 
@@ -71,10 +75,16 @@ impl OpenCodeRunner {
             let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
             if event_type == "text" {
+                // Format 1: text nested in part object
                 if let Some(part) = event.get("part") {
                     if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
                         texts.push(text.to_string());
+                        continue;
                     }
+                }
+                // Format 2: text directly in event (newer opencode versions)
+                if let Some(text) = event.get("text").and_then(|v| v.as_str()) {
+                    texts.push(text.to_string());
                 }
             }
         }
@@ -489,6 +499,21 @@ mod tests {
         assert_eq!(parsed.response.summary, "hello");
         assert_eq!(parsed.input_tokens, Some(17509));
         assert_eq!(parsed.output_tokens, Some(3));
+    }
+
+    /// Newer opencode versions emit text directly in the event (no "part" wrapper).
+    /// The extract_text method must handle both formats.
+    #[test]
+    fn parse_opencode_ndjson_direct_text_format() {
+        let raw = r#"{"type":"step_start","timestamp":1000,"sessionID":"ses_abc"}
+{"type":"text","timestamp":1001,"sessionID":"ses_abc","text":"{\"status\":\"done\",\"summary\":\"fixed\",\"accomplished\":[],\"remaining\":[],\"files\":[]}"}
+{"type":"step_finish","timestamp":1002,"sessionID":"ses_abc","part":{"type":"step-finish","reason":"stop","tokens":{"input":200,"output":10}}}"#;
+
+        let parsed = runner().parse_response(raw).unwrap();
+        assert_eq!(parsed.response.status, "done");
+        assert_eq!(parsed.response.summary, "fixed");
+        assert_eq!(parsed.input_tokens, Some(200));
+        assert_eq!(parsed.output_tokens, Some(10));
     }
 
     #[test]

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -453,6 +453,57 @@ pub struct ReviewIssue {
     pub description: String,
 }
 
+/// Parse a review response from raw agent output, handling NDJSON streams.
+///
+/// This is the primary entry point for review response parsing. It handles:
+/// 1. Direct JSON (`ReviewResponse` object)
+/// 2. Markdown with ` ```json ` code blocks containing a `ReviewResponse`
+/// 3. NDJSON streams (opencode `run --format json` output) — extracts text
+///    from `type:"text"` events and then applies steps 1 & 2
+///
+/// Use this in the review pipeline instead of `parse_review_response` so that
+/// raw opencode NDJSON output is handled even when the normal agent-envelope
+/// parsing chain fails (e.g. format change, empty summary).
+pub fn parse_review_from_output(output: &str) -> anyhow::Result<ReviewResponse> {
+    // Step 1: direct JSON / markdown parse
+    if let Ok(r) = parse_review_response(output) {
+        return Ok(r);
+    }
+
+    // Step 2: NDJSON — extract text events and parse the concatenated text
+    let extracted = ndjson_extract_text(output);
+    if !extracted.is_empty() {
+        return parse_review_response(&extracted)
+            .map_err(|e| anyhow::anyhow!("parse failed after NDJSON extraction: {e}"));
+    }
+
+    anyhow::bail!("failed to parse review response from output")
+}
+
+/// Extract the concatenated text content from an NDJSON event stream.
+///
+/// Handles two text event formats emitted by different opencode versions:
+/// - Format 1 (current): `{"type":"text","part":{"type":"text","text":"..."}}`
+/// - Format 2 (newer):   `{"type":"text","text":"..."}`
+fn ndjson_extract_text(ndjson: &str) -> String {
+    ndjson
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|e| e.get("type").and_then(|v| v.as_str()) == Some("text"))
+        .filter_map(|e| {
+            // Format 1: text nested under "part"
+            e.get("part")
+                .and_then(|p| p.get("text"))
+                .and_then(|t| t.as_str())
+                .map(str::to_string)
+                // Format 2: text directly in event
+                .or_else(|| e.get("text").and_then(|t| t.as_str()).map(str::to_string))
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
 /// Parse a review response from already-unwrapped text.
 ///
 /// Expects the raw result text (already extracted from the agent envelope
@@ -709,5 +760,77 @@ That's all."#;
     #[test]
     fn extract_json_block_none_when_missing() {
         assert!(extract_json_block("no code blocks here").is_none());
+    }
+
+    // ── parse_review_from_output ─────────────────────────────────
+
+    #[test]
+    fn parse_review_from_output_direct_json() {
+        let json = r#"{"decision":"approve","notes":"LGTM","test_results":"pass","issues":[]}"#;
+        let resp = parse_review_from_output(json).unwrap();
+        assert_eq!(resp.decision, "approve");
+    }
+
+    #[test]
+    fn parse_review_from_output_markdown() {
+        let md = "Review complete.\n\n```json\n{\"decision\":\"request_changes\",\"notes\":\"Fix it\",\"issues\":[]}\n```\n";
+        let resp = parse_review_from_output(md).unwrap();
+        assert_eq!(resp.decision, "request_changes");
+    }
+
+    /// opencode NDJSON stream — text events use the `part.text` format.
+    #[test]
+    fn parse_review_from_output_ndjson_part_format() {
+        let ndjson = concat!(
+            r#"{"type":"step_start","timestamp":1000,"sessionID":"ses_abc"}"#,
+            "\n",
+            r#"{"type":"text","timestamp":1001,"part":{"type":"text","text":"Reviewing the PR...\n\n```json\n{\"decision\":\"approve\",\"notes\":\"All checks pass\",\"test_results\":\"pass\",\"issues\":[]}\n```\n"}}"#,
+            "\n",
+            r#"{"type":"step_finish","timestamp":1002,"part":{"type":"step-finish","reason":"stop"}}"#,
+        );
+        let resp = parse_review_from_output(ndjson).unwrap();
+        assert_eq!(resp.decision, "approve");
+        assert_eq!(resp.notes, "All checks pass");
+    }
+
+    /// opencode NDJSON stream — text events use the newer `text` directly-in-event format.
+    #[test]
+    fn parse_review_from_output_ndjson_direct_text_format() {
+        let ndjson = concat!(
+            r#"{"type":"step_start","timestamp":1000,"sessionID":"ses_abc"}"#,
+            "\n",
+            r#"{"type":"text","timestamp":1001,"sessionID":"ses_abc","text":"Here is my review:\n\n```json\n{\"decision\":\"request_changes\",\"notes\":\"Fix the bug\",\"test_results\":\"fail\",\"issues\":[]}\n```\n"}"#,
+            "\n",
+            r#"{"type":"step_finish","timestamp":1002,"sessionID":"ses_abc"}"#,
+        );
+        let resp = parse_review_from_output(ndjson).unwrap();
+        assert_eq!(resp.decision, "request_changes");
+        assert_eq!(resp.notes, "Fix the bug");
+    }
+
+    /// opencode NDJSON with ReviewResponse JSON directly in a text event (no markdown wrapper).
+    #[test]
+    fn parse_review_from_output_ndjson_direct_json_in_text_event() {
+        let ndjson = concat!(
+            r#"{"type":"step_start","timestamp":1000}"#,
+            "\n",
+            r#"{"type":"text","timestamp":1001,"part":{"type":"text","text":"{\"decision\":\"approve\",\"notes\":\"LGTM\",\"test_results\":\"pass\",\"issues\":[]}"}}"#,
+            "\n",
+            r#"{"type":"step_finish","timestamp":1002}"#,
+        );
+        let resp = parse_review_from_output(ndjson).unwrap();
+        assert_eq!(resp.decision, "approve");
+    }
+
+    /// Concatenated text events produce a valid ReviewResponse.
+    #[test]
+    fn parse_review_from_output_ndjson_concatenated_text() {
+        let ndjson = concat!(
+            r#"{"type":"text","timestamp":1001,"part":{"type":"text","text":"Here is my\n"}}"#,
+            "\n",
+            r#"{"type":"text","timestamp":1002,"part":{"type":"text","text":"review:\n\n```json\n{\"decision\":\"approve\",\"notes\":\"OK\",\"test_results\":\"pass\",\"issues\":[]}\n```\n"}}"#,
+        );
+        let resp = parse_review_from_output(ndjson).unwrap();
+        assert_eq!(resp.decision, "approve");
     }
 }


### PR DESCRIPTION
## Summary

- **Two root causes** for `invalid response: {"type":"step_start"...}` errors on every opencode review attempt
- **opencode format change**: newer opencode emits `{"type":"text","text":"..."}` directly in the event (no `part` wrapper, adds `sessionID`); the old parser only handled `part.text`, so `extract_text` returned `None` for all events
- **ReviewResponse vs AgentResponse mismatch**: even when text was extracted, `parser::parse` wraps output in `AgentResponse`; a `ReviewResponse` JSON has no `status`/`summary` fields so `map_generic_response` left `summary=""` and `parse_review_response("")` failed

## Changes

**`opencode.rs`** — `extract_text` now handles both event formats:
- Format 1 (existing): `{"type":"text","part":{"type":"text","text":"..."}}`
- Format 2 (newer): `{"type":"text","text":"..."}` — text directly in event

**`response.rs`** — new `parse_review_from_output(output)`:
- Tries direct JSON / markdown code block first
- Falls back to NDJSON text extraction (`ndjson_extract_text`) then re-parses

**`review.rs`** — two-stage resilient review parsing:
1. Stage 1: strip agent envelope via `parse_response`; on `InvalidResponse` or empty summary, fall back to raw output (instead of aborting)
2. Stage 2: use `parse_review_from_output` which handles JSON, markdown, and NDJSON

## Test plan

- [x] `parse_opencode_ndjson_direct_text_format` — newer opencode format with `text` directly in event
- [x] `parse_review_from_output_ndjson_part_format` — NDJSON with `part.text` format
- [x] `parse_review_from_output_ndjson_direct_text_format` — NDJSON with direct text format
- [x] `parse_review_from_output_ndjson_direct_json_in_text_event` — ReviewResponse JSON directly in text event
- [x] `parse_review_from_output_ndjson_concatenated_text` — multi-event concatenation
- [x] `parse_review_from_output_direct_json` and `parse_review_from_output_markdown`
- [x] `cargo fmt`, `cargo clippy` (0 warnings), `cargo test` (394 pass, 0 fail)

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)