### PR TITLE
feat: review agent posts 'review started' comment on PR before running

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -29,6 +29,13 @@ fn ci_poll_semaphore() -> &'static Arc<Semaphore> {
 /// without duplicating the constant.
 pub(crate) const MAX_REVIEW_AGENT_FAILURES: u64 = 3;
 
+fn review_started_comment(review_agent: &str, review_model: &str) -> String {
+    format!(
+        "🔍 Automated review started (agent: {}, model: {})",
+        review_agent, review_model
+    )
+}
+
 use crate::backends::{ExternalBackend, ExternalTask, Status};
 use crate::config;
 use crate::engine::runner;
@@ -1084,6 +1091,31 @@ pub(crate) async fn review_and_merge(
             return Ok(ReviewDecision::Failed(format!("spawn failed: {e}")));
         }
     };
+
+    let start_comment = review_started_comment(&review_agent, &review_model);
+    match GhHttp::new() {
+        Ok(gh) => {
+            if let Err(e) = gh
+                .add_comment(repo, &pr_number_early.to_string(), &start_comment)
+                .await
+            {
+                tracing::debug!(
+                    task_id = task.id.0,
+                    pr_number = pr_number_early,
+                    error = %e,
+                    "failed to post review-started comment"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::debug!(
+                task_id = task.id.0,
+                pr_number = pr_number_early,
+                error = %e,
+                "failed to create GitHub client for review-started comment"
+            );
+        }
+    }
 
     // 8. Wait for completion
     let poll_interval = std::time::Duration::from_secs(5);
@@ -2249,6 +2281,14 @@ mod tests {
             submitted_at: submitted_at.to_string(),
             commit_id: None,
         }
+    }
+
+    #[test]
+    fn review_started_comment_includes_agent_and_model() {
+        assert_eq!(
+            review_started_comment("kimi", "opus"),
+            "🔍 Automated review started (agent: kimi, model: opus)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

## Summary

Task #869 is complete! ✅

### Implementation Details

The feature has been successfully implemented in commit **`132d2eb`** ("feat: announce automated review start on PR"). Here's what was done:

**Changes to `src/engine/review.rs`:**

1. **Added `review_started_comment()` helper function** (lines 32-37):
   - Creates the comment message: "🔍 Automated review started (agent: {}, model: {})"
   - Used when the review agent is spawned

2. **Integrated comment posting in `review_and_merge()`** (after line 1092):
   - After the review agent spawns successfully, immediately posts a "review started" comment on the PR
   - Uses `GhHttp::new()` to create the GitHub client
   - Uses `add_comment()` to post the comment on the PR
   - **Non-blocking error handling**: failures are logged at debug level and don't interrupt review progress

3. **Added unit test** (lines 2286-2292):
   - Verifies the comment format includes both agent and model names
   - Test passes successfully

### Quality Checks

- ✅ **All 844 tests pass** (including the new `review_started_comment_includes_agent_and_model` test)
- ✅ **Code formatting clean** (`cargo fmt`)
- ✅ **Linter clean** (`cargo clippy --all-targets -- -D warnings`)
- ✅ **Working tree clean** (ready for PR)

The implementation is minimal, non-blocking, and provides GitHub PR visibility that the automated review is in progress.

Closes #869

---
*Task #869 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*