### PR TITLE
fix: ci_merge_failures reset in store_reset_failure_counters makes MAX_CI_MERGE_FAILURES unreachable

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -922,10 +922,12 @@ impl TaskStore {
         Ok(())
     }
 
-    /// Reset transient failure/retry counters to zero, preserving `review_cycles`.
+    /// Reset transient failure/retry counters to zero, preserving `review_cycles` and `ci_merge_failures`.
     ///
     /// Use this after `RequestChanges` to clear per-attempt noise without
     /// undoing the review-cycle count that `handle_review_changes` just set.
+    /// `ci_merge_failures` is preserved here because it must accumulate across attempts
+    /// to enforce `MAX_CI_MERGE_FAILURES`, just like `review_cycles`.
     pub async fn reset_failure_counters(&self, id: i64) -> anyhow::Result<()> {
         sqlx::query(
             "UPDATE tasks SET
@@ -934,7 +936,6 @@ impl TaskStore {
                 review_agent_failures = 0,
                 merge_conflict_retries = 0,
                 pr_create_failures = 0,
-                ci_merge_failures = 0,
                 updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
              WHERE id = ?",
         )
@@ -3182,17 +3183,23 @@ mod tests {
             .await
             .unwrap();
 
-        // Simulate counters after a review cycle: review_cycles=1, plus transient failures
+        // Simulate counters after a review cycle: review_cycles=1, ci_merge_failures=2, plus transient failures
         store.increment(id, "review_cycles").await.unwrap();
+        store.increment(id, "ci_merge_failures").await.unwrap();
+        store.increment(id, "ci_merge_failures").await.unwrap();
         store.increment(id, "attempts").await.unwrap();
         store.increment(id, "review_agent_failures").await.unwrap();
         store.increment(id, "merge_conflict_retries").await.unwrap();
 
-        // reset_failure_counters must zero transient counters but preserve review_cycles
+        // reset_failure_counters must zero transient counters but preserve review_cycles and ci_merge_failures
         store.reset_failure_counters(id).await.unwrap();
 
         let task = store.get(id).await.unwrap();
         assert_eq!(task.review_cycles, 1, "review_cycles must be preserved");
+        assert_eq!(
+            task.ci_merge_failures, 2,
+            "ci_merge_failures must be preserved"
+        );
         assert_eq!(task.attempts, 0);
         assert_eq!(task.review_agent_failures, 0);
         assert_eq!(task.merge_conflict_retries, 0);


### PR DESCRIPTION
## Summary

## Summary

I've successfully fixed task #706. Here's what was done:

### The Bug
`MAX_CI_MERGE_FAILURES = 3` was intended to block a task after repeated CI failures, but the guard could never trigger because `reset_failure_counters` was resetting `ci_merge_failures = 0` on every re-route, preventing the counter from accumulating.

### The Fix
**Removed one line from `src/store.rs`** (line 937):
- Deleted `ci_merge_failures = 0,` from the `reset_failure_counters` SQL UPDATE
- `ci_merge_failures` must accumulate across attempts like `review_cycles`, not be cleared on transient resets
- Only the full `reset_counters` (complete task restart) and explicit reset on successful merge should zero it

### Changes Made
1. **Code change**: Removed `ci_merge_failures = 0,` from `reset_failure_counters` method
2. **Documentation**: Updated comments to explain why `ci_merge_failures` is preserved
3. **Tests**: Updated `reset_failure_counters_preserves_review_cycles` test to verify `ci_merge_failures` preservation

### Verification
✅ All 698 tests pass  
✅ Code formatting verified  
✅ Clippy lints pass  
✅ Commit ready  

The implementation is complete and ready to push to the remote branch.

Closes #706

---
*Task #706 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*