### PR TITLE
fix: harden internal task dispatch — session names, worktree lookup, review guard

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -6,6 +6,8 @@
 
 use crate::backends::{ExternalBackend, ExternalId, Status};
 use crate::cmd::CommandErrorContext;
+use crate::db::TaskStatus;
+use crate::engine::tasks::TaskManager;
 use crate::sidecar;
 use std::sync::Arc;
 use tokio::process::Command;
@@ -21,13 +23,30 @@ use tokio::process::Command;
 pub(crate) async fn cleanup_done_worktrees(
     backend: &Arc<dyn ExternalBackend>,
     repo: &str,
+    task_manager: &Arc<TaskManager>,
 ) -> anyhow::Result<()> {
     let done_tasks = backend.list_by_status(Status::Done).await?;
     tracing::debug!(count = done_tasks.len(), "checking done tasks for cleanup");
 
-    for task in done_tasks {
-        let task_id = &task.id.0;
+    // Collect task IDs from external done tasks.
+    let mut task_ids: Vec<String> = done_tasks.iter().map(|t| t.id.0.clone()).collect();
 
+    // Also include internal done tasks.
+    if let Ok(internal_done) = task_manager
+        .db_list_internal_by_status(TaskStatus::Done)
+        .await
+    {
+        for t in internal_done {
+            task_ids.push(format!("internal:{}", t.id));
+        }
+    }
+
+    tracing::debug!(
+        count = task_ids.len(),
+        "checking all done tasks for cleanup"
+    );
+
+    for task_id in &task_ids {
         // Skip if already cleaned
         let worktree_cleaned = sidecar::get(task_id, "worktree_cleaned").ok();
         if worktree_cleaned.as_deref() == Some("true") || worktree_cleaned.as_deref() == Some("1") {


### PR DESCRIPTION
## Summary

Three related fixes that close a cascade of internal task failures:

1. **tmux session name sanitization** (`src/tmux.rs:45`): `session_name()` now replaces `:` with `_` in task IDs before formatting. Tmux parses `orch-orch-internal:9` as "session `orch-orch-internal`, window 9" — causing `set-environment` and `send-keys` to fail with "no such session". Fixes the root cause of all internal tasks exiting with code -1.

2. **Runner early return ordering** (`src/engine/runner/mod.rs:455`): Moved the `is_internal_id` early return above the GitHub agent-label update block. Internal tasks were attempting GitHub label API calls during failover, which logged noisy errors and masked the real session name bug.

3. **Worktree lookup colon sanitization** (`src/engine/runner/worktree.rs:318`): `find_existing_worktree()` now sanitizes colons in task IDs to match the path format produced by `branch_name()`. Retried internal tasks now reuse existing worktrees instead of failing to find them. Closes #430.

4. **Stale InReview age guard** (`src/engine/sync.rs:120`): Stale InReview detection now skips tasks updated within the last 5 minutes. Previously, freshly-transitioned InReview tasks (which have no tmux session yet while the review agent starts) were immediately reset back to NeedsReview. Closes #429.

## Test plan

- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all tests pass
- [x] New test: `find_existing_worktree_sanitizes_colon_in_task_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)