### PR TITLE
bug: list_tasks with status filter bypasses SQLite store, reads stale GitHub labels

### DIFF
--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -182,8 +182,8 @@ impl TaskManager {
                 }
             }
 
-            // Get external tasks with this status
-            let external_tasks = self.backend.list_by_status(backend_status).await?;
+            // Get external tasks with this status (store-first, same pattern as list_external_by_status)
+            let external_tasks = self.list_external_by_status(backend_status).await?;
             for t in external_tasks {
                 tasks.push(Task::External(t));
             }


### PR DESCRIPTION
## Summary

Please approve the push command so I can push the branch to remote, then I can open a PR.

The fix is a one-line change in `src/engine/tasks.rs:186`: replaced `self.backend.list_by_status(backend_status)` with `self.list_external_by_status(backend_status)`. This makes `orch task list --status <X>` use the store-first pattern (SQLite as authoritative source) instead of reading stale GitHub labels directly. All 674 tests pass.

---
*Task #630 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*