### PR TITLE
fix: agent_system.md contradicts itself on push — agents write confusing summaries

### DIFF
--- a/prompts/agent_system.md
+++ b/prompts/agent_system.md
@@ -71,7 +71,7 @@ Before you write the output JSON, run these checks. If ANY fails, go back and fi
 
 Do NOT report `"status": "done"` unless all checks pass. If you made changes but did not commit, your status is `needs_review`, not `done`.
 
-**Reminder:** Do NOT push or create PRs — the orchestrator handles that automatically.
+**Reminder:** Do NOT push or create PRs — the orchestrator handles that automatically. Do not ask for push approval in your summary, and do not mention pushing. Focus your summary on what you accomplished, not on the push step.
 
 ## Output Format
 
@@ -93,7 +93,7 @@ Your final output MUST be a JSON object with these fields:
 Note: `delegations` is optional — only include it when delegating subtasks.
 
 Status rules:
-- **done**: all work is committed, pushed, PR created, and tests pass. You must have produced a visible result (committed code, posted a comment, or completed the requested action). Pure research with no output is `in_progress`. **Never report done if you did not complete the task.**
+- **done**: all work is committed and tests pass. You must have produced a visible result (committed code, posted a comment, or completed the requested action). The orchestrator pushes and creates the PR automatically — do NOT mention pushing in your summary. Pure research with no output is `in_progress`. **Never report done if you did not complete the task.**
 - **in_progress**: partial work was committed but more remains.
 - **blocked**: waiting on dependencies, missing information, delegated subtasks, or **the task is unclear / you don't have enough context to proceed**. When blocked, explain what information is missing in `reason` so a human can unblock you.
 - **needs_review**: encountered errors you cannot resolve.


### PR DESCRIPTION
## Summary

Perfect! I've successfully fixed the contradiction in `prompts/agent_system.md`.

## Summary

**Changed files:**
- `prompts/agent_system.md` (2 edits)

**What was fixed:**

1. **Line 96 (done status)**: Removed "pushed, PR created" from the status definition. Now it reads:
   > "all work is committed and tests pass... The orchestrator pushes and creates the PR automatically — do NOT mention pushing in your summary."

2. **Line 74 (reminder)**: Added explicit guidance:
   > "Do not ask for push approval in your summary, and do not mention pushing. Focus your summary on what you accomplished, not on the push step."

**Why this fixes the issue:**

The original prompt had contradictory instructions:
- Line 59: "Do NOT push" — agents can't push
- Line 96: "done requires... pushed" — agents thought they needed to push to be done

This created the confusing summaries like "please approve the push" even though the task was complete. The fix clarifies that agents should never mention pushing and that the orchestrator handles it automatically.

**Verification:**
- ✅ All 743 tests pass
- ✅ Conventional commit message
- ✅ Clean working tree

Closes #737

---
*Task #737 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*