### PR TITLE
CaptureService: byte-offset tmux diffing

### DIFF
--- a/src/channels/capture.rs
+++ b/src/channels/capture.rs
@@ -13,9 +13,12 @@ use crate::channels::tmux;
 use crate::channels::transport::Transport;
 use crate::channels::OutputChunk;
 use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+
+pub(crate) const MAX_OUTPUT_BUFFER_BYTES: usize = 1024 * 1024;
 
 /// Buffer for tracking session output state.
 #[derive(Debug, Clone)]
@@ -26,6 +29,10 @@ pub struct OutputBuffer {
     pub task_id: String,
     /// Content from the last capture
     pub last_content: String,
+    /// Byte length of the last capture
+    pub last_len: usize,
+    /// Hash of the last capture (for dedup)
+    pub last_hash: Option<[u8; 32]>,
     /// When the last capture occurred
     pub last_capture: DateTime<Utc>,
 }
@@ -56,6 +63,8 @@ impl CaptureService {
             session: session.to_string(),
             task_id: task_id.to_string(),
             last_content: String::new(),
+            last_len: 0,
+            last_hash: None,
             last_capture: Utc::now(),
         };
         self.buffers
@@ -160,45 +169,73 @@ impl CaptureService {
                     },
                 };
 
-                // Diff against previous content
-                if current_content != buffer.last_content {
-                    let new_content = if buffer.last_content.is_empty() {
-                        current_content.clone()
-                    } else {
-                        match current_content.find(&buffer.last_content) {
-                            Some(_pos) => {
-                                let last_pos = current_content.rfind(&buffer.last_content);
-                                if let Some(last) = last_pos {
-                                    let offset = last + buffer.last_content.len();
-                                    if offset < current_content.len() {
-                                        current_content[offset..].to_string()
-                                    } else {
-                                        String::new()
-                                    }
-                                } else {
-                                    current_content.clone()
-                                }
-                            }
-                            None => current_content.clone(),
-                        }
-                    };
-
-                    if !new_content.is_empty() {
-                        let chunk = OutputChunk {
-                            content: new_content,
-                            is_final: false,
-                        };
-                        self.transport.push_output(&task_id, chunk).await;
-                    }
-
-                    // Update buffer
+                let new_content = {
                     let mut buffers = self.buffers.write().await;
-                    if let Some(buf) = buffers.get_mut(&task_id) {
-                        buf.last_content = current_content;
-                        buf.last_capture = Utc::now();
-                    }
+                    buffers
+                        .get_mut(&task_id)
+                        .and_then(|buf| buf.diff_and_update(&current_content))
+                };
+
+                if let Some(new_content) = new_content {
+                    let chunk = OutputChunk {
+                        content: new_content,
+                        is_final: false,
+                    };
+                    self.transport.push_output(&task_id, chunk).await;
                 }
             }
         }
     }
+}
+
+impl OutputBuffer {
+    pub(crate) fn diff_and_update(&mut self, current_content: &str) -> Option<String> {
+        let current_bytes = current_content.as_bytes();
+        let current_len = current_bytes.len();
+        let current_hash = hash_bytes(current_bytes);
+
+        if self.last_len == current_len && self.last_hash == Some(current_hash) {
+            self.last_capture = Utc::now();
+            return None;
+        }
+
+        let new_content = if self.last_len >= current_len {
+            current_content.to_string()
+        } else {
+            let mut offset = self.last_len.min(current_len);
+            while offset < current_len && !current_content.is_char_boundary(offset) {
+                offset += 1;
+            }
+            String::from_utf8_lossy(&current_bytes[offset..]).to_string()
+        };
+
+        self.last_len = current_len;
+        self.last_hash = Some(current_hash);
+        self.last_content = cap_content(current_content);
+        self.last_capture = Utc::now();
+
+        if new_content.is_empty() {
+            None
+        } else {
+            Some(new_content)
+        }
+    }
+}
+
+fn hash_bytes(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
+}
+
+fn cap_content(content: &str) -> String {
+    if content.len() <= MAX_OUTPUT_BUFFER_BYTES {
+        return content.to_string();
+    }
+
+    let mut start = content.len() - MAX_OUTPUT_BUFFER_BYTES;
+    while start < content.len() && !content.is_char_boundary(start) {
+        start += 1;
+    }
+    content[start..].to_string()
 }

--- a/src/channels/transport.rs
+++ b/src/channels/transport.rs
@@ -32,6 +32,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{broadcast, RwLock};
 
+const MAX_OUTPUT_CHUNK_BYTES: usize = 64 * 1024;
+
 /// A live connection between a channel thread and a tmux session.
 #[derive(Debug, Clone)]
 pub struct SessionBinding {
@@ -98,17 +100,31 @@ impl Transport {
 
     /// Push an output chunk to all subscribers of a task.
     pub async fn push_output(&self, task_id: &str, chunk: OutputChunk) {
-        let bindings = self.bindings.read().await;
-        if let Some(binding) = bindings.get(task_id) {
-            // Ignore send errors (no active receivers)
-            let _ = binding.output_tx.send(chunk.clone());
+        if chunk.content.is_empty() {
+            let bindings = self.bindings.read().await;
+            if let Some(binding) = bindings.get(task_id) {
+                let _ = binding.output_tx.send(chunk.clone());
+            }
+            return;
         }
-        // Update last_output cache regardless of subscribers so capture service
-        // can read the latest PTY-managed session content.
-        if !chunk.content.is_empty() {
-            let mut last = self.last_output.write().await;
-            let entry = last.entry(task_id.to_string()).or_insert_with(String::new);
-            entry.push_str(&chunk.content);
+
+        let parts = split_chunks(&chunk.content, MAX_OUTPUT_CHUNK_BYTES);
+        let last_index = parts.len().saturating_sub(1);
+
+        for (idx, part) in parts.into_iter().enumerate() {
+            let part_chunk = OutputChunk {
+                content: part,
+                is_final: chunk.is_final && idx == last_index,
+            };
+            let bindings = self.bindings.read().await;
+            if let Some(binding) = bindings.get(task_id) {
+                let _ = binding.output_tx.send(part_chunk.clone());
+            }
+            if !part_chunk.content.is_empty() {
+                let mut last = self.last_output.write().await;
+                let entry = last.entry(task_id.to_string()).or_insert_with(String::new);
+                entry.push_str(&part_chunk.content);
+            }
         }
     }
 
@@ -157,6 +173,27 @@ impl Transport {
     pub fn subscribe_notifications(&self) -> broadcast::Receiver<TaskNotification> {
         self.notification_tx.subscribe()
     }
+}
+
+fn split_chunks(content: &str, max_bytes: usize) -> Vec<String> {
+    if content.len() <= max_bytes {
+        return vec![content.to_string()];
+    }
+
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    let total = content.len();
+
+    while start < total {
+        let mut end = (start + max_bytes).min(total);
+        while end < total && !content.is_char_boundary(end) {
+            end += 1;
+        }
+        chunks.push(content[start..end].to_string());
+        start = end;
+    }
+
+    chunks
 }
 
 /// How an incoming message should be handled.

--- a/tests/capture_diff.rs
+++ b/tests/capture_diff.rs
@@ -1,0 +1,80 @@
+#[allow(dead_code)]
+mod channels {
+    pub mod tmux {
+        pub async fn capture_pane(_session: &str) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+
+        pub async fn is_session_dead(_session: &str) -> bool {
+            false
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct OutputChunk {
+        pub content: String,
+        pub is_final: bool,
+    }
+
+    pub mod transport {
+        use crate::channels::OutputChunk;
+
+        #[derive(Debug)]
+        pub struct Transport;
+
+        impl Transport {
+            pub async fn get_session_output(&self, _task_id: &str) -> Option<String> {
+                None
+            }
+
+            pub async fn push_output(&self, _task_id: &str, _chunk: OutputChunk) {}
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[path = "../src/channels/capture.rs"]
+mod capture;
+
+use capture::{OutputBuffer, MAX_OUTPUT_BUFFER_BYTES};
+
+fn buffer() -> OutputBuffer {
+    OutputBuffer {
+        session: "session".to_string(),
+        task_id: "task".to_string(),
+        last_content: String::new(),
+        last_len: 0,
+        last_hash: None,
+        last_capture: chrono::Utc::now(),
+    }
+}
+
+#[test]
+fn repeated_capture_no_duplicate_output() {
+    let mut buf = buffer();
+    let first = buf.diff_and_update("hello");
+    assert_eq!(first.as_deref(), Some("hello"));
+
+    let second = buf.diff_and_update("hello");
+    assert!(second.is_none());
+}
+
+#[test]
+fn pane_clear_resets_offset() {
+    let mut buf = buffer();
+    let _ = buf.diff_and_update("line1\nline2\nline3");
+    let cleared = buf.diff_and_update("line1\n");
+
+    assert_eq!(cleared.as_deref(), Some("line1\n"));
+    assert_eq!(buf.last_len, "line1\n".len());
+}
+
+#[test]
+fn large_output_is_capped() {
+    let mut buf = buffer();
+    let big = "a".repeat(MAX_OUTPUT_BUFFER_BYTES + 1024);
+    let _ = buf.diff_and_update(&big);
+
+    assert!(buf.last_content.len() <= MAX_OUTPUT_BUFFER_BYTES);
+    assert_eq!(buf.last_len, big.len());
+}


### PR DESCRIPTION
Summary:\nImplemented byte-offset diffing for tmux capture output with capped buffer storage and hash-based deduplication to avoid brittle string searches. Updated transport output handling to chunk large payloads and added tests covering repeated captures, pane clears, and large output. This improves reliability and reduces duplicate output for streaming sessions.\n\n### Changes\n- Implemented byte-offset diffing, buffer caps, and capture hashing in src/channels/capture.rs\n- Added chunking for large output payloads in src/channels/transport.rs\n- Added capture diff tests for repeated captures, pane clears, and large output in tests/capture_diff.rs\n\nFiles modified:\n- src/channels/capture.rs: track last_len/hash, cap stored content, and compute new content via byte offsets\n- src/channels/transport.rs: split large output chunks to 64 KiB boundaries before broadcast\n- tests/capture_diff.rs: new unit tests for capture diff edge cases\n