### PR TITLE
bug: CI timeout in auto_merge_pr re-routes to NeedsReview (review agent) instead of New (original agent)

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1327,7 +1327,7 @@ pub(crate) async fn auto_merge_pr(
                             "CI checks still pending after timeout — re-routing to agent"
                         );
                         task_manager
-                            .update_task_status(&task.id, Status::NeedsReview)
+                            .update_task_status(&task.id, Status::New)
                             .await?;
                     }
                     return Ok(());


### PR DESCRIPTION
## Summary

I've committed the fix locally. Please approve the `git push` command to push it to the remote branch.

---
*Task #631 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*