### PR TITLE
feat: switch agents to streaming NDJSON output for real-time visibility

### DIFF
--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -352,13 +352,33 @@ impl LlmRouter {
 
     /// Parse the LLM response into a structured format.
     ///
-    /// Handles: direct JSON, Claude `--output-format json` envelopes,
-    /// markdown code blocks, and raw text with embedded JSON.
+    /// Handles: direct JSON, Claude `--output-format stream-json` NDJSON,
+    /// Claude `--output-format json` envelopes, markdown code blocks, and raw
+    /// text with embedded JSON.
     pub fn parse_llm_response(&self, response: &str) -> anyhow::Result<LlmRouteResponse> {
         let trimmed = response.trim();
         if trimmed.is_empty() {
             anyhow::bail!("empty LLM response");
         }
+
+        // Pre-step: if this is Claude NDJSON (--output-format stream-json), find the
+        // last "type":"result" line. This normalises NDJSON to the same single-line
+        // envelope that step 1 already knows how to unwrap.
+        let trimmed = trimmed
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .rev()
+            .find(|line| {
+                serde_json::from_str::<serde_json::Value>(line)
+                    .ok()
+                    .and_then(|v| {
+                        v.get("type")
+                            .and_then(|t| t.as_str())
+                            .map(|t| t == "result")
+                    })
+                    .unwrap_or(false)
+            })
+            .unwrap_or(trimmed);
 
         // Step 1: Unwrap Claude JSON envelope if present.
         // Claude --output-format json returns {"type":"result","result":"...","usage":{...}}

--- a/src/engine/runner/agents/claude.rs
+++ b/src/engine/runner/agents/claude.rs
@@ -8,26 +8,26 @@
 //! ```bash
 //! claude -p --model {model} \
 //!   --permission-mode bypassPermissions \
-//!   --output-format json \
+//!   --output-format stream-json \
 //!   --disallowedTools '...' \
 //!   --append-system-prompt "{sys_file}" \
 //!   < "{msg_file}"
 //! ```
 //!
-//! ## Output format (`--output-format json`)
+//! ## Output format (`--output-format stream-json`)
 //!
-//! Single JSON object:
-//! ```json
-//! {
-//!   "type": "result",
-//!   "subtype": "success",
-//!   "is_error": false,
-//!   "duration_ms": 2006,
-//!   "result": "```json\n{\"status\": \"done\", ...}\n```",
-//!   "usage": {"input_tokens": 10, "output_tokens": 78},
-//!   "modelUsage": {"claude-haiku-4-5-20251001": {"inputTokens": 10, ...}}
-//! }
+//! NDJSON event stream; the final event is always `"type": "result"`:
+//! ```jsonl
+//! {"type":"system","subtype":"init",...}
+//! {"type":"assistant","message":{...}}
+//! {"type":"tool_use","tool":{...}}
+//! {"type":"tool_result","result":{...}}
+//! {"type":"result","subtype":"success","is_error":false,"duration_ms":2006,"result":"...","usage":{"input_tokens":10,"output_tokens":78},"modelUsage":{...}}
 //! ```
+//!
+//! Backward compatible with `--output-format json` (single JSON blob) — the
+//! parser finds the last `"type":"result"` line whether it is NDJSON or a
+//! pretty-printed single object.
 //!
 //! ## Kimi/MiniMax wrappers
 //!
@@ -202,7 +202,7 @@ impl AgentRunner for ClaudeRunner {
         format!(
             r#"{timeout_cmd} {binary} -p {model_flag} \
   --permission-mode {permission_mode} \
-  --output-format json \
+  --output-format stream-json \
   {tool_flag} \
   --append-system-prompt "{sys_file}" \
   < "{msg_file}""#,
@@ -222,6 +222,14 @@ impl AgentRunner for ClaudeRunner {
             return Err(AgentError::InvalidResponse { raw: String::new() });
         }
 
+        // For NDJSON (--output-format stream-json): find the last line whose JSON
+        // has "type":"result" — that is the final envelope. For a single-line JSON
+        // blob (--output-format json backward compat) this also finds it correctly.
+        if let Some(result_line) = find_ndjson_result_line(trimmed) {
+            return self.parse_envelope(result_line);
+        }
+
+        // Fallback: treat the whole string as the envelope (e.g. pretty-printed JSON)
         self.parse_envelope(trimmed)
     }
 
@@ -237,7 +245,7 @@ impl AgentRunner for ClaudeRunner {
     ) -> anyhow::Result<tokio::process::Command> {
         let mut cmd = tokio::process::Command::new(&self.binary);
         cmd.env_remove("CLAUDECODE"); // allow nested invocation
-        cmd.arg("--output-format").arg("json").arg("--print");
+        cmd.arg("--output-format").arg("stream-json").arg("--print");
         if let Some(m) = model {
             cmd.arg("--model").arg(m);
         }
@@ -292,6 +300,26 @@ fn translate_allowed_tools(
         }
     }
     tools
+}
+
+/// Find the last NDJSON line whose JSON contains `"type": "result"`.
+///
+/// Used to extract the final result event from Claude `--output-format stream-json`
+/// output. Returns `None` if no such line is found (e.g. pretty-printed single JSON).
+fn find_ndjson_result_line(text: &str) -> Option<&str> {
+    text.lines()
+        .filter(|l| !l.trim().is_empty())
+        .rev()
+        .find(|line| {
+            serde_json::from_str::<serde_json::Value>(line)
+                .ok()
+                .and_then(|v| {
+                    v.get("type")
+                        .and_then(|t| t.as_str())
+                        .map(|t| t == "result")
+                })
+                .unwrap_or(false)
+        })
 }
 
 /// Extract input/output tokens from the Claude envelope's usage objects.
@@ -480,7 +508,7 @@ mod tests {
         );
         assert!(cmd.contains("--model opus"));
         assert!(cmd.contains("claude -p"));
-        assert!(cmd.contains("--output-format json"));
+        assert!(cmd.contains("--output-format stream-json"));
         assert!(cmd.contains("--permission-mode bypassPermissions"));
         assert!(cmd.contains("--disallowedTools 'Bash(rm *)'"));
     }
@@ -562,6 +590,80 @@ mod tests {
         let raw = include_str!("../../../../tests/fixtures/claude_error_rate_limit.json");
         let err = runner().parse_response(raw).unwrap_err();
         assert!(matches!(err, AgentError::RateLimit { .. }), "got: {err:?}");
+    }
+
+    // ── NDJSON / stream-json fixtures ────────────────────────────
+
+    #[test]
+    fn fixture_claude_stream_success() {
+        let raw = include_str!("../../../../tests/fixtures/claude_stream_success.jsonl");
+        let parsed = runner().parse_response(raw).unwrap();
+        assert_eq!(parsed.response.status, "done");
+        assert!(parsed.response.summary.contains("Implemented"));
+        assert_eq!(parsed.response.accomplished.len(), 2);
+        assert_eq!(parsed.input_tokens, Some(15000));
+        assert_eq!(parsed.output_tokens, Some(3500));
+        assert_eq!(parsed.duration_ms, Some(45000));
+    }
+
+    #[test]
+    fn fixture_claude_stream_error() {
+        let raw = include_str!("../../../../tests/fixtures/claude_stream_error.jsonl");
+        let err = runner().parse_response(raw).unwrap_err();
+        assert!(matches!(err, AgentError::Auth { .. }), "got: {err:?}");
+    }
+
+    #[test]
+    fn fixture_claude_stream_rate_limit() {
+        let raw = include_str!("../../../../tests/fixtures/claude_stream_rate_limit.jsonl");
+        let err = runner().parse_response(raw).unwrap_err();
+        assert!(matches!(err, AgentError::RateLimit { .. }), "got: {err:?}");
+    }
+
+    #[test]
+    fn parse_ndjson_with_intermediate_events() {
+        // Parser must ignore intermediate events and only look at the result line
+        let raw = concat!(
+            r#"{"type":"system","subtype":"init"}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"role":"assistant","content":[]}}"#,
+            "\n",
+            r#"{"type":"tool_use","tool":{"name":"Read","input":{}}}"#,
+            "\n",
+            r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":1000,"result":"{\"status\":\"done\",\"summary\":\"streamed\",\"accomplished\":[],\"remaining\":[],\"files\":[]}","usage":{"input_tokens":5,"output_tokens":10}}"#,
+            "\n"
+        );
+        let parsed = runner().parse_response(raw).unwrap();
+        assert_eq!(parsed.response.status, "done");
+        assert_eq!(parsed.response.summary, "streamed");
+        assert_eq!(parsed.input_tokens, Some(5));
+        assert_eq!(parsed.output_tokens, Some(10));
+    }
+
+    #[test]
+    fn parse_ndjson_skips_malformed_lines() {
+        // Malformed intermediate lines should be ignored; result line still parsed
+        let raw = concat!(
+            "not valid json\n",
+            r#"{"type":"partial_update","data":"something"}"#,
+            "\n",
+            r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":500,"result":"{\"status\":\"done\",\"summary\":\"ok\",\"accomplished\":[],\"remaining\":[],\"files\":[]}","usage":{"input_tokens":1,"output_tokens":2}}"#,
+            "\n"
+        );
+        let parsed = runner().parse_response(raw).unwrap();
+        assert_eq!(parsed.response.status, "done");
+        assert_eq!(parsed.response.summary, "ok");
+    }
+
+    #[test]
+    fn parse_single_line_json_backward_compat() {
+        // Single-line JSON (--output-format json) still works
+        let raw = r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":2000,"result":"{\"status\":\"done\",\"summary\":\"backward compat\",\"accomplished\":[],\"remaining\":[],\"files\":[]}","usage":{"input_tokens":50,"output_tokens":25}}"#;
+        let parsed = runner().parse_response(raw).unwrap();
+        assert_eq!(parsed.response.status, "done");
+        assert_eq!(parsed.response.summary, "backward compat");
+        assert_eq!(parsed.input_tokens, Some(50));
+        assert_eq!(parsed.output_tokens, Some(25));
     }
 
     // ── Kimi / MiniMax (Claude-compatible wrappers) ───────────────

--- a/src/engine/runner/direct.rs
+++ b/src/engine/runner/direct.rs
@@ -178,8 +178,28 @@ async fn run_shell_command(
 }
 
 /// Extract text and token usage from a Claude JSON envelope or raw output.
+///
+/// Handles both single JSON blobs (`--output-format json`) and NDJSON streams
+/// (`--output-format stream-json`): finds the last line with `"type":"result"`.
 pub(crate) fn extract_from_envelope(raw: &str) -> (String, Option<u64>, Option<u64>) {
-    if let Ok(value) = serde_json::from_str::<serde_json::Value>(raw) {
+    // Find the result line: last NDJSON line with "type":"result", or the full string
+    let candidate = raw
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .rev()
+        .find(|line| {
+            serde_json::from_str::<serde_json::Value>(line)
+                .ok()
+                .and_then(|v| {
+                    v.get("type")
+                        .and_then(|t| t.as_str())
+                        .map(|t| t == "result")
+                })
+                .unwrap_or(false)
+        })
+        .unwrap_or(raw);
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(candidate) {
         if let Some(obj) = value.as_object() {
             if obj.get("type").and_then(|v| v.as_str()) == Some("result") {
                 let text = obj
@@ -213,6 +233,22 @@ mod tests {
         assert_eq!(text, "Hello world");
         assert_eq!(input, Some(10));
         assert_eq!(output, Some(5));
+    }
+
+    #[test]
+    fn test_extract_from_envelope_ndjson_stream() {
+        let raw = concat!(
+            r#"{"type":"system","subtype":"init"}"#,
+            "\n",
+            r#"{"type":"assistant","message":{}}"#,
+            "\n",
+            r#"{"type":"result","result":"streamed result","usage":{"input_tokens":20,"output_tokens":8}}"#,
+            "\n"
+        );
+        let (text, input, output) = extract_from_envelope(raw);
+        assert_eq!(text, "streamed result");
+        assert_eq!(input, Some(20));
+        assert_eq!(output, Some(8));
     }
 
     #[test]

--- a/tests/fixtures/claude_stream_error.jsonl
+++ b/tests/fixtures/claude_stream_error.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","apiKeySource":"environment","cwd":"/tmp/work","model":"claude-sonnet-4-6","permissionMode":"bypassPermissions"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I'll look at the issue."}]}}
+{"type":"result","subtype":"error","is_error":true,"duration_ms":500,"result":"credit balance too low","usage":{},"permission_denials":[]}

--- a/tests/fixtures/claude_stream_rate_limit.jsonl
+++ b/tests/fixtures/claude_stream_rate_limit.jsonl
@@ -1,0 +1,2 @@
+{"type":"system","subtype":"init","apiKeySource":"environment","cwd":"/tmp/work","model":"claude-sonnet-4-6","permissionMode":"bypassPermissions"}
+{"type":"result","subtype":"error","is_error":true,"duration_ms":1000,"result":"Error: 429 Too Many Requests - rate limit exceeded. Please try again in 30 seconds.","usage":{},"permission_denials":[]}

--- a/tests/fixtures/claude_stream_success.jsonl
+++ b/tests/fixtures/claude_stream_success.jsonl
@@ -1,0 +1,5 @@
+{"type":"system","subtype":"init","apiKeySource":"environment","cwd":"/tmp/work","model":"claude-sonnet-4-6","permissionMode":"bypassPermissions","tools":["Read","Write","Edit","Bash"]}
+{"type":"assistant","message":{"id":"msg_01","type":"message","role":"assistant","content":[{"type":"text","text":"I'll implement this feature now."}],"model":"claude-sonnet-4-6","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":20}}}
+{"type":"tool_use","tool":{"name":"Read","input":{"file_path":"/tmp/file.rs"}}}
+{"type":"tool_result","result":{"content":"fn main() {}"}}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":45000,"result":"```json\n{\"status\": \"done\", \"summary\": \"Implemented the feature\", \"accomplished\": [\"Added new function\", \"Updated tests\"], \"remaining\": [], \"files\": [\"src/main.rs\", \"tests/test.rs\"]}\n```","usage":{"input_tokens":15000,"output_tokens":3500},"modelUsage":{"claude-sonnet-4-6":{"inputTokens":15000,"outputTokens":3500}},"permission_denials":[]}


### PR DESCRIPTION
## Summary

All done. Here's a summary of changes:

**`src/engine/runner/agents/claude.rs`**
- `build_command`: `--output-format json` → `--output-format stream-json`
- `router_command`: `--output-format json` → `--output-format stream-json`
- Added `find_ndjson_result_line()` helper: scans lines in reverse for last `"type":"result"` JSON line
- Updated `parse_response`: tries NDJSON extraction first, falls back to full-string envelope (backward compat with pretty-printed JSON)
- Added 5 new tests: 3 fixture-based (stream_success, stream_error, stream_rate_limit) + 2 inline (intermediate events ignored, malformed lines skipped) + 1 backward-compat test

**`src/engine/runner/direct.rs`**
- `extract_from_envelope`: scans for last NDJSON result line before parsing, falls back to full string
- Added `test_extract_from_envelope_ndjson_stream` test

**`src/engine/router/llm.rs`**
- `parse_llm_response`: added pre-step to find the last `"type":"result"` line from NDJSON before the existing envelope-unwrap logic

**`tests/fixtures/`**
- Added `claude_stream_success.jsonl`, `claude_stream_error.jsonl`, `claude_stream_rate_limit.jsonl`

Closes #847

---
*Task #847 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*