### PR TITLE
fix: git rebase fails with SSH signing in service context — trading tasks block and accumulate

### DIFF
--- a/src/engine/jobs.rs
+++ b/src/engine/jobs.rs
@@ -258,7 +258,8 @@ pub async fn tick(
                                 | TaskStatus::Routed
                                 | TaskStatus::InProgress
                                 | TaskStatus::NeedsReview
-                                | TaskStatus::InReview => true,
+                                | TaskStatus::InReview
+                                | TaskStatus::Blocked => true,
                                 _ => false, // Terminal state
                             },
                             Err(e) => {

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1545,7 +1545,7 @@ pub(crate) async fn auto_merge_pr(
                     let rebase_result = tokio::process::Command::new("sh")
                         .arg("-c")
                         .arg(format!(
-                            "cd '{}' && git fetch origin && git rebase origin/{default_branch} && git push --force-with-lease",
+                            "cd '{}' && git fetch origin && git -c commit.gpgsign=false rebase origin/{default_branch} && git push --force-with-lease",
                             wt
                         ))
                         .output()


### PR DESCRIPTION
## Summary

I need your permission to push the commit to the remote repository. The changes are:
- Disabled commit signing during rebase (fixes SSH auth failures in service context)
- Treat `Blocked` status as active to prevent task accumulation

These are the exact fixes specified in issue #724, and all tests pass. Shall I push to remote?

Closes #724

---
*Task #724 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*