### PR TITLE
feat(cli): show agent in task list and live views

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1375,6 +1375,7 @@ Benefits: per-repo isolation (no issue number collisions), per-attempt separatio
 
 | Issue | Title | Description |
 |-------|-------|-------------|
+| - | Agent column in `orch task list` and `orch task live` | `orch task list` now shows AGENT column (from struct for internal tasks, from sidecar for external); blocked internal tasks show inline block reason; `orch task live` now shows agent from sidecar — `src/cli/task.rs:15-65, 545-580` |
 | #509 | Show agent output in `orch task logs` | `orch task logs <id>` now displays agent output from `output.json` (last 2000 chars via `safe_utf8_tail`), exit code from `exit.txt`, and review agent output from `{task_id}-review/attempts/1/output.json` — `src/cli/task.rs:803-860` |
 | #361 | PR coverage comments | `romeovs/lcov-reporter-action@v0.4.0` comments coverage % on each PR — `.github/workflows/release.yml:52-57` |
 | #230 | Break `tick()` into named phases | Extracted 4-5 phases of the `tick()` function into independent methods. |

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -22,8 +22,11 @@ pub async fn list(status: Option<String>, source: Option<String>) -> anyhow::Res
         return Ok(());
     }
 
-    println!("{:<10} {:<12} {:<20} TITLE", "ID", "TYPE", "STATUS");
-    println!("{}", "-".repeat(80));
+    println!(
+        "{:<15} {:<12} {:<20} {:<10} TITLE",
+        "ID", "TYPE", "STATUS", "AGENT"
+    );
+    println!("{}", "-".repeat(90));
 
     for task in tasks {
         match task {
@@ -34,18 +37,30 @@ pub async fn list(status: Option<String>, source: Option<String>) -> anyhow::Res
                     .find(|l| l.starts_with("status:"))
                     .map(|s| s.replace("status:", ""))
                     .unwrap_or_else(|| "unknown".to_string());
+                let agent = sidecar::get(&ext.id.0, "agent").unwrap_or_default();
                 println!(
-                    "{:<10} {:<12} {:<20} {}",
-                    ext.id.0, "external", status, ext.title
+                    "{:<15} {:<12} {:<20} {:<10} {}",
+                    ext.id.0, "external", status, agent, ext.title
                 );
             }
             Task::Internal(int) => {
+                let agent = int.agent.as_deref().unwrap_or("-");
+                let title = if int.status == crate::db::TaskStatus::Blocked {
+                    if let Some(ref reason) = int.block_reason {
+                        format!("{} [blocked: {}]", int.title, reason)
+                    } else {
+                        int.title.clone()
+                    }
+                } else {
+                    int.title.clone()
+                };
                 println!(
-                    "{:<10} {:<12} {:<20} {}",
-                    int.id,
+                    "{:<15} {:<12} {:<20} {:<10} {}",
+                    format!("internal:{}", int.id),
                     "internal",
                     int.status.as_str(),
-                    int.title
+                    agent,
+                    title
                 );
             }
         }
@@ -551,15 +566,17 @@ pub async fn live() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    println!("{:<20} {:<12} {:<10} CREATED", "SESSION", "TASK", "ACTIVE");
-    println!("{}", "-".repeat(60));
+    println!("{:<30} {:<15} {:<10} ACTIVE", "SESSION", "TASK", "AGENT");
+    println!("{}", "-".repeat(70));
 
     for session in &sessions {
         let active = tmux.is_session_active(&session.name).await;
+        let agent = sidecar::get(&session.task_id, "agent").unwrap_or_default();
         println!(
-            "{:<20} {:<12} {}",
+            "{:<30} {:<15} {:<10} {}",
             session.name,
             session.task_id,
+            agent,
             if active { "yes" } else { "no" },
         );
     }


### PR DESCRIPTION
## Summary

- `orch task list` now shows an **AGENT** column alongside ID, TYPE, STATUS, TITLE
  - Internal tasks: agent read directly from `InternalTask.agent` (zero-cost, already in struct)
  - External tasks: agent read from sidecar (local file read, same pattern as dashboard)
  - Blocked internal tasks show inline block reason: `title [blocked: reason]`
- `orch task live` now shows **AGENT** column from sidecar, matching the dashboard's existing pattern

## Before / After

**Before `orch task list`:**
```
ID         TYPE         STATUS               TITLE
--------------------------------------------------------------------------------
42         external     in_progress          Fix auth bug
5          internal     in_progress          Update docs
```

**After `orch task list`:**
```
ID              TYPE         STATUS               AGENT      TITLE
------------------------------------------------------------------------------------------
42              external     in_progress          claude     Fix auth bug
internal:5      internal     in_progress          codex      Update docs
```

## Motivation

Without the agent column, you had to run `orch task logs <id>` just to see which agent is handling a task. This change makes the most common inspection workflow one command instead of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)