### PR TITLE
bug: InReview recovery resets PRs that are only waiting for human review

### DIFF
--- a/migrations/008_review_session_expected.sql
+++ b/migrations/008_review_session_expected.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tasks ADD COLUMN review_session_expected INTEGER NOT NULL DEFAULT 0;

--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -145,6 +145,36 @@ pub(crate) async fn store_set(
     }
 }
 
+pub(crate) async fn review_session_expected(
+    store: &Arc<TaskStore>,
+    repo: &str,
+    task_id: &str,
+) -> bool {
+    match store.resolve_task_id(repo, task_id).await {
+        Ok(Some(store_id)) => store
+            .get(store_id)
+            .await
+            .map(|task| task.review_session_expected)
+            .unwrap_or(false),
+        Ok(None) | Err(_) => false,
+    }
+}
+
+pub(crate) async fn set_review_session_expected(
+    store: &Arc<TaskStore>,
+    repo: &str,
+    task_id: &str,
+    expected: bool,
+) {
+    store_set(
+        &Some(Arc::clone(store)),
+        repo,
+        task_id,
+        &[("review_session_expected", serde_json::json!(expected))],
+    )
+    .await;
+}
+
 /// Increment a counter in the task store.
 ///
 /// Uses `store.increment()` for an atomic SQL `field + 1`.

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -884,12 +884,16 @@ pub async fn serve() -> anyhow::Result<()> {
     // Channel for weight signals from task runners back to the router
     let (weight_tx, mut weight_rx) = mpsc::channel::<WeightSignal>(64);
 
-    // Reset stale InReview tasks on startup — if a review agent was running when
-    // the engine restarted, the tmux session is gone. Move back to NeedsReview
-    // so the next tick re-triggers the review agent.
+    // Reset only InReview tasks that still expected a live review session when
+    // the engine restarted. Tasks that are merely waiting on a human response on
+    // an open PR should remain InReview.
     for engine in &project_engines {
         if let Ok(in_review) = engine.backend.list_by_status(Status::InReview).await {
             for task in &in_review {
+                if !cleanup::review_session_expected(&engine.store, &engine.repo, &task.id.0).await
+                {
+                    continue;
+                }
                 if let Err(e) = engine
                     .backend
                     .update_status(&task.id, Status::NeedsReview)
@@ -900,6 +904,14 @@ pub async fn serve() -> anyhow::Result<()> {
                         err = %e,
                         "failed to reset stale InReview task on startup"
                     );
+                } else {
+                    cleanup::set_review_session_expected(
+                        &engine.store,
+                        &engine.repo,
+                        &task.id.0,
+                        false,
+                    )
+                    .await;
                 }
             }
             if !in_review.is_empty() {
@@ -920,6 +932,9 @@ pub async fn serve() -> anyhow::Result<()> {
         {
             for task in &internal_in_review {
                 let task_id = task.id.0.clone();
+                if !cleanup::review_session_expected(&engine.store, &engine.repo, &task_id).await {
+                    continue;
+                }
                 if let Err(e) = engine
                     .task_manager
                     .update_task_status(&ExternalId(task_id.clone()), Status::NeedsReview)
@@ -930,6 +945,14 @@ pub async fn serve() -> anyhow::Result<()> {
                         err = %e,
                         "failed to reset stale internal InReview task on startup"
                     );
+                } else {
+                    cleanup::set_review_session_expected(
+                        &engine.store,
+                        &engine.repo,
+                        &task_id,
+                        false,
+                    )
+                    .await;
                 }
             }
             if !internal_in_review.is_empty() {

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -70,8 +70,8 @@ fn any_changes_requested_in_reviews(reviews: &[GitHubReview]) -> bool {
 }
 
 use super::cleanup::{
-    cleanup_task_worktree, store_increment, store_reset_counters, store_reset_failure_counters,
-    store_set,
+    cleanup_task_worktree, set_review_session_expected, store_increment, store_reset_counters,
+    store_reset_failure_counters, store_set,
 };
 use super::router::Router;
 use super::tasks::TaskManager;
@@ -615,6 +615,8 @@ pub(crate) async fn review_and_merge(
     task_manager: &Arc<TaskManager>,
     store: &Arc<TaskStore>,
 ) -> anyhow::Result<ReviewDecision> {
+    set_review_session_expected(store, repo, &task.id.0, true).await;
+
     // 2. Load worktree path, branch, summary, and pr_number from store — single DB round-trip.
     let stored_task = store
         .get_by_external_id(repo, &task.id.0)

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -118,6 +118,11 @@ pub fn spawn(
                         continue;
                     }
 
+                    super::super::cleanup::set_review_session_expected(
+                        &store, &repo, &task.id.0, true,
+                    )
+                    .await;
+
                     // Insert into dispatching set.
                     {
                         let mut guard = dispatching.lock().unwrap_or_else(|e| e.into_inner());
@@ -233,6 +238,13 @@ pub fn spawn(
                                 ReviewOutcome::Ok
                             }
                         };
+                        super::super::cleanup::set_review_session_expected(
+                            &store_c,
+                            &repo_s,
+                            &tid,
+                            false,
+                        )
+                        .await;
                         match outcome {
                             ReviewOutcome::Reset => {
                                 // Kill any stale tmux review session before resetting — the

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -40,7 +40,7 @@ async fn kv_set_prefer_store(store: &Option<&Arc<TaskStore>>, key: &str, value: 
     }
 }
 
-use super::cleanup::{check_merged_prs, cleanup_done_worktrees};
+use super::cleanup::{check_merged_prs, cleanup_done_worktrees, review_session_expected};
 use super::review::review_open_prs;
 use super::EngineConfig;
 
@@ -172,6 +172,14 @@ pub(crate) async fn sync_tick(
                 }
             }
 
+            if !review_session_expected(store, repo, &task.id.0).await {
+                tracing::debug!(
+                    task_id = task.id.0,
+                    "InReview task is waiting on PR review, skipping stale review-session recovery"
+                );
+                continue;
+            }
+
             let review_task_id = format!("{}-review", task.id.0);
             let review_session = tmux.session_name(repo, &review_task_id);
             let has_session = tmux.session_exists(&review_session).await;
@@ -196,6 +204,9 @@ pub(crate) async fn sync_tick(
                     .await
                 {
                     tracing::error!(task_id = %task.id.0, err = %e, "failed to reset stale InReview task — task may be stuck in InReview indefinitely");
+                } else {
+                    super::cleanup::set_review_session_expected(store, repo, &task.id.0, false)
+                        .await;
                 }
             }
         }
@@ -1036,6 +1047,64 @@ mod tests {
              spawned review task panics — without DispatchGuard the key leaks and \
              the task gets stuck in a permanent review loop"
         );
+    }
+
+    #[tokio::test]
+    async fn stale_in_review_recovery_skips_tasks_waiting_for_human_review() {
+        let store = Arc::new(crate::store::TaskStore::open_memory().await.unwrap());
+        let backend: Arc<dyn ExternalBackend> = IngestMockBackend::with_tasks(vec![]);
+        let task_manager = Arc::new(TaskManager::with_store(
+            backend.clone(),
+            store.clone(),
+            "owner/repo".to_string(),
+        ));
+        let tmux = Arc::new(TmuxManager::new());
+        let router = Arc::new(RwLock::new(crate::engine::router::Router::from_config()));
+        let dispatching: Arc<std::sync::Mutex<std::collections::HashSet<String>>> =
+            Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
+
+        let id = store
+            .upsert_external(&crate::store::UpsertExternal {
+                repo: "owner/repo",
+                ext_id: "55",
+                title: "Waiting for human review",
+                body: "",
+                author: "",
+                url: "",
+                labels: &[],
+                origin: "github",
+            })
+            .await
+            .unwrap();
+        store
+            .update_status(id, crate::store::TaskStatus::InReview)
+            .await
+            .unwrap();
+        store
+            .set_fields(id, &[("branch", serde_json::json!("feature/55"))])
+            .await
+            .unwrap();
+        sqlx::query("UPDATE tasks SET updated_at = '2020-01-01T00:00:00Z' WHERE id = ?")
+            .bind(id)
+            .execute(store.pool())
+            .await
+            .unwrap();
+
+        sync_tick(
+            &backend,
+            &tmux,
+            "owner/repo",
+            &EngineConfig::default(),
+            &router,
+            &task_manager,
+            &store,
+            &dispatching,
+        )
+        .await
+        .unwrap();
+
+        let task = store.get(id).await.unwrap();
+        assert_eq!(task.status, crate::store::TaskStatus::InReview);
     }
 
     #[test]

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -22,6 +22,7 @@ use crate::tmux::TmuxManager;
 use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock, Semaphore};
 
+use super::cleanup::{review_session_expected, set_review_session_expected};
 use super::dispatch_guard::DispatchGuard;
 use super::review::{review_and_merge, ReviewDecision, MAX_REVIEW_AGENT_FAILURES};
 use super::EngineConfig;
@@ -231,6 +232,14 @@ pub(crate) async fn tick_recover_stuck_tasks(
         .list_external_by_status(Status::InReview)
         .await?;
     for task in &in_review {
+        if !review_session_expected(store, repo, &task.id.0).await {
+            tracing::debug!(
+                task_id = task.id.0,
+                "in_review task is waiting on PR review, skipping stuck-session recovery"
+            );
+            continue;
+        }
+
         let review_task_id = format!("{}-review", task.id.0);
         let session_name = tmux.session_name(repo, &review_task_id);
         let has_session = tmux.session_exists(&session_name).await;
@@ -272,6 +281,8 @@ pub(crate) async fn tick_recover_stuck_tasks(
                     "failed to reset stuck in_review task status"
                 );
                 continue;
+            } else {
+                set_review_session_expected(store, repo, &task.id.0, false).await;
             }
             if let Err(e) = backend
                 .post_comment(
@@ -300,6 +311,14 @@ pub(crate) async fn tick_recover_stuck_tasks(
         .await?;
     for task in &internal_in_review {
         let task_id = task.id.0.clone();
+        if !review_session_expected(store, repo, &task_id).await {
+            tracing::debug!(
+                task_id,
+                "internal in_review task is waiting on PR review, skipping stuck-session recovery"
+            );
+            continue;
+        }
+
         let review_task_id = format!("{}-review", task_id);
         let session_name = tmux.session_name(repo, &review_task_id);
         let has_session = tmux.session_exists(&session_name).await;
@@ -332,6 +351,8 @@ pub(crate) async fn tick_recover_stuck_tasks(
                     ?e,
                     "failed to reset stuck internal in_review task status"
                 );
+            } else {
+                set_review_session_expected(store, repo, &task_id, false).await;
             }
         }
     }
@@ -656,6 +677,13 @@ pub(crate) async fn tick_dispatch_tasks(
                                     tracing::warn!(task_id, err = %e, "failed to transition to InReview");
                                 }
                                 Ok(_) => {
+                                    set_review_session_expected(
+                                        &store_for_spawn,
+                                        &repo_owned,
+                                        &task_id,
+                                        true,
+                                    )
+                                    .await;
                                     review_spawned = true;
                                     let backend_clone = backend.clone();
                                     let task_manager_for_review = task_manager_for_spawn.clone();
@@ -832,6 +860,13 @@ pub(crate) async fn tick_dispatch_tasks(
                                                 .await;
                                             }
                                         }
+                                        set_review_session_expected(
+                                            &store_for_review,
+                                            &repo_owned,
+                                            &task_id_for_review,
+                                            false,
+                                        )
+                                        .await;
                                         // _dispatch_guard drops here, removing the key
                                         // even if review_and_merge panicked.
                                     }));
@@ -1304,6 +1339,7 @@ mod tests {
             .update_status(id, crate::store::TaskStatus::InReview)
             .await
             .unwrap();
+        crate::engine::cleanup::set_review_session_expected(&store, "owner/repo", "99", true).await;
         set_task_updated_at_past(&store, id).await;
 
         tick_recover_stuck_tasks(
@@ -1404,6 +1440,13 @@ mod tests {
             .update_status(id, crate::store::TaskStatus::InReview)
             .await
             .unwrap();
+        crate::engine::cleanup::set_review_session_expected(
+            &store,
+            "owner/repo",
+            "internal:1",
+            true,
+        )
+        .await;
         set_task_updated_at_past(&store, id).await;
 
         tick_recover_stuck_tasks(
@@ -1422,6 +1465,61 @@ mod tests {
             task.status,
             crate::store::TaskStatus::NeedsReview,
             "stuck internal InReview task should be reset to NeedsReview"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_stuck_tasks_skips_external_in_review_waiting_for_human_review() {
+        let store = Arc::new(crate::store::TaskStore::open_memory().await.unwrap());
+        let mock = MockBackend::new();
+        let status_updates = mock.status_updates.clone();
+        let backend: Arc<dyn ExternalBackend> = Arc::new(mock);
+        let task_manager = Arc::new(crate::engine::tasks::TaskManager::with_store(
+            backend.clone(),
+            store.clone(),
+            "owner/repo".to_string(),
+        ));
+        let tmux = Arc::new(crate::tmux::TmuxManager::new());
+        let config = EngineConfig {
+            no_session_stuck_timeout: 600,
+            stuck_timeout: 1800,
+            ..EngineConfig::default()
+        };
+
+        let id = store
+            .upsert_external(&crate::store::UpsertExternal {
+                repo: "owner/repo",
+                ext_id: "101",
+                title: "Waiting For Human Review",
+                body: "",
+                author: "",
+                url: "",
+                labels: &[],
+                origin: "github",
+            })
+            .await
+            .unwrap();
+        store
+            .update_status(id, crate::store::TaskStatus::InReview)
+            .await
+            .unwrap();
+        set_task_updated_at_past(&store, id).await;
+
+        tick_recover_stuck_tasks(
+            &backend,
+            &tmux,
+            "owner/repo",
+            &task_manager,
+            &config,
+            &store,
+        )
+        .await
+        .unwrap();
+
+        let updates = status_updates.lock().unwrap();
+        assert!(
+            updates.is_empty(),
+            "InReview task waiting for human review should not be reset"
         );
     }
 

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -88,6 +88,7 @@ pub struct Task {
     pub pr_create_failures: i32,
     pub review_agent_failures: i32,
     pub review_cycles: i32,
+    pub review_session_expected: bool,
 
     // Tokens & Cost
     pub input_tokens: i64,
@@ -493,6 +494,7 @@ impl TaskStore {
             "pr_create_failures",
             "review_agent_failures",
             "review_cycles",
+            "review_session_expected",
             "input_tokens",
             "output_tokens",
             "input_cost_usd",
@@ -583,6 +585,7 @@ impl TaskStore {
             pr_create_failures = 0,
             ci_merge_failures = 0,
             review_cycles = 0,
+            review_session_expected = 0,
             updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
          WHERE id = ?",
         )
@@ -606,6 +609,7 @@ impl TaskStore {
             review_agent_failures = 0,
             merge_conflict_retries = 0,
             pr_create_failures = 0,
+            review_session_expected = 0,
             updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
          WHERE id = ?",
         )
@@ -930,6 +934,7 @@ impl TaskStore {
             pr_create_failures: row.get("pr_create_failures"),
             review_agent_failures: row.get("review_agent_failures"),
             review_cycles: row.get("review_cycles"),
+            review_session_expected: row.get::<i32, _>("review_session_expected") != 0,
             input_tokens: row.get("input_tokens"),
             output_tokens: row.get("output_tokens"),
             input_cost_usd: row.get("input_cost_usd"),

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -1570,6 +1570,30 @@ async fn resolve_task_id_internal_returns_none() {
     );
 }
 
+#[tokio::test]
+async fn set_fields_persists_review_session_expected() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let id = store
+        .create(&NewTask {
+            external_id: Some("42".to_string()),
+            repo: "owner/repo".to_string(),
+            origin: "github".to_string(),
+            title: "Issue 42".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    store
+        .set_fields(id, &[("review_session_expected", serde_json::json!(true))])
+        .await
+        .unwrap();
+
+    let task = store.get(id).await.unwrap();
+    assert!(task.review_session_expected);
+}
+
 // ── prune_old_runs ──────────────────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

I need permission to push. The fix is already complete:

- **Commit**: `f318a45 fix: preserve in-review tasks awaiting human review`
- **All 850 tests pass**, formatting clean, clippy clean
- **No PR created yet** — the branch needs to be pushed first

The fix introduces a `review_session_expected` flag (migration + store field) that is set to `true` when a review agent is about to be dispatched, and cleared when it finishes. Both recovery paths (startup reset in `mod.rs` and stale-session recovery in `sync.rs`) now skip tasks where this flag is `false`, meaning tasks waiting for human PR review are left untouched.

Please allow the push so I can create the PR.

Closes #875

---
*Task #875 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*