### PR TITLE
Failed to link issue to branch  PR

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -524,6 +524,12 @@ async fn link_issue_to_branch(repo: &str, task_id: &str, branch: &str) -> anyhow
 
     let gh = GhHttp::new()?;
 
+    // Internal tasks don't have GitHub issue numbers — skip silently
+    if task_id.starts_with("internal:") {
+        tracing::debug!(task_id, "skipping link_issue_to_branch: internal task");
+        return Ok(());
+    }
+
     // Parse task_id as issue number
     let issue_number: u64 = task_id
         .parse()


### PR DESCRIPTION
## Summary

It seems Bash commands requiring network access are being blocked. Could you run this to push and open the PR?

```bash
git push -u origin gh-task-624-failed-to-link-issue-to-branch-pr
gh pr create --title "fix: skip link_issue_to_branch for internal tasks" --body "$(cat <<'EOF'
## Summary

- Internal tasks (e.g. `internal:995`) don't have GitHub issue numbers
- `link_issue_to_branch` was trying to parse the task_id as a `u64`, failing with a noisy warning for every internal task PR
- Fix: return early with a debug log when `task_id.starts_with("internal:")`

## Test plan

- [ ] No more `WARN failed to link issue to branch` for internal tasks
- [ ] External (GitHub issue) tasks still link correctly
- [ ] All 674 tests pass

Fixes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)"
```

---
*Task #624 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*