### PR TITLE
Fix review feedback: throttle review agents in sync tick

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -679,6 +679,7 @@ Before any Rust work, the current bash version needs to be rock-solid. This give
 - [x] Internal tasks design — implemented (SQLite + engine integration)
 - [x] Weighted round-robin for agent routing — PR #94 merged
 - [x] Worktree cleanup for stuck/failed tasks — implemented in sync_tick
+- [x] Throttle review agent spawns in sync_tick — semaphore guard to avoid API bursts
 
 ### Metrics to Collect Before v1
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -832,7 +832,7 @@ pub async fn serve() -> anyhow::Result<()> {
                         for engine in &project_engines {
                             let repo = engine.repo.clone();
                             REPO_CONTEXT.scope(repo, async {
-                                if let Err(e) = sync::sync_tick(&engine.backend, &tmux, &engine.repo, &db, &config, &router, &engine.task_manager).await {
+                                if let Err(e) = sync::sync_tick(&engine.backend, &tmux, &engine.repo, &db, &config, &semaphore, &router, &engine.task_manager).await {
                                     tracing::error!(repo = %engine.repo, ?e, "sync tick failed for project");
                                 }
                             }).await;

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -20,6 +20,7 @@ use crate::tmux::TmuxManager;
 use std::sync::Arc;
 use tokio::process::Command;
 use tokio::sync::RwLock;
+use tokio::sync::Semaphore;
 
 use super::cleanup::{check_merged_prs, cleanup_done_worktrees};
 use super::review::{review_and_merge, review_open_prs, ReviewDecision};
@@ -31,12 +32,14 @@ use super::EngineConfig;
 /// - Cleanup finished worktrees
 /// - Check for merged PRs → mark tasks done
 /// - Scan for @mentions
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn sync_tick(
     backend: &Arc<dyn ExternalBackend>,
     tmux: &Arc<TmuxManager>,
     repo: &str,
     db: &Arc<Db>,
     config: &EngineConfig,
+    semaphore: &Arc<Semaphore>,
     router: &Arc<RwLock<Router>>,
     task_manager: &Arc<TaskManager>,
 ) -> anyhow::Result<()> {
@@ -94,6 +97,13 @@ pub(crate) async fn sync_tick(
         for task in needs_review_tasks {
             let task_id = &task.id.0;
             tracing::info!(task_id, "triggering review agent for needs_review task");
+            let permit = match semaphore.clone().try_acquire_owned() {
+                Ok(p) => p,
+                Err(_) => {
+                    tracing::debug!("all parallel slots busy, skipping remaining review tasks");
+                    break;
+                }
+            };
             // Transition to InReview — this IS the atomic guard against duplicates.
             // For internal tasks, task_manager routes to SQLite; for external to GitHub labels.
             if let Err(e) = task_manager
@@ -101,6 +111,7 @@ pub(crate) async fn sync_tick(
                 .await
             {
                 tracing::warn!(task_id, err = %e, "failed to transition to InReview");
+                drop(permit);
                 continue;
             }
             let backend_c = backend.clone();
@@ -150,6 +161,8 @@ pub(crate) async fn sync_tick(
                         reset_to_needs_review_with_retry(&backend_c, &tid).await;
                     }
                 }
+
+                drop(permit);
             }));
         }
 


### PR DESCRIPTION
Summary:
Adds semaphore-based throttling for review agent spawns in `sync_tick` so catch-up reviews respect the global parallel limit and avoid API bursts. The review gate only transitions to `in_review` after acquiring a permit, releasing it when the review finishes. Records the change in the project plan.

### Changes
- `src/engine/sync.rs`: add a semaphore guard around review-agent spawning and release permits after completion.
- `src/engine/mod.rs`: pass the global semaphore into `sync_tick`.
- `PLAN.md`: note the sync tick review throttling.
