### PR TITLE
fix: document settled architecture on portable-pty removal

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1337,6 +1337,8 @@ Benefits: per-repo isolation (no issue number collisions), per-attempt separatio
 
 ## Key Dependencies
 
+> **Note on portable-pty:** This crate was removed in PR #420 as part of a settled architecture decision (see AGENTS.md). Agents run inside tmux sessions — tmux IS the PTY. Do not reintroduce external PTY-based runners.
+
 | Crate | Purpose | Status |
 |-------|---------|--------|
 | `tokio` | Async runtime | In use |


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #492: Adds clarifying documentation to PLAN.md about the settled architecture decision on `portable-pty` removal.

### Changes

- Added note to PLAN.md Key Dependencies section explaining that `portable-pty` was removed in PR #420
- Clarifies that tmux IS the PTY and external PTY-based runners should NOT be reintroduced
- References AGENTS.md as the source of truth for settled architecture decisions

### Related

- Review feedback on PR #492 (internal:21 task)
- Settled architecture documented in AGENTS.md
- Original removal: PR #420

## Test plan

- [x] Documentation change reviewed for accuracy
- [x] Verified portable-pty line correctly shows removed status
- [x] Confirmed this aligns with AGENTS.md settled decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)