### PR TITLE
Code development: orch

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -14,6 +14,11 @@ const MAX_MERGE_CONFLICT_RETRIES: u64 = 3;
 /// the task is blocked for human intervention instead of re-entering NeedsReview.
 const MAX_CI_MERGE_FAILURES: u64 = 3;
 
+/// Maximum number of consecutive review agent failures before the task is blocked
+/// for human intervention. Exported so `tick` and `sync` use the same threshold
+/// without duplicating the constant.
+pub(crate) const MAX_REVIEW_AGENT_FAILURES: u64 = 3;
+
 use crate::backends::{ExternalBackend, ExternalId, ExternalTask, Status};
 use crate::config;
 use crate::engine::runner;

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -23,10 +23,8 @@ use tokio::sync::RwLock;
 use tokio::sync::Semaphore;
 
 use super::cleanup::{check_merged_prs, cleanup_done_worktrees};
-use super::review::{review_and_merge, review_open_prs, ReviewDecision};
+use super::review::{review_and_merge, review_open_prs, ReviewDecision, MAX_REVIEW_AGENT_FAILURES};
 use super::EngineConfig;
-
-const MAX_REVIEW_AGENT_FAILURES: u64 = 3;
 
 /// Sync tick — runs every 45s.
 ///

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -24,10 +24,8 @@ use crate::tmux::TmuxManager;
 use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock, Semaphore};
 
-use super::review::{review_and_merge, ReviewDecision};
+use super::review::{review_and_merge, ReviewDecision, MAX_REVIEW_AGENT_FAILURES};
 use super::EngineConfig;
-
-const MAX_REVIEW_AGENT_FAILURES: u64 = 3;
 
 /// Phase 1 of tick: poll tmux for finished sessions and clean them up.
 pub(crate) async fn tick_check_session_completions(
@@ -595,9 +593,15 @@ pub(crate) async fn tick_dispatch_tasks(
                                                 }
                                             }
                                             Ok(_) => {
+                                                // Reset all review-cycle failure counters on success
+                                                // so a subsequent retry doesn't inherit stale values.
                                                 let _ = sidecar::set(
                                                     &task_id_for_review,
-                                                    &["review_agent_failures=0".to_string()],
+                                                    &[
+                                                        "review_agent_failures=0".to_string(),
+                                                        "merge_conflict_retries=0".to_string(),
+                                                        "pr_create_failures=0".to_string(),
+                                                    ],
                                                 );
                                             } // Approve or RequestChanges handled inside
                                         }


### PR DESCRIPTION
## Summary

The `git push` is being blocked by tool permissions (requires user approval for push commands). The code changes are committed locally at `84d94b3`. 

Please approve the push — the changes are ready:

```
git push origin gh-task-internal-52-code-development-orch
```

Or run it manually. Once pushed, I'll create the PR.

---

**What was done:**

1. **Moved `MAX_REVIEW_AGENT_FAILURES` to `review.rs`** as `pub(crate) const` — removes the duplicate definition in `sync.rs` and `tick.rs`. This prevents the two copies from diverging (exactly the class of bug that caused counter-related issues recently).

2. **Fixed counter reset inconsistency in `tick.rs`** — the success path of the main-tick review handler only reset `review_agent_failures=0` but not `merge_conflict_retries` or `pr_create_failures`. The `sync` catch-up path already reset all three. Now both paths are consistent, so stale failure counts can't prematurely block a task after a successful review cycle.

---
*Task internal-52 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*