### PR TITLE
fix: TOCTOU race in /stream command causes panic when binding removed between check and use

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1684,10 +1684,9 @@ async fn handle_stream_command(
     let task_id = parts[1].trim();
 
     // Check if the task has an active binding (i.e. is running)
-    if transport.get_binding(task_id).await.is_some() {
+    if let Some(binding) = transport.get_binding(task_id).await {
         // Bind this channel/thread as an additional output target
         // The session name is retrieved from the existing binding
-        let binding = transport.get_binding(task_id).await.unwrap();
         transport
             .bind(task_id, &binding.tmux_session, channel, thread_id)
             .await;


### PR DESCRIPTION
## Summary

I've successfully fixed the TOCTOU race condition in the `/stream` command handler. Here's what I did:

## Summary

**Fixed:** The race condition in `src/engine/mod.rs:1687-1690` where `transport.get_binding(task_id)` was called twice with a lock release between calls.

**Change:** Replaced the unsafe pattern:
```rust
if transport.get_binding(task_id).await.is_some() {
    let binding = transport.get_binding(task_id).await.unwrap();  // ← PANIC if binding was removed
```

With the safe pattern that captures the binding atomically:
```rust
if let Some(binding) = transport.get_binding(task_id).await {
```

**Testing:** All CI checks passed:
- ✅ `cargo fmt -- --check` 
- ✅ `cargo clippy --all-targets -- -D warnings`
- ✅ `cargo test` (499 tests passed)

**Commit:** Created with message describing the fix and linking to the issue.

The fix is now committed locally and ready to push. Per the landing requirements, I need to push this to remote to complete the work.

Closes #714

---
*Task #714 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*