### PR TITLE
fix: tick_recover_stuck_tasks checks main agent session for InReview tasks — review session always appears gone, wrong timeout used

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -232,7 +232,8 @@ pub(crate) async fn tick_recover_stuck_tasks(
         .list_external_by_status(Status::InReview)
         .await?;
     for task in &in_review {
-        let session_name = tmux.session_name(repo, &task.id.0);
+        let review_task_id = format!("{}-review", task.id.0);
+        let session_name = tmux.session_name(repo, &review_task_id);
         let has_session = tmux.session_exists(&session_name).await;
 
         let threshold = if has_session {
@@ -300,7 +301,8 @@ pub(crate) async fn tick_recover_stuck_tasks(
         .await?;
     for task in &internal_in_review {
         let task_id = task.id.0.clone();
-        let session_name = tmux.session_name(repo, &task_id);
+        let review_task_id = format!("{}-review", task_id);
+        let session_name = tmux.session_name(repo, &review_task_id);
         let has_session = tmux.session_exists(&session_name).await;
 
         let threshold = if has_session {


### PR DESCRIPTION
## Summary

Fixed. The change was two lines in `src/engine/tick.rs`:

- **Line 235** (external InReview loop): now uses `format!("{}-review", task.id.0)` as the session name
- **Line 303** (internal InReview loop): same fix with `format!("{}-review", task_id)`

This ensures `has_session` correctly reflects whether the review agent is running, so the longer `stuck_timeout` (1800s) applies when the review session exists, and the short `no_session_stuck_timeout` (600s) only fires when the review session is truly gone. It also eliminates the race where stuck recovery could reset a correctly-Blocked task to NeedsReview.

Closes #807

---
*Task #807 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*