### PR TITLE
bug: review PR-creation 422 retry path counts as a failure

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -772,9 +772,10 @@ pub(crate) async fn review_and_merge(
                                         &[("pr_number", serde_json::json!(n as i64))],
                                     )
                                     .await;
-                                    return Ok(ReviewDecision::Failed(
-                                        "found existing PR after 422, retry".to_string(),
-                                    ));
+                                    // PR creation recovered successfully, so do not count this as a
+                                    // review-agent failure. The next review pass can use the stored
+                                    // PR number immediately.
+                                    return Ok(ReviewDecision::Skipped);
                                 }
                             }
                             tracing::warn!(
@@ -858,9 +859,10 @@ pub(crate) async fn review_and_merge(
                                                 pr_url = %pr_url,
                                                 "PR already exists (from CLI stderr) — retrying review"
                                             );
-                                            return Ok(ReviewDecision::Failed(
-                                                "PR already exists, retry".to_string(),
-                                            ));
+                                            // PR creation recovered successfully, so skip the failure
+                                            // path and let the next review pass continue from the
+                                            // resolved PR number.
+                                            return Ok(ReviewDecision::Skipped);
                                         }
                                     }
                                     tracing::error!(


### PR DESCRIPTION
## Summary

Recovered PR-creation 422/"already exists" paths now return a non-failure review decision, so the caller won't increment `review_agent_failures` after successfully resolving the PR number.

### What was done

- Changed `src/engine/review.rs` so both GhHttp and CLI "PR already exists" recovery paths return `ReviewDecision::Skipped` instead of `Failed`
- Kept the resolved `pr_number` update so the next review pass continues against the correct PR
- Ran `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` successfully
- Committed the fix in `6755971` (`fix: treat recovered PR create 422 as non-failure`)


Closes #851

---
*Task #851 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4-mini`*