### PR TITLE
Throttle concurrent review agents in sync_tick to prevent API rate exhaustion

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1274,6 +1274,7 @@ Last updated: 2026-03-03 (366 tests, ~98% parity)
 | Agent memory across retries | `src/sidecar.rs` | PR #122 |
 | Self-improvement loop | `src/engine/jobs.rs` | PR #120 |
 | Polling fallback for webhooks | `src/channels/github.rs` | PR #131 |
+| Throttle concurrent review agents in sync_tick (`max_concurrent_reviews`) | `src/engine/sync.rs`, `src/engine/mod.rs` | Issue #508 |
 
 ### Remaining Gaps
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -75,6 +75,8 @@ pub struct EngineConfig {
     pub webhook_health_check_interval: Option<std::time::Duration>,
     /// Maximum parallel task executions
     pub max_parallel: usize,
+    /// Maximum concurrent review agents per sync batch (default: same as max_parallel)
+    pub max_concurrent_reviews: usize,
     /// Stuck task timeout for tasks with an active tmux session (seconds)
     pub stuck_timeout: u64,
     /// Stuck task timeout for tasks with no active tmux session (seconds).
@@ -96,6 +98,7 @@ impl Default for EngineConfig {
             sync_interval: std::time::Duration::from_secs(45),
             webhook_health_check_interval: Some(std::time::Duration::from_secs(60)),
             max_parallel: 4,
+            max_concurrent_reviews: 4,
             stuck_timeout: 1800,
             no_session_stuck_timeout: 600,
             auto_create_followup_on_changes: true,
@@ -125,6 +128,14 @@ impl EngineConfig {
         if let Ok(val) = crate::config::get("engine.max_parallel") {
             if let Ok(n) = val.parse::<usize>() {
                 config.max_parallel = n;
+                // max_concurrent_reviews defaults to max_parallel unless overridden
+                config.max_concurrent_reviews = n;
+            }
+        }
+
+        if let Ok(val) = crate::config::get("engine.max_concurrent_reviews") {
+            if let Ok(n) = val.parse::<usize>() {
+                config.max_concurrent_reviews = n;
             }
         }
 

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -19,7 +19,7 @@ use crate::sidecar::REPO_CONTEXT;
 use crate::tmux::TmuxManager;
 use std::sync::Arc;
 use tokio::process::Command;
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, Semaphore};
 
 use super::cleanup::{check_merged_prs, cleanup_done_worktrees};
 use super::review::{review_and_merge, review_open_prs, ReviewDecision};
@@ -91,6 +91,9 @@ pub(crate) async fn sync_tick(
             }
         }
 
+        // Semaphore to cap concurrent review agents — prevents thundering herd when
+        // the backlog is large (e.g. 79 tasks all firing ~300+ GitHub API calls at once).
+        let review_sem = Arc::new(Semaphore::new(config.max_concurrent_reviews.max(1)));
         for task in needs_review_tasks {
             let task_id = &task.id.0;
             tracing::info!(task_id, "triggering review agent for needs_review task");
@@ -110,7 +113,12 @@ pub(crate) async fn sync_tick(
             let repo_s = repo.to_string();
             let router_c = router.clone();
             let repo_ctx = repo_s.clone();
+            let sem_c = review_sem.clone();
             tokio::spawn(REPO_CONTEXT.scope(repo_ctx, async move {
+                // Acquire permit before running the review agent.
+                // This is held for the duration of the task so only
+                // max_concurrent_reviews agents run simultaneously.
+                let _permit = sem_c.acquire_owned().await;
                 let tid = task_c.id.0.clone();
                 let needs_reset = match review_and_merge(
                     &task_c,


### PR DESCRIPTION
## Summary

Done. Here's a summary of the changes:

**`src/engine/mod.rs`**
- Added `max_concurrent_reviews: usize` field to `EngineConfig` (default: 4, matching `max_parallel`)
- In `from_config()`: when `engine.max_parallel` is set, `max_concurrent_reviews` defaults to the same value; a separate `engine.max_concurrent_reviews` key can override it independently

**`src/engine/sync.rs`**
- Added `Semaphore` to imports
- Before the review spawning loop, creates `Arc<Semaphore::new(config.max_concurrent_reviews.max(1))>`
- Each spawned task acquires an owned permit before calling `review_and_merge`, limiting concurrent reviews to N at a time

With the default of 4, a backlog of 79 `needs_review` tasks will drain at 4 concurrent agents rather than all 79 at once, preventing the thundering herd and GitHub API rate exhaustion.

---
*Task #508 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*