### PR TITLE
bug: resolve_task_id fallback query missing repo filter — wrong task resolved in multi-repo setup

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1062,10 +1062,13 @@ impl TaskStore {
             if let Some(task) = self.get_by_external_id(repo, task_id).await? {
                 return Ok(Some(task.id));
             }
-            // Fallback: try the numeric suffix as a direct store ID
+            // Fallback: try the numeric suffix as a direct store ID.
+            // Must include the repo filter to avoid resolving a task that
+            // belongs to a different repository in a multi-repo setup.
             if let Ok(id) = suffix.parse::<i64>() {
-                let exists = sqlx::query("SELECT id FROM tasks WHERE id = ?")
+                let exists = sqlx::query("SELECT id FROM tasks WHERE id = ? AND repo = ?")
                     .bind(id)
+                    .bind(repo)
                     .fetch_optional(&self.pool)
                     .await?;
                 if exists.is_some() {

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -4331,3 +4331,41 @@ async fn control_sessions_are_isolated() {
     assert!(a_msgs[0].content.contains("in A"));
     assert!(b_msgs[0].content.contains("in B"));
 }
+
+/// Regression test: resolve_task_id fallback must not cross repo boundaries.
+///
+/// When the primary external_id lookup fails, the numeric-suffix fallback used
+/// to query `SELECT id FROM tasks WHERE id = ?` with no repo filter.  In a
+/// multi-repo setup this could resolve a task that belongs to a different repo.
+#[tokio::test]
+async fn resolve_task_id_fallback_respects_repo() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    // Create an internal task for repo-a.  The store assigns id=1 and sets
+    // external_id = "internal:1".
+    let id_a = store
+        .create_internal("owner/repo-a", "Task A", "body", "test", "src-a")
+        .await
+        .unwrap();
+
+    // Corrupt: remove the external_id so the primary lookup fails and the
+    // code falls through to the numeric-suffix fallback path.
+    sqlx::query("UPDATE tasks SET external_id = NULL WHERE id = ?")
+        .bind(id_a)
+        .execute(store.pool())
+        .await
+        .unwrap();
+
+    // repo-b should NOT resolve task "internal:{id_a}" — the numeric id
+    // belongs to repo-a, not repo-b.
+    let resolved = store
+        .resolve_task_id("owner/repo-b", &format!("internal:{id_a}"))
+        .await
+        .unwrap();
+
+    assert!(
+        resolved.is_none(),
+        "fallback must not resolve a task from a different repo (got {:?})",
+        resolved
+    );
+}


### PR DESCRIPTION
## Summary

All 782 tests pass. Here's what was done:

**Fix:** Added `AND repo = ?` to the fallback query in `src/store/tasks.rs:1067`, with `.bind(repo)`. This ensures the numeric-suffix fallback in `resolve_task_id` cannot cross repo boundaries.

**Test:** Added `resolve_task_id_fallback_respects_repo` in `src/store/tests.rs` — it creates an internal task for `owner/repo-a`, strips its `external_id` to force the fallback path, then asserts that `resolve_task_id("owner/repo-b", "internal:1")` returns `None`.

Closes #837

---
*Task #837 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*