### PR TITLE
fix: inject GitHub token into SSH→HTTPS insteadOf rewrite for push

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -287,7 +287,8 @@ pub async fn push_branch(dir: &Path, branch: &str, default_branch: &str) -> anyh
     tracing::info!(branch = branch_to_push, "pushing branch");
 
     let token = crate::github::token::shared()
-        .get_token_sync()
+        .get_token()
+        .await
         .ok()
         .flatten();
     let insteadof = token.map_or_else(


### PR DESCRIPTION
## Summary

- Fixes push failures for SSH-remote projects where the GitHub token was not injected into the HTTPS URL produced by the `insteadOf` rewrite
- Uses async `get_token()` instead of the sync variant to properly support GitHub App tokens
- Simplifies the implementation by inlining auth logic directly into `push_branch()` (removes the `build_git_auth_args()` helper and its now-redundant unit tests)

## Root Cause

`push_branch()` rewrote `git@github.com:` → `https://github.com/` via `insteadOf`, but didn't inject credentials. Orch-managed bare clones were unaffected (token already embedded in remote URL), but local projects with SSH remotes got bare HTTPS URLs and failed with "Authentication failed".

## Fix

```rust
let insteadof = token.map_or_else(
    || "url.https://github.com/.insteadOf=git@github.com:".to_string(),
    |t| format!("url.https://x-access-token:{t}@github.com/.insteadOf=git@github.com:"),
);
```

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run` — 674 passed, 12 skipped

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)