### PR TITLE
fix: resolve_repo_root uses correct bare-clone path format

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -207,9 +207,14 @@ pub(crate) async fn resolve_repo_root(repo: &str) -> anyhow::Result<String> {
     }
 
     // Fallback: try bare clone in ~/.orch/projects/
-    let bare = crate::home::projects_dir()
-        .map(|d| d.join(repo.replace('/', "__")))
-        .unwrap_or_default();
+    let parts: Vec<&str> = repo.split('/').collect();
+    let bare = if parts.len() == 2 {
+        crate::home::projects_dir()
+            .map(|d| d.join(parts[0]).join(format!("{}.git", parts[1])))
+            .unwrap_or_default()
+    } else {
+        std::path::PathBuf::new()
+    };
     if bare.exists() {
         return Ok(bare.display().to_string());
     }


### PR DESCRIPTION
## Summary
Fixes the path format used for bare-clone projects in `resolve_repo_root()`. The function was building paths as `~/.orch/projects/owner__repo` but actual bare clones are stored at `~/.orch/projects/{owner}/{repo}.git`.

## Impact
- **Before**: Cleanup failed for all orch-managed projects → worktrees/branches never cleaned up after PR merges
- **After**: Cleanup works correctly, stale worktrees are properly removed

## Changes
- Updated fallback path construction to match `runner/mod.rs::resolve_project_dir()`
- Splits repo on `/` and constructs path as `projects/{owner}/{repo}.git`

## Testing
- ✅ All 484 unit tests pass
- ✅ All integration tests pass
- ✅ Formatting and clippy checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)