### PR TITLE
bug: job scheduler treats NeedsReview/InReview as terminal — creates duplicate tasks

### DIFF
--- a/src/engine/jobs.rs
+++ b/src/engine/jobs.rs
@@ -204,7 +204,9 @@ pub async fn tick(
                         match status.map(|s| s.as_str()) {
                             Some("status:in_progress")
                             | Some("status:routed")
-                            | Some("status:new") => true,
+                            | Some("status:new")
+                            | Some("status:needs_review")
+                            | Some("status:in_review") => true,
                             None => true,     // No status label — treat as active
                             Some(_) => false, // Terminal state
                         }
@@ -240,9 +242,11 @@ pub async fn tick(
                     if let Ok(Some(store_id)) = s.resolve_task_id(repo, &task_id_clone).await {
                         match s.get(store_id).await {
                             Ok(task) => match task.status {
-                                TaskStatus::New | TaskStatus::Routed | TaskStatus::InProgress => {
-                                    true
-                                }
+                                TaskStatus::New
+                                | TaskStatus::Routed
+                                | TaskStatus::InProgress
+                                | TaskStatus::NeedsReview
+                                | TaskStatus::InReview => true,
                                 _ => false, // Terminal state
                             },
                             Err(e) => {


### PR DESCRIPTION
## Summary

Please approve the push command so I can push the branch to remote. The fix is committed locally — two lines added to `src/engine/jobs.rs`:

1. **External tasks** (line ~207-209): added `Some("status:needs_review") | Some("status:in_review")` to the active match arm
2. **Internal tasks** (line ~248-249): added `TaskStatus::NeedsReview | TaskStatus::InReview` to the active match arm

All 674 tests pass.

---
*Task #629 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*