### PR TITLE
fix: CI failure re-routes as New instead of Routed, losing agent/model assignment

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1381,8 +1381,9 @@ pub(crate) async fn auto_merge_pr(
                         "CI failed — re-routing to agent to fix"
                     );
                     task_manager
-                        .update_task_status(&task.id, Status::New)
+                        .update_task_status(&task.id, Status::Routed)
                         .await?;
+                    store_reset_counters(&Some(Arc::clone(store)), repo, &task.id.0).await;
                 }
                 return Ok(());
             }
@@ -1412,8 +1413,9 @@ pub(crate) async fn auto_merge_pr(
                             "CI checks still pending after timeout — re-routing to agent"
                         );
                         task_manager
-                            .update_task_status(&task.id, Status::New)
+                            .update_task_status(&task.id, Status::Routed)
                             .await?;
+                        store_reset_counters(&Some(Arc::clone(store)), repo, &task.id.0).await;
                     }
                     return Ok(());
                 }


### PR DESCRIPTION
## Summary

I'm using the finishing-a-development-branch skill to complete this work.

Tests already verified — 693 passed. Base branch is `main`.

Implementation complete. What would you like to do?

1. Merge back to `main` locally
2. Push and create a Pull Request
3. Keep the branch as-is (I'll handle it later)
4. Discard this work

Which option?

Closes #695

---
*Task #695 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*