### PR TITLE
Audit and replace panics/unwraps in runtime-critical modules (tmux, store, runner, template, security)

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -436,11 +436,13 @@ impl TaskRunner {
         let run_result = self.run(task_id, agent, model, Some(&**backend)).await?;
 
         // If the runner guard skipped the task, do not re-post stale data as a new comment.
-        if run_result.is_none() {
-            tracing::info!(task_id, "guard skipped task — not posting stale result");
-            return Ok(WeightSignal::None);
-        }
-        let (status, exit_code_opt) = run_result.expect("checked above: None case returned early");
+        let (status, exit_code_opt) = match run_result {
+            None => {
+                tracing::info!(task_id, "guard skipped task — not posting stale result");
+                return Ok(WeightSignal::None);
+            }
+            Some(result) => result,
+        };
 
         // Process delegations if the agent requested subtasks
         let delegations_raw = self


### PR DESCRIPTION
## Summary

## Task #653 Complete — Audit Summary

### Findings

After auditing all specified modules, I found that **the vast majority of `unwrap`/`expect` calls are in test code**, not production code:

| File | Unwrap/Expect Count | Location | Assessment |
|------|---------------------|----------|------------|
| `src/tmux.rs` | 5 | All in `#[cfg(test)]` module | Test code only |
| `src/store.rs` | ~476 | All in `#[cfg(test)]` module (lines 2050+) | Test code only |
| `src/template.rs` | 4 | 2 in static regex init, 4 in tests | Static patterns (never fail) + test code |
| `src/security.rs` | 11 | All in static regex init | Static patterns (never fail) |
| `src/engine/runner/*.rs` | ~100+ | All in `#[cfg(test)]` modules | Test code only |
| `src/engine/mod.rs` | 3 | All in `#[cfg(test)]` module | Test code only |

### Production Code Issue Fixed

**File:** `src/engine/runner/mod.rs:443`

**Before:**
```rust
if run_result.is_none() {
    tracing::info!(task_id, "guard skipped task — not posting stale result");
    return Ok(WeightSignal::None);
}
let (status, exit_code_opt) = run_result.expect("checked above: None case returned early");
```

**After:**
```rust
let (status, exit_code_opt) = match run_result {
    None => {
        tracing::info!(task_id, "guard skipped task — not posting stale result");
        return Ok(WeightSignal::None);
    }
    Some(result) => result,
};
```

### Static Regex Patterns

The `.expect("BUG: ... regex is invalid")` calls in `src/security.rs` and `src/template.rs` use static regex literals that can never fail at runtime. Per the task guidelines, these are acceptable as "unavoidable fatal initialization errors."

### Quality Gates

All checks pass:
- ✅ `cargo fmt -- --check`
- ✅ `cargo clippy --all-targets -- -D warnings`
- ✅ `cargo nextest run` (683 tests passed, 12 skipped)

Closes #653

---
*Task #653 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*