### PR TITLE
Fix review reroute for internal tasks

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -622,8 +622,8 @@ pub(crate) async fn review_and_merge(
                     reason = %reason,
                     "no PR and no commits — re-routing for retry"
                 );
-                let _ = backend
-                    .update_status(&task.id, crate::backends::Status::New)
+                let _ = task_manager
+                    .update_task_status(&task.id, crate::backends::Status::New)
                     .await;
                 return Ok(ReviewDecision::Skipped);
             }


### PR DESCRIPTION
### Summary
- route internal tasks that have no PR/commits back through `task_manager` so the right backend handles `internal:*` IDs

### Changes
- `src/engine/review.rs`: swap the early exit inside `review_and_merge` to call `task_manager.update_task_status` instead of `backend.update_status`

### Testing
- Not run (not requested)