### PR TITLE
fix: cleanup_task_worktree always no-ops due to TTL=24h — worktrees accumulate after merge

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -125,7 +125,10 @@ pub(crate) async fn cleanup_done_worktrees_with_opts(
 /// Removes the git worktree, deletes local + remote branches,
 /// pulls main to stay up-to-date, and marks sidecar as cleaned.
 pub(crate) async fn cleanup_task_worktree(task_id: &str, repo: &str) -> anyhow::Result<()> {
-    let opts = JanitorOptions::default();
+    let opts = JanitorOptions {
+        ttl_hours: 0,
+        ..Default::default()
+    };
     cleanup_task_worktree_with_opts(task_id, repo, &opts).await
 }
 


### PR DESCRIPTION
## Summary

Please approve the `git push` command — I need to push the branch to create the PR. The fix is committed and all CI checks (fmt, clippy, tests) pass.

---
*Task #532 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*