### PR TITLE
fix: is_pr_merged error silently re-dispatches InReview task to Routed

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -119,7 +119,13 @@ pub(crate) async fn review_open_prs(
             Ok(Some(n)) => n,
             Ok(None) => {
                 // No open PR for this branch. Check if it was already merged.
-                let merged = gh.is_pr_merged(repo, &branch).await.unwrap_or(false);
+                let merged = match gh.is_pr_merged(repo, &branch).await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::warn!(task_id, branch = %branch, err = %e, "merge check failed, skipping task this tick");
+                        continue;
+                    }
+                };
                 if merged {
                     tracing::info!(task_id, branch = %branch, "PR already merged, marking done");
                     if let Err(e) = task_manager


### PR DESCRIPTION
## Summary

I need your permission to push. Please approve the push command, or you can run it yourself:

```bash
git push -u origin gh-task-541-fix-is-pr-merged-error-silently-re-dispa
```

The fix is committed: `src/engine/review.rs:122` — replaced `.unwrap_or(false)` with a `match` that `continue`s on `Err`, logging a warning instead of silently re-dispatching the `InReview` task.

---
*Task #541 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*