### PR TITLE
fix: auto_close_task_on_approval and workflow.auto_merge are inconsistent — automated review ignores the flag

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1214,9 +1214,13 @@ pub(crate) async fn review_and_merge(
     // 13. Handle the decision
     match decision {
         ReviewDecision::Approve => {
-            let auto_merge = config::get("workflow.auto_merge")
-                .map(|v| v == "true")
-                .unwrap_or(true);
+            // Use the same flag as the human-review path (review_open_prs).
+            // Falls back to workflow.auto_merge for backwards-compatibility,
+            // but auto_close_task_on_approval takes precedence when set.
+            let auto_merge = config::get("workflow.auto_close_task_on_approval")
+                .or_else(|_| config::get("workflow.auto_merge"))
+                .map(|v| v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false);
 
             if auto_merge {
                 if let Err(e) = auto_merge_pr(


### PR DESCRIPTION
## Summary

All 685 tests pass. The fix:

- `review_and_merge` (automated review path) now checks `workflow.auto_close_task_on_approval` first, falling back to `workflow.auto_merge` for backwards-compatibility
- Default changed from `true` to `false` — matching the `EngineConfig` default, so users who haven't set either flag won't get unexpected auto-merges
- The human review path (`review_open_prs`) already uses `auto_close_task_on_approval` — both paths are now consistent

---
*Task internal-3083 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*