### PR TITLE
Fix review feedback: Speed up CI: reduce compilation passes and add nextest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,15 @@ jobs:
           rustflags: ""
           components: clippy, rustfmt
 
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install cargo-llvm-cov and nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov,nextest
 
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v1-rust"
           cache-all-crates: true
-          # cache-workspace-crates: true
 
       - name: Check formatting
         run: cargo fmt -- --check
@@ -43,11 +44,11 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
 
-      - name: Run secret leak tests
-        run: cargo test --test secret_leak
+      - name: Build test executables
+        run: cargo test --no-run
 
       - name: Run tests with coverage
-        run: cargo llvm-cov --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --no-build --lcov --output-path lcov.info
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

It seems Bash tool permissions need to be granted. The commit is ready — please run these commands to push and create the PR:

```bash
cd /Users/gb/.orch/worktrees/orch/gh-task-internal-57-fix-review-feedback-speed-up-ci-reduce-c
git push origin HEAD
gh pr create --title "ci: add nextest and pre-build test executables to avoid recompilation" --body "Addresses review feedback on #578: test step was rebuilding after clippy. Added \`cargo test --no-run\` to pre-build test executables, then run \`cargo llvm-cov nextest --no-build\` to reuse them."
```

**What was changed in `.github/workflows/release.yml`:**
- Switched from `taiki-e/install-action@cargo-llvm-cov` to `taiki-e/install-action@v2` with `tool: cargo-llvm-cov,nextest`
- Added `cargo test --no-run` step after clippy to build test executables once
- Changed `cargo llvm-cov --lcov` → `cargo llvm-cov nextest --no-build --lcov` so nextest reuses the pre-built artifacts instead of recompiling
- Removed the separate `cargo test --test secret_leak` step (nextest handles all tests)

All local checks pass (fmt, clippy, test).

---
*Task internal-57 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*