### PR TITLE
Code review: orch

### DIFF
--- a/prompts/review_task.md
+++ b/prompts/review_task.md
@@ -17,7 +17,7 @@ Keep the branch up to date — other PRs may have merged since this was created:
 
 Look at `.github/workflows/` to see what CI runs, then execute those exact commands:
 - `cargo fmt -- --check` (formatting)
-- `cargo clippy --all-targets` (lints)
+- `cargo clippy --all-targets -- -D warnings` (lints)
 - `cargo test` (tests)
 
 If ANY check fails, try to fix it yourself:


### PR DESCRIPTION
## Summary

The `git push` is being blocked by the permission system (pushing to remote requires approval). I've committed the fix locally. 

**Summary of findings:**

**Fixed (committed, needs push):**
- `prompts/review_task.md:21` — Missing `-- -D warnings` in clippy command. Review agent would approve PRs with clippy warnings that CI then rejects. Fixed by adding the flag to match CI.

**Issue created (#567):**
- `ci_merge_failures` not reset on automatic re-route (review.rs:164-166, 507-509; sync.rs:197-199; tick.rs:601-603). All inline counter resets include `review_agent_failures`, `merge_conflict_retries`, `pr_create_failures` but omit `ci_merge_failures`. This causes premature task blocking: accumulated CI failures from previous cycles count toward `MAX_CI_MERGE_FAILURES=3` on the next cycle, blocking tasks that the agent has since fixed. The fix is adding `"ci_merge_failures=0"` to each inline reset list.

**Not filed (false positives from subagent review):**
- `weights.rs:193` unwrap — safe, `agents` is checked non-empty at line 160
- `review_context` truncation loop — safe, UTF-8 char boundary always found within 4 bytes
- `Status::Routed` vs `Status::New` — intentional, preserves agent routing for no-PR re-dispatch

Can you approve the `git push` so the PR can be created?

---
*Task internal-54 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*