### PR TITLE
fix: use configured default branch in merge-conflict rebase

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1118,10 +1118,12 @@ pub(crate) async fn auto_merge_pr(
                         worktree = %wt,
                         "attempting rebase to resolve merge conflict"
                     );
+                    let default_branch =
+                        config::get("gh.default_branch").unwrap_or_else(|_| "main".to_string());
                     let rebase_result = tokio::process::Command::new("sh")
                         .arg("-c")
                         .arg(format!(
-                            "cd '{}' && git fetch origin && git rebase origin/main && git push --force-with-lease",
+                            "cd '{}' && git fetch origin && git rebase origin/{default_branch} && git push --force-with-lease",
                             wt
                         ))
                         .output()

--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -82,8 +82,6 @@ pub async fn auto_commit(
 
     let commit_msg = format!("{title}\n\nTask #{task_id}\nAgent: {agent}\nAttempt: {attempt}");
 
-    tracing::info!(task_id, "auto-committing uncommitted changes");
-
     // git add -A
     let add = Command::new("git")
         .args(["add", "-A"])


### PR DESCRIPTION
## Summary

- **`src/engine/review.rs:1124`**: Replace hardcoded `origin/main` with `config::get("gh.default_branch")` in the merge-conflict rebase command. Every other rebase/PR operation in `review.rs` (lines 490, 532, 657) already uses this pattern — the new rebase-on-conflict code added in c62ce12 missed it. Fixes repositories where the default branch is not `main`.

- **`src/engine/runner/git_ops.rs:85`**: Remove duplicate `tracing::info!` call emitting identical "auto-committing uncommitted changes" log line twice.

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)