### PR TITLE
bug: engine health checks don't include internal tasks — stuck recovery, NeedsReview catch-up, and stale InReview detection are blind to SQLite tasks

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -6,6 +6,8 @@
 
 use crate::backends::{ExternalBackend, ExternalId, Status};
 use crate::cmd::CommandErrorContext;
+use crate::db::TaskStatus;
+use crate::engine::tasks::TaskManager;
 use crate::sidecar;
 use std::sync::Arc;
 use tokio::process::Command;
@@ -21,13 +23,30 @@ use tokio::process::Command;
 pub(crate) async fn cleanup_done_worktrees(
     backend: &Arc<dyn ExternalBackend>,
     repo: &str,
+    task_manager: &Arc<TaskManager>,
 ) -> anyhow::Result<()> {
     let done_tasks = backend.list_by_status(Status::Done).await?;
     tracing::debug!(count = done_tasks.len(), "checking done tasks for cleanup");
 
-    for task in done_tasks {
-        let task_id = &task.id.0;
+    // Collect task IDs from external done tasks.
+    let mut task_ids: Vec<String> = done_tasks.iter().map(|t| t.id.0.clone()).collect();
 
+    // Also include internal done tasks.
+    if let Ok(internal_done) = task_manager
+        .db_list_internal_by_status(TaskStatus::Done)
+        .await
+    {
+        for t in internal_done {
+            task_ids.push(format!("internal:{}", t.id));
+        }
+    }
+
+    tracing::debug!(
+        count = task_ids.len(),
+        "checking all done tasks for cleanup"
+    );
+
+    for task_id in &task_ids {
         // Skip if already cleaned
         let worktree_cleaned = sidecar::get(task_id, "worktree_cleaned").ok();
         if worktree_cleaned.as_deref() == Some("true") || worktree_cleaned.as_deref() == Some("1") {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -22,7 +22,7 @@ pub mod sync;
 pub mod tasks;
 pub mod tick;
 
-use crate::backends::ExternalBackend;
+use crate::backends::{ExternalBackend, ExternalId};
 use crate::channels::capture::CaptureService;
 use crate::channels::discord_ws::DiscordGateway;
 use crate::channels::github::start_webhook_server;
@@ -675,6 +675,36 @@ pub async fn serve() -> anyhow::Result<()> {
                 );
             }
         }
+
+        // Also reset internal (SQLite) InReview tasks on startup.
+        use crate::db::TaskStatus as DbStatus;
+        if let Ok(internal_in_review) = engine
+            .task_manager
+            .db_list_internal_by_status(DbStatus::InReview)
+            .await
+        {
+            for task in &internal_in_review {
+                let task_id = format!("internal:{}", task.id);
+                if let Err(e) = engine
+                    .task_manager
+                    .update_task_status(&ExternalId(task_id.clone()), Status::NeedsReview)
+                    .await
+                {
+                    tracing::warn!(
+                        task_id,
+                        err = %e,
+                        "failed to reset stale internal InReview task on startup"
+                    );
+                }
+            }
+            if !internal_in_review.is_empty() {
+                tracing::info!(
+                    repo = %engine.repo,
+                    count = internal_in_review.len(),
+                    "reset stale internal InReview tasks to NeedsReview on startup"
+                );
+            }
+        }
     }
 
     // Main loop
@@ -793,7 +823,7 @@ pub async fn serve() -> anyhow::Result<()> {
                         for engine in &project_engines {
                             let repo = engine.repo.clone();
                             REPO_CONTEXT.scope(repo, async {
-                                if let Err(e) = sync::sync_tick(&engine.backend, &tmux, &engine.repo, &db, &config, &router).await {
+                                if let Err(e) = sync::sync_tick(&engine.backend, &tmux, &engine.repo, &db, &config, &router, &engine.task_manager).await {
                                     tracing::error!(repo = %engine.repo, ?e, "sync tick failed for project");
                                 }
                             }).await;

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -9,11 +9,12 @@
 //! - Owner /slash command scanning
 //! - Skill repository syncing
 
-use crate::backends::{ExternalBackend, ExternalId, Status};
+use crate::backends::{ExternalBackend, ExternalId, ExternalTask, Status};
 use crate::cmd::CommandErrorContext;
 use crate::config;
 use crate::db::{Db, TaskStatus};
 use crate::engine::router::Router;
+use crate::engine::tasks::TaskManager;
 use crate::sidecar::REPO_CONTEXT;
 use crate::tmux::TmuxManager;
 use std::sync::Arc;
@@ -37,11 +38,12 @@ pub(crate) async fn sync_tick(
     db: &Arc<Db>,
     config: &EngineConfig,
     router: &Arc<RwLock<Router>>,
+    task_manager: &Arc<TaskManager>,
 ) -> anyhow::Result<()> {
     tracing::debug!("sync tick");
 
     // 1. Cleanup worktrees for done tasks
-    if let Err(e) = cleanup_done_worktrees(backend, repo).await {
+    if let Err(e) = cleanup_done_worktrees(backend, repo, task_manager).await {
         tracing::warn!(err = %e, "worktree cleanup failed");
     }
 
@@ -65,68 +67,127 @@ pub(crate) async fn sync_tick(
         .map(|v| v != "false")
         .unwrap_or(true);
     if enable_review {
-        if let Ok(needs_review) = backend.list_by_status(Status::NeedsReview).await {
-            for task in needs_review {
-                let task_id = &task.id.0;
-                tracing::info!(task_id, "triggering review agent for needs_review task");
-                // Transition to InReview — this IS the atomic guard against duplicates.
-                // The GitHub label update is idempotent; if another dispatch already claimed
-                // this task it will already be InReview and this update is a no-op.
-                if let Err(e) = backend.update_status(&task.id, Status::InReview).await {
-                    tracing::warn!(task_id, err = %e, "failed to transition to InReview");
-                    continue;
-                }
-                let backend_c = backend.clone();
-                let tmux_c = tmux.clone();
-                let task_c = task.clone();
-                let repo_s = repo.to_string();
-                let router_c = router.clone();
-                let repo_ctx = repo_s.clone();
-                tokio::spawn(REPO_CONTEXT.scope(repo_ctx, async move {
-                    let tid = task_c.id.0.clone();
-                    let needs_reset =
-                        match review_and_merge(&task_c, &backend_c, &tmux_c, &repo_s, &router_c)
-                            .await
-                        {
-                            Ok(ReviewDecision::Failed(reason)) => {
-                                tracing::error!(
-                                    task_id = tid,
-                                    reason,
-                                    "review agent failed — resetting to NeedsReview for retry"
-                                );
-                                true
-                            }
-                            Err(e) => {
-                                tracing::error!(
-                                    task_id = tid, error = %e,
-                                    "review_and_merge failed — resetting to NeedsReview for retry"
-                                );
-                                true
-                            }
-                            Ok(_) => false,
-                        };
-                    if needs_reset {
-                        reset_to_needs_review_with_retry(&backend_c, &tid).await;
-                    }
-                }));
+        // Collect all NeedsReview tasks: external + internal.
+        let mut needs_review_tasks = backend
+            .list_by_status(Status::NeedsReview)
+            .await
+            .unwrap_or_default();
+        if let Ok(internal_needs_review) = task_manager
+            .db_list_internal_by_status(TaskStatus::NeedsReview)
+            .await
+        {
+            for t in internal_needs_review {
+                needs_review_tasks.push(ExternalTask {
+                    id: ExternalId(format!("internal:{}", t.id)),
+                    title: t.title,
+                    body: t.body,
+                    state: "open".to_string(),
+                    labels: vec!["status:needs_review".to_string()],
+                    author: t.source,
+                    created_at: t.created_at.to_rfc3339(),
+                    updated_at: t.updated_at.to_rfc3339(),
+                    url: String::new(),
+                });
             }
         }
 
-        // Detect stale InReview tasks (review agent crashed, no active tmux session).
-        if let Ok(in_review) = backend.list_by_status(Status::InReview).await {
-            for task in in_review {
-                let review_task_id = format!("{}-review", task.id.0);
-                let review_session = tmux.session_name(repo, &review_task_id);
-                let has_session = tmux.session_exists(&review_session).await;
-                if !has_session {
-                    tracing::warn!(
-                        task_id = task.id.0,
-                        session = %review_session,
-                        "InReview task has no active review session — resetting to NeedsReview"
-                    );
-                    if let Err(e) = backend.update_status(&task.id, Status::NeedsReview).await {
-                        tracing::error!(task_id = %task.id.0, err = %e, "failed to reset stale InReview task — task may be stuck in InReview indefinitely");
+        for task in needs_review_tasks {
+            let task_id = &task.id.0;
+            tracing::info!(task_id, "triggering review agent for needs_review task");
+            // Transition to InReview — this IS the atomic guard against duplicates.
+            // For internal tasks, task_manager routes to SQLite; for external to GitHub labels.
+            if let Err(e) = task_manager
+                .update_task_status(&task.id, Status::InReview)
+                .await
+            {
+                tracing::warn!(task_id, err = %e, "failed to transition to InReview");
+                continue;
+            }
+            let backend_c = backend.clone();
+            let task_manager_c = task_manager.clone();
+            let tmux_c = tmux.clone();
+            let task_c = task.clone();
+            let repo_s = repo.to_string();
+            let router_c = router.clone();
+            let repo_ctx = repo_s.clone();
+            tokio::spawn(REPO_CONTEXT.scope(repo_ctx, async move {
+                let tid = task_c.id.0.clone();
+                let needs_reset = match review_and_merge(
+                    &task_c, &backend_c, &tmux_c, &repo_s, &router_c,
+                )
+                .await
+                {
+                    Ok(ReviewDecision::Failed(reason)) => {
+                        tracing::error!(
+                            task_id = tid,
+                            reason,
+                            "review agent failed — resetting to NeedsReview for retry"
+                        );
+                        true
                     }
+                    Err(e) => {
+                        tracing::error!(
+                            task_id = tid, error = %e,
+                            "review_and_merge failed — resetting to NeedsReview for retry"
+                        );
+                        true
+                    }
+                    Ok(_) => false,
+                };
+                if needs_reset {
+                    if tid.starts_with("internal:") {
+                        // Internal tasks: update SQLite via task_manager.
+                        let _ = task_manager_c
+                            .update_task_status(&ExternalId(tid.clone()), Status::NeedsReview)
+                            .await;
+                    } else {
+                        // External tasks: retry with backoff.
+                        reset_to_needs_review_with_retry(&backend_c, &tid).await;
+                    }
+                }
+            }));
+        }
+
+        // Detect stale InReview tasks (review agent crashed, no active tmux session).
+        // Check external tasks.
+        let mut in_review_tasks = backend
+            .list_by_status(Status::InReview)
+            .await
+            .unwrap_or_default();
+        // Also include internal InReview tasks.
+        if let Ok(internal_in_review) = task_manager
+            .db_list_internal_by_status(TaskStatus::InReview)
+            .await
+        {
+            for t in internal_in_review {
+                in_review_tasks.push(ExternalTask {
+                    id: ExternalId(format!("internal:{}", t.id)),
+                    title: t.title,
+                    body: t.body,
+                    state: "open".to_string(),
+                    labels: vec!["status:in_review".to_string()],
+                    author: t.source,
+                    created_at: t.created_at.to_rfc3339(),
+                    updated_at: t.updated_at.to_rfc3339(),
+                    url: String::new(),
+                });
+            }
+        }
+        for task in in_review_tasks {
+            let review_task_id = format!("{}-review", task.id.0);
+            let review_session = tmux.session_name(repo, &review_task_id);
+            let has_session = tmux.session_exists(&review_session).await;
+            if !has_session {
+                tracing::warn!(
+                    task_id = task.id.0,
+                    session = %review_session,
+                    "InReview task has no active review session — resetting to NeedsReview"
+                );
+                if let Err(e) = task_manager
+                    .update_task_status(&task.id, Status::NeedsReview)
+                    .await
+                {
+                    tracing::error!(task_id = %task.id.0, err = %e, "failed to reset stale InReview task — task may be stuck in InReview indefinitely");
                 }
             }
         }


### PR DESCRIPTION
Resolves #448

Auto-created by orch review gate (agent forgot to open PR)