### PR TITLE
Code development: orch

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1716,11 +1716,10 @@ pub(crate) async fn handle_review_changes(
         tracing::warn!(task_id = task.id.0, pr_number, err = %e, "failed to post review comment on PR");
     }
 
-    // 3. Build review context
-    let review_context = format!(
-        "A reviewer has requested changes on your PR. Please address the following feedback:\n\n{}",
-        comment
-    );
+    // 3. Store review context.
+    //    The template (prompts/agent_message.md) already wraps PR_REVIEW_CONTEXT with
+    //    "A reviewer has requested changes on your PR. Please address the following feedback:",
+    //    so we store the comment body directly to avoid duplicating that header in the prompt.
     store_set(
         &Some(Arc::clone(store)),
         repo,
@@ -1730,10 +1729,7 @@ pub(crate) async fn handle_review_changes(
                 "review_cycles",
                 serde_json::json!((review_cycles + 1) as i64),
             ),
-            (
-                "pr_review_context",
-                serde_json::json!(review_context.clone()),
-            ),
+            ("pr_review_context", serde_json::json!(comment.clone())),
         ],
     )
     .await;
@@ -2098,9 +2094,26 @@ mod tests {
         );
 
         // pr_review_context must be stored for injection into the agent prompt.
+        // It must NOT contain the "A reviewer has requested changes" prefix — that
+        // prefix is already provided by the agent_message.md template wrapper so
+        // storing it here would duplicate the header in the agent prompt.
         assert!(
             !updated.pr_review_context.is_empty(),
             "pr_review_context must be stored so the re-dispatched agent sees the feedback"
+        );
+        assert!(
+            !updated
+                .pr_review_context
+                .starts_with("A reviewer has requested changes"),
+            "pr_review_context must NOT start with the template header — \
+             agent_message.md already adds it, double-prefix confuses the agent"
+        );
+        // The stored context must include the actual review content.
+        assert!(
+            updated
+                .pr_review_context
+                .contains("Please fix the type error on line 42"),
+            "pr_review_context must contain the review notes passed to handle_review_changes"
         );
 
         // review_cycles must have been incremented.


### PR DESCRIPTION
## Summary

The push permission is being blocked. The fix is committed locally. Here's a summary of what was done:

**Fix: Remove duplicate review header from `pr_review_context`**

**Bug found:** In `handle_review_changes` (`src/engine/review.rs`), `pr_review_context` was stored with the prefix:
> "A reviewer has requested changes on your PR. Please address the following feedback:"

But `agent_message.md` already wraps `{{PR_REVIEW_CONTEXT}}` with that exact same header. The agent was seeing the header **twice** in every re-dispatch prompt.

**Fix:** Store `comment` directly as `pr_review_context` instead of wrapping it in `review_context`. This aligns with how `review_open_prs` sets the field (no prefix wrapper).

**Tests updated:** Added two assertions to the regression test:
1. `pr_review_context` must NOT start with "A reviewer has requested changes" (guards against re-introducing the double header)
2. `pr_review_context` must contain the actual review notes

All 694 tests pass, clippy clean.

To push manually:
```bash
cd /Users/gb/.orch/worktrees/orch/gh-task-internal-3445-code-development-orch
git push -u origin gh-task-internal-3445-code-development-orch
```

---
*Task internal-3445 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*