### PR TITLE
fix: store explicit error_type in sidecar for reliable metrics classification

### DIFF
--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -77,6 +77,7 @@ pub async fn handle_error(
                         format!("model={next}"),
                         "status=new".to_string(),
                         format!("last_error=model {model} unavailable, trying {next}"),
+                        "error_type=failed".to_string(),
                     ],
                 )?;
                 // Skip normal failover — we're retrying same agent with different model
@@ -101,6 +102,7 @@ pub async fn handle_error(
                 &[
                     "status=needs_review".to_string(),
                     format!("last_error=waiting for input: {message}"),
+                    "error_type=failed".to_string(),
                 ],
             )?;
             return Ok(ErrorHandleResult::EarlyReturn);
@@ -178,6 +180,7 @@ pub async fn handle_error(
                         "status=new".to_string(),
                         format!("model_reroute_chain={new_tried}"),
                         format!("last_error=all agents exhausted, trying free model {free_model}"),
+                        format!("error_type={}", retryable.type_str()),
                     ],
                 )?;
                 return Ok(ErrorHandleResult::EarlyReturn);

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -264,21 +264,35 @@ impl TaskRunner {
         let duration_seconds = (completed_at - *started_at).num_milliseconds() as f64 / 1000.0;
 
         let final_status = sidecar::get(task_id, "status").unwrap_or_default();
-        let outcome = match final_status.as_str() {
-            "done" | "in_progress" | "in_review" => "success",
-            "needs_review" => {
-                let last_error = sidecar::get(task_id, "last_error").unwrap_or_default();
-                if last_error.contains("timeout") {
-                    "timeout"
-                } else if last_error.contains("rate limit") || last_error.contains("usage") {
-                    "rate_limit"
-                } else if last_error.contains("auth") || last_error.contains("billing") {
-                    "auth_error"
-                } else {
-                    "failed"
+        // Prefer the explicitly stored error_type set during error handling.
+        // Fall back to parsing last_error strings for backward compat with
+        // older sidecar entries that predate explicit error_type storage.
+        let explicit_error_type = sidecar::get(task_id, "error_type").unwrap_or_default();
+        let classify_error = |stored: &str, last_error: &str| -> &'static str {
+            match stored {
+                "timeout" => "timeout",
+                "rate_limit" => "rate_limit",
+                "auth_error" => "auth_error",
+                _ if !stored.is_empty() => "failed",
+                _ => {
+                    if last_error.contains("timeout") {
+                        "timeout"
+                    } else if last_error.contains("rate limit") || last_error.contains("usage") {
+                        "rate_limit"
+                    } else if last_error.contains("auth") || last_error.contains("billing") {
+                        "auth_error"
+                    } else {
+                        "failed"
+                    }
                 }
             }
-            "new" => "rerouted",
+        };
+        let outcome = match final_status.as_str() {
+            "done" | "in_progress" | "in_review" => "success",
+            "needs_review" | "new" => {
+                let last_error = sidecar::get(task_id, "last_error").unwrap_or_default();
+                classify_error(&explicit_error_type, &last_error)
+            }
             _ => "unknown",
         };
 
@@ -290,7 +304,13 @@ impl TaskRunner {
         .unwrap_or(0);
 
         if let Some(ref db) = self.db {
-            let error_type: Option<String> = sidecar::get(task_id, "last_error").ok();
+            // Use the explicit classified error type stored during error handling.
+            // Only set for failed/rerouted outcomes; None for successful tasks.
+            let error_type: Option<String> = if outcome == "success" {
+                None
+            } else {
+                Some(outcome.to_string())
+            };
 
             // Read cost data from sidecar
             let usage = sidecar::get_token_usage(task_id);

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -312,6 +312,19 @@ pub enum RetryableError {
     MissingTooling,
 }
 
+impl RetryableError {
+    /// Return a short classified string for this error type, stored in sidecar
+    /// and used for DB metrics rather than parsing `last_error` strings.
+    pub fn type_str(self) -> &'static str {
+        match self {
+            RetryableError::Timeout => "timeout",
+            RetryableError::UsageLimit => "rate_limit",
+            RetryableError::AuthError => "auth_error",
+            RetryableError::Failed | RetryableError::MissingTooling => "failed",
+        }
+    }
+}
+
 /// Handle failover for any retryable error type.
 /// Returns true if the task was rerouted, false if it should be marked needs_review.
 ///
@@ -353,6 +366,7 @@ pub fn handle_failover(
             &[
                 "status=needs_review".to_string(),
                 format!("last_error={error_message} (all agents exhausted)"),
+                format!("error_type={}", error_type.type_str()),
             ],
         ) {
             tracing::error!(task_id, ?e, "failed to update task status during failover");
@@ -383,6 +397,7 @@ pub fn handle_failover(
                 "model=".to_string(),
                 "status=new".to_string(),
                 format!("last_error={error_message}, rerouted to {next}"),
+                format!("error_type={}", error_type.type_str()),
             ],
         ) {
             tracing::error!(task_id, ?e, "failed to update task status during failover");
@@ -397,6 +412,7 @@ pub fn handle_failover(
         &[
             "status=needs_review".to_string(),
             format!("last_error={error_message}, no fallback agents"),
+            format!("error_type={}", error_type.type_str()),
         ],
     ) {
         tracing::error!(task_id, ?e, "failed to update task status during failover");
@@ -606,6 +622,15 @@ pub fn store_failure_memory(
 mod tests {
     use super::*;
     use crate::engine::runner::agents::{patterns, AgentError};
+
+    #[test]
+    fn retryable_type_str_returns_correct_labels() {
+        assert_eq!(RetryableError::Timeout.type_str(), "timeout");
+        assert_eq!(RetryableError::UsageLimit.type_str(), "rate_limit");
+        assert_eq!(RetryableError::AuthError.type_str(), "auth_error");
+        assert_eq!(RetryableError::Failed.type_str(), "failed");
+        assert_eq!(RetryableError::MissingTooling.type_str(), "failed");
+    }
 
     #[test]
     fn is_usage_limit_detects_rate_limit() {


### PR DESCRIPTION
## Summary

- **Root cause**: `record_metrics()` parsed `last_error` strings to classify errors, and rerouted tasks (`status=new`) were recorded as `outcome="rerouted"` with no error type — losing the actual failure reason across attempts
- **Fix**: Store a classified `error_type` key (`timeout` | `rate_limit` | `auth_error` | `failed`) in sidecar at every error-handling site, then read that key in `record_metrics()` instead of brittle string parsing
- **DB effect**: The `error_type` column in `task_metrics` now contains clean, queryable labels that match what `get_error_distribution_7d()` and the self-review job expect

## Changes

- `response.rs`: Add `RetryableError::type_str()` for canonical error labels; add `error_type=<label>` to all three `sidecar::set()` calls in `handle_failover()`
- `fallback.rs`: Add `error_type` to sidecar sets for `WaitingForInput`, `ModelUnavailable` model-switch, and free-model reroute paths
- `mod.rs`: Unify `needs_review` / `new` match arms — both use the same `classify_error()` closure that prefers the explicit sidecar key and falls back to string matching for backward compat; DB `error_type` field now holds the classified label, not the raw `last_error` message

## Test plan

- [x] `retryable_type_str_returns_correct_labels` — new unit test covering all five enum variants
- [x] All 438 existing tests pass
- [x] Build succeeds cleanly

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)