### PR TITLE
bug: notify subscriber hardcodes duration_seconds=0.0 — all channel notifications show "0s" duration

### DIFF
--- a/src/engine/events.rs
+++ b/src/engine/events.rs
@@ -22,6 +22,7 @@ pub struct TaskEvent {
     pub timestamp: String,
     pub title: Option<String>,
     pub summary: Option<String>,
+    pub duration_seconds: Option<f64>,
 }
 
 /// The event bus — wraps a tokio broadcast channel.
@@ -161,6 +162,7 @@ mod tests {
             timestamp: "2026-03-23T12:00:00Z".to_string(),
             title: None,
             summary: None,
+            duration_seconds: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("\"task_id\":\"123\""));
@@ -185,6 +187,7 @@ mod tests {
             timestamp: "2026-03-23T12:00:00Z".to_string(),
             title: None,
             summary: None,
+            duration_seconds: None,
         };
         bus.publish(event.clone());
         let received = rx.try_recv().unwrap();
@@ -229,6 +232,7 @@ mod tests {
             timestamp: "2026-03-23T12:00:00Z".to_string(),
             title: None,
             summary: None,
+            duration_seconds: None,
         };
         bus.publish(event);
 

--- a/src/engine/subscribers/notify.rs
+++ b/src/engine/subscribers/notify.rs
@@ -22,7 +22,7 @@ pub fn spawn(mut rx: broadcast::Receiver<TaskEvent>, transport: Arc<Transport>) 
                         title: event.title.unwrap_or_default(),
                         status: event.new_status.clone(),
                         agent: event.agent.unwrap_or_default(),
-                        duration_seconds: 0.0,
+                        duration_seconds: event.duration_seconds.unwrap_or(0.0),
                         summary: event.summary.unwrap_or_default(),
                         repo: Some(event.repo.clone()),
                     };

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -69,6 +69,7 @@ struct TaskSnapshot {
     error: Option<String>,
     title: Option<String>,
     summary: Option<String>,
+    duration_seconds: Option<f64>,
 }
 
 pub struct TaskManager {
@@ -386,32 +387,36 @@ impl TaskManager {
             _ => return TaskSnapshot::default(),
         };
         match store.get(store_id).await {
-            Ok(task) => TaskSnapshot {
-                old_status: Some(task.status.as_str().to_string()),
-                agent: task.agent.clone(),
-                model: task.model.clone(),
-                branch: if task.branch.is_empty() {
-                    None
-                } else {
-                    Some(task.branch.clone())
-                },
-                pr_number: task.pr_number.map(|n| n.to_string()),
-                error: if task.last_error.is_empty() {
-                    None
-                } else {
-                    Some(task.last_error.clone())
-                },
-                title: if task.title.is_empty() {
-                    None
-                } else {
-                    Some(task.title.clone())
-                },
-                summary: if task.summary.is_empty() {
-                    None
-                } else {
-                    Some(task.summary.clone())
-                },
-            },
+            Ok(task) => {
+                let duration_seconds = store.latest_task_metric_duration(task_id).await;
+                TaskSnapshot {
+                    old_status: Some(task.status.as_str().to_string()),
+                    agent: task.agent.clone(),
+                    model: task.model.clone(),
+                    branch: if task.branch.is_empty() {
+                        None
+                    } else {
+                        Some(task.branch.clone())
+                    },
+                    pr_number: task.pr_number.map(|n| n.to_string()),
+                    error: if task.last_error.is_empty() {
+                        None
+                    } else {
+                        Some(task.last_error.clone())
+                    },
+                    title: if task.title.is_empty() {
+                        None
+                    } else {
+                        Some(task.title.clone())
+                    },
+                    summary: if task.summary.is_empty() {
+                        None
+                    } else {
+                        Some(task.summary.clone())
+                    },
+                    duration_seconds,
+                }
+            }
             Err(_) => TaskSnapshot::default(),
         }
     }
@@ -433,6 +438,7 @@ impl TaskManager {
                 timestamp: chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
                 title: snapshot.title.clone(),
                 summary: snapshot.summary.clone(),
+                duration_seconds: snapshot.duration_seconds,
             };
             let _ = tx.send(event);
         }

--- a/src/store/metrics.rs
+++ b/src/store/metrics.rs
@@ -581,6 +581,19 @@ impl TaskStore {
             .collect())
     }
 
+    /// Get the duration_seconds from the most recent metric row for a task.
+    /// Returns `None` when no metric has been recorded yet.
+    pub async fn latest_task_metric_duration(&self, task_id: &str) -> Option<f64> {
+        sqlx::query_scalar(
+            "SELECT duration_seconds FROM task_metrics WHERE task_id = ? ORDER BY completed_at DESC LIMIT 1",
+        )
+        .bind(task_id)
+        .fetch_optional(&self.pool)
+        .await
+        .ok()
+        .flatten()
+    }
+
     /// Get count of self-improvement issues created this week.
     pub async fn count_self_improvement_issues_7d(&self) -> anyhow::Result<i64> {
         let key = self_improvement_key();


### PR DESCRIPTION
## Summary

All done. Here's a summary of the changes:

**Files changed:**

1. **`src/store/metrics.rs`** — added `latest_task_metric_duration(task_id)` that queries `task_metrics ORDER BY completed_at DESC LIMIT 1`

2. **`src/engine/tasks.rs`** — added `duration_seconds: Option<f64>` to `TaskSnapshot`; populated it in `read_task_snapshot()` by calling the new store method; propagated it in `publish_event()` into `TaskEvent`

3. **`src/engine/events.rs`** — added `duration_seconds: Option<f64>` to `TaskEvent`; updated 3 test constructors with `duration_seconds: None`

4. **`src/engine/subscribers/notify.rs`** — replaced the hardcoded `0.0` with `event.duration_seconds.unwrap_or(0.0)`

The duration is already recorded in `task_metrics` by the runner before `update_task_status(Done)` fires the event, so the query reliably finds the correct value.

Closes #840

---
*Task #840 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*