### PR TITLE
feat: bidirectional channel interaction — wire input to engine actions and fan out session output

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -745,11 +745,11 @@ Before any Rust work, the current bash version needs to be rock-solid. This give
 - [x] Multi-project support — PR #82 merged
 - [x] Config hot-reload wired into engine — PR #78 merged
 
-### Phase 3: Channels (scaffolding done, not wired)
+### Phase 3: Channels
 
 **Goal:** Multi-channel I/O for task management and live streaming.
 
-- [x] Channel trait + ChannelRegistry — `src/channels/mod.rs` (scaffolding)
+- [x] Channel trait + ChannelRegistry — `src/channels/mod.rs`
 - [x] Transport layer — `src/channels/transport.rs` (session bindings, broadcast)
 - [x] Tmux channel — `src/channels/tmux.rs` (pane monitoring)
 - [x] Capture service — `src/channels/capture.rs` (output diffing + streaming)
@@ -761,6 +761,8 @@ Before any Rust work, the current bash version needs to be rock-solid. This give
 - [x] Mention detection via webhooks (#112) — webhook handler + polling fallback
 - [x] Polling fallback when webhooks not configured — PR #131 merged
 - [x] Wire channels into engine event loop — PR #81 merged
+- [x] **Bidirectional channel wiring** — `src/engine/mod.rs` `handle_channel_message()`: `TaskSession` → tmux send-keys or slash command; `Command` → `/status` + owner commands; `NewTask` → create internal task + bind thread + start fanout
+- [x] **Output fanout streaming** — `src/channels/stream.rs` `fanout_output()`: per-channel rate limiting + message splitting + final-chunk flush
 
 ### Phase 4: CLI & User-Facing Commands
 

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -15,6 +15,7 @@ pub mod discord_ws;
 pub mod github;
 pub mod notification;
 pub mod slack;
+pub mod stream;
 pub mod telegram;
 pub mod tmux;
 pub mod transport;

--- a/src/channels/stream.rs
+++ b/src/channels/stream.rs
@@ -1,0 +1,239 @@
+//! Output streaming — fans out session output to bound channel threads.
+//!
+//! When an agent session is bound to one or more channel threads (Telegram,
+//! Discord, Slack), this module streams `OutputChunk` broadcasts to those
+//! threads in real-time.
+//!
+//! Platform limits and rate limiting:
+//! - Telegram: 4 KB per message, 100 ms between sends
+//! - Discord:  2 KB per message, 500 ms between sends
+//! - Slack:    4 KB per message, 200 ms between sends
+
+use crate::channels::transport::Transport;
+use crate::channels::{ChannelRegistry, OutgoingMessage};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::time::{Duration, Instant};
+
+const TELEGRAM_MAX_BYTES: usize = 4096;
+const DISCORD_MAX_BYTES: usize = 2000;
+const SLACK_MAX_BYTES: usize = 4000;
+
+fn platform_max_bytes(channel_name: &str) -> usize {
+    match channel_name {
+        "telegram" => TELEGRAM_MAX_BYTES,
+        "discord" => DISCORD_MAX_BYTES,
+        "slack" => SLACK_MAX_BYTES,
+        _ => TELEGRAM_MAX_BYTES,
+    }
+}
+
+fn platform_rate(channel_name: &str) -> Duration {
+    match channel_name {
+        "telegram" => Duration::from_millis(100),
+        "discord" => Duration::from_millis(500),
+        "slack" => Duration::from_millis(200),
+        _ => Duration::from_millis(500),
+    }
+}
+
+/// Split content into chunks that fit within the platform's message size limit.
+fn split_for_platform(content: &str, channel_name: &str) -> Vec<String> {
+    let max = platform_max_bytes(channel_name);
+    if content.len() <= max {
+        return vec![content.to_string()];
+    }
+
+    let mut parts = Vec::new();
+    let mut start = 0;
+    while start < content.len() {
+        let mut end = (start + max).min(content.len());
+        // Walk back to a UTF-8 char boundary
+        while end > start && !content.is_char_boundary(end) {
+            end -= 1;
+        }
+        if end == start {
+            // Single char exceeds limit — skip one byte (shouldn't happen with valid UTF-8)
+            end = start + 1;
+        }
+        parts.push(content[start..end].to_string());
+        start = end;
+    }
+    parts
+}
+
+/// Send a message to a specific channel thread, finding the channel by name.
+async fn send_to_thread(
+    channels: &Arc<ChannelRegistry>,
+    channel_name: &str,
+    thread_id: &str,
+    body: String,
+) {
+    for ch in channels.iter() {
+        if ch.name() == channel_name {
+            let msg = OutgoingMessage {
+                thread_id: thread_id.to_string(),
+                body,
+                reply_to: None,
+                metadata: serde_json::json!({}),
+            };
+            if let Err(e) = ch.send(&msg).await {
+                tracing::warn!(channel = channel_name, thread_id, ?e, "stream: send failed");
+            }
+            return;
+        }
+    }
+    tracing::debug!(
+        channel = channel_name,
+        "stream: channel not found in registry"
+    );
+}
+
+/// Fan out output chunks from a task to all bound channel threads.
+///
+/// Subscribes to the task's output broadcast in `transport`, accumulates
+/// content per channel thread, applies rate limiting, and terminates when
+/// the stream receives a final chunk or is closed.
+///
+/// This function should be spawned as a background task when a channel
+/// thread is bound to an agent session.
+pub async fn fanout_output(
+    task_id: String,
+    transport: Arc<Transport>,
+    channels: Arc<ChannelRegistry>,
+) {
+    let mut rx = match transport.subscribe(&task_id).await {
+        Some(r) => r,
+        None => {
+            tracing::debug!(task_id, "fanout: no binding for task, cannot subscribe");
+            return;
+        }
+    };
+
+    tracing::debug!(task_id, "fanout: started output streaming");
+
+    // Per channel-name: last send time (for rate limiting)
+    let mut last_send: HashMap<String, Instant> = HashMap::new();
+    // Per thread-key ("channel:thread_id"): buffered content pending send
+    let mut buffers: HashMap<String, String> = HashMap::new();
+
+    loop {
+        match rx.recv().await {
+            Ok(chunk) => {
+                let is_final = chunk.is_final;
+
+                if !chunk.content.is_empty() {
+                    // Look up current binding to find connected threads
+                    if let Some(binding) = transport.get_binding(&task_id).await {
+                        let now = Instant::now();
+
+                        for thread_key in &binding.connected_threads {
+                            let (ch_name, thread_id) = match thread_key.split_once(':') {
+                                Some(p) => p,
+                                None => continue,
+                            };
+
+                            // Append new content to this thread's buffer
+                            buffers
+                                .entry(thread_key.clone())
+                                .or_default()
+                                .push_str(&chunk.content);
+
+                            // Check if enough time has passed since last send
+                            let rate = platform_rate(ch_name);
+                            let can_send = last_send
+                                .get(ch_name)
+                                .map(|t| now.duration_since(*t) >= rate)
+                                .unwrap_or(true);
+
+                            if can_send {
+                                if let Some(buffered) = buffers.remove(thread_key) {
+                                    let parts = split_for_platform(&buffered, ch_name);
+                                    for part in parts {
+                                        send_to_thread(&channels, ch_name, thread_id, part).await;
+                                    }
+                                    last_send.insert(ch_name.to_string(), now);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if is_final {
+                    // Flush all remaining buffers
+                    if let Some(binding) = transport.get_binding(&task_id).await {
+                        for thread_key in &binding.connected_threads {
+                            if let Some(buffered) = buffers.remove(thread_key) {
+                                if !buffered.is_empty() {
+                                    let (ch_name, thread_id) = match thread_key.split_once(':') {
+                                        Some(p) => p,
+                                        None => continue,
+                                    };
+                                    let parts = split_for_platform(&buffered, ch_name);
+                                    for part in parts {
+                                        send_to_thread(&channels, ch_name, thread_id, part).await;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    tracing::debug!(task_id, "fanout: final chunk received, stream complete");
+                    break;
+                }
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                tracing::warn!(
+                    task_id,
+                    missed = n,
+                    "fanout: output receiver lagged, some output dropped"
+                );
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                tracing::debug!(task_id, "fanout: output broadcast closed");
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_short_content_unchanged() {
+        let parts = split_for_platform("hello", "telegram");
+        assert_eq!(parts, vec!["hello"]);
+    }
+
+    #[test]
+    fn split_long_content_telegram() {
+        let content = "a".repeat(5000);
+        let parts = split_for_platform(&content, "telegram");
+        assert!(parts.len() >= 2);
+        for p in &parts {
+            assert!(p.len() <= TELEGRAM_MAX_BYTES);
+        }
+        // Reassembled content equals original
+        assert_eq!(parts.join(""), content);
+    }
+
+    #[test]
+    fn split_long_content_discord() {
+        let content = "x".repeat(3000);
+        let parts = split_for_platform(&content, "discord");
+        assert!(parts.len() >= 2);
+        for p in &parts {
+            assert!(p.len() <= DISCORD_MAX_BYTES);
+        }
+        assert_eq!(parts.join(""), content);
+    }
+
+    #[test]
+    fn platform_max_bytes_known_channels() {
+        assert_eq!(platform_max_bytes("telegram"), 4096);
+        assert_eq!(platform_max_bytes("discord"), 2000);
+        assert_eq!(platform_max_bytes("slack"), 4000);
+        assert_eq!(platform_max_bytes("unknown"), 4096);
+    }
+}

--- a/src/channels/transport.rs
+++ b/src/channels/transport.rs
@@ -134,6 +134,11 @@ impl Transport {
         last.get(task_id).cloned()
     }
 
+    /// Get the session binding for a specific task, if any.
+    pub async fn get_binding(&self, task_id: &str) -> Option<SessionBinding> {
+        self.bindings.read().await.get(task_id).cloned()
+    }
+
     /// Route an incoming message to the appropriate handler.
     /// Returns the task_id if this message maps to an existing session.
     pub async fn route(&self, msg: &IncomingMessage) -> MessageRoute {

--- a/src/engine/commands.rs
+++ b/src/engine/commands.rs
@@ -268,7 +268,7 @@ pub async fn scan_commands(
 }
 
 /// Execute a single owner command against a task.
-async fn execute_command(
+pub async fn execute_command(
     backend: &Arc<dyn ExternalBackend>,
     gh: &GhHttp,
     repo: &str,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -382,24 +382,25 @@ pub async fn serve() -> anyhow::Result<()> {
 
     // Spawn tasks to handle incoming channel messages (if any channels are active)
     let transport_for_messages = transport.clone();
+    let tmux_for_messages = tmux.clone();
+    let capture_for_messages = capture_for_tick.clone();
+    let channels_for_messages = channel_registry.clone();
+    // Lightweight engine references for command execution and task creation
+    let engine_refs: Vec<(String, Arc<dyn ExternalBackend>, Arc<TaskManager>)> = project_engines
+        .iter()
+        .map(|e| (e.repo.clone(), e.backend.clone(), e.task_manager.clone()))
+        .collect();
     for mut rx in channel_receivers {
         let transport = transport_for_messages.clone();
+        let tmux = tmux_for_messages.clone();
+        let capture = capture_for_messages.clone();
+        let channels = channels_for_messages.clone();
+        let engine_refs = engine_refs.clone();
         tokio::spawn(async move {
             while let Some(msg) = rx.recv().await {
                 tracing::debug!(channel = %msg.channel, thread = %msg.thread_id, "received message from channel");
-
-                // Route the message through transport
-                match transport.route(&msg).await {
-                    crate::channels::transport::MessageRoute::TaskSession { task_id } => {
-                        tracing::debug!(task_id = %task_id, "message routed to existing session");
-                    }
-                    crate::channels::transport::MessageRoute::Command { raw } => {
-                        tracing::debug!(command = %raw, "message is a command");
-                    }
-                    crate::channels::transport::MessageRoute::NewTask => {
-                        tracing::debug!("message would create new task");
-                    }
-                }
+                handle_channel_message(msg, &transport, &tmux, &capture, &channels, &engine_refs)
+                    .await;
             }
         });
     }
@@ -1008,6 +1009,215 @@ pub async fn serve() -> anyhow::Result<()> {
     let _ = transport;
     tracing::info!("orch engine stopped");
     Ok(())
+}
+
+/// Send a reply message to a specific channel thread.
+///
+/// Iterates the channel registry and finds the channel by name,
+/// then sends the message to the given thread ID.
+async fn send_channel_reply(
+    channels: &Arc<ChannelRegistry>,
+    channel_name: &str,
+    thread_id: &str,
+    body: String,
+) {
+    for ch in channels.iter() {
+        if ch.name() == channel_name {
+            let msg = OutgoingMessage {
+                thread_id: thread_id.to_string(),
+                body,
+                reply_to: None,
+                metadata: serde_json::json!({}),
+            };
+            if let Err(e) = ch.send(&msg).await {
+                tracing::warn!(
+                    channel = channel_name,
+                    thread_id,
+                    ?e,
+                    "failed to send channel reply"
+                );
+            }
+            return;
+        }
+    }
+    tracing::debug!(
+        channel = channel_name,
+        "channel not found in registry for reply"
+    );
+}
+
+/// Forward a text message to an agent's tmux session via send-keys.
+async fn forward_to_tmux(transport: &Arc<Transport>, task_id: &str, text: &str) {
+    if let Some(binding) = transport.get_binding(task_id).await {
+        if let Err(e) = crate::channels::tmux::send_keys(&binding.tmux_session, text).await {
+            tracing::warn!(
+                task_id,
+                session = %binding.tmux_session,
+                ?e,
+                "failed to forward message to tmux session"
+            );
+        } else {
+            tracing::debug!(
+                task_id,
+                session = %binding.tmux_session,
+                "forwarded message to tmux"
+            );
+        }
+    } else {
+        tracing::warn!(task_id, "no tmux binding found, cannot forward message");
+    }
+}
+
+/// Handle an incoming channel message by routing it to the appropriate action.
+///
+/// - `TaskSession`: slash command → execute on task; otherwise → forward to tmux
+/// - `Command`: global commands like `/status`; task-specific commands need a task thread
+/// - `NewTask`: create an internal task, bind thread, start output fanout
+async fn handle_channel_message(
+    msg: IncomingMessage,
+    transport: &Arc<Transport>,
+    _tmux: &Arc<TmuxManager>,
+    capture: &Arc<CaptureService>,
+    channels: &Arc<ChannelRegistry>,
+    engine_refs: &[(String, Arc<dyn ExternalBackend>, Arc<TaskManager>)],
+) {
+    use crate::backends::ExternalId;
+    use crate::channels::stream::fanout_output;
+    use crate::channels::transport::MessageRoute;
+    use crate::engine::commands::{execute_command, parse_command};
+    use crate::engine::tasks::{CreateTaskRequest, TaskType};
+
+    match transport.route(&msg).await {
+        MessageRoute::TaskSession { task_id } => {
+            let body = msg.body.trim().to_string();
+            let channel = msg.channel.clone();
+            let thread_id = msg.thread_id.clone();
+
+            if body.starts_with('/') {
+                // Parse slash command and execute it on the bound task
+                if let Some(cmd) = parse_command(&body) {
+                    if let Some((repo, backend, _)) = engine_refs.first() {
+                        let gh = GhHttp::new();
+                        let ext_id = ExternalId(task_id.clone());
+                        let result = execute_command(backend, &gh, repo, &ext_id, &cmd).await;
+                        let reply = match result {
+                            Ok(r) => r,
+                            Err(e) => format!("Command `{cmd}` failed: {e}"),
+                        };
+                        send_channel_reply(channels, &channel, &thread_id, reply).await;
+                    }
+                } else {
+                    // Unknown command — forward to agent as-is
+                    forward_to_tmux(transport, &task_id, &body).await;
+                }
+            } else {
+                // Regular message — forward to the agent's tmux session
+                forward_to_tmux(transport, &task_id, &body).await;
+            }
+        }
+
+        MessageRoute::Command { raw } => {
+            let cmd_str = raw.trim().to_string();
+            let channel = msg.channel.clone();
+            let thread_id = msg.thread_id.clone();
+
+            // /status is not in OwnerCommand — handle it specially
+            if cmd_str == "/status" || cmd_str.starts_with("/status ") {
+                let mut lines = vec!["**Active tasks:**".to_string()];
+                for (repo, _, task_manager) in engine_refs {
+                    match task_manager
+                        .list_external_by_status(Status::InProgress)
+                        .await
+                    {
+                        Ok(tasks) => {
+                            for t in &tasks {
+                                lines.push(format!("- #{} [{}]: {}", t.id.0, repo, t.title));
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(repo, err = %e, "failed to list in-progress tasks");
+                        }
+                    }
+                }
+                if lines.len() == 1 {
+                    lines.push("No tasks currently in progress.".to_string());
+                }
+                send_channel_reply(channels, &channel, &thread_id, lines.join("\n")).await;
+            } else if let Some(cmd) = parse_command(&cmd_str) {
+                let reply = format!(
+                    "Command `{cmd}` requires a task context. \
+                     Send it in a thread that is bound to a running task."
+                );
+                send_channel_reply(channels, &channel, &thread_id, reply).await;
+            } else {
+                let reply = "Available commands: /status (list tasks), /retry, /close, \
+                             /block, /unblock, /review — send task-specific commands in a task thread."
+                    .to_string();
+                send_channel_reply(channels, &channel, &thread_id, reply).await;
+            }
+        }
+
+        MessageRoute::NewTask => {
+            let channel = msg.channel.clone();
+            let thread_id = msg.thread_id.clone();
+
+            // Pick the first configured project for new tasks from channels
+            if let Some((repo, _, task_manager)) = engine_refs.first() {
+                let title = if msg.body.len() > 80 {
+                    format!("{}…", &msg.body[..80])
+                } else {
+                    msg.body.clone()
+                };
+                let req = CreateTaskRequest {
+                    title,
+                    body: msg.body.clone(),
+                    task_type: TaskType::Internal,
+                    labels: vec!["channel-created".to_string()],
+                    source: channel.clone(),
+                    source_id: thread_id.clone(),
+                };
+                match task_manager.create_task(req).await {
+                    Ok(task) => {
+                        use crate::engine::tasks::Task;
+                        let task_id = match &task {
+                            Task::Internal(t) => format!("internal:{}", t.id),
+                            Task::External(t) => t.id.0.clone(),
+                        };
+                        // Bind the thread to the new task
+                        transport
+                            .bind(
+                                &task_id,
+                                &format!("orch-{repo}-{task_id}"),
+                                &channel,
+                                &thread_id,
+                            )
+                            .await;
+                        // Register the session with CaptureService (graceful if no session yet)
+                        capture
+                            .register_session(&task_id, &format!("orch-{repo}-{task_id}"))
+                            .await;
+                        // Spawn output fanout for this task
+                        let transport_clone = transport.clone();
+                        let channels_clone = channels.clone();
+                        let task_id_clone = task_id.clone();
+                        tokio::spawn(async move {
+                            fanout_output(task_id_clone, transport_clone, channels_clone).await;
+                        });
+                        let reply =
+                            format!("Task created: `{task_id}` — I'll start working on it now.");
+                        send_channel_reply(channels, &channel, &thread_id, reply).await;
+                    }
+                    Err(e) => {
+                        tracing::warn!(repo, err = %e, "failed to create task from channel message");
+                        let reply = format!("Failed to create task: {e}");
+                        send_channel_reply(channels, &channel, &thread_id, reply).await;
+                    }
+                }
+            } else {
+                tracing::warn!("no project configured, cannot create task from channel message");
+            }
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Implements the full bidirectional channel loop described in issue #431.

**Input wiring (`engine/mod.rs`)**
- `TaskSession`: slash command → `execute_command` on the bound task; plain text → `tmux send-keys` forwarded to the running agent
- `Command` (unbound thread): `/status` lists in-progress tasks; task-specific commands (`/retry`, `/close`, etc.) respond with "use in a task thread"
- `NewTask`: creates an internal task from the message, binds the channel thread, registers with `CaptureService`, spawns output fanout, replies with the task ID

**Output fanout (`src/channels/stream.rs`, new)**
- Subscribes to per-task `OutputChunk` broadcast via `Transport::subscribe`
- Fans out to all bound channel threads (parsed from `SessionBinding.connected_threads`)
- Per-channel rate limiting: Telegram 100ms, Discord 500ms, Slack 200ms
- Splits messages to fit platform limits: Telegram 4KB, Discord 2KB, Slack 4KB
- Flushes remaining buffers on `is_final`; exits on stream close

**Supporting changes**
- `Transport::get_binding(task_id)` — look up a specific task's `SessionBinding`
- `channels/mod.rs` — register `stream` module
- `engine/commands::execute_command` — made `pub` for channel dispatch

## Test plan

- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo test` — 488 passed, 0 failed
- [ ] Manual: send `/status` from Telegram → see in-progress task list
- [ ] Manual: send a message in a bound thread → see it appear in tmux session
- [ ] Manual: create a task via Telegram message → watch output stream back

🤖 Generated with [Claude Code](https://claude.com/claude-code)