### PR TITLE
fix: abort stuck rebases and skip large-history rebases in worktree setup

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -100,6 +100,15 @@ pub async fn auto_commit(
     Ok(true)
 }
 
+/// Maximum number of commits to replay during a rebase.
+///
+/// If a branch has diverged so far from the default branch that it would
+/// require replaying more than this many commits, we skip the rebase entirely.
+/// This prevents degenerate cases (e.g. a branch forked from the very first
+/// commit that now sits 300+ commits behind main) from producing hundreds of
+/// add/add conflicts that block the agent and leave the worktree unusable.
+const MAX_REBASE_COMMITS: usize = 50;
+
 /// Rebase the current branch on the default branch.
 ///
 /// Run before the agent starts to ensure the worktree has the latest code.
@@ -115,6 +124,38 @@ pub async fn rebase_on_default(dir: &Path, default_branch: &str) {
         .current_dir(dir)
         .output_with_context()
         .await;
+
+    // Count commits that would be replayed.  If the branch diverged too far
+    // back we skip the rebase: replaying hundreds of historical commits produces
+    // massive add/add conflicts (the branch adds files that main already has)
+    // and leaves the worktree stuck.
+    let commit_count = Command::new("git")
+        .args([
+            "rev-list",
+            "--count",
+            &format!("origin/{default_branch}..HEAD"),
+        ])
+        .current_dir(dir)
+        .output_with_context()
+        .await
+        .ok()
+        .and_then(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .trim()
+                .parse::<usize>()
+                .ok()
+        })
+        .unwrap_or(0);
+
+    if commit_count > MAX_REBASE_COMMITS {
+        tracing::warn!(
+            default_branch,
+            commit_count,
+            max = MAX_REBASE_COMMITS,
+            "skipping rebase: branch has too many commits to replay safely"
+        );
+        return;
+    }
 
     let output = Command::new("git")
         .args(["rebase", &format!("origin/{default_branch}")])

--- a/src/engine/runner/worktree.rs
+++ b/src/engine/runner/worktree.rs
@@ -192,6 +192,21 @@ pub async fn setup_worktree(
         anyhow::bail!("empty branch name for task {task_id}");
     }
 
+    // Abort any in-progress rebase in an existing worktree.
+    //
+    // Agents can leave a worktree stuck mid-rebase (e.g. after running
+    // `git rebase -i` interactively).  The next dispatch attempt would
+    // inherit that broken state, causing all subsequent git operations to
+    // fail.  Aborting here is safe: if no rebase is in progress git exits
+    // with a non-zero code which we silently ignore.
+    if worktree_dir.exists() {
+        let _ = Command::new("git")
+            .args(["rebase", "--abort"])
+            .current_dir(&worktree_dir)
+            .output_with_context()
+            .await;
+    }
+
     // Create worktree if it doesn't exist
     if !worktree_dir.exists() {
         tracing::info!(task_id, worktree = %worktree_dir.display(), "creating worktree");


### PR DESCRIPTION
## Summary

Fixes two related bugs that caused worktrees to get permanently stuck in unrebaseable states (root cause of issue #469).

### Bug 1 — Stuck interactive rebase inherited by retry

Agents can run `git rebase -i` inside their worktree and exit mid-rebase (e.g. due to rate limits or auth errors). On the next dispatch attempt `setup_worktree` reuses the existing directory, inheriting the broken rebase state and failing immediately.

**Fix:** Before the agent starts, call `git rebase --abort` in any existing worktree. Non-fatal — silently ignored when no rebase is in progress.

### Bug 2 — Large-history rebase produces hundreds of add/add conflicts

Branches created from a very early fork point (e.g. the project's initial commit) cause `rebase_on_default` to replay hundreds of commits on top of main. Every file that main already added appears as an add/add conflict, making the rebase impossible and leaving the worktree unusable.

This is exactly what happened with the `internal:8` review task: its branch forked from commit `52ee82f` (initial commit) and had 349 commits to replay onto `6492b49` — resulting in add/add conflicts across all of `Cargo.toml`, `src/**`, `docs/**`, etc.

**Fix:** Count commits to replay before starting the rebase. If the count exceeds `MAX_REBASE_COMMITS` (50), skip the rebase entirely and let the agent work from its current branch state.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`

Closes #469

---
*Task #469 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*