### PR TITLE
fix: review_and_merge silently swallows DB errors — misreports them as 'no worktree found'

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -35,6 +35,7 @@ use crate::engine::runner;
 use crate::github::http::GhHttp;
 use crate::github::types::{GitHubReview, GitHubReviewComment, PullRequestReview};
 use crate::tmux::TmuxManager;
+use anyhow::Context;
 use std::sync::{Arc, OnceLock};
 use tokio::sync::{RwLock, Semaphore};
 
@@ -611,8 +612,7 @@ pub(crate) async fn review_and_merge(
     let stored_task = store
         .get_by_external_id(repo, &task.id.0)
         .await
-        .ok()
-        .flatten();
+        .with_context(|| format!("store lookup failed for task {}", task.id.0))?;
 
     let worktree_path = match stored_task.as_ref().map(|t| t.worktree.as_str()) {
         Some(w) if !w.is_empty() => std::path::PathBuf::from(w),


### PR DESCRIPTION
## Summary

Perfect! I've successfully fixed issue #799. Here's the summary:

## Fix Complete ✓

### What Was Fixed
The `review_and_merge` function in `src/engine/review.rs` was silently swallowing database errors using `.ok().flatten()`, making them indistinguishable from "task not found". This caused:
1. DB errors to be misreported as "no worktree found"
2. Failure counts to accumulate 
3. Tasks to be permanently blocked after 3 attempts

### The Solution
Replaced the error-swallowing pattern with proper error propagation:

**Before:**
```rust
let stored_task = store
    .get_by_external_id(repo, &task.id.0)
    .await
    .ok()
    .flatten();
```

**After:**
```rust
let stored_task = store
    .get_by_external_id(repo, &task.id.0)
    .await
    .with_context(|| format!("store lookup failed for task {}", task.id.0))?;
```

### Changes Made
- Added `use anyhow::Context;` import
- Changed error handling to propagate actual DB errors with context
- All 752 tests pass ✓
- Code formatting and clippy checks pass ✓

### Commit
```
e97053f fix: propagate DB errors in review_and_merge instead of swallowing them
```

The fix ensures operators see actual database errors (locked DB, I/O failure) instead of misleading "no worktree found" messages, allowing proper debugging and retry handling.

Closes #799

---
*Task #799 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*