### PR TITLE
bug: review gate workflow doesn't re-trigger on new PR comments

### DIFF
--- a/.github/workflows/orch-review.yml
+++ b/.github/workflows/orch-review.yml
@@ -5,6 +5,8 @@ name: Orch Review Gate
 
 on:
   push:
+  issue_comment:
+    types: [created]
   workflow_dispatch: {}
 
 permissions:
@@ -15,26 +17,37 @@ permissions:
 jobs:
   review-gate:
     runs-on: ubuntu-latest
-    # Skip the default branch - only gate feature branches with PRs
-    if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+    # On push: skip the default branch. On issue_comment: only run for PR comments with a review header.
+    if: >-
+      (github.event_name == 'push' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && startsWith(github.event.comment.body, '## Automated Review')) ||
+      github.event_name == 'workflow_dispatch'
     steps:
       - name: Check automated review status
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
-          BRANCH="${GITHUB_REF#refs/heads/}"
 
-          # Find the open PR for this branch
-          PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" \
-            --state open --json number -q '.[0].number' 2>/dev/null || true)
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            PR_NUMBER="$COMMENT_PR_NUMBER"
+            echo "Triggered by comment on PR #${PR_NUMBER}"
+          else
+            BRANCH="${GITHUB_REF#refs/heads/}"
 
-          if [ -z "$PR_NUMBER" ]; then
-            echo "No open PR for branch $BRANCH - skipping review gate."
-            exit 0
+            # Find the open PR for this branch
+            PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" \
+              --state open --json number -q '.[0].number' 2>/dev/null || true)
+
+            if [ -z "$PR_NUMBER" ]; then
+              echo "No open PR for branch $BRANCH - skipping review gate."
+              exit 0
+            fi
+
+            echo "Checking review status for PR #${PR_NUMBER} (branch: $BRANCH)"
           fi
-
-          echo "Checking review status for PR #${PR_NUMBER} (branch: $BRANCH)"
 
           # Get the latest "Automated Review" comment body
           LATEST_BODY=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \


### PR DESCRIPTION
## Summary

Done. Here's a summary of what changed in `.github/workflows/orch-review.yml`:

**New trigger:**
```yaml
issue_comment:
  types: [created]
```

**Updated `if` condition** — uses `>-` folded scalar so the expression evaluates as a single line with three branches:
- `push`: same as before, skip default branch
- `issue_comment`: only fire on PR comments (not issue comments) whose body starts with `## Automated Review`
- `workflow_dispatch`: always run

**PR number resolution in script:**
- On `issue_comment`: use `COMMENT_PR_NUMBER` env var (set from `github.event.issue.number`) — no branch lookup needed
- On `push`/`workflow_dispatch`: original branch→PR lookup logic unchanged

---
*Task #301 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch)*