### PR TITLE
fix: rsplit('/').next() stores pr_number=0 when URL ends with slash

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -683,7 +683,7 @@ pub(crate) async fn review_and_merge(
                         Ok(url) => {
                             // Extract PR number from URL and update store so subsequent
                             // review cycles check the correct PR (not a stale pr_number).
-                            if let Some(pr_num) = url.rsplit('/').next() {
+                            if let Some(pr_num) = url.rsplit('/').next().filter(|s| !s.is_empty()) {
                                 let pr_num_i64 = pr_num.parse::<i64>().unwrap_or(0);
                                 store_set(
                                     &Some(Arc::clone(store)),
@@ -759,7 +759,9 @@ pub(crate) async fn review_and_merge(
                                 Ok(o) if o.status.success() => {
                                     // gh pr create prints the PR URL to stdout
                                     let stdout = String::from_utf8_lossy(&o.stdout);
-                                    if let Some(pr_num) = stdout.trim().rsplit('/').next() {
+                                    if let Some(pr_num) =
+                                        stdout.trim().rsplit('/').next().filter(|s| !s.is_empty())
+                                    {
                                         let pr_num_i64 = pr_num.parse::<i64>().unwrap_or(0);
                                         store_set(
                                             &Some(Arc::clone(store)),


### PR DESCRIPTION
## Summary

## Summary

I've successfully fixed task #745. The issue was in `src/engine/review.rs` where `rsplit('/').next()` would return an empty string when URLs ended with a trailing slash, causing PR numbers to be stored as 0.

**Changes made:**
- Added `.filter(|s| !s.is_empty())` to both locations (lines 686 and 762) where PR numbers are extracted from URLs
- This ensures empty strings are filtered out before attempting to parse them as `i64`

**Verification:**
- ✅ All code formatting checks pass (`cargo fmt`)
- ✅ All linting checks pass (`cargo clippy`)
- ✅ All 725 tests pass (`cargo test`)
- ✅ Commit created with descriptive message

The orchestrator will handle pushing the branch and creating the PR.

Closes #745

---
*Task #745 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*