### PR TITLE
Code development: orch

### DIFF
--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -210,6 +210,15 @@ impl LlmRouter {
         Ok(prompt)
     }
 
+    /// Invalidate the skills catalog cache so the next routing call reloads from disk.
+    ///
+    /// Called after `skills_sync()` updates skill files on disk.
+    pub fn invalidate_skills_catalog(&self) {
+        if let Ok(mut cache) = self.skills_catalog.lock() {
+            *cache = None;
+        }
+    }
+
     /// Load skills catalog from skills.yml or skills directory.
     /// Cached after first load to avoid blocking I/O in async context.
     fn load_skills_catalog(&self) -> String {

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -118,6 +118,13 @@ impl Router {
         self.weights.ensure_agents(&new_agents);
     }
 
+    /// Invalidate the skills catalog cache so the next routing call reloads from disk.
+    ///
+    /// Call this after `skills_sync()` writes new/updated skill files.
+    pub fn invalidate_skills_catalog(&self) {
+        self.llm_router.invalidate_skills_catalog();
+    }
+
     /// Discover available agent CLIs in PATH.
     /// Checks all agents from the configured list.
     fn discover_agents(configured_agents: &[String]) -> Vec<String> {

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -393,8 +393,15 @@ pub(crate) async fn sync_tick(
     }
 
     // 7. Sync skill repositories
-    if let Err(e) = skills_sync().await {
-        tracing::warn!(err = %e, "skills sync failed");
+    match skills_sync().await {
+        Ok(()) => {
+            // Invalidate the LLM router's skills catalog cache so new/updated
+            // skill files are picked up on the next routing call.
+            router.read().await.invalidate_skills_catalog();
+        }
+        Err(e) => {
+            tracing::warn!(err = %e, "skills sync failed");
+        }
     }
 
     Ok(())

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -201,6 +201,19 @@ pub(crate) async fn tick_recover_stuck_tasks(
                     "recovering stuck internal task: no session found — reclaiming early → new"
                 );
             }
+            // Reset routing state so the LLM router is used on the next attempt
+            // (same reset that external tasks perform).
+            super::cleanup::store_set(
+                &Some(Arc::clone(store)),
+                repo,
+                &task_id,
+                &[
+                    ("agent", serde_json::Value::Null),
+                    ("model", serde_json::Value::Null),
+                    ("route_attempts", serde_json::json!(0)),
+                ],
+            )
+            .await;
             if let Err(e) = task_manager
                 .update_task_status(&ExternalId(task_id.clone()), Status::New)
                 .await


### PR DESCRIPTION
## Summary

It seems the push commands keep requiring approval. Please approve the `git push` command so I can push the commit to remote.

The commit `da84419` is ready locally with both fixes:

1. **#679** (`tick.rs`): Internal stuck tasks now reset `agent`, `model`, and `route_attempts=0` in the store (same as external tasks), preventing fallback to round-robin routing after recovery.

2. **#678** (`router/llm.rs`, `router/mod.rs`, `sync.rs`): Added `invalidate_skills_catalog()` to `LlmRouter` and exposed it on `Router`. `sync_tick` now calls it after a successful `skills_sync()` so newly-installed or updated skills are picked up on the next routing call without a service restart.

---
*Task internal-2963 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*