### PR TITLE
fix: reset ci_merge_failures counter on auto re-route

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -164,6 +164,7 @@ pub(crate) async fn review_open_prs(
                                 "review_agent_failures=0".to_string(),
                                 "merge_conflict_retries=0".to_string(),
                                 "pr_create_failures=0".to_string(),
+                                "ci_merge_failures=0".to_string(),
                             ],
                         ) {
                             tracing::warn!(task_id, err = %e, "failed to reset per-cycle counters on no-PR re-dispatch");
@@ -507,6 +508,7 @@ pub(crate) async fn review_open_prs(
                         "review_agent_failures=0".to_string(),
                         "merge_conflict_retries=0".to_string(),
                         "pr_create_failures=0".to_string(),
+                        "ci_merge_failures=0".to_string(),
                     ],
                 ) {
                     tracing::warn!(task_id, err = %e, "failed to reset per-cycle counters on re-dispatch");

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -197,6 +197,7 @@ pub(crate) async fn sync_tick(
                                 "review_agent_failures=0".to_string(),
                                 "merge_conflict_retries=0".to_string(),
                                 "pr_create_failures=0".to_string(),
+                                "ci_merge_failures=0".to_string(),
                             ],
                         );
                         ReviewOutcome::Ok

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -601,6 +601,7 @@ pub(crate) async fn tick_dispatch_tasks(
                                                         "review_agent_failures=0".to_string(),
                                                         "merge_conflict_retries=0".to_string(),
                                                         "pr_create_failures=0".to_string(),
+                                                        "ci_merge_failures=0".to_string(),
                                                     ],
                                                 );
                                             } // Approve or RequestChanges handled inside


### PR DESCRIPTION
## Summary

Please approve the push. Once pushed, you can open a PR from `gh-task-567-fix-reset-ci-merge-failures-counter-on-a` into `main`.

The fix adds `"ci_merge_failures=0".to_string()` to all 4 inline counter reset lists:
- `review.rs:164` (no-PR re-dispatch)
- `review.rs:507` (CHANGES_REQUESTED re-dispatch)
- `sync.rs:197` (CHANGES_REQUESTED re-route in sync tick)
- `tick.rs:601` (re-route on retry/similar)

---
*Task #567 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*