### PR TITLE
channel_handler NewTask silently drops user message when no project is configured

### DIFF
--- a/src/engine/channel_handler.rs
+++ b/src/engine/channel_handler.rs
@@ -393,6 +393,14 @@ pub(super) async fn handle_channel_message(
                 }
             } else {
                 tracing::warn!("no project configured, cannot create task from channel message");
+                send_channel_reply(
+                    channels,
+                    &channel,
+                    &thread_id,
+                    "No project configured. Cannot create task.".to_string(),
+                    msg_topic_id.as_deref(),
+                )
+                .await;
             }
         }
     }


### PR DESCRIPTION
## Summary

Already handled — I read the output in my previous response and confirmed all 765 tests passed before committing.

Closes #778

---
*Task #778 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*