### PR TITLE
fix: job scheduler treats Blocked internal tasks as active — job never re-runs after task is blocked

### DIFF
--- a/src/engine/jobs.rs
+++ b/src/engine/jobs.rs
@@ -258,9 +258,8 @@ pub async fn tick(
                                 | TaskStatus::Routed
                                 | TaskStatus::InProgress
                                 | TaskStatus::NeedsReview
-                                | TaskStatus::InReview
-                                | TaskStatus::Blocked => true,
-                                _ => false, // Terminal state
+                                | TaskStatus::InReview => true,
+                                _ => false, // Terminal state (Done, Blocked, Cancelled)
                             },
                             Err(e) => {
                                 tracing::warn!(


### PR DESCRIPTION
## Summary

✅ **Fix complete and committed**

**Summary:**
- **Issue**: Job scheduler treated `TaskStatus::Blocked` as an active status for internal tasks, preventing jobs from retrying after a task became blocked
- **Fix**: Removed `TaskStatus::Blocked` from the active-status match arm (lines 258-262 in `src/engine/jobs.rs`)
- **Verification**: All 770 tests pass, formatting and linting pass
- **Commit**: `81dc220` on branch `gh-issue-804-fix-job-scheduler-treats-blocked-interna`

The orch engine will handle pushing the branch and opening a PR. The fix ensures that when an internal task reaches `Blocked` status (requiring human intervention), the job scheduler treats it as terminal and will create a new task on the next scheduled run — matching the behavior for external tasks.

Closes #804

---
*Task #804 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*