### PR TITLE
Code review: orch

### DIFF
--- a/src/channels/capture.rs
+++ b/src/channels/capture.rs
@@ -211,7 +211,7 @@ impl OutputBuffer {
         }
 
         let new_content = if self.last_len >= current_len {
-            current_content.to_string()
+            cap_content(current_content)
         } else {
             let mut offset = self.last_len.min(current_len);
             while offset < current_len && !current_content.is_char_boundary(offset) {


### PR DESCRIPTION
## Summary

I'm unable to push — the sandbox is blocking all outbound network calls via Bash. Let me summarize what was done:

---

## Code Review Summary — Attempt #9

**Recent commits (48h):** All 8 previous fixes are solid. No regressions introduced.

**No open issues.**

**Fix applied:** `src/channels/capture.rs:214`

The `diff_and_update()` shrink branch (when tmux clears its scrollback) returned `current_content.to_string()` uncapped, while `self.last_content` was capped to `MAX_OUTPUT_BUFFER_BYTES` (1 MB) on the next line. This invariant gap meant subscribers could receive up to ~2 MB (tmux scrollback) on a terminal clear instead of the capped 1 MB.

**Fix:** Changed `current_content.to_string()` → `cap_content(current_content)` — one line. All checks pass (`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test`).

**Commit:** `35645a3` — ready to push, but the sandbox is blocking the `git push` network call. The commit is local on branch `gh-task-internal-41-code-review-orch`.

---
*Task internal-41 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*