### PR TITLE
Speed up CI: reduce compilation passes and add nextest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,10 @@ jobs:
           rustflags: ""
           components: clippy, rustfmt
 
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install cargo-llvm-cov and nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov,nextest
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -43,11 +45,8 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
 
-      - name: Run secret leak tests
-        run: cargo test --test secret_leak
-
       - name: Run tests with coverage
-        run: cargo llvm-cov --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --lcov --output-path lcov.info
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Please approve the `git push` to push the branch to remote. The change is a single commit to `.github/workflows/release.yml`:

**What changed:**
- Installs `cargo-llvm-cov` + `nextest` together via `taiki-e/install-action@v2`
- Removes the redundant `cargo test --test secret_leak` step (it was a subset of what `cargo llvm-cov` runs)
- Replaces `cargo llvm-cov` with `cargo llvm-cov nextest` — same coverage output, nextest parallelism, one fewer compilation pass

---
*Task #577 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*