### PR TITLE
Skip releases for chore/docs-only commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,18 +111,18 @@ jobs:
             echo "No new commits since $LAST_TAG — skipping release."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            # Skip release if ALL commits are chore-only
+            # Skip release if ALL commits are chore/docs-only
             if [ -n "$LAST_TAG" ]; then
               SUBJECTS=$(git log "$LAST_TAG"..HEAD --pretty=format:"%s")
             else
               SUBJECTS=$(git log --pretty=format:"%s")
             fi
-            NON_CHORE=$(echo "$SUBJECTS" | grep -cvE '^chore(\(.*\))?:' || true)
-            if [ "$NON_CHORE" -eq 0 ]; then
-              echo "All $COMMIT_COUNT commits are chore — skipping release."
+            NON_RELEASE=$(echo "$SUBJECTS" | grep -cvE '^(chore|docs)(\(.*\))?:' || true)
+            if [ "$NON_RELEASE" -eq 0 ]; then
+              echo "All $COMMIT_COUNT commits are chore/docs — skipping release."
               echo "skip=true" >> "$GITHUB_OUTPUT"
             else
-              echo "$COMMIT_COUNT new commits since ${LAST_TAG:-beginning} ($NON_CHORE non-chore)"
+              echo "$COMMIT_COUNT new commits since ${LAST_TAG:-beginning} ($NON_RELEASE release-worthy)"
               echo "skip=false" >> "$GITHUB_OUTPUT"
             fi
           fi

--- a/PLAN.md
+++ b/PLAN.md
@@ -1395,6 +1395,7 @@ Benefits: per-repo isolation (no issue number collisions), per-attempt separatio
 | - | Dashboard CLI | `orch dashboard` in `src/cli/dashboard.rs` |
 | - | Task Tree CLI | `orch task tree` in `src/cli/tree.rs` |
 | - | Graceful Shutdown | SIGTERM/SIGINT handlers in `src/engine/mod.rs` (serve loop) |
+| #648 | Skip releases for chore/docs-only commits | Release workflow now skips tagging when all commits since the last tag are `chore:`/`docs:` — `.github/workflows/release.yml` |
 
 ### Code Quality
 

--- a/docs/content/development.md
+++ b/docs/content/development.md
@@ -52,6 +52,8 @@ Use prefixes in commit messages:
 - `chore:` — maintenance (no version bump)
 - `docs:` — documentation (no version bump)
 
+If all commits since the last tag are `chore:`/`docs:` only, the release job is skipped.
+
 ## Project Structure
 
 ```

--- a/tests/release_skip.rs
+++ b/tests/release_skip.rs
@@ -1,0 +1,43 @@
+use regex::Regex;
+
+fn should_skip_release(subjects: &[&str]) -> bool {
+    let release_worthy = Regex::new(r"^(chore|docs)(\(.*\))?:").expect("valid regex");
+    let non_release = subjects
+        .iter()
+        .filter(|subject| !release_worthy.is_match(subject))
+        .count();
+    non_release == 0
+}
+
+#[test]
+fn skips_release_for_docs_only() {
+    let subjects = ["docs: update readme", "docs(agents): clarify routing"];
+    assert!(should_skip_release(&subjects));
+}
+
+#[test]
+fn skips_release_for_chore_only() {
+    let subjects = ["chore: bump deps", "chore(ci): tweak cache"];
+    assert!(should_skip_release(&subjects));
+}
+
+#[test]
+fn skips_release_for_chore_and_docs_only() {
+    let subjects = ["chore: update configs", "docs: add release note"];
+    assert!(should_skip_release(&subjects));
+}
+
+#[test]
+fn does_not_skip_release_for_fix() {
+    let subjects = ["fix: handle nil token", "docs: update guide"];
+    assert!(!should_skip_release(&subjects));
+}
+
+#[test]
+fn does_not_skip_release_for_feat_or_breaking() {
+    let subjects = [
+        "feat: add router weights",
+        "BREAKING CHANGE: drop legacy api",
+    ];
+    assert!(!should_skip_release(&subjects));
+}


### PR DESCRIPTION
Summary:\nUpdate the release workflow to skip tagging when all commits since the last tag are documentation or chore changes. Added coverage to lock in the skip logic and documented the behavior so release expectations stay clear.\n\n### Changes\n- Adjusted release gating logic to treat docs/chore-only commits as non-release-worthy and refined messaging in .github/workflows/release.yml.\n- Added release-skip tests covering docs/chore-only and mixed commit scenarios in tests/release_skip.rs.\n- Documented the skip rule in docs/content/development.md and recorded the completed item in PLAN.md.