### PR TITLE
fix: review gate loops indefinitely when auto-PR creation fails

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -25,6 +25,9 @@ use super::router::Router;
 use super::tasks::TaskManager;
 use super::EngineConfig;
 
+/// Maximum consecutive PR-creation failures before blocking the task.
+const MAX_PR_CREATE_FAILURES: u64 = 3;
+
 /// Review agent decision result.
 #[derive(Debug, Clone)]
 pub(crate) enum ReviewDecision {
@@ -37,6 +40,8 @@ pub(crate) enum ReviewDecision {
     },
     /// Review agent failed or crashed (reason stored for logging).
     Failed(String),
+    /// Unrecoverable failure — task should be blocked for human intervention.
+    Blocked(String),
     /// No PR exists — nothing to review, task marked done directly.
     Skipped,
 }
@@ -619,6 +624,17 @@ pub(crate) async fn review_and_merge(
                                     stderr = %stderr,
                                     "failed to create missing PR — work may be stuck"
                                 );
+                                let failures = sidecar::get_u64(&task.id.0, "pr_create_failures")
+                                    .saturating_add(1);
+                                let _ = sidecar::set(
+                                    &task.id.0,
+                                    &[format!("pr_create_failures={failures}")],
+                                );
+                                if failures >= MAX_PR_CREATE_FAILURES {
+                                    return Ok(ReviewDecision::Blocked(format!(
+                                        "no PR, create failed {failures} times: {stderr}"
+                                    )));
+                                }
                                 return Ok(ReviewDecision::Failed(format!(
                                     "no PR, create failed: {stderr}"
                                 )));
@@ -629,6 +645,17 @@ pub(crate) async fn review_and_merge(
                                     error = %e,
                                     "failed to run gh pr create"
                                 );
+                                let failures = sidecar::get_u64(&task.id.0, "pr_create_failures")
+                                    .saturating_add(1);
+                                let _ = sidecar::set(
+                                    &task.id.0,
+                                    &[format!("pr_create_failures={failures}")],
+                                );
+                                if failures >= MAX_PR_CREATE_FAILURES {
+                                    return Ok(ReviewDecision::Blocked(format!(
+                                        "no PR, gh error {failures} times: {e}"
+                                    )));
+                                }
                                 return Ok(ReviewDecision::Failed(format!("no PR, gh error: {e}")));
                             }
                         }

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -123,7 +123,12 @@ pub(crate) async fn sync_tick(
             let repo_ctx = repo_s.clone();
             tokio::spawn(REPO_CONTEXT.scope(repo_ctx, async move {
                 let tid = task_c.id.0.clone();
-                let needs_reset = match review_and_merge(
+                enum ReviewOutcome {
+                    Reset,
+                    Block,
+                    Ok,
+                }
+                let outcome = match review_and_merge(
                     &task_c,
                     &backend_c,
                     &tmux_c,
@@ -133,33 +138,47 @@ pub(crate) async fn sync_tick(
                 )
                 .await
                 {
+                    Ok(ReviewDecision::Blocked(reason)) => {
+                        tracing::error!(
+                            task_id = tid,
+                            reason,
+                            "review gate blocked after repeated failures — marking task blocked"
+                        );
+                        ReviewOutcome::Block
+                    }
                     Ok(ReviewDecision::Failed(reason)) => {
                         tracing::error!(
                             task_id = tid,
                             reason,
                             "review agent failed — resetting to NeedsReview for retry"
                         );
-                        true
+                        ReviewOutcome::Reset
                     }
                     Err(e) => {
                         tracing::error!(
                             task_id = tid, error = %e,
                             "review_and_merge failed — resetting to NeedsReview for retry"
                         );
-                        true
+                        ReviewOutcome::Reset
                     }
-                    Ok(_) => false,
+                    Ok(_) => ReviewOutcome::Ok,
                 };
-                if needs_reset {
-                    if tid.starts_with("internal:") {
-                        // Internal tasks: update SQLite via task_manager.
-                        let _ = task_manager_c
-                            .update_task_status(&ExternalId(tid.clone()), Status::NeedsReview)
-                            .await;
-                    } else {
-                        // External tasks: retry with backoff.
-                        reset_to_needs_review_with_retry(&backend_c, &tid).await;
+                match outcome {
+                    ReviewOutcome::Reset => {
+                        if tid.starts_with("internal:") {
+                            let _ = task_manager_c
+                                .update_task_status(&ExternalId(tid.clone()), Status::NeedsReview)
+                                .await;
+                        } else {
+                            reset_to_needs_review_with_retry(&backend_c, &tid).await;
+                        }
                     }
+                    ReviewOutcome::Block => {
+                        let _ = task_manager_c
+                            .update_task_status(&ExternalId(tid.clone()), Status::Blocked)
+                            .await;
+                    }
+                    ReviewOutcome::Ok => {}
                 }
 
                 drop(permit);

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -491,6 +491,19 @@ pub(crate) async fn tick_dispatch_tasks(
                                         )
                                         .await
                                         {
+                                            Ok(ReviewDecision::Blocked(reason)) => {
+                                                tracing::error!(
+                                                    task_id = task_id_for_review,
+                                                    reason,
+                                                    "review gate blocked after repeated failures — marking task blocked"
+                                                );
+                                                let _ = task_manager_for_review
+                                                    .update_task_status(
+                                                        &ExternalId(task_id_for_review.clone()),
+                                                        Status::Blocked,
+                                                    )
+                                                    .await;
+                                            }
                                             Ok(ReviewDecision::Failed(reason)) => {
                                                 tracing::error!(
                                                     task_id = task_id_for_review,


### PR DESCRIPTION
## Summary

The commit is ready locally. Please approve the push to send it to remote.

Here's a summary of what was done:

**Changes:**

- **`src/engine/review.rs`**: Added `MAX_PR_CREATE_FAILURES = 3` constant and a new `ReviewDecision::Blocked(String)` variant. In the two PR creation failure paths (bad exit code + I/O error), the code now reads `pr_create_failures` from the sidecar, increments it, writes it back, and returns `Blocked` once the threshold is reached.

- **`src/engine/tick.rs`**: Added a `ReviewDecision::Blocked` arm that sets `Status::Blocked` instead of resetting to `NeedsReview`.

- **`src/engine/sync.rs`**: Replaced the `bool` `needs_reset` pattern with a tri-state `ReviewOutcome` enum (`Reset`/`Block`/`Ok`) so `Blocked` decisions also set `Status::Blocked` here.

The loop `needs_review → in_review → Failed → needs_review` now breaks after 3 failures and surfaces the task as `blocked` for human intervention.

---
*Task #536 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*