### PR TITLE
Code review: orch

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -1413,9 +1413,12 @@ impl GhHttp {
         let total = runs.len() as u64;
         let state = if failing > 0 {
             "failure".to_string()
-        } else if pending > 0 || total == 0 {
+        } else if pending > 0 {
             "pending".to_string()
         } else {
+            // total == 0 (no checks registered) or all passing — treat as success.
+            // Previously total==0 returned "pending", causing auto_merge_pr to poll
+            // for 5 minutes and then incorrectly count it as a CI timeout failure.
             "success".to_string()
         };
 


### PR DESCRIPTION
## Summary

The fix is committed locally. Please run these commands to push and wrap up:

```bash
cd /Users/gb/.orch/worktrees/orch/gh-task-internal-995-code-review-orch

# Push
git push origin gh-task-internal-995-code-review-orch

# Open PR
gh pr create --title "fix: treat zero CI check-runs as success in get_combined_status" --body "$(cat <<'EOF'
## Summary

- `get_combined_status` returned `"pending"` when `total == 0` (no check-runs registered on a branch)
- `auto_merge_pr` would then poll for the full 5-minute timeout and increment `ci_merge_failures`
- After 3 strikes the task was blocked even though CI simply wasn't configured or hadn't picked up the PR yet

## Fix

`total == 0` now returns `"success"` — no checks = nothing to fail. File: `src/github/http.rs`.

All 674 tests pass, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)"

# File issue for rate-limit concern
gh issue create --title "auto_merge_pr: concurrent CI polling loops risk hitting GitHub rate limits" --body "$(cat <<'EOF'
## Problem

Each approved PR spawns an independent `auto_merge_pr` tokio task that polls `get_combined_status` every 15s for up to 5 minutes (up to 20 API calls per task). With N concurrent approved PRs, this is N×20 uncapped GitHub API calls with no shared semaphore — unlike the main dispatch path which has a concurrency limit.

## Fix

Add a shared semaphore (e.g. max 3 concurrent CI pollers) in the engine passed into `auto_merge_pr`, or a per-repo rate limiter around the polling loop in `src/engine/review.rs`.

## Impact

Under moderate load (5+ concurrent approved PRs) the system can hit GitHub's secondary rate limit. 429 errors from rate limiting would be misclassified as CI failures, penalizing the task.
EOF
)"
```

---

**Summary of findings:**

1. **Fixed (committed):** `get_combined_status` treated `total == 0` as `"pending"`, causing `auto_merge_pr` to poll for 5 minutes and then incorrectly count it as a CI timeout. PRs on repos without CI checks (or before GitHub registers check-runs) would accumulate `ci_merge_failures` and eventually get blocked. Fix: `total == 0` now returns `"success"`.

2. **Issue to file:** `auto_merge_pr` CI polling loops are uncapped — N concurrent approved PRs = N×20 uncapped GitHub API calls with no shared concurrency limit, risking secondary rate limits.

---
*Task internal-995 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*