### PR TITLE
fix: review_agent_failures counter not reset when task is re-routed for human review changes

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -473,6 +473,11 @@ pub(crate) async fn review_open_prs(
                 tracing::warn!(task_id, err = %e, "failed to set status to routed for re-dispatch");
             } else {
                 tracing::info!(task_id, "re-dispatching task to address review feedback");
+                // Reset the review_agent_failures counter so transient failures from the
+                // previous review cycle don't count against the budget for the next cycle.
+                if let Err(e) = sidecar::set(task_id, &["review_agent_failures=0".to_string()]) {
+                    tracing::warn!(task_id, err = %e, "failed to reset review_agent_failures on re-dispatch");
+                }
             }
         }
     }

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -270,6 +270,12 @@ pub(crate) async fn sync_tick(
                     session = %review_session,
                     "InReview task has no active review session — resetting to NeedsReview"
                 );
+                // Reset the failure counter: stale-session recovery is an infrastructure
+                // event (tmux crash, service restart) not a genuine agent parse failure.
+                // Keeping the counter would unfairly consume the budget for the next cycle.
+                if let Err(e) = sidecar::set(&task.id.0, &["review_agent_failures=0".to_string()]) {
+                    tracing::warn!(task_id = %task.id.0, err = %e, "failed to reset review_agent_failures on stale-session recovery");
+                }
                 if let Err(e) = task_manager
                     .update_task_status(&task.id, Status::NeedsReview)
                     .await


### PR DESCRIPTION
## Summary

Please approve the push so I can push the branch to remote. Alternatively, you can run `git push` manually in the worktree directory:

```
/Users/gb/.orch/worktrees/orch/gh-task-553-fix-review-agent-failures-counter-not-re
```

The changes are committed and ready. Here's a summary of what was done:

**`src/engine/review.rs`** — after successfully setting status to `Routed` on human review changes-requested re-dispatch, reset `review_agent_failures=0` so the previous cycle's transient failures don't carry over.

**`src/engine/sync.rs`** — before resetting a stale `InReview` task to `NeedsReview` (triggered by no active tmux session), reset `review_agent_failures=0` since a tmux crash or service restart is an infrastructure event, not a genuine agent parse failure.

---
*Task #553 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*