### PR TITLE
Code development: orch

### DIFF
--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -396,12 +396,8 @@ pub async fn retry(id: i64) -> anyhow::Result<()> {
     let db = Db::open(&db_path)?;
     if let Ok(task) = db.get_internal_task(id).await {
         let internal_id = format!("internal:{}", task.id);
-        // Reset sidecar
-        crate::sidecar::set(
-            &internal_id,
-            &["attempts=0".to_string(), "route_attempts=0".to_string()],
-        )
-        .ok();
+        // Reset sidecar (attempts + all failure counters)
+        crate::sidecar::reset_task_counters(&internal_id);
         // Reset DB status to New
         db.update_internal_task_status(id, TaskStatus::New).await?;
         println!(
@@ -425,12 +421,8 @@ pub async fn retry(id: i64) -> anyhow::Result<()> {
         }
     }
 
-    // Reset sidecar state so the task starts fresh
-    crate::sidecar::set(
-        &ext_id.0,
-        &["attempts=0".to_string(), "route_attempts=0".to_string()],
-    )
-    .ok();
+    // Reset sidecar state (attempts + all failure counters) so the task starts fresh
+    crate::sidecar::reset_task_counters(&ext_id.0);
 
     // Reset to new
     backend.update_status(&ext_id, Status::New).await?;
@@ -444,11 +436,7 @@ pub async fn retry(id: i64) -> anyhow::Result<()> {
 
 async fn reset_internal_sidecar(id: i64) {
     let internal_id = format!("internal:{}", id);
-    crate::sidecar::set(
-        &internal_id,
-        &["attempts=0".to_string(), "route_attempts=0".to_string()],
-    )
-    .ok();
+    crate::sidecar::reset_task_counters(&internal_id);
 }
 
 /// Unblock a task or all blocked tasks.
@@ -470,11 +458,7 @@ pub async fn unblock(id: &str) -> anyhow::Result<()> {
 
         let mut external_count = 0;
         for task in blocked.iter().chain(needs_review.iter()) {
-            crate::sidecar::set(
-                &task.id.0,
-                &["attempts=0".to_string(), "route_attempts=0".to_string()],
-            )
-            .ok();
+            crate::sidecar::reset_task_counters(&task.id.0);
             backend.update_status(&task.id, Status::New).await?;
             external_count += 1;
         }
@@ -530,11 +514,7 @@ pub async fn unblock(id: &str) -> anyhow::Result<()> {
     }
 
     let ext_id = ExternalId(id.to_string());
-    crate::sidecar::set(
-        &ext_id.0,
-        &["attempts=0".to_string(), "route_attempts=0".to_string()],
-    )
-    .ok();
+    crate::sidecar::reset_task_counters(&ext_id.0);
     backend.update_status(&ext_id, Status::New).await?;
     println!("Unblocked task #{} (attempts reset)", id);
 

--- a/src/engine/commands.rs
+++ b/src/engine/commands.rs
@@ -284,37 +284,29 @@ pub async fn execute_command(
 ) -> anyhow::Result<String> {
     match command {
         OwnerCommand::Retry => {
-            // Remove agent labels, reset attempts, reset to new
+            // Remove agent labels, reset attempts and all failure counters, reset to new
             let task = backend.get_task(task_id).await?;
             for label in &task.labels {
                 if label.starts_with("agent:") {
                     backend.remove_label(task_id, label).await.ok();
                 }
             }
-            // Reset sidecar state so the task starts fresh
-            crate::sidecar::set(
-                &task_id.0,
-                &["attempts=0".to_string(), "route_attempts=0".to_string()],
-            )
-            .ok();
+            // Reset sidecar state (attempts + all failure counters) so the task starts fresh
+            crate::sidecar::reset_task_counters(&task_id.0);
             backend.update_status(task_id, Status::New).await?;
             Ok("`/retry` — reset attempts, cleared agent, reset to `status:new`".to_string())
         }
 
         OwnerCommand::Reroute(agent) => {
-            // Remove existing agent labels and reset attempts
+            // Remove existing agent labels and reset attempts and all failure counters
             let task = backend.get_task(task_id).await?;
             for label in &task.labels {
                 if label.starts_with("agent:") {
                     backend.remove_label(task_id, label).await.ok();
                 }
             }
-            // Reset sidecar state so the task starts fresh
-            crate::sidecar::set(
-                &task_id.0,
-                &["attempts=0".to_string(), "route_attempts=0".to_string()],
-            )
-            .ok();
+            // Reset sidecar state (attempts + all failure counters) so the task starts fresh
+            crate::sidecar::reset_task_counters(&task_id.0);
             // Optionally set new agent
             if let Some(agent_name) = agent {
                 let label = format!("agent:{agent_name}");

--- a/src/sidecar.rs
+++ b/src/sidecar.rs
@@ -263,6 +263,27 @@ pub fn set(task_id: &str, fields: &[String]) -> anyhow::Result<()> {
     })
 }
 
+/// Reset all task failure counters when a task is retried or unblocked by a human.
+///
+/// Resets both execution counters (`attempts`, `route_attempts`) and review-cycle
+/// counters (`review_agent_failures`, `merge_conflict_retries`, `pr_create_failures`,
+/// `ci_merge_failures`, `review_cycles`) so that stale failures from a previous cycle
+/// do not prematurely block the new cycle.
+pub fn reset_task_counters(task_id: &str) {
+    let _ = set(
+        task_id,
+        &[
+            "attempts=0".to_string(),
+            "route_attempts=0".to_string(),
+            "review_agent_failures=0".to_string(),
+            "merge_conflict_retries=0".to_string(),
+            "pr_create_failures=0".to_string(),
+            "ci_merge_failures=0".to_string(),
+            "review_cycles=0".to_string(),
+        ],
+    );
+}
+
 /// Read a numeric sidecar field as u64. Missing or invalid values return 0.
 pub fn get_u64(task_id: &str, field: &str) -> u64 {
     get(task_id, field)
@@ -676,6 +697,49 @@ mod tests {
             compare_and_swap(&task_id, "review_started", "false", "true").unwrap(),
             "CAS should succeed when expected matches actual value"
         );
+
+        // Cleanup
+        let _ = state_dir().map(|d| std::fs::remove_file(d.join(format!("{task_id}.json"))));
+    }
+
+    #[test]
+    fn reset_task_counters_zeros_all_failure_fields() {
+        let task_id = format!(
+            "test-reset-counters-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .subsec_nanos()
+        );
+        let _ = state_dir().map(|d| std::fs::remove_file(d.join(format!("{task_id}.json"))));
+
+        // Seed with non-zero failure counters
+        set(
+            &task_id,
+            &[
+                "attempts=5".to_string(),
+                "route_attempts=2".to_string(),
+                "review_agent_failures=3".to_string(),
+                "merge_conflict_retries=3".to_string(),
+                "pr_create_failures=3".to_string(),
+                "ci_merge_failures=3".to_string(),
+                "review_cycles=2".to_string(),
+                "agent=claude".to_string(), // non-counter field should be preserved
+            ],
+        )
+        .unwrap();
+
+        reset_task_counters(&task_id);
+
+        assert_eq!(get_u64(&task_id, "attempts"), 0);
+        assert_eq!(get_u64(&task_id, "route_attempts"), 0);
+        assert_eq!(get_u64(&task_id, "review_agent_failures"), 0);
+        assert_eq!(get_u64(&task_id, "merge_conflict_retries"), 0);
+        assert_eq!(get_u64(&task_id, "pr_create_failures"), 0);
+        assert_eq!(get_u64(&task_id, "ci_merge_failures"), 0);
+        assert_eq!(get_u64(&task_id, "review_cycles"), 0);
+        // Non-counter field should be untouched
+        assert_eq!(get(&task_id, "agent").unwrap(), "claude");
 
         // Cleanup
         let _ = state_dir().map(|d| std::fs::remove_file(d.join(format!("{task_id}.json"))));


### PR DESCRIPTION
## Summary

The push isn't being blocked by a hook — the user's permission settings are blocking it. Let me summarize what was done and ask the user to push.

The commit is ready locally. Here's a summary of what was implemented:

**Fix: reset all failure counters on human-initiated retry/unblock**

**Problem:** When a task gets blocked (e.g., hit `MAX_MERGE_CONFLICT_RETRIES=3` or `MAX_CI_MERGE_FAILURES=3`), and a human does `/retry`, `/reroute`, `orch task retry`, or `orch task unblock`, only `attempts=0` and `route_attempts=0` were reset. The failure counters (`review_agent_failures`, `merge_conflict_retries`, `pr_create_failures`, `ci_merge_failures`, `review_cycles`) kept their stale values, causing the task to be immediately blocked again on its next review pass.

**Fix:**
- Added `sidecar::reset_task_counters(task_id)` that zeros all 7 counters in one call
- Used it in `/retry` and `/reroute` slash commands (`engine/commands.rs`)
- Used it in `orch task retry` and `orch task unblock` (`cli/task.rs`)
- Added a unit test verifying all counters are zeroed while non-counter fields are preserved

The commit `a9a2ea0` is on branch `gh-task-internal-49-code-development-orch`. Please approve the push so CI can validate it.

---
*Task internal-49 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*