### PR TITLE
fix: cap consecutive review agent failures to prevent infinite NeedsReview retry loop

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -15,7 +15,7 @@ use crate::config;
 use crate::db::{Db, TaskStatus};
 use crate::engine::router::Router;
 use crate::engine::tasks::TaskManager;
-use crate::sidecar::REPO_CONTEXT;
+use crate::sidecar::{self, REPO_CONTEXT};
 use crate::tmux::TmuxManager;
 use std::sync::Arc;
 use tokio::process::Command;
@@ -25,6 +25,8 @@ use tokio::sync::Semaphore;
 use super::cleanup::{check_merged_prs, cleanup_done_worktrees};
 use super::review::{review_and_merge, review_open_prs, ReviewDecision};
 use super::EngineConfig;
+
+const MAX_REVIEW_AGENT_FAILURES: u64 = 3;
 
 /// Sync tick — runs every 45s.
 ///
@@ -147,21 +149,53 @@ pub(crate) async fn sync_tick(
                         ReviewOutcome::Block
                     }
                     Ok(ReviewDecision::Failed(reason)) => {
-                        tracing::error!(
-                            task_id = tid,
-                            reason,
-                            "review agent failed — resetting to NeedsReview for retry"
-                        );
-                        ReviewOutcome::Reset
+                        let failures =
+                            sidecar::get_u64(&tid, "review_agent_failures").saturating_add(1);
+                        let _ = sidecar::set(&tid, &[format!("review_agent_failures={failures}")]);
+                        if failures >= MAX_REVIEW_AGENT_FAILURES {
+                            tracing::error!(
+                                task_id = tid,
+                                reason,
+                                failures,
+                                "review agent failed too many times — blocking task"
+                            );
+                            ReviewOutcome::Block
+                        } else {
+                            tracing::error!(
+                                task_id = tid,
+                                reason,
+                                failures,
+                                "review agent failed — resetting to NeedsReview for retry"
+                            );
+                            ReviewOutcome::Reset
+                        }
                     }
                     Err(e) => {
-                        tracing::error!(
-                            task_id = tid, error = %e,
-                            "review_and_merge failed — resetting to NeedsReview for retry"
-                        );
-                        ReviewOutcome::Reset
+                        let failures =
+                            sidecar::get_u64(&tid, "review_agent_failures").saturating_add(1);
+                        let _ = sidecar::set(&tid, &[format!("review_agent_failures={failures}")]);
+                        if failures >= MAX_REVIEW_AGENT_FAILURES {
+                            tracing::error!(
+                                task_id = tid,
+                                error = %e,
+                                failures,
+                                "review_and_merge failed too many times — blocking task"
+                            );
+                            ReviewOutcome::Block
+                        } else {
+                            tracing::error!(
+                                task_id = tid,
+                                error = %e,
+                                failures,
+                                "review_and_merge failed — resetting to NeedsReview for retry"
+                            );
+                            ReviewOutcome::Reset
+                        }
                     }
-                    Ok(_) => ReviewOutcome::Ok,
+                    Ok(_) => {
+                        let _ = sidecar::set(&tid, &["review_agent_failures=0".to_string()]);
+                        ReviewOutcome::Ok
+                    }
                 };
                 match outcome {
                     ReviewOutcome::Reset => {

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -27,6 +27,8 @@ use tokio::sync::{mpsc, RwLock, Semaphore};
 use super::review::{review_and_merge, ReviewDecision};
 use super::EngineConfig;
 
+const MAX_REVIEW_AGENT_FAILURES: u64 = 3;
+
 /// Phase 1 of tick: poll tmux for finished sessions and clean them up.
 pub(crate) async fn tick_check_session_completions(
     tmux: &Arc<TmuxManager>,
@@ -505,32 +507,99 @@ pub(crate) async fn tick_dispatch_tasks(
                                                     .await;
                                             }
                                             Ok(ReviewDecision::Failed(reason)) => {
-                                                tracing::error!(
-                                                    task_id = task_id_for_review,
-                                                    reason,
-                                                    "review agent failed — resetting to NeedsReview for retry"
+                                                let failures = sidecar::get_u64(
+                                                    &task_id_for_review,
+                                                    "review_agent_failures",
+                                                )
+                                                .saturating_add(1);
+                                                let _ = sidecar::set(
+                                                    &task_id_for_review,
+                                                    &[format!(
+                                                        "review_agent_failures={failures}"
+                                                    )],
                                                 );
-                                                let _ = task_manager_for_review
-                                                    .update_task_status(
-                                                        &ExternalId(task_id_for_review.clone()),
-                                                        Status::NeedsReview,
-                                                    )
-                                                    .await;
+                                                if failures >= MAX_REVIEW_AGENT_FAILURES {
+                                                    tracing::error!(
+                                                        task_id = task_id_for_review,
+                                                        reason,
+                                                        failures,
+                                                        "review agent failed too many times — blocking task"
+                                                    );
+                                                    let _ = task_manager_for_review
+                                                        .update_task_status(
+                                                            &ExternalId(
+                                                                task_id_for_review.clone(),
+                                                            ),
+                                                            Status::Blocked,
+                                                        )
+                                                        .await;
+                                                } else {
+                                                    tracing::error!(
+                                                        task_id = task_id_for_review,
+                                                        reason,
+                                                        failures,
+                                                        "review agent failed — resetting to NeedsReview for retry"
+                                                    );
+                                                    let _ = task_manager_for_review
+                                                        .update_task_status(
+                                                            &ExternalId(
+                                                                task_id_for_review.clone(),
+                                                            ),
+                                                            Status::NeedsReview,
+                                                        )
+                                                        .await;
+                                                }
                                             }
                                             Err(e) => {
-                                                tracing::error!(
-                                                    task_id = task_id_for_review,
-                                                    error = %e,
-                                                    "review_and_merge failed — resetting to NeedsReview for retry"
+                                                let failures = sidecar::get_u64(
+                                                    &task_id_for_review,
+                                                    "review_agent_failures",
+                                                )
+                                                .saturating_add(1);
+                                                let _ = sidecar::set(
+                                                    &task_id_for_review,
+                                                    &[format!(
+                                                        "review_agent_failures={failures}"
+                                                    )],
                                                 );
-                                                let _ = task_manager_for_review
-                                                    .update_task_status(
-                                                        &ExternalId(task_id_for_review.clone()),
-                                                        Status::NeedsReview,
-                                                    )
-                                                    .await;
+                                                if failures >= MAX_REVIEW_AGENT_FAILURES {
+                                                    tracing::error!(
+                                                        task_id = task_id_for_review,
+                                                        error = %e,
+                                                        failures,
+                                                        "review_and_merge failed too many times — blocking task"
+                                                    );
+                                                    let _ = task_manager_for_review
+                                                        .update_task_status(
+                                                            &ExternalId(
+                                                                task_id_for_review.clone(),
+                                                            ),
+                                                            Status::Blocked,
+                                                        )
+                                                        .await;
+                                                } else {
+                                                    tracing::error!(
+                                                        task_id = task_id_for_review,
+                                                        error = %e,
+                                                        failures,
+                                                        "review_and_merge failed — resetting to NeedsReview for retry"
+                                                    );
+                                                    let _ = task_manager_for_review
+                                                        .update_task_status(
+                                                            &ExternalId(
+                                                                task_id_for_review.clone(),
+                                                            ),
+                                                            Status::NeedsReview,
+                                                        )
+                                                        .await;
+                                                }
                                             }
-                                            Ok(_) => {} // Approve or RequestChanges handled inside
+                                            Ok(_) => {
+                                                let _ = sidecar::set(
+                                                    &task_id_for_review,
+                                                    &["review_agent_failures=0".to_string()],
+                                                );
+                                            } // Approve or RequestChanges handled inside
                                         }
                                     }));
                                 }


### PR DESCRIPTION
## Summary

Done with the local work. Here's a summary of the fix:

**Changed files:** `src/engine/sync.rs` and `src/engine/tick.rs`

**What changed:**
- Added `MAX_REVIEW_AGENT_FAILURES: u64 = 3` constant in both files
- In both `ReviewDecision::Failed` and `Err(e)` handlers:
  - Read + increment `review_agent_failures` sidecar counter
  - If counter >= 3 → `Blocked` (stops the loop)
  - Otherwise → `NeedsReview` as before, with `failures` logged
- On success (`Ok(_)`) → reset `review_agent_failures=0` so transient failures don't permanently accumulate

The pattern exactly mirrors `pr_create_failures` from `review.rs`. Ready to push when you approve.

---
*Task #548 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*