### PR TITLE
feat: event-driven parent unblocking — reduce latency from 10s tick to near-zero

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -971,6 +971,17 @@ pub async fn serve() -> anyhow::Result<()> {
     }
     tracing::info!("review subscriber started");
 
+    // Spawn unblock subscribers — react to Done events, unblock parent tasks immediately
+    for engine in &project_engines {
+        subscribers::unblock::spawn(
+            event_bus.subscribe(),
+            engine.backend.clone(),
+            engine.task_manager.clone(),
+            engine.repo.clone(),
+        );
+    }
+    tracing::info!("unblock subscriber started");
+
     // Spawn notify subscriber — reacts to ALL events, pushes to transport.
     // Spawned once (not per-project) since the transport handles all repos.
     subscribers::notify::spawn(event_bus.subscribe(), transport.clone());

--- a/src/engine/subscribers/mod.rs
+++ b/src/engine/subscribers/mod.rs
@@ -1,3 +1,4 @@
 pub mod dispatch;
 pub mod notify;
 pub mod review;
+pub mod unblock;

--- a/src/engine/subscribers/unblock.rs
+++ b/src/engine/subscribers/unblock.rs
@@ -1,0 +1,42 @@
+//! Reacts to Done events — unblocks parent tasks immediately.
+
+use crate::backends::ExternalBackend;
+use crate::engine::events::TaskEvent;
+use crate::engine::tasks::TaskManager;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+/// Spawn a task that listens for Done events and unblocks parent tasks.
+///
+/// This mirrors the logic in `tick_unblock_parents` but triggers instantly
+/// instead of waiting for the next tick. The tick-loop call remains as a
+/// fallback for any events missed due to subscriber lag.
+pub fn spawn(
+    mut rx: broadcast::Receiver<TaskEvent>,
+    backend: Arc<dyn ExternalBackend>,
+    task_manager: Arc<TaskManager>,
+    repo: String,
+) {
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) if event.new_status == "done" && event.repo == repo => {
+                    tracing::info!(
+                        task_id = event.task_id,
+                        "event-driven parent unblock triggered"
+                    );
+                    if let Err(e) =
+                        crate::engine::tick::tick_unblock_parents(&backend, &task_manager).await
+                    {
+                        tracing::warn!(?e, "event-driven unblock failed (tick will retry)");
+                    }
+                }
+                Ok(_) => {} // Not a done event or different repo
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::debug!(n, "unblock subscriber lagged, tick will catch up");
+                }
+                Err(_) => break, // Channel closed
+            }
+        }
+    });
+}


### PR DESCRIPTION
## Summary

All 781 tests pass. The implementation is complete:

- **`src/engine/subscribers/unblock.rs`** — new subscriber that listens for `done` events and calls `tick_unblock_parents` immediately
- **`src/engine/subscribers/mod.rs`** — added `pub mod unblock;`
- **`src/engine/mod.rs`** — spawns the unblock subscriber per-project alongside dispatch and review subscribers

Parent tasks will now be unblocked near-instantly when children complete, instead of waiting up to 10s for the next tick. The tick-loop call remains as a fallback for lagged events.

Closes #827

---
*Task #827 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*