### PR TITLE
Reliability: Audit & remove panicking unwrap/expect across core modules (http, tmux, sidecar, token, template, home)

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -59,7 +59,7 @@ fn invalidate_cache(path: &PathBuf) {
 
 /// Start the file watcher if not already running.
 fn ensure_watcher() {
-    let mut watcher_guard = FILE_WATCHER.lock().unwrap();
+    let mut watcher_guard = FILE_WATCHER.lock().unwrap_or_else(|e| e.into_inner());
     if watcher_guard.is_some() {
         return;
     }


### PR DESCRIPTION
## Summary

The sandbox is blocking push permissions. The commit is ready locally. Here's the summary:

**Audit complete for task #600.** Changes made:

- **Fixed** `src/config/mod.rs:62`: Changed `FILE_WATCHER.lock().unwrap()` → `unwrap_or_else(|e| e.into_inner())` to recover from a poisoned mutex instead of panicking in production.

**Audit findings — remaining items are intentional:**
- `src/github/http.rs:216` — `expect("BUG: reqwest client config is statically valid...")` — TLS init failure is unrecoverable
- `src/security.rs`, `src/template.rs` — static regex `expect("BUG: ...")` — hardcoded patterns that can't fail
- `src/tmux.rs`, `src/token.rs`, `src/home.rs` — only `unwrap_or*` safe defaults in production; bare `.unwrap()` only in test code
- `src/sidecar.rs` — file no longer exists

Previous related fixes: #595 (cli/slack/http), #587 (get_all_pages).

All 671 tests pass. Please approve the `git push` to push and open the PR.

---
*Task #600 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*