### PR TITLE
BUG: issue dedup skips recently-closed issues, causing duplicate creation on re-dispatch

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -309,11 +309,21 @@ impl ExternalBackend for GitHubBackend {
     }
 
     async fn has_open_issue_with_title(&self, title: &str, label: &str) -> anyhow::Result<bool> {
-        let issues = self.gh.list_issues(&self.repo, label).await?;
-        Ok(issues
-            .iter()
-            .filter(|i| i.pull_request.is_none()) // Exclude PRs
-            .any(|i| i.title == title))
+        // Check open issues first
+        let open_issues = self.gh.list_issues(&self.repo, label).await?;
+        if open_issues.iter().any(|i| i.title == title) {
+            return Ok(true);
+        }
+        // Also check issues closed within the last 24h — prevents re-creating a bug
+        // that was just fixed and merged (the PR close event removes the open issue).
+        let since = (chrono::Utc::now() - chrono::Duration::hours(24))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        let closed = self
+            .gh
+            .list_issues_closed_since(&self.repo, label, &since)
+            .await?;
+        Ok(closed.iter().any(|i| i.title == title))
     }
 
     async fn health_check(&self) -> anyhow::Result<()> {

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -721,6 +721,33 @@ impl GhHttp {
             .collect())
     }
 
+    /// List closed issues updated since `since` (ISO 8601), filtered by label.
+    ///
+    /// Used for dedup checks — prevents re-creating issues that were recently closed.
+    pub async fn list_issues_closed_since(
+        &self,
+        repo: &str,
+        label: &str,
+        since: &str,
+    ) -> anyhow::Result<Vec<GitHubIssue>> {
+        let url = format!("{GITHUB_API}/repos/{repo}/issues");
+        let all: Vec<GitHubIssue> = self
+            .get_all_pages(
+                &url,
+                &[
+                    ("labels", label),
+                    ("state", "closed"),
+                    ("since", since),
+                    ("per_page", "100"),
+                ],
+            )
+            .await?;
+        Ok(all
+            .into_iter()
+            .filter(|i| i.pull_request.is_none())
+            .collect())
+    }
+
     /// List all open issues (no label filter, paginated).
     pub async fn list_all_open_issues(&self, repo: &str) -> anyhow::Result<Vec<GitHubIssue>> {
         let url = format!("{GITHUB_API}/repos/{repo}/issues");


### PR DESCRIPTION
## Summary

It seems push commands need explicit approval. Please approve the push to remote so the work can be submitted.

The fix is committed locally:

**Changes made:**

1. **`src/github/http.rs`** — Added `list_issues_closed_since(repo, label, since)` method that queries the GitHub API for closed issues updated after a given ISO 8601 timestamp.

2. **`src/backends/github.rs`** — Updated `has_open_issue_with_title` to make a second API call checking issues closed in the last 24h. If any closed issue has the same title, it's treated as a duplicate. This prevents the recreate-after-merge loop.

The fix uses Option A from the issue — the GitHub API's native `state=closed&since=<timestamp>` filter, so it's efficient and adds only one extra API call per dedup check.

---
*Task #626 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*