### PR TITLE
docs: revert incorrect documentation changes

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -3,4 +3,4 @@ title = "Documentation"
 sort_by = "weight"
 +++
 
-Orchestrator documentation — a lightweight bash orchestrator for autonomous coding agents.
+Orchestrator documentation — a Rust-based orchestrator for autonomous coding agents.

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -2,50 +2,52 @@
 title = "CLI Reference"
 description = "Commands, namespaces, and background service"
 weight = 6
-++ 
+++
 
 ## Namespaces
 
 ```bash
-orch task list|tree|add|plan|route|run|next|poll|retry|unblock|agent|stream|watch|unlock
-orch service start|stop|restart|status|install|uninstall
-orch gh pull|push|sync
-orch project info|create|list|add
+orch task list|add|get|status|route|run|retry|unblock|attach|live|kill|publish|cost|tree
+orch service start|stop|restart|status
 orch job add|list|remove|enable|disable|tick
-orch skills list|sync
+orch project add|remove|list
+orch stream <task_id>
+orch dashboard
+orch metrics
+orch cost
 ```
 
-Top-level shortcuts: `init`, `chat`, `status`, `dashboard`, `log`, `start`, `stop`, `restart`, `info`, `agents`, `version`.
-
- `orch` is a short alias for `orchestrator`.
+Top-level shortcuts: `serve`, `init`, `log`, `agents`, `version`, `completions`.
 
 ## Task Commands
 
 ```bash
 orch task add "title" --body "body" --labels "comma,separated"  # create a task
 orch task add "title" -p owner/repo   # create a task for a managed project
-orch task plan "title" "body"          # create a plan/decompose task
 orch task list                          # list tasks for current project
 orch task tree                          # show parent-child tree
+orch task get <id>                      # get task details
+orch task status                        # show task status summary
 orch task route <id>                    # route a task to an agent
 orch task run <id>                      # run a specific task
-orch task next                          # route + run next pending task
-orch task poll                          # process all pending tasks (runs routed tasks)
 orch task retry <id>                    # reset task to new
 orch task unblock <id>                  # reset a needs_review/stalled task to new
 orch task unblock all                   # reset all needs_review/blocked tasks
-orch task agent <id> <agent>            # manually set task agent
-orch task watch                         # watch task status changes
-orch task unlock                        # clear stale locks
+orch task attach <id>                   # attach to a running agent's tmux session
+orch task live                          # list active agent tmux sessions
+orch task kill <id>                     # kill a running agent tmux session
+orch task publish <id>                  # publish internal task to GitHub
+orch task cost <id>                     # show token cost breakdown for a task
+orch stream <id>                        # stream live output from a running task
 ```
 
 ## Background Service
 
 ```bash
-orch start                # start background server
-orch stop                 # stop background server
-orch restart              # restart server
-orch info                 # show server status (PID, uptime)
+orch service start      # start background service
+orch service stop       # stop background service
+orch service restart    # restart service
+orch service status     # show service status
 ```
 
 With Homebrew:
@@ -55,49 +57,41 @@ brew services stop orch
 brew services restart orch
 ```
 
-The server runs a background service which ticks every `engine.tick_interval` seconds (default 10s):
-- Polls for new/routed tasks and runs them
-- Checks for stuck tasks and recovers or marks `needs_review`
+The service ticks every `engine.tick_interval` seconds (default 10s):
+- Syncs GitHub issues and PR events (webhook or polling)
+- Routes new tasks to agents via LLM router
+- Dispatches routed tasks into tmux sessions in worktrees
 - Runs due scheduled jobs (per-project)
-- Syncs with GitHub (sync interval configurable; webhook mode preferred)
-
-Install as a launchd service (auto-starts on login):
-```bash
-orch service install      # create launchd plist
-orch service uninstall    # remove launchd plist
-```
-
-## Chat Mode
-
-```bash
-orch chat
-```
-
- Interactive mode with readline support. Talk to the orchestrator, add tasks, check status. Chat tasks run in the current `PROJECT_DIR` without worktrees.
+- Recovers stuck tasks (no tmux session, age >10 min → reset to `new`)
 
 ## Dashboard & Status
 
 ```bash
-orch status                 # show task counts for current project
-orch status --global        # show all projects
-orch status --json          # JSON output
-orch dashboard              # full dashboard view
+orch dashboard              # full dashboard view (tasks, sessions, activity)
+orch task status            # show task counts for current project
+orch metrics                # show task metrics summary
+orch cost                   # show cost tracking and token usage
 orch log                    # tail server logs
 ```
 
-## GitHub Commands
+## Project Commands
 
 ```bash
-orch gh pull                # import issues into tasks
-orch gh push                # push task updates to issues
-orch gh sync                # both directions
-orch project add owner/repo  # bare clone + import issues
-orch project info            # show GitHub Project field IDs
-orch project info --fix      # auto-fill project config
-orch project create "name"   # create or link a GitHub Project v2
-orch project list             # list managed bare-clone projects
-orch project list org=ORG     # list GitHub Projects v2 + managed projects
-orch project list user=USER   # list GitHub Projects v2 + managed projects
+orch project add owner/repo   # bare clone + import issues
+orch project add /path/to/repo # register a local project
+orch project list              # list registered projects
+orch project remove owner/repo # remove a project from registry
+```
+
+## Job Commands
+
+```bash
+orch job list                             # list scheduled jobs
+orch job add "title" --cron "0 9 * * *"  # add a cron job
+orch job remove <id>                      # remove a job
+orch job enable <id>                      # enable a job
+orch job disable <id>                     # disable a job
+orch job tick                             # run one job scheduler tick manually
 ```
 
 ## Agent Management
@@ -112,10 +106,8 @@ orch agents                 # list available agents and their status
 |-----|----------|
 | Server log | `~/.orch/state/orch.log` |
 | Server archive | `~/.orch/state/orch.archive.log` |
-| Jobs log | `~/.orch/state/jobs.log` |
-| Per-task output | `~/.orch/state/output-{id}.json` |
-| Per-task tools | `~/.orch/state/tools-{id}.json` |
-| Per-task prompts | `~/.orch/state/prompt-{id}.md` |
-| Task context | `~/.orch/contexts/task-{id}.md` |
+| Per-task sidecar | `~/.orch/state/<repo>/tasks/<id>/sidecar.json` |
+| Per-task output | `~/.orch/state/<repo>/tasks/<id>/attempts/<n>/output.json` |
+| Per-task prompts | `~/.orch/state/<repo>/tasks/<id>/attempts/<n>/prompt-sys.md` |
 | Brew stdout | `/opt/homebrew/var/log/orch.log` |
 | Brew stderr | `/opt/homebrew/var/log/orch.error.log` |

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -1,6 +1,6 @@
 +++
 title = "Getting Started"
-description = "Install orchestrator and run your first task"
+description = "Install orch and run your first task"
 weight = 1
 +++
 
@@ -22,7 +22,7 @@ brew install --cask codex         # Codex (if available)
 brew install opencode             # OpenCode
 ```
 
-Optional: `gh` for GitHub sync (legacy interactive flows), `bats` for tests.
+Optional: `gh` for GitHub sync, `bats` for tests.
 
 ## Quick Start
 
@@ -32,8 +32,8 @@ Optional: `gh` for GitHub sync (legacy interactive flows), `bats` for tests.
 cd ~/projects/my-app
 orch init               # configure project (optional GitHub setup)
 orch task add "title"   # add a task
-orch task next          # route + run next task
-orch start              # start background server
+orch task run <id>      # run a specific task
+orch service start      # start background service
 ```
 
 ### Option B: Any GitHub repo
@@ -41,12 +41,10 @@ orch start              # start background server
 ```bash
 orch project add owner/repo          # bare clone + import issues
 orch task add "title" -p owner/repo  # add a task to that project
-orch start                           # serve loop picks it up
+orch service start                   # service picks it up automatically
 ```
 
 Bare clones live at `~/.orch/projects/<owner>/<repo>.git`. Agents always work in worktrees — never in the main clone. Worktrees are under `~/.orch/worktrees/<project>/<branch>/`.
-
-`orch` is a short alias for `orchestrator` — use `orch` for the lightweight CLI.
 
 ## GitHub Authentication
 
@@ -114,7 +112,7 @@ echo 'export GH_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxx"' >> ~/.private
 chmod 600 ~/.private
 ```
 
-Runner scripts automatically source `~/.private` if it exists.
+The service sources `~/.private` if it exists.
 
 **Option B — launchd `EnvironmentVariables`** in the plist (for system-wide installs):
 
@@ -140,15 +138,15 @@ All runtime state lives in `~/.orch/` (`ORCH_HOME`):
 
 | File | Description |
 |------|-------------|
-| `tasks.yml` | Task database |
-| `jobs.yml` | Scheduled job definitions |
-| `config.yml` | Runtime configuration |
+| `config.yml` | Global runtime configuration |
+| `orch.db` | SQLite task database (internal tasks, metrics, KV store) |
 | `skills.yml` | Approved skill repositories and catalog |
-| `skills/` | Cloned skill repositories (via `skills-sync`) |
-| `contexts/` | Persisted context files per task/profile |
-| `projects/` | Bare clones added via `project add` |
+| `skills/` | Cloned skill repositories (via `orch skills sync`) |
+| `projects/` | Bare clones added via `orch project add` |
 | `worktrees/` | Agent worktrees (`<project>/<branch>/`) |
-| `.orch/` | Runtime state (pid, logs, locks, output, tool history, prompts) |
+| `state/` | Runtime state (logs, prompts, sidecar JSON, per-task output) |
+
+Per-project config lives at `{project_path}/.orch.yml` (for GitHub repo and job definitions).
 
 Source files:
 
@@ -156,20 +154,16 @@ Source files:
 |------|-------------|
 | `prompts/agent_system.md` | System prompt (workflow, rules, output format) |
 | `prompts/agent_message.md` | Task message (task details, context, memory) |
-| `prompts/agent_memory_entry.md` | Memory entry template (per-attempt learnings) |
-| `prompts/allowed_tools.md` | Tool permissions (appended to system when configured) |
 | `prompts/route.md` | Routing + profile generation prompt |
 | `prompts/review_system.md` | Review agent system prompt |
 | `prompts/review_task.md` | Review task prompt (diff, commits, criteria) |
-| `scripts/*.sh` | Orchestration commands |
-| `tests/orchestrator.bats` | Tests (bats framework) |
 
 ## How It Works
 
-1. **Add a task** to `tasks.yml` (or via `orchestrator task add`).
-2. **Route the task** with an LLM that chooses executor + builds a specialized profile and selects skills.
-3. **Run the task** with the chosen executor in agentic mode. The agent runs inside the worktree (`PROJECT_DIR`) with controlled tool access.
-4. **Output**: the agent writes results to `~/.orch/state/{repo}/tasks/{id}/attempts/{n}/output.json` and the orchestrator also writes a machine-side sidecar (`~/.orch/state/{repo}/tasks/{id}/sidecar.json`).
-5. **Review**: if enabled, a different agent reviews the PR and posts a GitHub review.
-6. **Delegation**: if the agent returns `delegations`, child tasks are created and the parent is blocked until children finish.
-7. **Error handling**: if the agent fails or returns `blocked`, the error is commented on the GitHub issue with a `blocked` label.
+1. **Add a task** via `orch task add` (or via a GitHub issue / scheduled job).
+2. **Route the task** — the LLM router chooses executor + builds a specialized profile and selects skills.
+3. **Run the task** — the chosen executor runs in agentic mode inside a tmux session in the task worktree (`PROJECT_DIR`) with controlled tool access.
+4. **Output** — the agent writes results to `~/.orch/state/{repo}/tasks/{id}/attempts/{n}/output.json`; the engine writes a sidecar (`~/.orch/state/{repo}/tasks/{id}/sidecar.json`).
+5. **Review** — if enabled, a different agent reviews the PR and posts a GitHub review comment.
+6. **Delegation** — if the agent returns `delegations`, child tasks are created and the parent is blocked until children finish.
+7. **Error handling** — if the agent fails or returns `blocked`, the error is commented on the GitHub issue with a `needs_review` label.

--- a/docs/content/workflow.md
+++ b/docs/content/workflow.md
@@ -12,16 +12,16 @@ How the orchestrator runs tasks end-to-end.
 Issue → Branch + Worktree → Agent works → Push → PR → Review Agent → Merge → Cleanup
 ```
 
-1. **Issue** — created via `orchestrator task add` or `jobs_tick`
-2. **Branch + Worktree** — orchestrator creates via `gh issue develop` + `git worktree add`
+1. **Issue** — created via `orch task add` or a scheduled job (`orch job tick`)
+2. **Branch + Worktree** — engine creates via `gh issue develop` + `git worktree add`
 3. **Agent works** — runs inside worktree, edits files, commits changes
-4. **Push** — orchestrator pushes the branch after agent finishes
+4. **Push** — engine pushes the branch after agent finishes
 5. **PR** — agent creates with `gh pr create --base main` and `Closes #N`
 6. **Review** — opposite agent reviews the PR via `gh pr review` (approve / request changes / reject)
 7. **Fix + Reply** — fix review findings, reply to each comment, resolve threads
 8. **Merge** — squash merge with conventional commit prefix (`feat:` / `fix:`)
 9. **Release** — CI auto-tags, generates changelog, creates GitHub release, updates Homebrew
-10. **Cleanup** — (TODO) orchestrator detects merged PR, removes worktree + local branch
+10. **Cleanup** — engine detects merged PR, removes worktree + local branch
 
 ## Mention-Driven Tasks
 
@@ -46,28 +46,29 @@ new → routed → in_progress → needs_review → in_review → done (merged)
                             → blocked
 ```
 
-- **new**: task created (via `add` or `jobs_tick`)
+- **new**: task created (via `orch task add` or a scheduled job)
 - **routed**: LLM router assigned agent, model, profile, skills
 - **in_progress**: agent is running
-- **done**: PR merged (or agent completed with no code changes)
-- **in_review**: review agent is actively running on the PR
-- **blocked**: agent hit a blocker or crashed (rare; human intervention needed)
 - **needs_review**: PR exists and is queued for review, or max attempts exceeded
+- **in_review**: review agent is actively running on the PR
+- **done**: PR merged (or agent completed with no code changes)
+- **blocked**: waiting on child tasks to complete
 
-## Poll Loop
+## Engine Tick
 
-`serve.sh` ticks every 10s:
+The Rust engine ticks every `engine.tick_interval` seconds (default 10s):
 
-1. `poll.sh` — finds `new`/`routed` tasks, runs them in parallel (up to `POLL_JOBS=4`)
-2. `poll.sh` — detects stuck `in_progress` tasks (no lock held, stale >30min), resets to `new`
-3. `poll.sh` — checks blocked parents: if all children are `done`, unblocks parent
-4. `jobs_tick.sh` — checks cron schedules, creates tasks for due jobs
-5. `review_prs.sh` — auto-reviews open PRs (if review agent enabled)
-6. `cleanup_worktrees.sh` — removes worktrees for merged PRs
+1. **Sync** — imports new GitHub issues, syncs labels, detects PR events (webhook or polling)
+2. **Route** — assigns agent, model, and profile to `new` tasks via LLM router
+3. **Dispatch** — launches routed tasks in tmux sessions inside worktrees
+4. **Unblock** — if all children of a blocked parent are `done`, resets parent to `new`
+5. **Review** — when a task transitions `needs_review → in_review`, launches review agent
+6. **Jobs** — runs due scheduled jobs (cron, per-project)
+7. **Recovery** — detects stuck `in_progress` tasks (no tmux session, >10 min) and resets to `new`
 
 ## Worktrees
 
-The orchestrator creates worktrees before launching agents. Agents do NOT create worktrees themselves.
+The engine creates worktrees before launching agents. Agents do NOT create worktrees themselves.
 
 **Worktree path:** `~/.orch/worktrees/<project>/<branch>/`
 
@@ -78,12 +79,12 @@ The orchestrator creates worktrees before launching agents. Agents do NOT create
 4. Agent runs inside the worktree directory (`PROJECT_DIR` is set to worktree)
 
 **After agent finishes:**
-- Orchestrator pushes the branch (`git push -u origin <branch>`) if there are unpushed commits. The runner injects `GH_TOKEN` into the spawned runner environment so agents do not need to authenticate with `gh` themselves and agents should avoid calling GitHub directly.
+- Engine pushes the branch (`git push -u origin <branch>`) if there are unpushed commits. The runner injects `GH_TOKEN` into the spawned runner environment so agents do not need to authenticate with `gh` themselves and agents should avoid calling GitHub directly.
 - Agent should NOT run `git push` itself
 
 ## Agent Invocation
 
-`run_task.sh` runs the agent:
+The Rust runner spawns the agent inside a tmux session:
 
 ```bash
 claude -p \
@@ -116,20 +117,20 @@ claude -p \
 
 After agent completion, if a PR is open and `enable_review_agent` is true:
 
-1. Status overridden to `in_review`
+1. Status transitions to `needs_review`, then `in_review` (this transition is the atomic guard)
 2. Opposite agent selected (codex wrote → claude reviews)
 3. PR diff fetched via `gh pr diff`
-4. Review agent evaluates and returns `approve`, `request_changes`, or `reject`
-5. Real GitHub PR review posted via `gh pr review`
+4. Review agent evaluates and posts a comment with `## Automated Review — Approve/Changes Requested` header
+5. CI workflow reads the review comment to determine approval
 
 See the [Review Agent](@/review-agent.md) page for full details.
 
 ## Stuck Task Recovery
 
-`poll.sh` detects stuck tasks:
+The engine detects stuck tasks:
 
-1. **No agent assigned** — task stuck `in_progress` without an agent → set to `needs_review`
-2. **Dead agent** — task has agent but no lock file and `updated_at` older than `stuck_timeout` (default 30min) → reset to `new`
+1. **No tmux session found** — task `in_progress` with no live session and age >10 min → reset to `new`
+2. **Max attempts exceeded** — task goes to `needs_review` (not `blocked`) and the forced `agent:*` label is removed so an owner can reassign or inspect the task
 
 Note: `stuck_timeout` is separate from the task execution timeout. Task execution is limited by `workflow.timeout_seconds` (or `workflow.timeout_by_complexity`), which controls how long an agent run is allowed to execute before being killed (exit 124 / TIMEOUT).
 


### PR DESCRIPTION
## Summary

- Restores docs from main that were incorrectly changed by previous agent attempts
- `_index.md`: fixes "lightweight bash orchestrator" → "Rust-based orchestrator"
- `cli.md`: restores real commands (attach, live, kill, publish, cost, get, status, stream) and removes invented commands (next, poll, agent, watch, unlock)
- `getting-started.md`, `workflow.md`: restored from main

## Code review findings

Created issue #459: **bug: tmux session names for internal tasks contain colons** — `session_name()` uses raw task_id `"internal:8"`, tmux interprets the colon as `session:window` separator, creates session as `orch-orch-internal_8`, and all subsequent `has-session` checks return false. Root cause for internal tasks always appearing stuck (confirmed with local tmux test).

Existing open issues already track:
- #452: blocked tasks trigger review agent (infinite loop)
- #448: engine health checks exclude internal tasks
- #446: task status command excludes internal tasks  
- #443: external tasks not set to NeedsReview on runner failure
- #441: unblock command ignores internal tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)