### PR TITLE
Not all commits to main should create a new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,18 +111,18 @@ jobs:
             echo "No new commits since $LAST_TAG — skipping release."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            # Skip release if ALL commits are chore-only
+            # Skip release if ALL commits are chore/docs/test-only (non-release commits)
             if [ -n "$LAST_TAG" ]; then
               SUBJECTS=$(git log "$LAST_TAG"..HEAD --pretty=format:"%s")
             else
               SUBJECTS=$(git log --pretty=format:"%s")
             fi
-            NON_CHORE=$(echo "$SUBJECTS" | grep -cvE '^chore(\(.*\))?:' || true)
-            if [ "$NON_CHORE" -eq 0 ]; then
-              echo "All $COMMIT_COUNT commits are chore — skipping release."
+            NON_RELEASE=$(echo "$SUBJECTS" | grep -cvE '^(chore|docs|test)(\(.*\))?:' || true)
+            if [ "$NON_RELEASE" -eq 0 ]; then
+              echo "All $COMMIT_COUNT commits are chore/docs/test — skipping release."
               echo "skip=true" >> "$GITHUB_OUTPUT"
             else
-              echo "$COMMIT_COUNT new commits since ${LAST_TAG:-beginning} ($NON_CHORE non-chore)"
+              echo "$COMMIT_COUNT new commits since ${LAST_TAG:-beginning} ($NON_RELEASE non-chore/docs/test)"
               echo "skip=false" >> "$GITHUB_OUTPUT"
             fi
           fi
@@ -267,7 +267,7 @@ jobs:
               FEATURES+="- ${line}"$'\n'
             elif echo "$line" | grep -qE '^fix(\(.*\))?:'; then
               FIXES+="- ${line}"$'\n'
-            elif echo "$line" | grep -qE '^chore(\(.*\))?:'; then
+            elif echo "$line" | grep -qE '^(chore|docs|test)(\(.*\))?:'; then
               continue
             else
               OTHER+="- ${line}"$'\n'


### PR DESCRIPTION
## Summary

Perfect! I've successfully completed the fix for task #648. Here's what was done:

## Summary of Changes

**File modified:** `.github/workflows/release.yml`

**Key changes:**
1. **Line 120**: Updated regex pattern from `^chore(\(.*\))?:` to `^(chore|docs|test)(\(.*\))?:` 
   - Now matches `chore:`, `docs:`, and `test:` commits (with optional scope)

2. **Line 114**: Updated comment and variable name from "chore-only" to "chore/docs/test-only"

3. **Line 270**: Updated changelog exclusion to also skip `docs:` and `test:` commits in addition to `chore:`

**Behavior:**
- Commits with `chore:`, `docs:`, or `test:` prefixes will no longer trigger a release
- If all commits since the last tag are of these types, the workflow skips the release
- These commit types are also excluded from the changelog

**Commit created:** `c3ddfb9` - "fix: skip release for chore/docs/test commits only"

**Next step:** The changes need to be pushed to remote. Run:
```bash
git push
```

---
*Task #648 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*