### PR TITLE
fix: blocked task reset to NeedsReview when auto_merge_pr returns Err

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1148,7 +1148,8 @@ pub(crate) async fn auto_merge_pr(
                         &format!("{}{}", comment, footer),
                     )
                     .await;
-                return Err(e);
+                // Task is already Blocked — return Ok so the caller does not reset to NeedsReview.
+                return Ok(());
             }
 
             // Try rebase in the worktree
@@ -1192,7 +1193,8 @@ pub(crate) async fn auto_merge_pr(
                                 task_manager
                                     .update_task_status(&task.id, Status::Blocked)
                                     .await?;
-                                return Err(merge_err);
+                                // Task is already Blocked — return Ok so the caller does not reset to NeedsReview.
+                                return Ok(());
                             }
                             // Merge succeeded after rebase — fall through to done
                             task_manager


### PR DESCRIPTION
## Summary

Please approve the `git push` to push the fix to the remote branch. The change is committed locally at `be656a5`.

**Summary of the fix:**

In `src/engine/review.rs`, both intentional-block paths in `auto_merge_pr` were returning `Err` after already setting the task to `Blocked`. This caused `sync.rs` to unconditionally reset the status back to `NeedsReview`, creating an infinite review loop.

Changed both `return Err(...)` → `return Ok(())` at:
- Line 1151: retry limit exceeded path  
- Line 1195: post-rebase merge still failing path

---
*Task #539 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*