### PR TITLE
fix: merge_conflict_retries and pr_create_failures never reset on re-route, causing premature blocking

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -150,6 +150,18 @@ pub(crate) async fn review_open_prs(
                         .await
                     {
                         tracing::warn!(task_id, err = %e, "failed to update status to routed");
+                    } else {
+                        // Reset merge conflict and PR creation counters on re-dispatch so failures
+                        // from the previous review cycle don't prematurely block the next cycle.
+                        if let Err(e) = sidecar::set(
+                            task_id,
+                            &[
+                                "merge_conflict_retries=0".to_string(),
+                                "pr_create_failures=0".to_string(),
+                            ],
+                        ) {
+                            tracing::warn!(task_id, err = %e, "failed to reset merge conflict counters");
+                        }
                     }
                 }
                 continue;
@@ -477,10 +489,17 @@ pub(crate) async fn review_open_prs(
                 tracing::warn!(task_id, err = %e, "failed to set status to routed for re-dispatch");
             } else {
                 tracing::info!(task_id, "re-dispatching task to address review feedback");
-                // Reset the review_agent_failures counter so transient failures from the
-                // previous review cycle don't count against the budget for the next cycle.
-                if let Err(e) = sidecar::set(task_id, &["review_agent_failures=0".to_string()]) {
-                    tracing::warn!(task_id, err = %e, "failed to reset review_agent_failures on re-dispatch");
+                // Reset counters so transient failures from the previous review cycle don't
+                // count against the budget for the next cycle.
+                if let Err(e) = sidecar::set(
+                    task_id,
+                    &[
+                        "review_agent_failures=0".to_string(),
+                        "merge_conflict_retries=0".to_string(),
+                        "pr_create_failures=0".to_string(),
+                    ],
+                ) {
+                    tracing::warn!(task_id, err = %e, "failed to reset review failure counters on re-dispatch");
                 }
             }
         }

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -193,7 +193,14 @@ pub(crate) async fn sync_tick(
                         }
                     }
                     Ok(_) => {
-                        let _ = sidecar::set(&tid, &["review_agent_failures=0".to_string()]);
+                        let _ = sidecar::set(
+                            &tid,
+                            &[
+                                "review_agent_failures=0".to_string(),
+                                "merge_conflict_retries=0".to_string(),
+                                "pr_create_failures=0".to_string(),
+                            ],
+                        );
                         ReviewOutcome::Ok
                     }
                 };


### PR DESCRIPTION
## Summary

I've successfully fixed the bug in three places:

## Summary of Changes

**Problem**: The `merge_conflict_retries` and `pr_create_failures` counters were never reset to 0, causing tasks to block prematurely when re-routed after human feedback (same class of bug as #553).

**Fixes Applied**:

1. **src/engine/review.rs (lines 146-162)** - Added counter resets in the no-open-PR re-dispatch path:
   - When a task is in review but has no open PR, it's re-dispatched to allow the agent to create a new PR
   - Now resets both `merge_conflict_retries` and `pr_create_failures` to 0

2. **src/engine/review.rs (lines 478-489)** - Enhanced existing resets in the human-changes path:
   - When a human requests changes, the task is re-routed back to Routed status
   - Now resets all three counters: `review_agent_failures`, `merge_conflict_retries`, and `pr_create_failures`

3. **src/engine/sync.rs (lines 195-206)** - Updated success reset:
   - When a review succeeds, now resets all three counters instead of just `review_agent_failures`

**Verification**:
- ✅ All tests pass (502 tests, 0 failures)
- ✅ Clippy linter passes (no warnings)
- ✅ Formatting check passes
- ✅ Commit created with proper conventional commit message

To complete the landing-the-plane workflow, I need to push the changes. Please grant permission for the bash command to run `git push` to the remote repository.

---
*Task #556 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*