### PR TITLE
feat(cli): show agent output in orch task logs

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1374,6 +1374,7 @@ Benefits: per-repo isolation (no issue number collisions), per-attempt separatio
 
 | Issue | Title | Description |
 |-------|-------|-------------|
+| #509 | Show agent output in `orch task logs` | `orch task logs <id>` now displays agent output from `output.json` (last 2000 chars via `safe_utf8_tail`), exit code from `exit.txt`, and review agent output from `{task_id}-review/attempts/1/output.json` — `src/cli/task.rs:803-860` |
 | #361 | PR coverage comments | `romeovs/lcov-reporter-action@v0.4.0` comments coverage % on each PR — `.github/workflows/release.yml:52-57` |
 | #230 | Break `tick()` into named phases | Extracted 4-5 phases of the `tick()` function into independent methods. |
 | #144 | Cost Tracking CLI and Budget Enforcement | `orch cost` command in `src/cli/cost.rs` — per-task and aggregate cost reporting |

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -5,6 +5,7 @@ use crate::config;
 use crate::engine::router::Router;
 use crate::engine::runner::TaskRunner;
 use crate::engine::tasks::{parse_internal_id, CreateTaskRequest, Task, TaskFilter, TaskType};
+use crate::home;
 use crate::sidecar;
 use crate::tmux::TmuxManager;
 use anyhow::Context;
@@ -800,9 +801,63 @@ pub async fn logs(id: &str) -> anyhow::Result<()> {
         }
     }
 
+    // Show agent output from last attempt if available
+    let repo = config::get_current_repo().unwrap_or_default();
+    if let Ok(attempts_str) = sidecar::get(&sidecar_key, "attempts") {
+        if let Ok(attempt_n) = attempts_str.parse::<u32>() {
+            if attempt_n > 0 {
+                match home::task_attempt_dir(&repo, &sidecar_key, attempt_n) {
+                    Ok(attempt_dir) => {
+                        let output_file = attempt_dir.join("output.json");
+                        let exit_file = attempt_dir.join("exit.txt");
+
+                        if output_file.exists() {
+                            if let Ok(content) = std::fs::read_to_string(&output_file) {
+                                let tail = crate::engine::runner::response_handler::safe_utf8_tail(
+                                    &content, 2000,
+                                );
+                                let truncated = if content.len() > 2000 {
+                                    format!(
+                                        "...({} chars truncated)...\n{}",
+                                        content.len() - tail.len(),
+                                        tail
+                                    )
+                                } else {
+                                    content.clone()
+                                };
+                                println!("\n--- Last attempt output (attempt {}) ---", attempt_n);
+                                println!("{}", truncated);
+                            }
+                        }
+
+                        if exit_file.exists() {
+                            if let Ok(exit_code) = std::fs::read_to_string(&exit_file) {
+                                println!("Exit code: {}", exit_code.trim());
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        println!("(could not resolve attempt dir: {})", e);
+                    }
+                }
+            }
+        }
+    }
+
+    // Show review agent output if available
+    let review_task_id = format!("{}-review", sidecar_key);
+    if let Ok(review_attempt_dir) = home::task_attempt_dir(&repo, &review_task_id, 1) {
+        let review_output_file = review_attempt_dir.join("output.json");
+        if review_output_file.exists() {
+            if let Ok(content) = std::fs::read_to_string(&review_output_file) {
+                println!("\n--- Review agent output ---");
+                println!("{}", content);
+            }
+        }
+    }
+
     // If tmux session is live, append recent pane capture
     let tmux = TmuxManager::new();
-    let repo = config::get_current_repo().unwrap_or_default();
     let session = tmux.session_name(&repo, &sidecar_key);
     if tmux.session_exists(&session).await {
         println!(


### PR DESCRIPTION
## Summary

- `orch task logs <id>` now displays agent output from `output.json` (last 2000 chars), exit code from `exit.txt`, and review agent output from `{task_id}-review/attempts/1/output.json`
- Fixes UTF-8 truncation: uses `safe_utf8_tail` from `response_handler` instead of raw byte slice indexing (which could panic at multi-byte char boundaries)
- No scope creep: only `src/cli/task.rs` and `PLAN.md` are changed

Closes #509

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)