### PR TITLE
Avoid panics in template and security paths

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -436,11 +436,13 @@ impl TaskRunner {
         let run_result = self.run(task_id, agent, model, Some(&**backend)).await?;
 
         // If the runner guard skipped the task, do not re-post stale data as a new comment.
-        if run_result.is_none() {
-            tracing::info!(task_id, "guard skipped task — not posting stale result");
-            return Ok(WeightSignal::None);
-        }
-        let (status, exit_code_opt) = run_result.expect("checked above: None case returned early");
+        let (status, exit_code_opt) = match run_result {
+            Some(result) => result,
+            None => {
+                tracing::info!(task_id, "guard skipped task — not posting stale result");
+                return Ok(WeightSignal::None);
+            }
+        };
 
         // Process delegations if the agent requested subtasks
         let delegations_raw = self

--- a/src/security.rs
+++ b/src/security.rs
@@ -17,91 +17,105 @@ pub struct LeakMatch {
 
 /// Patterns that indicate leaked secrets.
 /// Each tuple: (rule_name, regex_pattern, is_high_confidence)
-static LEAK_PATTERNS: LazyLock<Vec<(&str, Regex, bool)>> = LazyLock::new(|| {
-    vec![
-        // API keys and tokens
-        (
-            "aws_access_key",
-            Regex::new(r"AKIA[0-9A-Z]{16}")
-                .expect("BUG: aws_access_key regex is invalid"),
-            true,
-        ),
-        (
-            "aws_secret_key",
-            Regex::new(r"(?i)aws[_\-]?secret[_\-]?access[_\-]?key\s*[=:]\s*\S+")
-                .expect("BUG: aws_secret_key regex is invalid"),
-            true,
-        ),
-        (
-            "github_token",
-            Regex::new(r"gh[pousr]_[A-Za-z0-9_]{36,}")
-                .expect("BUG: github_token regex is invalid"),
-            true,
-        ),
-        (
-            "github_pat",
-            Regex::new(r"github_pat_[A-Za-z0-9_]{22,}")
-                .expect("BUG: github_pat regex is invalid"),
-            true,
-        ),
-        (
-            "openai_api_key",
-            Regex::new(r"sk-[A-Za-z0-9\-]{20,}")
-                .expect("BUG: openai_api_key regex is invalid"),
-            true,
-        ),
-        (
-            "anthropic_api_key",
-            Regex::new(r"sk-ant-[A-Za-z0-9\-]{20,}")
-                .expect("BUG: anthropic_api_key regex is invalid"),
-            true,
-        ),
-        (
-            "slack_token",
-            Regex::new(r"xox[baprs]-[0-9A-Za-z\-]{10,}")
-                .expect("BUG: slack_token regex is invalid"),
-            true,
-        ),
-        (
-            "stripe_key",
-            Regex::new(r"[sr]k_(live|test)_[A-Za-z0-9]{20,}")
-                .expect("BUG: stripe_key regex is invalid"),
-            true,
-        ),
-        (
-            "telegram_bot_token",
-            Regex::new(r"\d{8,10}:[A-Za-z0-9_-]{35}")
-                .expect("BUG: telegram_bot_token regex is invalid"),
-            false, // lower confidence, could be other things
-        ),
-        // Private keys
-        (
-            "private_key",
-            Regex::new(r"-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----")
-                .expect("BUG: private_key regex is invalid"),
-            true,
-        ),
-        // Generic patterns (lower confidence)
-        (
-            "generic_secret",
-            Regex::new(r#"(?i)(password|secret|token|api[_\-]?key)\s*[=:]\s*["']?[A-Za-z0-9+/=_\-]{16,}["']?"#)
-                .expect("BUG: generic_secret regex is invalid"),
-            false,
-        ),
-        (
-            "connection_string",
-            Regex::new(r"(?i)(postgres|mysql|mongodb|redis)://[^\s]{10,}")
-                .expect("BUG: connection_string regex is invalid"),
-            true,
-        ),
-        (
-            "bearer_token",
-            Regex::new(r"(?i)bearer\s+[A-Za-z0-9\-._~+/]+=*")
-                .expect("BUG: bearer_token regex is invalid"),
-            false,
-        ),
-    ]
-});
+struct LeakPatternSpec {
+    rule: &'static str,
+    pattern: &'static str,
+    high_confidence: bool,
+}
+
+const LEAK_PATTERN_SPECS: &[LeakPatternSpec] = &[
+    // API keys and tokens
+    LeakPatternSpec {
+        rule: "aws_access_key",
+        pattern: r"AKIA[0-9A-Z]{16}",
+        high_confidence: true,
+    },
+    LeakPatternSpec {
+        rule: "aws_secret_key",
+        pattern: r"(?i)aws[_\-]?secret[_\-]?access[_\-]?key\s*[=:]\s*\S+",
+        high_confidence: true,
+    },
+    LeakPatternSpec {
+        rule: "github_token",
+        pattern: r"gh[pousr]_[A-Za-z0-9_]{36,}",
+        high_confidence: true,
+    },
+    LeakPatternSpec {
+        rule: "github_pat",
+        pattern: r"github_pat_[A-Za-z0-9_]{22,}",
+        high_confidence: true,
+    },
+    LeakPatternSpec {
+        rule: "openai_api_key",
+        pattern: r"sk-[A-Za-z0-9\-]{20,}",
+        high_confidence: true,
+    },
+    LeakPatternSpec {
+        rule: "anthropic_api_key",
+        pattern: r"sk-ant-[A-Za-z0-9\-]{20,}",
+        high_confidence: true,
+    },
+    LeakPatternSpec {
+        rule: "slack_token",
+        pattern: r"xox[baprs]-[0-9A-Za-z\-]{10,}",
+        high_confidence: true,
+    },
+    LeakPatternSpec {
+        rule: "stripe_key",
+        pattern: r"[sr]k_(live|test)_[A-Za-z0-9]{20,}",
+        high_confidence: true,
+    },
+    LeakPatternSpec {
+        rule: "telegram_bot_token",
+        pattern: r"\d{8,10}:[A-Za-z0-9_-]{35}",
+        high_confidence: false,
+    },
+    // Private keys
+    LeakPatternSpec {
+        rule: "private_key",
+        pattern: r"-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----",
+        high_confidence: true,
+    },
+    // Generic patterns (lower confidence)
+    LeakPatternSpec {
+        rule: "generic_secret",
+        pattern: r#"(?i)(password|secret|token|api[_\-]?key)\s*[=:]\s*["']?[A-Za-z0-9+/=_\-]{16,}["']?"#,
+        high_confidence: false,
+    },
+    LeakPatternSpec {
+        rule: "connection_string",
+        pattern: r"(?i)(postgres|mysql|mongodb|redis)://[^\s]{10,}",
+        high_confidence: true,
+    },
+    LeakPatternSpec {
+        rule: "bearer_token",
+        pattern: r"(?i)bearer\s+[A-Za-z0-9\-._~+/]+=*",
+        high_confidence: false,
+    },
+];
+
+fn build_leak_patterns(specs: &[LeakPatternSpec]) -> Vec<(&'static str, Regex, bool)> {
+    let mut patterns = Vec::new();
+
+    for spec in specs {
+        match Regex::new(spec.pattern) {
+            Ok(regex) => patterns.push((spec.rule, regex, spec.high_confidence)),
+            Err(err) => {
+                tracing::error!(
+                    rule = spec.rule,
+                    pattern = spec.pattern,
+                    error = %err,
+                    "failed to compile leak detection regex"
+                );
+            }
+        }
+    }
+
+    patterns
+}
+
+static LEAK_PATTERNS: LazyLock<Vec<(&str, Regex, bool)>> =
+    LazyLock::new(|| build_leak_patterns(LEAK_PATTERN_SPECS));
 
 /// Scan text for potential leaked secrets.
 ///
@@ -243,5 +257,26 @@ mod tests {
     fn clean_text_has_no_leaks() {
         let text = "This is normal agent output.\nFixed bug in parser.rs\nAll tests pass.";
         assert!(!has_leaks(text));
+    }
+
+    #[test]
+    fn build_leak_patterns_skips_invalid_regex() {
+        let specs = [
+            LeakPatternSpec {
+                rule: "good",
+                pattern: r"good",
+                high_confidence: true,
+            },
+            LeakPatternSpec {
+                rule: "bad",
+                pattern: r"(",
+                high_confidence: false,
+            },
+        ];
+
+        let patterns = build_leak_patterns(&specs);
+
+        assert!(patterns.iter().any(|(rule, _, _)| *rule == "good"));
+        assert!(!patterns.iter().any(|(rule, _, _)| *rule == "bad"));
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -5,14 +5,22 @@ use std::io::{self, Write};
 use std::sync::LazyLock;
 
 /// Matches `{{#if VAR}}...{{/if}}` blocks (non-greedy, dotall).
-static IF_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?s)\{\{#if\s+(\w+)\}\}(.*?)\{\{/if\}\}")
-        .expect("BUG: if_pattern regex is invalid")
-});
+fn compile_pattern(pattern: &str, label: &str) -> Result<Regex, String> {
+    Regex::new(pattern).map_err(|err| format!("invalid {label} regex: {err}"))
+}
+
+fn if_pattern() -> Result<&'static Regex, String> {
+    static IF_PATTERN: LazyLock<Result<Regex, String>> =
+        LazyLock::new(|| compile_pattern(r"(?s)\{\{#if\s+(\w+)\}\}(.*?)\{\{/if\}\}", "if_pattern"));
+    IF_PATTERN.as_ref().map_err(|err| err.clone())
+}
 
 /// Matches `{{VAR}}` variable placeholders.
-static VAR_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\{\{(\w+)\}\}").expect("BUG: var_pattern regex is invalid"));
+fn var_pattern() -> Result<&'static Regex, String> {
+    static VAR_PATTERN: LazyLock<Result<Regex, String>> =
+        LazyLock::new(|| compile_pattern(r"\{\{(\w+)\}\}", "var_pattern"));
+    VAR_PATTERN.as_ref().map_err(|err| err.clone())
+}
 
 fn render_template_with_vars(
     template: &str,
@@ -22,7 +30,7 @@ fn render_template_with_vars(
 
     loop {
         let mut changed = false;
-        let new_data = IF_PATTERN
+        let new_data = if_pattern()?
             .replace_all(&data, |caps: &regex::Captures| {
                 changed = true;
                 let var_name = &caps[1];
@@ -40,7 +48,7 @@ fn render_template_with_vars(
         }
     }
 
-    let result = VAR_PATTERN
+    let result = var_pattern()?
         .replace_all(&data, |caps: &regex::Captures| {
             let var_name = &caps[1];
             vars.get(var_name).cloned().unwrap_or_default()
@@ -155,5 +163,11 @@ mod tests {
         let result =
             render_template(f.path().to_str().unwrap(), &["MY_VAR=hello".to_string()]).unwrap();
         assert_eq!(result.trim(), "value=hello");
+    }
+
+    #[test]
+    fn compile_pattern_rejects_invalid_regex() {
+        let err = compile_pattern("(", "bad_pattern").unwrap_err();
+        assert!(err.contains("bad_pattern"));
     }
 }


### PR DESCRIPTION
Summary:
- Replaced panic-on-regex-init in template and security utilities with fallible compilation, logging, and error propagation to prevent crashes on unexpected regex failures.
- Made runner guard handling use an explicit match instead of an expect.
- Added unit tests that exercise invalid-regex paths.

### Changes
- src/security.rs: define leak pattern specs, compile with logging and skip invalid patterns; add test coverage for invalid regex handling.
- src/template.rs: add compile helpers, store regex compilation results, and propagate errors during rendering; add invalid-regex test.
- src/engine/runner/mod.rs: avoid expect when handling skipped runs.
