### PR TITLE
fix: auto_merge_pr returns Ok(()) on approve-comment failure, leaving task stuck in InReview

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1301,9 +1301,11 @@ pub(crate) async fn auto_merge_pr(
             tracing::warn!(
                 task_id = task.id.0,
                 pr_number,
-                "automated review says changes_requested — skipping merge"
+                "automated review says changes_requested — approve comment was not posted, returning error"
             );
-            return Ok(());
+            anyhow::bail!(
+                "approve comment was not posted (latest review is changes_requested); task should be re-queued"
+            );
         }
         _ => {
             tracing::info!(


### PR DESCRIPTION
## Summary

Please approve the push, or run it manually:

```bash
git push -u origin gh-task-internal-3082-fix-auto-merge-pr-returns-ok-on-approve
```

**Summary of the fix:**

In `src/engine/review.rs:1300-1307`, changed `return Ok(())` to `anyhow::bail!(...)` in the `changes_requested` branch of `auto_merge_pr`'s defensive verify check.

**Before:** When the approve comment failed to post and the verify found `changes_requested`, the function silently returned `Ok(())`, which tick.rs treated as success (reset counters, task stays `InReview` → spin loop).

**After:** Returns `Err`, which propagates to `review_and_merge` as `Ok(ReviewDecision::Failed(...))`, which tick.rs handles by moving the task to `NeedsReview` (or `Blocked` after `MAX_REVIEW_AGENT_FAILURES`).

---
*Task internal-3082 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*