### PR TITLE
ci: add comments documenting purpose of each job in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Run Rust formatting, lints, and test suite with code coverage.
+  # Produces an lcov artifact and posts a coverage report on PRs.
+  # Uses cargo-llvm-cov for line/branch coverage — cheaper than tarpaulin.
   test:
     runs-on: ubuntu-latest
     steps:
@@ -59,6 +62,9 @@ jobs:
           lcov-file: lcov.info
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  # Scan the full git history for accidentally committed secrets (tokens, keys).
+  # Runs gitleaks with the project's .gitleaks.toml allowlist to suppress
+  # known false positives. fetch-depth: 0 is required for full-history scans.
   secrets:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- The `release.yml` file was already clean (no conflict markers, no duplicate jobs) — previous agents resolved those
- Added inline comments to the `test` and `secrets` jobs explaining their purpose:
  - `test`: explains cargo-llvm-cov choice vs tarpaulin, and that it posts coverage on PRs
  - `secrets`: explains the gitleaks full-history scan requirement and .gitleaks.toml allowlist

The existing job layout already satisfies all other task requirements:
- `permissions.contents: read` globally, `write` only in the `release` job
- Cross-compile (`build-macos`) and release gated on `main` + `check-release.outputs.skip == 'false'`
- Single consistent job structure (no duplicates)

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)