### PR TITLE
fix: correct SCHEMA_V4 backfill order; classify needs_review-with-PR as success

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -144,6 +144,11 @@ impl Db {
             conn.pragma_update(None, "user_version", 3)?;
         }
 
+        if version < 4 {
+            conn.execute_batch(SCHEMA_V4)?;
+            conn.pragma_update(None, "user_version", 4)?;
+        }
+
         Ok(())
     }
 
@@ -809,6 +814,31 @@ ALTER TABLE task_metrics ADD COLUMN output_tokens INTEGER DEFAULT NULL;
 ALTER TABLE task_metrics ADD COLUMN input_cost_usd REAL DEFAULT NULL;
 ALTER TABLE task_metrics ADD COLUMN output_cost_usd REAL DEFAULT NULL;
 ALTER TABLE task_metrics ADD COLUMN total_cost_usd REAL DEFAULT NULL;
+"#;
+
+/// Schema v4 — fix corrupt/non-RFC3339 timestamps in internal_tasks.
+///
+/// Some rows were inserted with NULL, empty, or SQLite-default format
+/// ("YYYY-MM-DD HH:MM:SS" without T/Z) that fails chrono::parse_from_rfc3339.
+/// Backfill order matters: convert space-formatted timestamps first, then
+/// backfill created_at (so it is non-NULL), then set updated_at = created_at
+/// for rows where updated_at is still NULL/empty.
+const SCHEMA_V4: &str = r#"
+UPDATE internal_tasks
+SET updated_at = substr(updated_at, 1, 10) || 'T' || substr(updated_at, 12, 8) || 'Z'
+WHERE updated_at IS NOT NULL AND updated_at != '' AND updated_at NOT LIKE '%T%';
+
+UPDATE internal_tasks
+SET created_at = substr(created_at, 1, 10) || 'T' || substr(created_at, 12, 8) || 'Z'
+WHERE created_at IS NOT NULL AND created_at != '' AND created_at NOT LIKE '%T%';
+
+UPDATE internal_tasks
+SET created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE created_at IS NULL OR created_at = '';
+
+UPDATE internal_tasks
+SET updated_at = created_at
+WHERE updated_at IS NULL OR updated_at = '';
 "#;
 
 #[cfg(test)]

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -275,7 +275,10 @@ impl TaskRunner {
             "new" => "rerouted",
             "needs_review" => {
                 let last_error = error_type.unwrap_or("");
-                if last_error.contains("timeout") {
+                if last_error.is_empty() {
+                    // No error: agent completed successfully and created a PR waiting for review
+                    "success"
+                } else if last_error.contains("timeout") {
                     "timeout"
                 } else if last_error.contains("rate limit") || last_error.contains("usage") {
                     "rate_limit"


### PR DESCRIPTION
## Summary

Addresses review feedback on PR #529.

### Bug fix: SCHEMA_V4 migration order (`src/db.rs`)

The original SCHEMA_V4 ran:
1. Convert space-format `updated_at` → RFC3339
2. Convert space-format `created_at` → RFC3339
3. `SET updated_at = created_at` WHERE `updated_at IS NULL OR ''`
4. `SET created_at = now()` WHERE `created_at IS NULL OR ''`

When **both** `created_at` and `updated_at` were NULL/empty, step 3 set `updated_at = NULL` (copying the NULL), then step 4 fixed `created_at`. Result: `updated_at` stayed NULL, causing corrupt rows and RFC3339 parse failures on every tick.

**Fix**: swap steps 3 and 4 — backfill `created_at` first, then copy it to `updated_at`.

### Also included: metrics outcome fix (`src/engine/runner/mod.rs`)

From the original PR #529: classify `needs_review` with no error as `"success"` instead of falling through to `"failed"`. Tasks that create a PR go `in_progress → needs_review` — they are successful completions, not failures.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)