### PR TITLE
fix: cron normalize_dow maps `0-5` to invalid range `7-5` — Sunday-anchored DOW ranges silently fail to parse

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -26,7 +26,7 @@ fn normalize_dow(expression: &str) -> String {
             if part == "0" {
                 "7".to_string()
             } else if let Some(rest) = part.strip_prefix("0-") {
-                format!("7-{rest}")
+                format!("1-{rest}")
             } else {
                 part.to_string()
             }
@@ -184,6 +184,20 @@ mod tests {
             result.is_ok(),
             "DOW=0 in list should be accepted: {result:?}"
         );
+    }
+
+    #[test]
+    fn dow_range_starting_at_zero_parses() {
+        // "0-5" = Sunday through Friday in standard cron
+        let result = check("0 9 * * 0-5", None);
+        assert!(result.is_ok(), "DOW range 0-5 should parse: {result:?}");
+    }
+
+    #[test]
+    fn dow_range_zero_to_four_parses() {
+        // "0-4" = Sunday through Thursday in standard cron
+        let result = check("0 9 * * 0-4", None);
+        assert!(result.is_ok(), "DOW range 0-4 should parse: {result:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Clean. All checks pass. The fix is complete:

**What was wrong:** `normalize_dow()` converted `0-` range prefixes to `7-`, producing expressions like `7-5` where start > end — invalid per the `cron` crate.

**Fix:** Replace `format!("7-{rest}")` with `format!("1-{rest}")`. In the `cron` crate's 1-7 numbering, 1 is Sunday, so `0-5` → `1-5` is a valid range (1 ≤ 5).

**Tests added:**
- `dow_range_starting_at_zero_parses` — `0 9 * * 0-5` parses without error
- `dow_range_zero_to_four_parses` — `0 9 * * 0-4` parses without error

Closes #817

---
*Task #817 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*