### PR TITLE
bug: notify subscriber fires on ALL status transitions — routed/in_progress notifications are unexpected and noisy

### DIFF
--- a/src/channels/notification.rs
+++ b/src/channels/notification.rs
@@ -13,8 +13,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NotificationLevel {
-    /// Broadcast all task completions.
+    /// Broadcast terminal/meaningful completions only: done, needs_review, blocked, failed.
+    /// Intermediate transitions (new, routed, in_progress, in_review) are suppressed.
+    /// This restores pre-event-bus behavior.
     All,
+    /// Broadcast every status transition, including intermediate states.
+    Verbose,
     /// Only broadcast errors (needs_review, blocked, failed).
     ErrorsOnly,
     /// Disable notifications entirely.
@@ -27,6 +31,7 @@ impl NotificationLevel {
         match crate::config::get("notifications.level") {
             Ok(val) => match val.as_str() {
                 "all" => Self::All,
+                "verbose" => Self::Verbose,
                 "errors_only" => Self::ErrorsOnly,
                 "none" => Self::None,
                 _ => Self::All,
@@ -38,7 +43,8 @@ impl NotificationLevel {
     /// Whether a notification with this status should be sent.
     pub fn should_notify(&self, status: &str) -> bool {
         match self {
-            Self::All => true,
+            Self::All => matches!(status, "done" | "needs_review" | "blocked" | "failed"),
+            Self::Verbose => true,
             Self::ErrorsOnly => {
                 matches!(status, "needs_review" | "blocked" | "failed")
             }
@@ -187,13 +193,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn notification_level_should_notify_all() {
+    fn notification_level_should_notify_all_terminal_only() {
         let level = NotificationLevel::All;
+        // Terminal/meaningful states — should notify
         assert!(level.should_notify("done"));
-        assert!(level.should_notify("in_progress"));
         assert!(level.should_notify("needs_review"));
         assert!(level.should_notify("blocked"));
         assert!(level.should_notify("failed"));
+        // Intermediate states — should NOT notify
+        assert!(!level.should_notify("new"));
+        assert!(!level.should_notify("routed"));
+        assert!(!level.should_notify("in_progress"));
+        assert!(!level.should_notify("in_review"));
+    }
+
+    #[test]
+    fn notification_level_should_notify_verbose_fires_for_all() {
+        let level = NotificationLevel::Verbose;
+        assert!(level.should_notify("done"));
+        assert!(level.should_notify("needs_review"));
+        assert!(level.should_notify("blocked"));
+        assert!(level.should_notify("failed"));
+        assert!(level.should_notify("new"));
+        assert!(level.should_notify("routed"));
+        assert!(level.should_notify("in_progress"));
+        assert!(level.should_notify("in_review"));
     }
 
     #[test]

--- a/src/engine/subscribers/notify.rs
+++ b/src/engine/subscribers/notify.rs
@@ -1,22 +1,30 @@
-//! Reacts to all status transitions — pushes notifications to channels.
+//! Reacts to status transitions — pushes notifications to channels for meaningful states.
+//!
+//! Only terminal/meaningful transitions are forwarded by default (`level: all`):
+//! `done`, `needs_review`, `blocked`, `failed`. Intermediate transitions
+//! (`new`, `routed`, `in_progress`, `in_review`) are suppressed unless
+//! `notifications.level: verbose` is set in config.
 
-use crate::channels::notification::TaskNotification;
+use crate::channels::notification::{NotificationLevel, TaskNotification};
 use crate::channels::transport::Transport;
 use crate::engine::events::TaskEvent;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
-/// Spawn a task that listens for all events and pushes to transport.
+/// Spawn a task that listens for events and pushes to transport.
 ///
 /// This subscriber is spawned ONCE (not per-project) since the transport
-/// handles all repos. It converts every `TaskEvent` into a `TaskNotification`
-/// and calls `transport.push_notification()`, so notifications fire immediately
-/// on status change instead of being scattered through tick/sync code.
+/// handles all repos. It filters events using `NotificationLevel::should_notify()`
+/// so only meaningful status transitions reach the channels.
 pub fn spawn(mut rx: broadcast::Receiver<TaskEvent>, transport: Arc<Transport>) {
+    let level = NotificationLevel::from_config();
     tokio::spawn(async move {
         loop {
             match rx.recv().await {
                 Ok(event) => {
+                    if !level.should_notify(&event.new_status) {
+                        continue;
+                    }
                     let notification = TaskNotification {
                         task_id: event.task_id.clone(),
                         title: event.title.unwrap_or_default(),


### PR DESCRIPTION
## Summary

All 788 tests pass. Here's a summary of the changes:

**`src/channels/notification.rs`**
- `NotificationLevel::All::should_notify()` now returns `true` only for terminal states: `done`, `needs_review`, `blocked`, `failed`. Intermediate states (`new`, `routed`, `in_progress`, `in_review`) return `false`.
- Added `NotificationLevel::Verbose` variant that returns `true` for every status — for users who explicitly want all transitions.
- `from_config()` handles `"verbose"` string.
- Updated test `notification_level_should_notify_all_terminal_only` to assert the corrected behavior, added `notification_level_should_notify_verbose_fires_for_all`.

**`src/engine/subscribers/notify.rs`**
- Loads `NotificationLevel::from_config()` once at spawn time.
- Skips `push_notification()` via `continue` when `level.should_notify(&event.new_status)` returns false.

This restores pre-event-bus behavior: `level: all` (the default) produces at most 2 notifications per task (`needs_review` + `done`). Users who want the verbose intermediate-state notifications can set `notifications.level: verbose`.

Closes #844

---
*Task #844 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*