### PR TITLE
Database rate_limits table has no cleanup - unbounded growth

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -450,7 +450,7 @@ impl Db {
         })
     }
 
-    /// Record a rate limit event.
+    /// Record a rate limit event. Prunes records older than 30 days on each insert.
     pub async fn record_rate_limit(
         &self,
         agent: &str,
@@ -458,6 +458,10 @@ impl Db {
         task_id: Option<&str>,
     ) -> anyhow::Result<i64> {
         let conn = self.conn.lock().await;
+        conn.execute(
+            "DELETE FROM rate_limits WHERE occurred_at < datetime('now', '-30 days')",
+            [],
+        )?;
         conn.execute(
             "INSERT INTO rate_limits (agent, limit_type, occurred_at, task_id) VALUES (?1, ?2, datetime('now'), ?3)",
             rusqlite::params![agent, limit_type, task_id],


### PR DESCRIPTION
## Summary

439 tests pass. The fix is minimal and correct:

**What changed** (`src/db.rs:453-471`): Added a `DELETE` before each `INSERT` in `record_rate_limit()`. On every rate limit event, records older than 30 days are pruned in the same locked connection, keeping the table bounded to ~30 days of history.

This approach was chosen over alternatives because:
- No new callers or periodic jobs needed
- Rate limit events are infrequent (only on API errors), so the DELETE cost is negligible  
- The cleanup runs in the same mutex lock as the insert, so no separate transaction needed
- The existing `idx_rate_limits_occurred_at` index makes the DELETE fast

---
*Task #335 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch)*