### PR TITLE
CI: Fix release workflow — skip macOS builds when no release, correct bump detection, and simplify formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,8 @@ jobs:
   # Cross-compile build jobs for macOS targets
   build-macos:
     needs: [test, secrets, check-release]
-    if: github.ref == 'refs/heads/main'
+    # Only run macOS cross-builds on main when check-release determined a release is needed
+    if: github.ref == 'refs/heads/main' && needs.check-release.outputs.skip == 'false'
     strategy:
       matrix:
         include:
@@ -176,18 +177,33 @@ jobs:
           LAST_TAG="${{ steps.check.outputs.last_tag }}"
 
           if [ -n "$LAST_TAG" ]; then
-            COMMITS=$(git log "$LAST_TAG"..HEAD --pretty=format:"%s")
+            COMMITS_SUBJECTS=$(git log "$LAST_TAG"..HEAD --pretty=format:"%s")
+            COMMITS_BODIES=$(git log "$LAST_TAG"..HEAD --pretty=format:"%B")
           else
-            COMMITS=$(git log --pretty=format:"%s")
+            COMMITS_SUBJECTS=$(git log --pretty=format:"%s")
+            COMMITS_BODIES=$(git log --pretty=format:"%B")
           fi
 
-          # Determine bump from commit prefixes: BREAKING CHANGE: → major, feat: → minor, everything else → patch
+          # Determine bump from conventional commits
+          # - breaking change subjects using ! (e.g. feat!: or feat(scope)!:) or
+          #   a BREAKING CHANGE: footer in the commit body → major
+          # - feat(...) → minor
+          # - otherwise → patch
           BUMP="patch"
-          if echo "$COMMITS" | grep -qE '^feat(\(.*\))?:'; then
-            BUMP="minor"
-          fi
-          if echo "$COMMITS" | grep -qE '^BREAKING CHANGE:|^breaking(\(.*\))?:'; then
+
+          # Major: subject uses the "!" breaking-change syntax
+          if echo "$COMMITS_SUBJECTS" | grep -qE '^[a-z]+(\(.*\))?!:'; then
             BUMP="major"
+          fi
+
+          # Major: any commit body contains a BREAKING CHANGE: footer (case-insensitive)
+          if echo "$COMMITS_BODIES" | grep -qiE 'BREAKING CHANGE:'; then
+            BUMP="major"
+          fi
+
+          # Minor: any feat scope in subjects (only if we haven't already detected major)
+          if [ "$BUMP" != "major" ] && echo "$COMMITS_SUBJECTS" | grep -qE '^feat(\(.*\))?:'; then
+            BUMP="minor"
           fi
 
           if [ -z "$LAST_TAG" ]; then
@@ -408,12 +424,74 @@ jobs:
           end
           FORMULA_EOF
 
-          # Replace placeholders
-          sed -i "s/VERSION_PLACEHOLDER/${VERSION_NO_V}/g" tap-repo/Formula/orch.rb
-          sed -i "s|ARM64_URL_PLACEHOLDER|${ARM64_URL}|g" tap-repo/Formula/orch.rb
-          sed -i "s/ARM64_SHA256_PLACEHOLDER/${ARM64_SHA}/g" tap-repo/Formula/orch.rb
-          sed -i "s|X86_64_URL_PLACEHOLDER|${X86_64_URL}|g" tap-repo/Formula/orch.rb
-          sed -i "s/X86_64_SHA256_PLACEHOLDER/${X86_64_SHA}/g" tap-repo/Formula/orch.rb
+          # Create formula: choose universal if both architectures point to the same URL,
+          # otherwise emit an explicit arch-specific formula.
+          if [ "${ARM64_URL}" = "${X86_64_URL}" ]; then
+            UNIVERSAL_URL="${ARM64_URL}"
+            UNIVERSAL_SHA="${ARM64_SHA}"
+            cat > tap-repo/Formula/orch.rb << 'FORMULA_EOF'
+            class Orch < Formula
+              desc "Multi-agent task orchestrator for AI coding agents (claude, codex, opencode)"
+              homepage "https://github.com/gabrielkoerich/orch"
+              version "VERSION_PLACEHOLDER"
+              license "MIT"
+
+              url "UNIVERSAL_URL_PLACEHOLDER"
+              sha256 "UNIVERSAL_SHA256_PLACEHOLDER"
+
+              depends_on "gh"
+              depends_on "tmux"
+
+              def install
+                bin.install "orch" => "orch"
+
+                # Install additional resources
+                (libexec/"prompts").install Dir["prompts/*"] if (buildpath/"prompts").exist?
+                libexec.install Dir["*.example.yml"] if Dir.glob("*.example.yml").any?
+                libexec.install "skills.yml" if (buildpath/"skills.yml").exist?
+              end
+
+              service do
+                run [opt_bin/"orch", "serve"]
+                keep_alive true
+                log_path var/"log/orch.log"
+                error_log_path var/"log/orch.error.log"
+              end
+
+              def caveats
+                <<~EOS
+                  To get started:
+                    cd ~/your-project
+                    orch init                     # configure project
+                    orch task add "title"         # add a task
+                    brew services start orch      # start background server
+
+                  Required agent CLIs (install at least one):
+                    brew install --cask claude-code   # Claude
+                    brew install --cask codex         # Codex
+                    brew install opencode             # OpenCode
+
+                  GitHub CLI (installed automatically):
+                    gh auth login   # authenticate if not already logged in
+                EOS
+              end
+
+              test do
+                assert_match "orch", shell_output("#{bin}/orch --version 2>&1", 0)
+              end
+            end
+            FORMULA_EOF
+
+            sed -i "s/VERSION_PLACEHOLDER/${VERSION_NO_V}/g" tap-repo/Formula/orch.rb
+            sed -i "s|UNIVERSAL_URL_PLACEHOLDER|${UNIVERSAL_URL}|g" tap-repo/Formula/orch.rb
+            sed -i "s/UNIVERSAL_SHA256_PLACEHOLDER/${UNIVERSAL_SHA}/g" tap-repo/Formula/orch.rb
+          else
+            sed -i "s/VERSION_PLACEHOLDER/${VERSION_NO_V}/g" tap-repo/Formula/orch.rb
+            sed -i "s|ARM64_URL_PLACEHOLDER|${ARM64_URL}|g" tap-repo/Formula/orch.rb
+            sed -i "s/ARM64_SHA256_PLACEHOLDER/${ARM64_SHA}/g" tap-repo/Formula/orch.rb
+            sed -i "s|X86_64_URL_PLACEHOLDER|${X86_64_URL}|g" tap-repo/Formula/orch.rb
+            sed -i "s/X86_64_SHA256_PLACEHOLDER/${X86_64_SHA}/g" tap-repo/Formula/orch.rb
+          fi
 
           # Display the formula
           echo "--- Generated Formula ---"

--- a/Formula/orch.rb
+++ b/Formula/orch.rb
@@ -1,0 +1,53 @@
+class Orch < Formula
+  desc "Multi-agent task orchestrator for AI coding agents (claude, codex, opencode)"
+  homepage "https://github.com/gabrielkoerich/orch"
+  # This local template is intentionally simple: prefer a single universal binary when
+  # possible. The CI release job will generate a formula with either a universal
+  # `url`/`sha256` or an arch-specific `on_macos` block depending on uploaded artifacts.
+  version "VERSION_PLACEHOLDER"
+  license "MIT"
+
+  url "UNIVERSAL_URL_PLACEHOLDER"
+  sha256 "UNIVERSAL_SHA256_PLACEHOLDER"
+
+  depends_on "gh"
+  depends_on "tmux"
+
+  def install
+    bin.install "orch" => "orch"
+
+    # Install additional resources if present in the tarball
+    (libexec/"prompts").install Dir["prompts/*"] if (buildpath/"prompts").exist?
+    libexec.install Dir["*.example.yml"] if Dir.glob("*.example.yml").any?
+    libexec.install "skills.yml" if (buildpath/"skills.yml").exist?
+  end
+
+  service do
+    run [opt_bin/"orch", "serve"]
+    keep_alive true
+    log_path var/"log/orch.log"
+    error_log_path var/"log/orch.error.log"
+  end
+
+  def caveats
+    <<~EOS
+      To get started:
+        cd ~/your-project
+        orch init                     # configure project
+        orch task add "title"         # add a task
+        brew services start orch      # start background server
+
+      Required agent CLIs (install at least one):
+        brew install --cask claude-code   # Claude
+        brew install --cask codex         # Codex
+        brew install opencode             # OpenCode
+
+      GitHub CLI (installed automatically):
+        gh auth login   # authenticate if not already logged in
+    EOS
+  end
+
+  test do
+    assert_match "orch", shell_output("#{bin}/orch --version 2>&1", 0)
+  end
+end


### PR DESCRIPTION
## Summary

**CI Release Fixes**

- Implemented the requested CI changes: skip macOS builds when no release is needed, correctly detect breaking-change commits using `!` or `BREAKING CHANGE:` footers, and simplify the Homebrew formula generation to avoid misleading arch-conditional templates.

What I changed
- Updated `.github/workflows/release.yml`:
  - **build-macos** job: now depends on `check-release` and has a guard so it only runs when `needs.check-release.outputs.skip == 'false'` (line ~74). This prevents macOS cross-compiles when `check-release` decides no release is required.
  - **check-release / Determine version bump**: improved bump detection (lines ~172-224):
    - Collects commit subjects and full commit bodies.
    - Detects breaking-change subjects using the `!` syntax (regex: `^[a-z]+(\(.*\))?!:`).
    - Also inspects commit bodies for `BREAKING CHANGE:` (case-insensitive).
    - Applies major bump for either case, minor bump for `feat(...)` only if no major detected, otherwise patch.
  - **Homebrew formula generation**: when creating the formula in the release job the script now emits either:
    - a single universal-binary formula (if both arch URLs are identical), or
    - retains the original arch-specific template logic when URLs differ.
    This avoids the previous confusing `on_macos` block that inserted the same universal URL twice.
  - Minor: added comments and a clearer template selection branch.

- Added `Formula/orch.rb`:
  - A simple, local formula template that prefers a universal `url`/`sha256`. The CI job will overwrite/place the real formula in the tap as needed. This file is a clear, unambiguous template that documents the preferred approach.

What I ran
- Verified changed files and committed:
  - `git add .github/workflows/release.yml Formula/orch.rb`
  - `git commit -m "ci(release): skip macOS builds when no release, detect '!' breaking changes, simplify formula template"`
  - `git push origin HEAD`

Files changed
- `.github/workflows/release.yml`
- `Formula/orch.rb`

Accomplished
- Prevent macOS cross-compiles on main when `check-release` indicates no release (saves CI minutes).
- Correctly detect breaking changes expressed with `!` in commit subjects and `BREAKING CHANGE:` in commit bodies — ensures proper semver bumping.
- Simplified and clarified Homebrew formula generation to avoid misleading arch-conditional placeholders.

Remaining
- Add an explicit CI assertion/job that fails if `build-macos` runs while `check-release` returns `skip=true`. Currently the workflow logic prevents it; if you want an explicit guard/test step (e.g., in `check-release` output validation stage or a separate `assert-skip` job), I can add it. (Suggested options below.)
- Optional: add unit tests or workflow dry-runs to verify bump detection on sample commit ranges (can add a small script + tests).
- Optional: update docs (README/AGENTS.md) to mention the formula behavior and the release job's universal-vs-arch logic.

Blockers
- None.

Reason
- (empty)

Delegations
- None.

Suggested next steps (pick one)
1. Add a CI assertion job that runs earlier and fails if `build-macos` executes while `check-release` outputs `skip=true` — I can add a lightweight `assert-skip` job that checks `needs.check-release.outputs.skip` and fails if it's `true` while `build-macos` was scheduled.
2. Add tests / fixture commits used by `check-release` to validate bump detection (e.g., test cases for `feat!:`, `feat(scope)!:`, `BREAKING CHANGE:`).
3. If you'd like universal artifacts (single tarball containing both arch bins), update release packaging to upload a single tarball and have the formula refer to that. Current change assumes arch-specific artifacts remain the default but supports the universal case.

If you want I will:
- Add the explicit CI assertion/job (option 1) now.
- Or add small unit tests / scripts to verify commit-parsing behavior (option 2).

Which would you like me to do next?

---
*Task #382 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch)*