### PR TITLE
Reliability: Audit & remove panicking unwrap/expect across core modules (http, tmux, sidecar, token, template, home)

### DIFF
--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -161,7 +161,11 @@ impl Channel for SlackChannel {
 
         let bot_token = self.bot_token.clone();
         let client = self.client.clone();
-        let channel_id = self.channel_id.clone().unwrap();
+        // SAFETY: checked is_none() above and returned early
+        let channel_id = self
+            .channel_id
+            .clone()
+            .expect("BUG: channel_id is Some; None case returned early above");
         let last_ts = self.last_ts.clone();
 
         tracing::info!(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -554,7 +554,10 @@ fn project_add_github(owner: &str, repo: &str) -> anyhow::Result<()> {
         println!("Bare clone already exists: {}", bare_path.display());
     } else {
         // Create parent directory
-        std::fs::create_dir_all(bare_path.parent().unwrap())?;
+        let parent = bare_path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("bare path has no parent: {}", bare_path.display()))?;
+        std::fs::create_dir_all(parent)?;
 
         println!("Cloning {slug} as bare repo...");
         let status = std::process::Command::new("gh")

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -213,7 +213,9 @@ impl GhHttp {
             .pool_max_idle_per_host(4)
             .timeout(Duration::from_secs(30))
             .build()
-            .expect("failed to build reqwest client");
+            .expect(
+                "BUG: reqwest client config is statically valid; TLS init failure is unrecoverable",
+            );
 
         Self {
             client,


### PR DESCRIPTION
## Summary

Please approve the push to remote so I can complete the task. Alternatively, you can run `git push` in the worktree directory:

```
cd ~/.orch/worktrees/orch/gh-task-590-reliability-audit-remove-panicking-unwra && git push
```

Here's a summary of what was done:

**Audit findings** — 3 files changed from a codebase-wide scan of production (non-test) unwrap/expect patterns:

| Location | Issue | Fix |
|---|---|---|
| `src/cli/mod.rs:557` | `bare_path.parent().unwrap()` panics if path somehow has no parent | Replaced with `ok_or_else(|| anyhow!(...))` to return a descriptive error |
| `src/channels/slack.rs:164` | `self.channel_id.clone().unwrap()` — logically safe but not self-documenting | Changed to `expect("BUG: ...")` with guard comment pointing to the early-return above |
| `src/github/http.rs:216` | `.expect("failed to build reqwest client")` — generic message | Improved to `expect("BUG: reqwest client config is statically valid; TLS init failure is unrecoverable")` following the `BUG:` convention |

All other unwraps in the 6 audited modules were confirmed safe:
- `tmux.rs`: all use safe `unwrap_or()`/`unwrap_or_default()` fallbacks
- `token.rs`: all production uses are `unwrap_or_default()`
- `template.rs`: regex expects are compile-time programmer invariants
- `home.rs`: zero unwraps, uses `?` throughout
- `sidecar.rs`: doesn't exist in the codebase

671/671 tests pass, clippy clean.

---
*Task #590 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*