### PR TITLE
fix: store_reset_counters in tick.rs resets review_cycles after every RequestChanges, making max_review_cycles unenforceable

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -178,6 +178,22 @@ pub(crate) async fn store_reset_counters(
     }
 }
 
+/// Reset transient failure/retry counters, preserving `review_cycles`.
+///
+/// Use this after a `RequestChanges` review decision so that per-attempt
+/// noise is cleared without undoing the cycle count set by `handle_review_changes`.
+pub(crate) async fn store_reset_failure_counters(
+    store: &Option<Arc<TaskStore>>,
+    repo: &str,
+    task_id: &str,
+) {
+    if let Some(ref store) = store {
+        if let Ok(Some(store_id)) = store.resolve_task_id(repo, task_id).await {
+            let _ = store.reset_failure_counters(store_id).await;
+        }
+    }
+}
+
 /// Get token usage from the store.
 pub(crate) async fn get_token_usage(
     store: &Option<Arc<TaskStore>>,
@@ -1559,6 +1575,39 @@ mod tests {
         let store: Option<Arc<TaskStore>> = None;
         // Should not panic
         store_reset_counters(&store, "owner/repo", "no-task").await;
+    }
+
+    #[tokio::test]
+    async fn store_reset_failure_counters_preserves_review_cycles() {
+        use crate::store::{NewTask, TaskStore};
+
+        let store = Arc::new(TaskStore::open_memory().await.unwrap());
+        let id = store
+            .create(&NewTask {
+                external_id: Some("93".to_string()),
+                repo: "owner/repo".to_string(),
+                origin: "github".to_string(),
+                title: "Failure counter test".to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let opt_store = Some(store.clone());
+        store_increment(&opt_store, "owner/repo", "93", "review_cycles").await;
+        store_increment(&opt_store, "owner/repo", "93", "attempts").await;
+        store_increment(&opt_store, "owner/repo", "93", "merge_conflict_retries").await;
+
+        // Calling the failure-only reset must preserve review_cycles
+        store_reset_failure_counters(&opt_store, "owner/repo", "93").await;
+
+        let task = store.get(id).await.unwrap();
+        assert_eq!(
+            task.review_cycles, 1,
+            "review_cycles must survive failure counter reset"
+        );
+        assert_eq!(task.attempts, 0);
+        assert_eq!(task.merge_conflict_retries, 0);
     }
 
     // ── get_total_tokens ──────────────────────────────────────────────────

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -257,9 +257,20 @@ pub(crate) async fn sync_tick(
                             ReviewOutcome::Reset
                         }
                     }
-                    Ok(_) => {
+                    Ok(ReviewDecision::Approve) | Ok(ReviewDecision::Skipped) => {
                         super::cleanup::store_reset_counters(&Some(store_c.clone()), &repo_s, &tid)
                             .await;
+                        ReviewOutcome::Ok
+                    }
+                    Ok(ReviewDecision::RequestChanges { .. }) => {
+                        // handle_review_changes already incremented review_cycles —
+                        // only reset transient per-attempt counters.
+                        super::cleanup::store_reset_failure_counters(
+                            &Some(store_c.clone()),
+                            &repo_s,
+                            &tid,
+                        )
+                        .await;
                         ReviewOutcome::Ok
                     }
                 };

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -670,16 +670,29 @@ pub(crate) async fn tick_dispatch_tasks(
                                                     }
                                                 }
                                             }
-                                            Ok(_) => {
-                                                // Reset all review-cycle failure counters on success
-                                                // so a subsequent retry doesn't inherit stale values.
+                                            Ok(super::review::ReviewDecision::Approve)
+                                            | Ok(super::review::ReviewDecision::Skipped) => {
+                                                // Full reset: task is done with the review cycle.
                                                 super::cleanup::store_reset_counters(
                                                     &Some(store_for_review.clone()),
                                                     &repo_owned,
                                                     &task_id_for_review,
                                                 )
                                                 .await;
-                                            } // Approve or RequestChanges handled inside
+                                            }
+                                            Ok(super::review::ReviewDecision::RequestChanges {
+                                                ..
+                                            }) => {
+                                                // handle_review_changes already incremented
+                                                // review_cycles — only reset transient per-attempt
+                                                // counters so the cycle count is preserved.
+                                                super::cleanup::store_reset_failure_counters(
+                                                    &Some(store_for_review.clone()),
+                                                    &repo_owned,
+                                                    &task_id_for_review,
+                                                )
+                                                .await;
+                                            }
                                         }
                                         // Release the per-task lock so sync_tick can act on this task.
                                         {

--- a/src/store.rs
+++ b/src/store.rs
@@ -890,6 +890,28 @@ impl TaskStore {
         Ok(())
     }
 
+    /// Reset transient failure/retry counters to zero, preserving `review_cycles`.
+    ///
+    /// Use this after `RequestChanges` to clear per-attempt noise without
+    /// undoing the review-cycle count that `handle_review_changes` just set.
+    pub async fn reset_failure_counters(&self, id: i64) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE tasks SET
+                attempts = 0,
+                route_attempts = 0,
+                review_agent_failures = 0,
+                merge_conflict_retries = 0,
+                pr_create_failures = 0,
+                ci_merge_failures = 0,
+                updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+             WHERE id = ?",
+        )
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     // ---------------------------------------------------------------
     // Routing
     // ---------------------------------------------------------------
@@ -3042,6 +3064,42 @@ mod tests {
         assert_eq!(task.agent, Some("claude".to_string()));
         assert_eq!(task.branch, "fix-123");
         assert_eq!(task.summary, "did something");
+    }
+
+    #[tokio::test]
+    async fn reset_failure_counters_preserves_review_cycles() {
+        let store = TaskStore::open_memory().await.unwrap();
+
+        let id = store
+            .create(&NewTask {
+                external_id: None,
+                repo: "owner/repo".to_string(),
+                origin: "internal".to_string(),
+                title: "Test".to_string(),
+                body: "".to_string(),
+                source: "manual".to_string(),
+                source_id: "".to_string(),
+                author: "".to_string(),
+                url: "".to_string(),
+                labels: vec![],
+            })
+            .await
+            .unwrap();
+
+        // Simulate counters after a review cycle: review_cycles=1, plus transient failures
+        store.increment(id, "review_cycles").await.unwrap();
+        store.increment(id, "attempts").await.unwrap();
+        store.increment(id, "review_agent_failures").await.unwrap();
+        store.increment(id, "merge_conflict_retries").await.unwrap();
+
+        // reset_failure_counters must zero transient counters but preserve review_cycles
+        store.reset_failure_counters(id).await.unwrap();
+
+        let task = store.get(id).await.unwrap();
+        assert_eq!(task.review_cycles, 1, "review_cycles must be preserved");
+        assert_eq!(task.attempts, 0);
+        assert_eq!(task.review_agent_failures, 0);
+        assert_eq!(task.merge_conflict_retries, 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Implementation complete. What would you like to do?

1. Merge back to `main` locally
2. Push and create a Pull Request
3. Keep the branch as-is (I'll handle it later)
4. Discard this work

Which option?

Closes #684

---
*Task #684 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*