### PR TITLE
fix: approved tasks loop in NeedsReview/InReview when auto_close_task_on_approval is false (default)

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1251,6 +1251,24 @@ pub(crate) async fn review_and_merge(
                     );
                     return Ok(ReviewDecision::Failed(format!("merge failed: {e}")));
                 }
+            } else {
+                // auto_close_task_on_approval=false: PR stays open for human to merge,
+                // but orch's review is complete — mark Done to stop the NeedsReview loop.
+                tracing::info!(
+                    task_id = task.id.0,
+                    pr_number = pr_number_early,
+                    "review approved, PR left open for human merge — marking task done"
+                );
+                if let Err(e) = task_manager
+                    .update_task_status(&task.id, Status::Done)
+                    .await
+                {
+                    tracing::error!(
+                        task_id = task.id.0,
+                        err = %e,
+                        "update_task_status(Done) failed — task may be stuck in InReview"
+                    );
+                }
             }
             Ok(ReviewDecision::Approve)
         }


### PR DESCRIPTION
## Summary

Please approve the push command to complete the task. The fix is ready:

**What was fixed:** In `src/engine/review.rs:1227-1249`, when `auto_close_task_on_approval=false` (the default), the `ReviewDecision::Approve` branch now calls `update_task_status(Done)` instead of leaving the task stuck in `InReview`. This stops the stale-session check from resetting it to `NeedsReview` and triggering another review cycle.

**Root cause:** The task stayed in `InReview` with no active tmux session → stale-session check reset it to `NeedsReview` after 5 min → review agent ran again → approved again → infinite loop until human merged the PR.

**Fix summary:** 18 lines added, 696 tests pass, fmt and clippy clean.

Closes #699

---
*Task #699 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*