### PR TITLE
bug: review agent cooldown fallback picks rate-limited agent over excluded task agent

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -161,7 +161,14 @@ impl Router {
                     && !crate::engine::runner::response::is_agent_in_cooldown(a)
             })
             .cloned()
-            // Fallback: ignore cooldown if all agents are cooled down
+            // Fallback: any non-cooled agent (including excluded) — healthy agent beats rate-limited one
+            .or_else(|| {
+                (0..n)
+                    .map(|offset| &self.available_agents[(idx + offset) % n])
+                    .find(|a| !crate::engine::runner::response::is_agent_in_cooldown(a))
+                    .cloned()
+            })
+            // Last resort: non-excluded even if cooled
             .or_else(|| {
                 (0..n)
                     .map(|offset| &self.available_agents[(idx + offset) % n])


### PR DESCRIPTION
## Summary

All 804 tests pass. The fix is clean and correct.

**What changed:** Reordered the fallback chain in `next_round_robin_agent()` at `src/engine/router/mod.rs:164-178`:

1. **Primary** (unchanged): non-excluded + non-cooled
2. **New fallback**: any non-cooled agent (including excluded) — a healthy excluded agent beats a rate-limited one
3. **Last resort**: non-excluded even if cooled
4. **Final fallback** (unchanged): any agent

This fixes the scenario where all non-excluded agents are on cooldown — instead of picking a cooled agent that will fail immediately, it now considers the excluded agent (e.g. claude after doing the task) which is healthy and available.

Closes #856

---
*Task #856 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*