### PR TITLE
docs: update evening retrospective with today's activity

### DIFF
--- a/docs/content/posts/evening-retrospective-2026-03-03.md
+++ b/docs/content/posts/evening-retrospective-2026-03-03.md
@@ -78,3 +78,59 @@ None. `gh issue list --state open` failed due to GitHub API connectivity, so no 
 1. **Align review prompt with sandbox constraints** (remove `git fetch` step, rely on pre-fetched refs). Confirm no open issue already exists before filing.
 2. **Monitor API rate limit behavior** with the new proactive handling under real load.
 3. **Watch re-route behavior** for `needs_review` tasks to ensure the loop fix sticks under concurrent task traffic.
+
+---
+
+## Evening Update — 2026-03-03 (Late)
+
+### Morning Review Follow-ups
+
+| Priority | Status | Notes |
+|----------|--------|-------|
+| Align review prompt | ✅ Done | `prompts/review_task.md` now uses `git rebase origin/main` instead of `git fetch`; matches agent_system.md guidance. |
+| Reduce stuck thresholds | ❌ Not done | Still pending; low priority but would improve responsiveness. |
+| Monitor review edge cases | ✅ Done | Review gate loop fix holding; no new stuck `in_review` reports. |
+
+### Today's Commits (Major Security & Reliability Push)
+
+The following significant changes landed today:
+
+| Commit | Description | Impact |
+|--------|-------------|--------|
+| `8c630f0` | Add tmux session env helpers, avoid embedding GH_TOKEN in runner scripts | Security: tokens no longer in per-task scripts |
+| `6a467ee` | Integrate async GitHub App token resolution in GhHttp | Reliability: native auth without gh CLI |
+| `a78c955` | CI: scope contents:write permission to release job only | Security: least privilege |
+| `6601d25` | fix: improve capture diffing | Reliability |
+| `843e1c5` | Drop runtime gh dependency from Homebrew formula; prefer native GhHttp | Simplicity: fewer runtime deps |
+| `e89b234` | Secure GH_TOKEN handling | Security |
+| `0157f63` | Make GhHttp primary for PR creation, remove gh CLI fallback | Reliability |
+| `22bca09` | Tests: prevent secret leakage in task artifacts | Security |
+| `21f0396` | Consolidate gh CLI usage, add safe wrapper | Reliability |
+| `f4a16e3` | Eliminate on-disk runner scripts — PTY-based agent runner | Simplicity |
+| `c27a1b2` | Add GitHub App auth and robust token resolver | Reliability |
+
+**Theme**: Major hardening around token handling, removing gh CLI dependency, and improving auth robustness.
+
+### Current Open Issues
+
+| Issue | Status | Agent | Priority |
+|-------|--------|-------|----------|
+| #404 | in_progress | minimax | Evening retrospective (this task) |
+| #395 | needs_review | claude | Discord Gateway WebSocket |
+| #386 | needs_review | claude | PTY-based runner (done, needs merge) |
+| #378 | in_progress | kimi | Centralize token resolver |
+| #372 | needs_review | opencode | Code development |
+
+### Observations
+
+1. **Prompt alignment complete**: Both `agent_system.md` and `review_task.md` now consistently instruct agents to use `git rebase` instead of `git fetch`, matching the orchestrator's pre-fetch workflow.
+2. **Security posture improved**: GH_TOKEN no longer embedded in per-task runner scripts; GitHub App auth integrated natively.
+3. **gh CLI dependency reduced**: Native `GhHttp` now handles PR creation and other GitHub API operations.
+4. **Test failures observed**: Some CI test failures occurred (see recent `gh run list`); may need investigation but review gate passed.
+
+### Tomorrow's Priorities (Updated)
+
+1. **Investigate test failures** — check recent CI failures for root cause
+2. **Merge #386** — PTY runner change is `needs_review`, should be ready
+3. **Stuck threshold reduction** — revisit lowering timeouts if not done
+4. **Monitor #378** — token resolver centralization in progress


### PR DESCRIPTION
## Summary
- Add evening update section to the 2026-03-03 retrospective
- Document morning review follow-ups (prompt alignment ✅, stuck thresholds ❌ not done, review edge cases ✅)
- List today's major security/reliability commits
- Update tomorrow's priorities

## Test plan
- [x] Review evening retrospective content for accuracy
- [x] Verify markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)