### PR TITLE
fix: break dispatch loop when work already merged + fix CI tmux test

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1316,16 +1316,24 @@ mod tests {
         use crate::channels::transport::Transport;
         use std::sync::Arc;
 
-        // Skip test if tmux is not available in the environment (CI may not have tmux)
-        if tokio::process::Command::new("tmux")
-            .arg("-V")
+        // Skip test if tmux cannot create sessions (CI has tmux binary but no server)
+        let probe_session = "orch-test-probe";
+        let probe_ok = tokio::process::Command::new("tmux")
+            .args(["new-session", "-d", "-s", probe_session])
             .output()
             .await
-            .is_err()
-        {
-            tracing::warn!("tmux not found, skipping integration_channel_to_tmux_to_capture test");
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !probe_ok {
+            tracing::warn!(
+                "tmux cannot create sessions, skipping integration_channel_to_tmux_to_capture test"
+            );
             return;
         }
+        let _ = tokio::process::Command::new("tmux")
+            .args(["kill-session", "-t", probe_session])
+            .output()
+            .await;
 
         // Create transport and capture service
         let transport = Arc::new(Transport::new());

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -815,6 +815,23 @@ pub(crate) async fn review_and_merge(
                     return Ok(ReviewDecision::Skipped);
                 }
 
+                // If the PR creation failed with 422/head-invalid, the work
+                // is already merged into main. Mark done instead of looping.
+                if last_error.contains("422") && last_error.contains("head") {
+                    tracing::info!(
+                        task_id = task.id.0,
+                        branch = %branch_name,
+                        "no PR — 422/head-invalid means work already merged, marking done"
+                    );
+                    if let Err(e) = task_manager
+                        .update_task_status(&task.id, crate::backends::Status::Done)
+                        .await
+                    {
+                        tracing::error!(task_id = task.id.0, err = %e, "update_task_status(Done) failed");
+                    }
+                    return Ok(ReviewDecision::Skipped);
+                }
+
                 tracing::warn!(
                     task_id = task.id.0,
                     branch = %branch_name,

--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -179,6 +179,7 @@ pub async fn handle_success(
                     has_pr = true;
                 }
                 Err(e) => {
+                    let err_str = format!("{e}");
                     tracing::error!(task_id, error = ?e, "create PR failed");
                     let msg = format!("create PR failed: {e}");
                     crate::engine::cleanup::store_set(
@@ -188,6 +189,17 @@ pub async fn handle_success(
                         &[("last_error", serde_json::json!(msg))],
                     )
                     .await;
+                    // 422 with "head" invalid means the branch has no diff
+                    // from main — the work is already merged. Clear
+                    // has_pushed so we fall through to the "done" path
+                    // instead of spinning in the review gate.
+                    if err_str.contains("422") && err_str.contains("head") {
+                        tracing::info!(
+                            task_id,
+                            "PR creation returned 422/head-invalid — branch has no diff from main, clearing has_pushed"
+                        );
+                        has_pushed = false;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- **Dispatch loop fix**: When PR creation fails with 422/head-invalid (work already merged via other PRs), the response handler now clears `has_pushed` so the task is marked `done` instead of `needs_review`. The review gate has a second safety net that detects this pattern and marks `Done` instead of re-routing to `New`.
- **CI fix**: `integration_channel_to_tmux_to_capture` now probes by actually creating a tmux session instead of just checking `tmux -V`. Fixes flaky CI failure on GitHub Actions where tmux binary exists but can't create sessions.

## Root causes
1. Task 619 was stuck in an infinite dispatch loop: agent reports "done" (work already merged) → push succeeds (existing branch) → PR creation fails 422 (no diff) → `needs_review` → review gate finds no PR/commits → re-routes to `New` → repeat
2. CI test only checked `tmux -V` which succeeds on GitHub runners, but `tmux new-session` fails without a terminal server

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run` — 672 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)