### PR TITLE
feat: add GitHub Pages deploy step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -437,3 +437,30 @@ jobs:
           fi
           git -C tap-repo commit -m "chore: update orch formula to ${VERSION}"
           git -C tap-repo push origin main
+
+  # Build Zola docs and deploy to GitHub Pages on every push to main.
+  deploy:
+    needs: [release]
+    if: github.ref == 'refs/heads/main'
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: zola@0.22.1
+      - run: zola --root docs build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/public
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Adds a `deploy` job to `.github/workflows/release.yml` that builds the Zola docs and publishes them to GitHub Pages
- The job depends on `release` (runs after release is published), only triggers on `main`, and uses proper GitHub Pages permissions (`pages: write`, `id-token: write`)
- The `docs/` directory with Zola config already existed — no docs structure changes needed

## Test plan

- [ ] Merge to main to trigger a release; the `deploy` job should run after `release` completes
- [ ] Verify the GitHub Pages environment is enabled in repo settings (Source: GitHub Actions)
- [ ] Check that the page is live at the configured base URL after deployment

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)