### PR TITLE
Race condition in sync_tick review agent dispatch

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -79,20 +79,30 @@ pub(crate) async fn sync_tick(
                 // The main tick uses an in-memory HashSet, but sync_tick needs a persistent
                 // guard since it runs independently and the status transition to InReview
                 // is async and may not be visible immediately.
-                if sidecar::get(task_id, "review_started").unwrap_or_default() == "true" {
-                    tracing::debug!(task_id, "review agent already started, skipping duplicate");
-                    continue;
-                }
-                if let Err(e) = sidecar::set(task_id, &["review_started=true".to_string()]) {
-                    tracing::warn!(task_id, err = %e, "failed to set review_started guard, skipping review");
-                    continue;
+                //
+                // compare_and_swap holds the exclusive file lock across both the read and
+                // write, eliminating the TOCTOU window that existed when get() and set()
+                // were two separate calls.
+                match sidecar::compare_and_swap(task_id, "review_started", "", "true") {
+                    Ok(false) => {
+                        tracing::debug!(
+                            task_id,
+                            "review agent already started, skipping duplicate"
+                        );
+                        continue;
+                    }
+                    Err(e) => {
+                        tracing::warn!(task_id, err = %e, "failed to set review_started guard, skipping review");
+                        continue;
+                    }
+                    Ok(true) => {} // claimed — proceed to dispatch
                 }
                 tracing::info!(task_id, "triggering review agent for needs_review task");
                 // Transition to InReview — this IS the guard against duplicates
                 if let Err(e) = backend.update_status(&task.id, Status::InReview).await {
                     tracing::warn!(task_id, err = %e, "failed to transition to InReview");
                     // Clear the guard on failure so it can be retried
-                    let _ = sidecar::set(task_id, &["review_started=false".to_string()]);
+                    let _ = sidecar::set(task_id, &["review_started=".to_string()]);
                     continue;
                 }
                 // Record timestamp so stale detection can apply a grace period
@@ -139,7 +149,7 @@ pub(crate) async fn sync_tick(
                     }
                     // Clear the review_started guard so the task can be reviewed again
                     // if it returns to NeedsReview status
-                    if let Err(e) = sidecar::set(&tid, &["review_started=false".to_string()]) {
+                    if let Err(e) = sidecar::set(&tid, &["review_started=".to_string()]) {
                         tracing::warn!(task_id = tid, err = %e, "failed to clear review_started guard");
                     }
                 }));
@@ -179,8 +189,7 @@ pub(crate) async fn sync_tick(
                         tracing::error!(task_id = %task.id.0, err = %e, "failed to reset stale InReview task — task may be stuck in InReview indefinitely");
                     }
                     // Clear the review_started guard so the task can be re-reviewed
-                    if let Err(e) = sidecar::set(&task.id.0, &["review_started=false".to_string()])
-                    {
+                    if let Err(e) = sidecar::set(&task.id.0, &["review_started=".to_string()]) {
                         tracing::warn!(task_id = %task.id.0, err = %e, "failed to clear review_started guard for stale task");
                     }
                 }

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -364,12 +364,27 @@ pub(crate) async fn tick_dispatch_tasks(
                             .unwrap_or(true);
                         tracing::info!(task_id, enable_review, "review gate check");
                         if enable_review {
-                            // Sidecar-based guard: prevents double-dispatch across tick invocations
-                            if sidecar::get(&task_id, "review_started").unwrap_or_default() == "true" {
-                                tracing::debug!(task_id, "review agent already started, skipping duplicate");
-                            } else if let Err(e) = sidecar::set(&task_id, &["review_started=true".to_string()]) {
-                                tracing::warn!(task_id, err = %e, "failed to set review_started guard, skipping review");
-                            } else {
+                            // Sidecar-based guard: prevents double-dispatch across tick invocations.
+                            // compare_and_swap holds the exclusive file lock across both the read
+                            // and write, eliminating the TOCTOU window that existed when get() and
+                            // set() were two separate calls.
+                            let claimed = match sidecar::compare_and_swap(
+                                &task_id,
+                                "review_started",
+                                "",
+                                "true",
+                            ) {
+                                Ok(false) => {
+                                    tracing::debug!(task_id, "review agent already started, skipping duplicate");
+                                    false
+                                }
+                                Err(e) => {
+                                    tracing::warn!(task_id, err = %e, "failed to set review_started guard, skipping review");
+                                    false
+                                }
+                                Ok(true) => true, // claimed — proceed to dispatch
+                            };
+                            if claimed {
                                 // Transition to InReview — this IS the guard against duplicates
                                 if let Err(e) = backend
                                     .update_status(
@@ -380,7 +395,7 @@ pub(crate) async fn tick_dispatch_tasks(
                                 {
                                     tracing::warn!(task_id, err = %e, "failed to transition to InReview");
                                     // Clear the guard since we couldn't transition
-                                    let _ = sidecar::set(&task_id, &["review_started=false".to_string()]);
+                                    let _ = sidecar::set(&task_id, &["review_started=".to_string()]);
                                 } else {
                                     let backend_clone = backend.clone();
                                     let tmux_clone = tmux.clone();
@@ -432,7 +447,7 @@ pub(crate) async fn tick_dispatch_tasks(
                                         }
                                         // Clear the review_started guard so the task can be reviewed again
                                         // if it returns to NeedsReview status
-                                        if let Err(e) = sidecar::set(&task_id_for_review, &["review_started=false".to_string()]) {
+                                        if let Err(e) = sidecar::set(&task_id_for_review, &["review_started=".to_string()]) {
                                             tracing::warn!(task_id = task_id_for_review, err = %e, "failed to clear review_started guard");
                                         }
                                     }));

--- a/src/sidecar.rs
+++ b/src/sidecar.rs
@@ -219,6 +219,33 @@ pub fn get(task_id: &str, field: &str) -> anyhow::Result<String> {
     }
 }
 
+/// Atomically compare-and-swap a sidecar field.
+///
+/// Reads the current value of `field` under an exclusive file lock.
+/// Missing fields are treated as empty string.
+/// If the current value equals `expected`, sets it to `new_value` and returns `Ok(true)`.
+/// Otherwise returns `Ok(false)` without modifying the file.
+///
+/// This prevents TOCTOU races where two callers both read the same value and both
+/// proceed to set it — only the one that wins the file lock will actually claim it.
+pub fn compare_and_swap(
+    task_id: &str,
+    field: &str,
+    expected: &str,
+    new_value: &str,
+) -> anyhow::Result<bool> {
+    let mut swapped = false;
+    with_locked_sidecar(task_id, |obj| {
+        let current = obj.get(field).and_then(|v| v.as_str()).unwrap_or("");
+        if current == expected {
+            obj.insert(field.to_string(), Value::String(new_value.to_string()));
+            swapped = true;
+        }
+        Ok(())
+    })?;
+    Ok(swapped)
+}
+
 /// Set one or more fields in a sidecar file.
 ///
 /// Each entry in `fields` is "key=value" format.
@@ -576,5 +603,80 @@ mod tests {
             deserialized.learnings,
             vec!["Use format! macro for string formatting"]
         );
+    }
+
+    /// Tests for `compare_and_swap` using the real sidecar path with a unique task ID.
+    ///
+    /// Uses the flat `~/.orch/state/{task_id}.json` path (no REPO_CONTEXT in tests).
+    #[test]
+    fn compare_and_swap_missing_field_matches_empty_expected() {
+        let task_id = format!(
+            "test-cas-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .subsec_nanos()
+        );
+        // Ensure clean state
+        let _ = state_dir().map(|d| std::fs::remove_file(d.join(format!("{task_id}.json"))));
+
+        // Missing field treated as "" — CAS("", "true") should succeed
+        assert!(
+            compare_and_swap(&task_id, "review_started", "", "true").unwrap(),
+            "CAS should succeed when field is missing (treated as empty)"
+        );
+
+        // Already "true" — CAS("", "true") should fail (field is no longer "")
+        assert!(
+            !compare_and_swap(&task_id, "review_started", "", "true").unwrap(),
+            "CAS should fail when field is already 'true'"
+        );
+
+        // Clear to "" — CAS("", "true") should succeed again
+        set(&task_id, &["review_started=".to_string()]).unwrap();
+        assert!(
+            compare_and_swap(&task_id, "review_started", "", "true").unwrap(),
+            "CAS should succeed after field is cleared to empty"
+        );
+
+        // Cleanup
+        let _ = state_dir().map(|d| std::fs::remove_file(d.join(format!("{task_id}.json"))));
+    }
+
+    #[test]
+    fn compare_and_swap_wrong_expected_does_not_overwrite() {
+        let task_id = format!(
+            "test-cas-wrong-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .subsec_nanos()
+        );
+        let _ = state_dir().map(|d| std::fs::remove_file(d.join(format!("{task_id}.json"))));
+
+        // Seed with "false"
+        set(&task_id, &["review_started=false".to_string()]).unwrap();
+
+        // CAS("", "true") should fail — actual value is "false", not ""
+        assert!(
+            !compare_and_swap(&task_id, "review_started", "", "true").unwrap(),
+            "CAS should fail when expected does not match actual value"
+        );
+
+        // Verify field was NOT modified
+        assert_eq!(
+            get(&task_id, "review_started").unwrap(),
+            "false",
+            "field should remain unchanged after failed CAS"
+        );
+
+        // CAS("false", "true") should succeed
+        assert!(
+            compare_and_swap(&task_id, "review_started", "false", "true").unwrap(),
+            "CAS should succeed when expected matches actual value"
+        );
+
+        // Cleanup
+        let _ = state_dir().map(|d| std::fs::remove_file(d.join(format!("{task_id}.json"))));
     }
 }


### PR DESCRIPTION
## Summary

Here's a summary of what was done:

## Fix: Atomic compare-and-swap for `review_started` guard

**Root cause**: The guard check (`sidecar::get`) and set (`sidecar::set`) were two separate operations. Even though `set` held an exclusive file lock internally, the lock didn't span the read — so two concurrent ticks could both read "not started", then both write "true", both dispatching review agents.

**Changes:**

**`src/sidecar.rs`** — Added `compare_and_swap()`:
- Uses `with_locked_sidecar` to hold the exclusive file lock across _both_ the read and write
- Reads `field`, compares to `expected` (missing field treated as `""`), only writes `new_value` if they match
- Returns `Ok(true)` if the swap succeeded, `Ok(false)` if it was already claimed
- Added two tests covering: missing→claimed→fail-on-retry, and wrong-expected-no-overwrite

**`src/engine/sync.rs`** and **`src/engine/tick.rs`** — Replaced check+set with CAS:
- `compare_and_swap(task_id, "review_started", "", "true")` — atomically claims the review slot
- All guard clears changed from `"review_started=false"` to `"review_started="` (empty string), matching the `""` expected value used by CAS for consistency across the full lifecycle (initial missing state, cleared state, and claimed state)

---
*Task #350 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch)*