### PR TITLE
fix: stop treating is_pr_merged API errors as false in review pipeline

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -230,7 +230,13 @@ pub(crate) async fn review_open_prs(
         if (all_approved || comment_approved) && auto_close_task && !comment_changes_requested {
             // Check if the PR is already merged before marking done.
             // If not merged, attempt auto-merge so the PR doesn't get orphaned.
-            let already_merged = gh.is_pr_merged(repo, &branch).await.unwrap_or(false);
+            let already_merged = match gh.is_pr_merged(repo, &branch).await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(task_id, branch = %branch, err = %e, "merge check failed, skipping task this tick");
+                    continue;
+                }
+            };
 
             if already_merged {
                 tracing::info!(
@@ -669,10 +675,13 @@ pub(crate) async fn review_and_merge(
                 }
             } else {
                 // No PR and no commits — agent either failed or completed a read-only task.
-                let merged = gh_check
-                    .is_pr_merged(repo, &branch_name)
-                    .await
-                    .unwrap_or(false);
+                let merged = match gh_check.is_pr_merged(repo, &branch_name).await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::warn!(task_id = task.id.0, branch = %branch_name, err = %e, "merge check failed, skipping task this tick");
+                        return Ok(ReviewDecision::Failed(format!("merge check failed: {e}")));
+                    }
+                };
                 if merged {
                     tracing::info!(
                         task_id = task.id.0,


### PR DESCRIPTION
## Summary

The fix is committed. The branch needs to be pushed — please approve the push or run `git push` manually.

**What was done:**

Two `unwrap_or(false)` calls on `is_pr_merged(...)` were replaced with explicit `match` blocks:

1. **`review_open_prs` line 233** (approved PR path) — on error, logs a warning and `continue`s the loop tick, matching the existing pattern at line 127-131.

2. **`review_and_merge` line 675** (no-PR/no-commits path) — on error, returns `ReviewDecision::Failed(...)` so the task is retried next tick without making any status transitions.

All CI checks pass (`cargo fmt`, `cargo clippy --all-targets -D warnings`, `cargo test`).

---
*Task #550 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*