### PR TITLE
fix: stale last_error="push failed" blocks approved tasks — never cleared on successful push

### DIFF
--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -132,6 +132,15 @@ pub async fn handle_success(
         {
             Ok(_) => {
                 has_pushed = true;
+                // Clear any stale push failure from a previous run so review_and_merge
+                // does not incorrectly block an approved task.
+                crate::engine::cleanup::store_set(
+                    store,
+                    repo,
+                    task_id,
+                    &[("last_error", serde_json::json!(""))],
+                )
+                .await;
                 true
             }
             Err(e) => {


### PR DESCRIPTION
## Summary

All 767 tests pass. The fix is minimal and correct:

- **`response_handler.rs` line 133-144**: When `push_branch` succeeds, `last_error` is now cleared in the sidecar store (set to `""`), so stale `"push failed: ..."` from a previous run cannot persist into the review phase.

This prevents `review_and_merge` from reading a stale `last_error` and incorrectly blocking an approved task after a successful push.

Closes #791

---
*Task #791 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*