### PR TITLE
fix: remove unused fields from Slack auth response

### DIFF
--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -59,10 +59,6 @@ struct PostMessageResponse {
 struct AuthTestResponse {
     ok: bool,
     error: Option<String>,
-    #[allow(dead_code)]
-    user_id: Option<String>,
-    #[allow(dead_code)]
-    bot_id: Option<String>,
 }
 
 impl SlackChannel {


### PR DESCRIPTION
Summary:\nRemove unused Slack auth response fields to keep deserialization clean and reduce dead code. This keeps the Slack channel response model aligned with what the code actually uses.\n\n### Changes\n- : drop unused  and  fields from \n\n### Notes\n- No behavior change expected; deserialization still validates  and .