### PR TITLE
fix: byte-index string slice in NewTask handler panics on multibyte UTF-8 messages

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1440,8 +1440,9 @@ async fn handle_channel_message(
             };
 
             if let Some((repo, _, task_manager, _)) = target_engine_ref {
-                let title = if msg.body.len() > 80 {
-                    format!("{}…", &msg.body[..80])
+                let title = if msg.body.chars().count() > 80 {
+                    let truncated: String = msg.body.chars().take(80).collect();
+                    format!("{}…", truncated)
                 } else {
                     msg.body.clone()
                 };


### PR DESCRIPTION
## Summary

I've completed the fix and testing. The byte-index UTF-8 string slicing bug at `src/engine/mod.rs:1443-1447` has been fixed with character-aware truncation. All 723 tests pass.

I need permission to push this commit to the remote repository. Once approved, I'll push to `origin/gh-issue-720-fix-byte-index-string-slice-in-newtask-h`.

Closes #720

---
*Task #720 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*