### PR TITLE
Remove unsafe env mutations in tests

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -1791,19 +1791,43 @@ mod tests {
     #[cfg(test)]
     mod pagination {
         use super::super::*;
+        use std::ffi::OsString;
         use std::sync::Arc;
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
+        struct EnvVarGuard {
+            key: &'static str,
+            previous: Option<OsString>,
+        }
+
+        impl EnvVarGuard {
+            fn set(key: &'static str, value: &str) -> Self {
+                let previous = std::env::var_os(key);
+                std::env::set_var(key, value);
+                Self { key, previous }
+            }
+        }
+
+        impl Drop for EnvVarGuard {
+            fn drop(&mut self) {
+                match self.previous.take() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+
         /// Build a minimal GhHttp pointing at a wiremock server.
         /// The token resolver reads GH_TOKEN; we set it to a dummy value.
-        fn make_client() -> GhHttp {
+        fn make_client() -> (GhHttp, EnvVarGuard) {
             // Ensure a token is available so auth_header() doesn't bail.
-            unsafe { std::env::set_var("GH_TOKEN", "test_token") };
-            GhHttp {
+            let guard = EnvVarGuard::set("GH_TOKEN", "test_token");
+            let client = GhHttp {
                 client: reqwest::Client::new(),
                 token_resolver: Arc::new(crate::github::token::TokenResolver::default_env()),
-            }
+            };
+            (client, guard)
         }
 
         #[tokio::test]
@@ -1820,7 +1844,7 @@ mod tests {
                 .mount(&server)
                 .await;
 
-            let gh = make_client();
+            let (gh, _guard) = make_client();
             let url = format!("{}/items", server.uri());
             let result: Vec<serde_json::Value> = gh.get_all_pages(&url, &[]).await.unwrap();
 
@@ -1859,7 +1883,7 @@ mod tests {
                 .mount(&server)
                 .await;
 
-            let gh = make_client();
+            let (gh, _guard) = make_client();
             let url = format!("{}/items", server.uri());
             let result: Vec<serde_json::Value> = gh.get_all_pages(&url, &[]).await.unwrap();
 
@@ -1899,7 +1923,7 @@ mod tests {
                 .mount(&server)
                 .await;
 
-            let gh = make_client();
+            let (gh, _guard) = make_client();
             let url = format!("{}/items", server.uri());
             let result: Vec<serde_json::Value> = gh.get_all_pages(&url, &[]).await.unwrap();
 
@@ -1924,7 +1948,7 @@ mod tests {
                 .mount(&server)
                 .await;
 
-            let gh = make_client();
+            let (gh, _guard) = make_client();
             let url = format!("{}/items", server.uri());
             let result: Vec<serde_json::Value> = gh.get_all_pages(&url, &[]).await.unwrap();
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -99,15 +99,43 @@ pub fn render_and_print(template_path: &str, extra_vars: &[String]) -> io::Resul
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
     use std::io::Write;
+    use std::sync::{Mutex, OnceLock};
     use tempfile::NamedTempFile;
+
+    fn env_mutex() -> &'static Mutex<()> {
+        static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_MUTEX.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     #[test]
     fn render_template_does_not_leak_env_vars() {
         // Set a sensitive env var that must NOT appear in the rendered output
-        unsafe {
-            std::env::set_var("ORCH_TEST_SECRET_TOKEN", "should-not-appear");
-        }
+        let _lock = env_mutex().lock().unwrap();
+        let _guard = EnvVarGuard::set("ORCH_TEST_SECRET_TOKEN", "should-not-appear");
 
         let mut f = NamedTempFile::new().unwrap();
         writeln!(f, "hello world").unwrap();
@@ -117,10 +145,6 @@ mod tests {
             !result.contains("should-not-appear"),
             "env var leaked into rendered template"
         );
-
-        unsafe {
-            std::env::remove_var("ORCH_TEST_SECRET_TOKEN");
-        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Replaces unsafe environment mutations in tests with scoped guards that restore prior values after each test. This keeps template and GitHub HTTP pagination tests hermetic without introducing new dependencies. The change also keeps GH_TOKEN setup localized to each test, avoiding cross-test leakage.

### Changes
- Added env var guard + mutex helpers for template tests to serialize and restore env updates.
- Wrapped GitHub HTTP pagination tests with an env guard that restores GH_TOKEN after each test.

### Files Modified
- src/template.rs: add env guard + mutex and remove unsafe env set/remove in tests.
- src/github/http.rs: add env guard for pagination tests and remove unsafe env set.
