### PR TITLE
bug: review agent tmux session not cleaned up on rate limit — blocks all retries with duplicate session

### DIFF
--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -235,6 +235,15 @@ pub fn spawn(
                         };
                         match outcome {
                             ReviewOutcome::Reset => {
+                                // Kill any stale tmux review session before resetting — the
+                                // session may still be alive if the agent hit a rate limit,
+                                // if two concurrent reviewers raced and the loser's spawn
+                                // failed with "duplicate session", or if review_and_merge
+                                // returned an error before reaching its own cleanup.
+                                // Killing a non-existent session is a harmless no-op.
+                                let stale_session =
+                                    tmux_c.session_name(&repo_s, &format!("{}-review", tid));
+                                tmux_c.kill_session(&stale_session).await.ok();
                                 // Backoff before re-queuing to prevent rapid spin
                                 // if the review agent keeps failing instantly.
                                 tokio::time::sleep(std::time::Duration::from_secs(10)).await;

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -734,6 +734,13 @@ pub(crate) async fn tick_dispatch_tasks(
                                                         failures,
                                                         "review agent failed — resetting to NeedsReview for retry"
                                                     );
+                                                    // Kill any stale review session so the
+                                                    // next retry can create a fresh one.
+                                                    let stale = tmux_clone.session_name(
+                                                        &repo_owned,
+                                                        &format!("{}-review", task_id_for_review),
+                                                    );
+                                                    tmux_clone.kill_session(&stale).await.ok();
                                                     if let Err(e) = task_manager_for_review
                                                         .update_task_status(
                                                             &ExternalId(
@@ -781,6 +788,13 @@ pub(crate) async fn tick_dispatch_tasks(
                                                         failures,
                                                         "review_and_merge failed — resetting to NeedsReview for retry"
                                                     );
+                                                    // Kill any stale review session so the
+                                                    // next retry can create a fresh one.
+                                                    let stale = tmux_clone.session_name(
+                                                        &repo_owned,
+                                                        &format!("{}-review", task_id_for_review),
+                                                    );
+                                                    tmux_clone.kill_session(&stale).await.ok();
                                                     if let Err(ue) = task_manager_for_review
                                                         .update_task_status(
                                                             &ExternalId(


### PR DESCRIPTION
## Summary

All checks pass. Here's a summary of what was changed:

**`src/engine/subscribers/review.rs`** — In `ReviewOutcome::Reset`:
- Before the 10s backoff sleep, kill the stale review session (`{task_id}-review`)

**`src/engine/tick.rs`** — In both reset-to-NeedsReview paths (for `ReviewDecision::Failed` and `Err(e)` from `review_and_merge`):
- Before calling `update_task_status(NeedsReview)`, kill the stale review session

The fix works by deriving the session name from the task ID (`{task_id}-review`) and calling `kill_session` before resetting the task. This handles the race where two concurrent reviewers spawn the same session name — when the second one fails with "duplicate session", the Reset handler kills the stale session so the next retry can create it fresh. Killing a non-existent session is a no-op (logs a warning and returns Ok).

Closes #855

---
*Task #855 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*