### PR TITLE
CI: skip macOS builds when no release is needed & tighten release permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -228,6 +228,8 @@ jobs:
     needs: [check-release, build-macos]
     if: github.ref == 'refs/heads/main' && needs.check-release.outputs.skip == 'false'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

All three acceptance criteria are already met:

1. **`build-macos` skips on chore-only pushes** — already had `needs: [test, secrets, check-release]` and `if: github.ref == 'refs/heads/main' && needs.check-release.outputs.skip == 'false'` (lines 75-77).

2. **`check-release` correctly sets `skip=true` for chore-only commits** — already implemented at lines 163-169 with the `grep -cvE '^chore(\(.*\))?:'` pattern.

3. **`release` job retains `contents: write`** — moved from the top-level block to the `release` job only. The diff shows:
   - Top-level: `contents: write` → `contents: read`
   - `release` job: added `permissions: contents: write`

---
*Task #400 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch)*