### PR TITLE
perf: replace 7 sequential SQLite queries with one in scan_mentions

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -302,23 +302,13 @@ async fn scan_mentions(backend: &Arc<dyn ExternalBackend>, db: &Arc<Db>) -> anyh
     // Get existing mention tasks across ALL statuses to avoid duplicates.
     // Only checking New status would miss tasks that progressed to InProgress/Done,
     // causing duplicate tasks on the next sync tick within the 24h window.
-    let mut existing_mentions = std::collections::HashSet::new();
-    for status in &[
-        TaskStatus::New,
-        TaskStatus::InProgress,
-        TaskStatus::Done,
-        TaskStatus::Blocked,
-        TaskStatus::Routed,
-        TaskStatus::InReview,
-        TaskStatus::NeedsReview,
-    ] {
-        let tasks = db.list_internal_tasks_by_status(*status).await?;
-        for t in tasks {
-            if t.source == "mention" {
-                existing_mentions.insert(t.source_id.clone());
-            }
-        }
-    }
+    let existing_mentions: std::collections::HashSet<String> = db
+        .list_all_internal_tasks()
+        .await?
+        .into_iter()
+        .filter(|t| t.source == "mention")
+        .map(|t| t.source_id.clone())
+        .collect();
 
     for mention in mentions {
         // Skip if already processed


### PR DESCRIPTION
## Summary

- `scan_mentions` in `src/engine/sync.rs` looped over all 7 `TaskStatus` variants, calling `db.list_internal_tasks_by_status()` once per variant — 7 round-trips to SQLite per sync tick (~45s interval)
- Replace with a single `db.list_all_internal_tasks()` call (one SQL query, no WHERE clause) and filter in Rust
- Also eliminates fragility: any future `TaskStatus` variant would silently miss dedup with the old approach

## Test plan
- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)