### PR TITLE
fix: codex and opencode auth error classifiers use bare "401"/"403" — same bug as #781, not fixed in #803

### DIFF
--- a/src/engine/runner/agents/codex.rs
+++ b/src/engine/runner/agents/codex.rs
@@ -190,8 +190,8 @@ impl CodexRunner {
         if lower.contains("unauthorized")
             || lower.contains("invalid key")
             || lower.contains("invalid api")
-            || lower.contains("401")
-            || lower.contains("403")
+            || super::patterns::contains_http_status(&lower, "401")
+            || super::patterns::contains_http_status(&lower, "403")
         {
             return AgentError::Auth {
                 message: message.to_string(),

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -313,7 +313,7 @@ pub(crate) mod patterns {
     ///   - `"http 401"` / `"http/1.1 401"`
     ///   - `"401 unauthorized"` / `"401\n"` / `"401"` at end-of-string
     ///   - `": 401"` when not immediately followed by another digit
-    fn contains_http_status(lower: &str, code: &str) -> bool {
+    pub fn contains_http_status(lower: &str, code: &str) -> bool {
         // Fast prefix checks that are inherently unambiguous.
         if lower.contains(&format!("http {code}")) || lower.contains(&format!("{code} ")) {
             return true;

--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -450,7 +450,10 @@ fn classify_opencode_message(message: &str) -> AgentError {
         };
     }
 
-    if lower.contains("unauthorized") || lower.contains("invalid key") || lower.contains("401") {
+    if lower.contains("unauthorized")
+        || lower.contains("invalid key")
+        || super::patterns::contains_http_status(&lower, "401")
+    {
         return AgentError::Auth {
             message: message.to_string(),
         };


### PR DESCRIPTION
## Summary

Done. The changes:

- **`mod.rs`**: Made `contains_http_status` `pub` so sibling modules can use it
- **`codex.rs:193-194`**: Replaced `lower.contains("401")` / `lower.contains("403")` with `patterns::contains_http_status()`
- **`opencode.rs:453`**: Replaced `lower.contains("401")` with `patterns::contains_http_status()`

All 771 tests pass, clippy clean.

Closes #810

---
*Task #810 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*