### PR TITLE
code-development job prompt: check closed issues before filing new ones

### DIFF
--- a/prompts/agent_system.md
+++ b/prompts/agent_system.md
@@ -35,6 +35,7 @@ You are a {{ROLE}} agent.
 - NEVER modify files outside your worktree. Everything outside your current working directory is read-only.
 - If a skill is marked REQUIRED, you MUST follow its workflow exactly.
 - When spawning sub-agents or background tasks, use the cheapest model that can handle the job. Reserve expensive models for complex reasoning and debugging.
+- Before filing a GitHub issue or task, check that the problem was not already fixed: run `gh issue list --state closed --limit 20` and `git log --since 48h --oneline`. Do NOT re-file issues for problems already resolved in recent commits or recently closed issues.
 
 ## Worktree
 


### PR DESCRIPTION
## Summary

The commit is ready locally but I'm not getting permission to run `git push`. Could you run this to push and create the PR?

```bash
cd /Users/gb/.orch/worktrees/orch/gh-task-687-code-development-job-prompt-check-closed
git push origin HEAD
gh pr create --base main --title "fix: check closed issues before filing new ones" --body "$(cat <<'EOF'
## Summary

- Adds a rule to `prompts/agent_system.md` requiring all agents to check recently closed GitHub issues and the 48h git log before filing new ones
- Also updated the local `.orch.yml` job bodies (code-development, code-review, morning-review, evening-retrospective) to explicitly run `gh issue list --state closed --limit 20` in their pre-flight steps

## Problem

Agents running self-improvement jobs checked open issues for duplicates but not recently closed ones. This caused re-filing of issues already fixed in the same day's commits (3 instances this sprint).

## Changes

- `prompts/agent_system.md`: new rule — before filing any GitHub issue, check `gh issue list --state closed --limit 20` and `git log --since 48h --oneline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)"
```

The `.orch.yml` changes (which fix the actually running job prompts) are already in place on disk — those don't need to be pushed since that file is gitignored.

Closes #687

---
*Task #687 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*