### PR TITLE
Fix review feedback: CI-safe integration agent test handling

### DIFF
--- a/tests/integration_agents.rs
+++ b/tests/integration_agents.rs
@@ -81,6 +81,46 @@ fn assert_ndjson(stdout: &str) -> Vec<serde_json::Value> {
     events
 }
 
+fn codex_completed_with_benign_shutdown_error(events: &[serde_json::Value]) -> bool {
+    let has_agent_message = events.iter().any(|e| {
+        e.get("type").and_then(|v| v.as_str()) == Some("item.completed")
+            && e.get("item")
+                .and_then(|i| i.get("type"))
+                .and_then(|v| v.as_str())
+                == Some("agent_message")
+    });
+
+    let has_turn_completed = events
+        .iter()
+        .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("turn.completed"));
+
+    let has_only_benign_error = events.iter().all(|e| {
+        if e.get("type").and_then(|v| v.as_str()) != Some("error") {
+            return true;
+        }
+        e.get("message").and_then(|v| v.as_str()) == Some("Failed to shutdown rollout recorder")
+    });
+
+    has_agent_message && has_turn_completed && has_only_benign_error
+}
+
+fn kimi_has_quota_error(stdout: &str) -> bool {
+    let Ok(val) = serde_json::from_str::<serde_json::Value>(stdout.trim()) else {
+        return false;
+    };
+
+    let is_error = val
+        .get("is_error")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let result = val.get("result").and_then(|v| v.as_str()).unwrap_or("");
+
+    is_error
+        && (result.contains("\"type\":\"permission_error\"")
+            || result.contains("usage limit")
+            || result.contains("quota"))
+}
+
 // ── Claude ────────────────────────────────────────────────────────
 
 #[test]
@@ -208,10 +248,14 @@ fn codex_responds_with_ndjson() {
         &stderr[..stderr.len().min(500)]
     );
 
+    let events = assert_ndjson(&stdout);
+    if !output.status.success() && codex_completed_with_benign_shutdown_error(&events) {
+        eprintln!("SKIP: codex exited non-zero due benign rollout recorder shutdown error");
+        return;
+    }
+
     assert!(output.status.success(), "codex failed: {stderr}");
     assert!(!stdout.is_empty(), "codex returned empty stdout");
-
-    let events = assert_ndjson(&stdout);
 
     // Check for error events
     let errors: Vec<_> = events
@@ -280,9 +324,29 @@ fn codex_stdin_pipe_mode() {
         &stderr[..stderr.len().min(500)]
     );
 
+    let events = assert_ndjson(&stdout);
+    if !output.status.success() && codex_completed_with_benign_shutdown_error(&events) {
+        eprintln!("SKIP: codex stdin exited non-zero due benign rollout recorder shutdown error");
+        return;
+    }
+
     assert!(output.status.success(), "codex stdin failed: {stderr}");
     assert!(!stdout.is_empty(), "codex stdin returned empty stdout");
-    assert_ndjson(&stdout);
+
+    // Parse again to keep parity with non-stdin test behavior.
+    let errors: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            let t = e.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            t == "error" || t == "turn.failed"
+        })
+        .collect();
+    if !errors.is_empty() {
+        for err in &errors {
+            eprintln!("  ERROR EVENT: {err}");
+        }
+        panic!("codex stdin returned error events");
+    }
 }
 
 // ── OpenCode ──────────────────────────────────────────────────────
@@ -314,6 +378,11 @@ fn opencode_responds_with_ndjson() {
         stderr.len(),
         &stderr[..stderr.len().min(500)]
     );
+
+    if !output.status.success() && stderr.contains("attempt to write a readonly database") {
+        eprintln!("SKIP: opencode database path is readonly in this environment");
+        return;
+    }
 
     assert!(output.status.success(), "opencode failed: {stderr}");
     assert!(!stdout.is_empty(), "opencode returned empty stdout");
@@ -361,6 +430,11 @@ fn opencode_with_permission_config_succeeds() {
         stderr.len(),
         &stderr[..stderr.len().min(500)]
     );
+
+    if !output.status.success() && stderr.contains("attempt to write a readonly database") {
+        eprintln!("SKIP: opencode database path is readonly in this environment");
+        return;
+    }
 
     assert!(
         output.status.success(),
@@ -424,6 +498,11 @@ fn kimi_responds_like_claude() {
         stderr.len(),
         &stderr[..stderr.len().min(500)]
     );
+
+    if !output.status.success() && kimi_has_quota_error(&stdout) {
+        eprintln!("SKIP: kimi account quota/permission limit in this environment");
+        return;
+    }
 
     assert!(output.status.success(), "kimi failed: {stderr}");
     assert!(!stdout.is_empty(), "kimi returned empty stdout");


### PR DESCRIPTION
## Summary
This PR addresses the requested review follow-up by making `tests/integration_agents.rs` resilient to known environment constraints that are not product regressions. The tests now explicitly detect and skip sandbox/quota-related failures while still asserting real agent-output correctness. This keeps the integration suite useful without causing CI noise from external tooling/account limitations.

### Changes
- Added Codex-specific handling for benign non-zero exits where NDJSON output shows a completed turn and only the known rollout-recorder shutdown error.
- Added OpenCode skip handling for readonly database environments (`attempt to write a readonly database`).
- Added Kimi skip handling for quota/permission-limit responses (403/usage limit envelope).
- Preserved strict failure behavior for other errors and for output-shape regressions.

### Files Modified
- `tests/integration_agents.rs`
  - Added helper functions to classify environment-only failures.
  - Updated Codex, OpenCode, and Kimi integration tests to use targeted skip logic.

### Design Notes
- The skip paths are narrow and signature-based to avoid masking legitimate failures.
- The tests still parse and validate agent output before allowing a skip where possible (Codex path), preserving behavioral coverage.
