### PR TITLE
fix: notify subscriber sends empty title/summary — channel notifications are missing task context

### DIFF
--- a/src/engine/events.rs
+++ b/src/engine/events.rs
@@ -20,6 +20,8 @@ pub struct TaskEvent {
     pub review_context: Option<String>,
     pub error: Option<String>,
     pub timestamp: String,
+    pub title: Option<String>,
+    pub summary: Option<String>,
 }
 
 /// The event bus — wraps a tokio broadcast channel.
@@ -157,6 +159,8 @@ mod tests {
             review_context: None,
             error: None,
             timestamp: "2026-03-23T12:00:00Z".to_string(),
+            title: None,
+            summary: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("\"task_id\":\"123\""));
@@ -179,6 +183,8 @@ mod tests {
             review_context: None,
             error: None,
             timestamp: "2026-03-23T12:00:00Z".to_string(),
+            title: None,
+            summary: None,
         };
         bus.publish(event.clone());
         let received = rx.try_recv().unwrap();
@@ -221,6 +227,8 @@ mod tests {
             review_context: None,
             error: None,
             timestamp: "2026-03-23T12:00:00Z".to_string(),
+            title: None,
+            summary: None,
         };
         bus.publish(event);
 

--- a/src/engine/subscribers/notify.rs
+++ b/src/engine/subscribers/notify.rs
@@ -19,11 +19,11 @@ pub fn spawn(mut rx: broadcast::Receiver<TaskEvent>, transport: Arc<Transport>) 
                 Ok(event) => {
                     let notification = TaskNotification {
                         task_id: event.task_id.clone(),
-                        title: String::new(),
+                        title: event.title.unwrap_or_default(),
                         status: event.new_status.clone(),
                         agent: event.agent.unwrap_or_default(),
                         duration_seconds: 0.0,
-                        summary: String::new(),
+                        summary: event.summary.unwrap_or_default(),
                         repo: Some(event.repo.clone()),
                     };
                     transport.push_notification(notification);

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -67,6 +67,8 @@ struct TaskSnapshot {
     branch: Option<String>,
     pr_number: Option<String>,
     error: Option<String>,
+    title: Option<String>,
+    summary: Option<String>,
 }
 
 pub struct TaskManager {
@@ -397,6 +399,16 @@ impl TaskManager {
                 } else {
                     Some(task.last_error.clone())
                 },
+                title: if task.title.is_empty() {
+                    None
+                } else {
+                    Some(task.title.clone())
+                },
+                summary: if task.summary.is_empty() {
+                    None
+                } else {
+                    Some(task.summary.clone())
+                },
             },
             Err(_) => TaskSnapshot::default(),
         }
@@ -417,6 +429,8 @@ impl TaskManager {
                 review_context: None,
                 error: snapshot.error.clone(),
                 timestamp: chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+                title: snapshot.title.clone(),
+                summary: snapshot.summary.clone(),
             };
             let _ = tx.send(event);
         }


### PR DESCRIPTION
## Summary

All CI gates pass: fmt clean, clippy clean, 781/781 tests pass.

**Summary of changes:**

- **`src/engine/events.rs`**: Added `title: Option<String>` and `summary: Option<String>` to `TaskEvent`. Updated 3 test constructors.

- **`src/engine/tasks.rs`**: Added `title` and `summary` to `TaskSnapshot`; populated them in `read_task_snapshot()` from `task.title` and `task.summary`; passed them through `publish_event()` into `TaskEvent`.

- **`src/engine/subscribers/notify.rs`**: Used `event.title.unwrap_or_default()` and `event.summary.unwrap_or_default()` instead of `String::new()`.

Closes #826

---
*Task #826 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*