### PR TITLE
bug: push fails for SSH-remote projects — token not injected when converting git@github.com to HTTPS

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -287,7 +287,8 @@ pub async fn push_branch(dir: &Path, branch: &str, default_branch: &str) -> anyh
     tracing::info!(branch = branch_to_push, "pushing branch");
 
     let token = crate::github::token::shared()
-        .get_token_sync()
+        .get_token()
+        .await
         .ok()
         .flatten();
     let insteadof = token.map_or_else(


### PR DESCRIPTION
## Summary

Please approve the push command to complete the landing. The fix is committed locally — I just need to `git pull --rebase && git push` to send it to remote.

---
*Task #633 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*