### PR TITLE
Review task prompt is too specific

### DIFF
--- a/prompts/review_task.md
+++ b/prompts/review_task.md
@@ -15,15 +15,13 @@ Keep the branch up to date — other PRs may have merged since this was created:
 
 ### Step 2: Run CI checks locally
 
-Look at `.github/workflows/` to see what CI runs, then execute those exact commands:
-- `cargo fmt -- --check` (formatting)
-- `cargo clippy --all-targets -- -D warnings` (lints)
-- `cargo test` (tests)
+1. Read `.github/workflows/` to identify what the CI pipeline runs (lint, format, test, build, etc.)
+2. Execute those exact commands locally — do not guess or hardcode language-specific commands
+3. Run only the checks that apply to the changed code (skip deploy/publish steps)
 
 If ANY check fails, try to fix it yourself:
-- Run `cargo fmt` for formatting issues
-- Fix clippy warnings directly
-- Fix compilation errors if straightforward
+- Apply auto-fixers if available (e.g. formatter --fix, linter --fix)
+- Fix errors directly if straightforward
 
 Commit your fixes, push, and re-run checks. If you cannot fix a failure, decision = `request_changes`.
 


### PR DESCRIPTION
## Summary

Please approve the push so I can push the branch and open a PR. The commit is ready at `581fdb8` with all CI checks passing.

The change replaces the hardcoded Rust commands in Step 2 of `prompts/review_task.md` with a generic instruction to read `.github/workflows/` and run exactly what CI runs — making it work for any language/project.

---
*Task #573 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*