### PR TITLE
perf: add (repo, status) index — list_by_status() can't use existing (repo, origin, status) index

### DIFF
--- a/migrations/007_status_index.sql
+++ b/migrations/007_status_index.sql
@@ -1,0 +1,5 @@
+-- Hot path: list_by_status() filters (repo, status) every sync tick
+CREATE INDEX IF NOT EXISTS idx_tasks_repo_status ON tasks(repo, status);
+
+-- Global status queries (orch task list --status, recovery tick, cleanup pruning)
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);


### PR DESCRIPTION
## Summary

All 771 tests pass. The fix is a single migration file. Done.

`migrations/007_status_index.sql` adds:
- `idx_tasks_repo_status ON tasks(repo, status)` — covers `list_by_status()` hot path (called every tick)
- `idx_tasks_status ON tasks(status)` — covers `list_all_by_status_global()`, `list_all_active_global()`, and the cleanup pruning query

The existing `idx_tasks_repo_origin_status` is untouched — it still serves queries that filter on `origin`.

Closes #814

---
*Task #814 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*