### PR TITLE
BUG: GitHub HTTP pagination may panic when Link header missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +436,24 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -831,6 +859,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1505,6 +1539,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1647,7 @@ dependencies = [
  "tracing-subscriber",
  "urlencoding",
  "which",
+ "wiremock",
 ]
 
 [[package]]
@@ -3483,6 +3528,29 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ futures = "0.3"
 tempfile = "3"
 tokio-test = "0.4"
 tower = { version = "0.5", features = ["util"] }
+wiremock = "0.6"
 
 [profile.release]
 opt-level = 3

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -552,7 +552,7 @@ impl GhHttp {
                     .send()
                     .await?
             } else {
-                let u = next_url.as_ref().unwrap();
+                let Some(u) = next_url.as_ref() else { break };
                 let auth = self.auth_header().await?;
                 self.client
                     .get(u)
@@ -1604,6 +1604,14 @@ mod tests {
         assert_eq!(parse_link_next(&headers), None);
     }
 
+    #[test]
+    fn parse_link_next_none_when_malformed() {
+        let mut headers = header::HeaderMap::new();
+        // Malformed: no angle-bracket URL, just garbage
+        headers.insert("link", "garbage; rel=\"next\"".parse().unwrap());
+        assert_eq!(parse_link_next(&headers), None);
+    }
+
     fn make_rl(base_secs: u64, max_secs: u64) -> RateLimit {
         RateLimit {
             remaining: None,
@@ -1709,5 +1717,152 @@ mod tests {
         // Backoff should use reset_at (~46s) not the base (30s)
         assert!(rl.backoff_delay.as_secs() >= 45);
         assert!(rl.backoff_delay.as_secs() <= 47);
+    }
+
+    // ── get_all_pages integration tests (wiremock) ────────────────────────
+
+    #[cfg(test)]
+    mod pagination {
+        use super::super::*;
+        use std::sync::Arc;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        /// Build a minimal GhHttp pointing at a wiremock server.
+        /// The token resolver reads GH_TOKEN; we set it to a dummy value.
+        fn make_client() -> GhHttp {
+            // Ensure a token is available so auth_header() doesn't bail.
+            unsafe { std::env::set_var("GH_TOKEN", "test_token") };
+            GhHttp {
+                client: reqwest::Client::new(),
+                token_resolver: Arc::new(crate::github::token::TokenResolver::default_env()),
+            }
+        }
+
+        #[tokio::test]
+        async fn get_all_pages_single_page() {
+            let server = MockServer::start().await;
+
+            Mock::given(method("GET"))
+                .and(path("/items"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!([{"id": 1}, {"id": 2}])),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let gh = make_client();
+            let url = format!("{}/items", server.uri());
+            let result: Vec<serde_json::Value> = gh.get_all_pages(&url, &[]).await.unwrap();
+
+            assert_eq!(result.len(), 2);
+            assert_eq!(result[0]["id"], 1);
+            assert_eq!(result[1]["id"], 2);
+        }
+
+        #[tokio::test]
+        async fn get_all_pages_follows_link_next() {
+            let server = MockServer::start().await;
+
+            // Page 1 — includes Link header pointing to page 2
+            Mock::given(method("GET"))
+                .and(path("/items"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!([{"id": 1}]))
+                        .insert_header(
+                            "Link",
+                            format!("<{}/items/page2>; rel=\"next\"", server.uri()),
+                        ),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            // Page 2 — no Link header (last page)
+            Mock::given(method("GET"))
+                .and(path("/items/page2"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!([{"id": 2}, {"id": 3}])),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let gh = make_client();
+            let url = format!("{}/items", server.uri());
+            let result: Vec<serde_json::Value> = gh.get_all_pages(&url, &[]).await.unwrap();
+
+            assert_eq!(result.len(), 3);
+            assert_eq!(result[0]["id"], 1);
+            assert_eq!(result[1]["id"], 2);
+            assert_eq!(result[2]["id"], 3);
+        }
+
+        #[tokio::test]
+        async fn get_all_pages_stops_when_link_header_absent_on_subsequent_page() {
+            // Simulates a proxy/transient response that drops the Link header mid-pagination.
+            // The previous `.unwrap()` would panic here; the fix breaks the loop instead.
+            let server = MockServer::start().await;
+
+            Mock::given(method("GET"))
+                .and(path("/items"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!([{"id": 1}]))
+                        .insert_header(
+                            "Link",
+                            format!("<{}/items/page2>; rel=\"next\"", server.uri()),
+                        ),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            // Page 2 response has NO Link header — pagination should stop cleanly.
+            Mock::given(method("GET"))
+                .and(path("/items/page2"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(serde_json::json!([{"id": 2}])),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let gh = make_client();
+            let url = format!("{}/items", server.uri());
+            let result: Vec<serde_json::Value> = gh.get_all_pages(&url, &[]).await.unwrap();
+
+            // Must not panic and must return both items collected so far.
+            assert_eq!(result.len(), 2);
+        }
+
+        #[tokio::test]
+        async fn get_all_pages_stops_on_malformed_link_header() {
+            // A malformed Link header (no angle-bracket URL) yields None from parse_link_next,
+            // which should stop pagination rather than panic.
+            let server = MockServer::start().await;
+
+            Mock::given(method("GET"))
+                .and(path("/items"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!([{"id": 1}]))
+                        .insert_header("Link", "garbage; rel=\"next\""),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let gh = make_client();
+            let url = format!("{}/items", server.uri());
+            let result: Vec<serde_json::Value> = gh.get_all_pages(&url, &[]).await.unwrap();
+
+            // Malformed Link header → pagination stops after first page, no panic.
+            assert_eq!(result.len(), 1);
+        }
     }
 }


### PR DESCRIPTION
## Summary

The push is being blocked by your permission settings. Please run this in your terminal to complete the push:

```bash
cd /Users/gb/.orch/worktrees/orch/gh-task-582-bug-github-http-pagination-may-panic-whe && git push
```

Here's a summary of what was done to fix #582:

**Fix** (`src/github/http.rs:555`):
- Replaced `next_url.as_ref().unwrap()` with `let Some(u) = next_url.as_ref() else { break };`
- If the Link header is absent or malformed on a subsequent page, pagination now stops cleanly instead of panicking

**Tests added** (all passing):
- `pagination::get_all_pages_single_page` — single page, no Link header
- `pagination::get_all_pages_follows_link_next` — multi-page with correct Link headers  
- `pagination::get_all_pages_stops_when_link_header_absent_on_subsequent_page` — the exact panic scenario from the bug report
- `pagination::get_all_pages_stops_on_malformed_link_header` — malformed Link header
- `parse_link_next_none_when_malformed` — unit test for malformed header parsing

All 671 tests pass (11 skipped). The commit is ready to push: `a463286`.

---
*Task #582 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*