### PR TITLE
feat: harden webhook server startup with exponential backoff and health CLI

### DIFF
--- a/src/channels/github.rs
+++ b/src/channels/github.rs
@@ -283,7 +283,10 @@ async fn webhook_health() -> impl IntoResponse {
 /// This only verifies the local HTTP listener is running. It does NOT verify
 /// that GitHub can reach the endpoint (NAT/firewall) or that the webhook
 /// secret is valid.
-pub async fn check_webhook_health(port: u16) -> bool {
+///
+/// Returns `(healthy, failure_reason)`.  `failure_reason` is `Some` when
+/// unhealthy and cleared (i.e. `None`) when the check succeeds.
+pub async fn check_webhook_health(port: u16) -> (bool, Option<String>) {
     let client = match reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build()
@@ -291,14 +294,49 @@ pub async fn check_webhook_health(port: u16) -> bool {
         Ok(c) => c,
         Err(e) => {
             tracing::warn!(?e, "failed to build HTTP client for webhook health check");
-            return false;
+            return (false, Some(format!("failed to build HTTP client: {e}")));
         }
     };
     let url = format!("http://localhost:{}/health", port);
     match client.get(&url).send().await {
-        Ok(response) => response.status().is_success(),
-        Err(_) => false,
+        Ok(response) if response.status().is_success() => (true, None),
+        Ok(response) => {
+            let reason = format!("health endpoint returned {}", response.status());
+            (false, Some(reason))
+        }
+        Err(e) => (false, Some(format!("health check request failed: {e}"))),
     }
+}
+
+/// Return `true` when `e` represents a transient TCP bind error (e.g. port
+/// already in use) that is worth retrying.
+pub fn is_transient_bind_error(e: &anyhow::Error) -> bool {
+    for cause in e.chain() {
+        if let Some(io_err) = cause.downcast_ref::<std::io::Error>() {
+            return matches!(
+                io_err.kind(),
+                std::io::ErrorKind::AddrInUse | std::io::ErrorKind::AddrNotAvailable
+            );
+        }
+    }
+    false
+}
+
+/// Compute an exponential-backoff delay for webhook startup retries.
+///
+/// Uses subsecond wall-clock bits as a cheap jitter source — no `rand` crate
+/// needed.  Delay is capped at 30 s.
+pub fn webhook_backoff_delay(attempt: u32) -> std::time::Duration {
+    let base_ms: u64 = 500;
+    let max_ms: u64 = 30_000;
+    let exp_ms = base_ms.saturating_mul(1u64 << (attempt.saturating_sub(1)).min(6));
+    let bounded_ms = exp_ms.min(max_ms);
+    let jitter_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_millis() as u64
+        % 500;
+    std::time::Duration::from_millis(bounded_ms + jitter_ms)
 }
 
 pub async fn start_webhook_server(
@@ -974,5 +1012,63 @@ mod tests {
             .try_recv()
             .expect("different delivery ID should produce a message");
         assert_eq!(msg2.thread_id, "200");
+    }
+
+    /// Verify that `is_transient_bind_error` correctly classifies EADDRINUSE.
+    #[test]
+    fn test_is_transient_bind_error_addr_in_use() {
+        let io_err = std::io::Error::from(std::io::ErrorKind::AddrInUse);
+        let err = anyhow::anyhow!(io_err);
+        assert!(is_transient_bind_error(&err));
+    }
+
+    /// Verify that non-bind errors are not classified as transient.
+    #[test]
+    fn test_is_transient_bind_error_other_error() {
+        let io_err = std::io::Error::from(std::io::ErrorKind::ConnectionRefused);
+        let err = anyhow::anyhow!(io_err);
+        assert!(!is_transient_bind_error(&err));
+    }
+
+    /// Verify that `webhook_backoff_delay` respects the 30 s cap.
+    #[test]
+    fn test_webhook_backoff_delay_cap() {
+        // At attempt 10 (well past the exponent cap) the base delay should be
+        // capped at 30 000 ms plus up to 499 ms of jitter.
+        let delay = webhook_backoff_delay(10);
+        assert!(
+            delay.as_millis() <= 30_500,
+            "delay exceeded 30 s cap + jitter: {:?}",
+            delay
+        );
+        assert!(
+            delay.as_millis() >= 500,
+            "delay should be at least base: {:?}",
+            delay
+        );
+    }
+
+    /// Integration test: a double-bind on the same `0.0.0.0` address fails
+    /// with EADDRINUSE, and `is_transient_bind_error` correctly classifies it.
+    ///
+    /// We test the bind step directly (not the full `start_webhook_server`)
+    /// because `axum::serve` runs until shutdown and would hang the test
+    /// suite if the first bind accidentally succeeded.
+    #[tokio::test]
+    async fn test_start_webhook_server_port_in_use() {
+        // Hold a listener on 0.0.0.0 (the same bind address used by start_webhook_server).
+        let holder = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
+        let port = holder.local_addr().unwrap().port();
+
+        // A second bind on the same address+port must fail.
+        let result = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}")).await;
+        drop(holder);
+
+        let io_err = result.expect_err("expected EADDRINUSE on duplicate bind");
+        let anyhow_err = anyhow::anyhow!(io_err);
+        assert!(
+            is_transient_bind_error(&anyhow_err),
+            "EADDRINUSE should be classified as transient: {anyhow_err}"
+        );
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@ pub mod job;
 pub mod service;
 pub mod task;
 pub mod tree;
+pub mod webhook;
 
 use crate::channels::capture::CaptureService;
 use crate::channels::transport::Transport;

--- a/src/cli/webhook.rs
+++ b/src/cli/webhook.rs
@@ -1,0 +1,40 @@
+//! `orch webhook` subcommands.
+
+use crate::webhook_status::WebhookStatus;
+
+/// Print the last-known webhook health state from `~/.orch/webhook_status.json`.
+pub fn status() -> anyhow::Result<()> {
+    match WebhookStatus::load() {
+        None => {
+            println!("Webhook status: unavailable");
+            println!("  (service not running or webhooks have never been configured)");
+        }
+        Some(s) => {
+            let health_str = if s.healthy { "healthy" } else { "unhealthy" };
+            let fallback_str = if s.fallback_mode {
+                "yes (polling)"
+            } else {
+                "no"
+            };
+            let port_str = s
+                .port
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "—".to_string());
+            let last_check = s
+                .last_check_utc
+                .map(|t| t.to_rfc3339())
+                .unwrap_or_else(|| "never".to_string());
+            let failure = s.last_failure_reason.as_deref().unwrap_or("none");
+
+            println!("Webhook status:");
+            println!("  Configured:       {}", s.configured);
+            println!("  Port:             {}", port_str);
+            println!("  Health:           {}", health_str);
+            println!("  Fallback mode:    {}", fallback_str);
+            println!("  Last check (UTC): {}", last_check);
+            println!("  Startup attempts: {}", s.startup_attempts);
+            println!("  Last failure:     {}", failure);
+        }
+    }
+    Ok(())
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -488,6 +488,11 @@ pub async fn serve() -> anyhow::Result<()> {
         .map(|v| v == "true")
         .unwrap_or(false);
 
+    // Shared status updated by the server-spawn task and the health-check loop.
+    let webhook_status = std::sync::Arc::new(std::sync::Mutex::new(
+        crate::webhook_status::WebhookStatus::default(),
+    ));
+
     if webhook_enabled {
         let port: u16 = crate::config::get("webhook.port")
             .ok()
@@ -502,10 +507,74 @@ pub async fn serve() -> anyhow::Result<()> {
 
         let (tx, mut rx) = tokio::sync::mpsc::channel::<IncomingMessage>(64);
 
-        // Spawn the HTTP server (runs until shutdown)
+        // Initialise status: configured, not yet healthy.
+        {
+            let mut s = webhook_status.lock().unwrap();
+            s.configured = true;
+            s.port = Some(port);
+            s.healthy = false;
+            s.fallback_mode = false;
+            s.save();
+        }
+
+        // Spawn the HTTP server with exponential-backoff retry on transient
+        // bind errors (e.g. EADDRINUSE).  After MAX_ATTEMPTS the engine falls
+        // back to polling and updates the shared status accordingly.
+        const WEBHOOK_MAX_ATTEMPTS: u32 = 5;
+        let status_for_spawn = webhook_status.clone();
         tokio::spawn(async move {
-            if let Err(e) = start_webhook_server(port, secret, webhook_repo, tx).await {
-                tracing::error!(?e, "webhook server failed");
+            use crate::channels::github::{is_transient_bind_error, webhook_backoff_delay};
+            let mut attempt = 0u32;
+            loop {
+                attempt += 1;
+                tracing::info!(attempt, port, "attempting to start webhook server");
+                match start_webhook_server(port, secret.clone(), webhook_repo.clone(), tx.clone())
+                    .await
+                {
+                    Ok(_) => {
+                        tracing::info!(attempt, "webhook server exited cleanly");
+                        break;
+                    }
+                    Err(e) => {
+                        let reason = e.to_string();
+                        tracing::error!(attempt, %reason, "webhook server failed");
+                        if attempt >= WEBHOOK_MAX_ATTEMPTS || !is_transient_bind_error(&e) {
+                            let kind = if attempt >= WEBHOOK_MAX_ATTEMPTS {
+                                "max attempts reached"
+                            } else {
+                                "non-transient error"
+                            };
+                            tracing::error!(
+                                attempt,
+                                %reason,
+                                kind,
+                                orch_webhook_in_fallback = true,
+                                "webhook server giving up, switching to polling fallback"
+                            );
+                            let mut s = status_for_spawn.lock().unwrap();
+                            s.fallback_mode = true;
+                            s.healthy = false;
+                            s.last_failure_reason = Some(reason);
+                            s.startup_attempts = attempt;
+                            s.save();
+                            break;
+                        }
+                        let delay = webhook_backoff_delay(attempt);
+                        tracing::warn!(
+                            attempt,
+                            delay_ms = delay.as_millis(),
+                            %reason,
+                            "webhook bind failed (transient), retrying with backoff"
+                        );
+                        {
+                            let mut s = status_for_spawn.lock().unwrap();
+                            s.startup_attempts = attempt;
+                            s.last_failure_reason = Some(reason);
+                            s.save();
+                        }
+                        tokio::time::sleep(delay).await;
+                    }
+                }
             }
         });
 
@@ -528,11 +597,20 @@ pub async fn serve() -> anyhow::Result<()> {
         });
 
         webhook_healthy = true;
-        tracing::info!(port, "webhook server started");
+        tracing::info!(port, orch_webhook_up = true, "webhook server started");
     } else {
         webhook_port = None;
         webhook_healthy = false;
-        tracing::info!("webhook server disabled, using polling fallback mode");
+        {
+            let mut s = webhook_status.lock().unwrap();
+            s.configured = false;
+            s.fallback_mode = true;
+            s.save();
+        }
+        tracing::info!(
+            orch_webhook_in_fallback = true,
+            "webhook server disabled, using polling fallback mode"
+        );
     }
 
     // Agent router (selects agent + model per task) - shared across projects
@@ -731,14 +809,32 @@ pub async fn serve() -> anyhow::Result<()> {
 
                     if last_webhook_health_check.elapsed() >= health_check_interval {
                         if let Some(port) = webhook_port {
-                            let health = crate::channels::github::check_webhook_health(port).await;
+                            let (health, failure_reason) =
+                                crate::channels::github::check_webhook_health(port).await;
                             if health != webhook_healthy {
                                 webhook_healthy = health;
                                 if webhook_healthy {
-                                    tracing::info!(port, "webhook health restored");
+                                    tracing::info!(port, orch_webhook_up = true, "webhook health restored");
                                 } else {
-                                    tracing::warn!(port, "webhook health check failed");
+                                    tracing::warn!(
+                                        port,
+                                        orch_webhook_up = false,
+                                        reason = failure_reason.as_deref().unwrap_or("unknown"),
+                                        "webhook health check failed"
+                                    );
                                 }
+                            }
+                            // Persist updated status.
+                            {
+                                let mut s = webhook_status.lock().unwrap();
+                                s.healthy = health;
+                                s.last_check_utc = Some(chrono::Utc::now());
+                                if health {
+                                    s.last_failure_reason = None;
+                                } else if failure_reason.is_some() {
+                                    s.last_failure_reason = failure_reason;
+                                }
+                                s.save();
                             }
                         }
                         last_webhook_health_check = std::time::Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ pub mod security;
 mod sidecar;
 mod template;
 mod tmux;
+mod webhook_status;
 
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{generate, Shell};
@@ -219,6 +220,17 @@ enum Commands {
         /// Shell type
         shell: Shell,
     },
+    /// Webhook server management
+    Webhook {
+        #[command(subcommand)]
+        action: WebhookAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum WebhookAction {
+    /// Show webhook server health status
+    Status,
 }
 
 #[derive(Subcommand)]
@@ -624,6 +636,11 @@ async fn main() -> anyhow::Result<()> {
             let mut cmd = Cli::command();
             generate(shell, &mut cmd, "orch", &mut std::io::stdout());
         }
+        Commands::Webhook { action } => match action {
+            WebhookAction::Status => {
+                cli::webhook::status()?;
+            }
+        },
     }
 
     Ok(())

--- a/src/webhook_status.rs
+++ b/src/webhook_status.rs
@@ -1,0 +1,69 @@
+//! Webhook server health state, persisted to `~/.orch/webhook_status.json`.
+//!
+//! The engine writes this file during startup and each health-check cycle.
+//! The `orch webhook status` CLI reads it so operators can inspect webhook
+//! health without tailing logs.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Persisted webhook health state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookStatus {
+    /// Whether webhooks are enabled in config.
+    pub configured: bool,
+    /// Listening port (None when disabled or not yet bound).
+    pub port: Option<u16>,
+    /// Whether the last health-check ping succeeded.
+    pub healthy: bool,
+    /// True when the engine has fallen back to polling due to startup failure.
+    pub fallback_mode: bool,
+    /// UTC timestamp of the last health-check attempt.
+    pub last_check_utc: Option<DateTime<Utc>>,
+    /// Human-readable reason for the last failure (cleared on recovery).
+    pub last_failure_reason: Option<String>,
+    /// How many bind attempts were made at startup.
+    pub startup_attempts: u32,
+}
+
+impl Default for WebhookStatus {
+    fn default() -> Self {
+        Self {
+            configured: false,
+            port: None,
+            healthy: false,
+            fallback_mode: true,
+            last_check_utc: None,
+            last_failure_reason: None,
+            startup_attempts: 0,
+        }
+    }
+}
+
+/// Path to `~/.orch/webhook_status.json`.
+pub fn status_path() -> anyhow::Result<PathBuf> {
+    Ok(crate::home::orch_home()?.join("webhook_status.json"))
+}
+
+impl WebhookStatus {
+    /// Persist the status to disk. Non-fatal: logs a warning on write failure.
+    pub fn save(&self) {
+        match status_path().and_then(|p| {
+            let json = serde_json::to_string_pretty(self)?;
+            std::fs::write(&p, json)?;
+            Ok(())
+        }) {
+            Ok(()) => {}
+            Err(e) => tracing::warn!(?e, "failed to persist webhook status"),
+        }
+    }
+
+    /// Load the last-known status from disk. Returns `None` if the file does
+    /// not exist or cannot be parsed.
+    pub fn load() -> Option<Self> {
+        let path = status_path().ok()?;
+        let json = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str(&json).ok()
+    }
+}


### PR DESCRIPTION
Closes #419

## Summary
- **Exponential backoff**: `start_webhook_server()` retries up to 5 times with 500ms base delay (capped at 30s) + jitter on transient bind errors (`EADDRINUSE`/`AddrNotAvailable`), then falls back to polling
- **Shared health state**: New `WebhookStatus` struct (persisted at `~/.orch/webhook_status.json`) tracks configured, port, healthy, fallback_mode, last_check_utc, last_failure_reason, and startup_attempts
- **`orch webhook status` CLI**: New subcommand reads the persisted JSON file and pretty-prints all fields for operator inspection
- **Metrics/tracing**: Structured fields `orch_webhook_up` and `orch_webhook_in_fallback` emitted on transitions; `check_webhook_health()` now returns `(bool, Option<String>)` with failure reason persisted and cleared on recovery
- **Tests**: Unit tests for `is_transient_bind_error`, `webhook_backoff_delay` 30s cap, and an async integration test that double-binds a real port to confirm EADDRINUSE is classified as transient

## Test plan
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (477 tests)
- [ ] Manual: run `orch serve` with webhooks enabled to observe backoff log lines on conflict
- [ ] Manual: `orch webhook status` reports health state after service starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)