### PR TITLE
Docs: align review reroute status

### DIFF
--- a/docs/content/review-agent.md
+++ b/docs/content/review-agent.md
@@ -97,7 +97,7 @@ agent completes (done) → PR detected → needs_review → in_review → review
                                                                    └─ reject → needs_review (PR closed)
 ```
 
-Review re-routing: when a review requests changes, the task is re-routed back to `New` status (not a child task). The agent reuses the existing worktree/branch and pushes fixes to the same PR. If `review_cycles >= max_review_cycles`, the task is blocked for human review.
+Review re-routing: when a review requests changes, the task is re-routed back to `Routed` status (not a child task). The agent reuses the existing worktree/branch and pushes fixes to the same PR. If `review_cycles >= max_review_cycles`, the task is blocked for human review.
 
 Without the review agent enabled, tasks with open PRs still transition to `in_review` but skip the automated review step.
 

--- a/specs.md
+++ b/specs.md
@@ -324,7 +324,7 @@ new → routed → in_progress → done (agent finishes)
 The original external task is re-routed with review context stored in the unified SQLite store. The agent reuses the existing worktree/branch and pushes fixes to the same PR. Key behaviors:
 
 - Review feedback is stored in the `pr_review_context` field via the store
-- The task is re-routed to `New` (not `Routed`) so it goes through the full routing pipeline
+- The task is re-routed to `Routed` for re-dispatch (skips LLM re-classification)
 - The `ci_merge_failures` counter is reset on auto re-route
 - `review_cycles` is incremented; when `>= max_review_cycles`, the task is blocked for human review
 - The agent sees review context in `build_agent_message()` when non-empty


### PR DESCRIPTION
Summary:
Updated the review re-routing docs to match actual behavior when changes are requested. This aligns the specs and review-agent guide with the current `Routed` status handling and avoids contradictory guidance.

### Changes
- `specs.md`: clarify review re-routing uses `Routed` status and skips LLM re-classification.
- `docs/content/review-agent.md`: align review re-routing description with `Routed` status behavior.

Files modified:
- `specs.md` — corrected review re-routing status and description.
- `docs/content/review-agent.md` — corrected review re-routing status description.
