### PR TITLE
bug: router model cooldowns are in-memory only — cleared on service restart, causing repeated pool exhaustion

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -3,9 +3,22 @@
 //! Shared by `engine::runner::response` (recording failures) and
 //! `engine::router::config` (avoiding cooled models during pool selection).
 //! Extracted here to avoid a circular dependency between the two.
+//!
+//! # Persistence
+//!
+//! Model-level cooldowns are persisted to the KV store in SQLite so they
+//! survive service restarts.  Call [`init_cooldown_store`] once at startup
+//! (after the `TaskStore` is open) to:
+//!
+//! 1. Register the store for background writes, and
+//! 2. Pre-load any unexpired cooldowns that were recorded before the last
+//!    restart.
+//!
+//! The in-memory map is the read-fast path; SQLite is the durable write path.
+//! Agent-level cooldowns are not persisted (they are short-lived and rare).
 
 use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 /// Cooldown duration for failed agents (30 minutes).
 pub const AGENT_COOLDOWN_SECS: i64 = 30 * 60;
@@ -14,6 +27,9 @@ pub const AGENT_COOLDOWN_SECS: i64 = 30 * 60;
 /// When a specific agent+model combo fails (e.g., model not available,
 /// model-specific rate limit), we ban that combo for longer.
 pub const MODEL_COOLDOWN_SECS: i64 = 60 * 60;
+
+/// KV key prefix for persisted model cooldowns.
+const KV_PREFIX: &str = "cooldown:model:";
 
 struct CooldownEntry {
     failed_at: i64,
@@ -27,6 +43,52 @@ fn cooldowns() -> &'static Mutex<HashMap<String, CooldownEntry>> {
     COOLDOWNS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Global store reference used for background KV writes.
+fn cooldown_store() -> &'static Mutex<Option<Arc<crate::store::TaskStore>>> {
+    static STORE: OnceLock<Mutex<Option<Arc<crate::store::TaskStore>>>> = OnceLock::new();
+    STORE.get_or_init(|| Mutex::new(None))
+}
+
+/// Initialise persistent cooldowns.
+///
+/// Must be called once at engine startup, after the `TaskStore` is opened.
+/// This registers the store for background KV writes and pre-loads any
+/// unexpired model cooldowns that were recorded before the last restart.
+pub async fn init_cooldown_store(store: Arc<crate::store::TaskStore>) {
+    // Load unexpired model cooldowns from KV into the in-memory map.
+    match store.kv_list_prefix(KV_PREFIX).await {
+        Ok(rows) => {
+            let now = chrono::Utc::now().timestamp();
+            let mut map = cooldowns().lock().unwrap_or_else(|e| e.into_inner());
+            for (key, value) in rows {
+                // key = "cooldown:model:{agent}:{model}"
+                // value = failed_at unix timestamp as string
+                let model_key = key.trim_start_matches(KV_PREFIX);
+                if let Ok(failed_at) = value.parse::<i64>() {
+                    if (now - failed_at) < MODEL_COOLDOWN_SECS {
+                        map.insert(
+                            model_key.to_string(),
+                            CooldownEntry {
+                                failed_at,
+                                reason: "persisted".to_string(),
+                            },
+                        );
+                    }
+                }
+            }
+            tracing::debug!(loaded = map.len(), "loaded model cooldowns from KV store");
+        }
+        Err(e) => {
+            tracing::warn!(err = %e, "failed to load cooldowns from KV store");
+        }
+    }
+
+    // Register the store for background writes on future failures.
+    if let Ok(mut slot) = cooldown_store().lock() {
+        *slot = Some(store);
+    }
+}
+
 /// Record that an agent has failed and should be temporarily avoided.
 pub fn record_agent_failure(agent_name: &str) {
     record_failure_with_reason(agent_name, "agent_error");
@@ -36,9 +98,26 @@ pub fn record_agent_failure(agent_name: &str) {
 ///
 /// The cooldown key is `"agent:model"` so we can track model-specific
 /// failures separately (e.g., codex with o3-mini fails but gpt-4o works).
+/// The failure is also persisted to the KV store via a background task.
 pub fn record_model_failure(agent_name: &str, model: &str) {
     let key = format!("{agent_name}:{model}");
     record_failure_with_reason(&key, "model_error");
+
+    // Persist to KV via a background Tokio task so restarts don't lose state.
+    let store_opt = cooldown_store().lock().ok().and_then(|g| g.clone());
+    if let Some(store) = store_opt {
+        let kv_key = format!("{KV_PREFIX}{key}");
+        let failed_at = chrono::Utc::now().timestamp().to_string();
+        tokio::spawn(async move {
+            if let Err(e) = store.kv_set(&kv_key, &failed_at).await {
+                tracing::warn!(
+                    kv_key,
+                    err = %e,
+                    "failed to persist model cooldown to KV store"
+                );
+            }
+        });
+    }
 }
 
 /// Check if a specific agent+model combo is in cooldown.
@@ -84,4 +163,80 @@ pub fn clear_expired_cooldowns() {
         };
         (now - entry.failed_at) < timeout
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fresh in-memory store for testing KV persistence.
+    async fn test_store() -> Arc<crate::store::TaskStore> {
+        Arc::new(
+            crate::store::TaskStore::open_memory()
+                .await
+                .expect("in-memory store"),
+        )
+    }
+
+    #[tokio::test]
+    async fn init_loads_unexpired_cooldowns_from_kv() {
+        let store = test_store().await;
+        let failed_at = chrono::Utc::now().timestamp();
+
+        // Pre-populate KV with a valid cooldown entry.
+        store
+            .kv_set(&format!("{KV_PREFIX}kimi:k2p5"), &failed_at.to_string())
+            .await
+            .unwrap();
+
+        // Also add an already-expired entry (failed 2 hours ago).
+        let expired_at = failed_at - (MODEL_COOLDOWN_SECS + 1);
+        store
+            .kv_set(
+                &format!("{KV_PREFIX}opencode:old-free"),
+                &expired_at.to_string(),
+            )
+            .await
+            .unwrap();
+
+        // Clear in-memory state before calling init.
+        {
+            let mut map = cooldowns().lock().unwrap();
+            map.clear();
+        }
+
+        init_cooldown_store(store).await;
+
+        assert!(
+            is_model_in_cooldown("kimi", "k2p5"),
+            "unexpired cooldown should be loaded"
+        );
+        assert!(
+            !is_model_in_cooldown("opencode", "old-free"),
+            "expired cooldown should not be loaded"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_model_failure_writes_to_kv() {
+        let store = test_store().await;
+
+        // Reset global store slot to this test store.
+        {
+            let mut slot = cooldown_store().lock().unwrap();
+            *slot = Some(store.clone());
+        }
+
+        record_model_failure("testagent", "testmodel");
+
+        // Give the background task time to complete.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let kv_key = format!("{KV_PREFIX}testagent:testmodel");
+        let stored = store.kv_get(&kv_key).await.unwrap();
+        assert!(stored.is_some(), "model failure should be persisted to KV");
+        let ts: i64 = stored.unwrap().parse().expect("timestamp string");
+        let now = chrono::Utc::now().timestamp();
+        assert!((now - ts).abs() < 5, "persisted timestamp should be recent");
+    }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -247,6 +247,10 @@ async fn init_project_engines() -> anyhow::Result<Vec<ProjectEngine>> {
         // Initialize unified task store (sqlx)
         let store = Arc::new(TaskStore::open(&crate::store::default_db_path()?).await?);
 
+        // Load persisted model cooldowns and register store for future writes.
+        // Only needs to run once — all engines share the same SQLite file.
+        crate::engine::cooldown::init_cooldown_store(store.clone()).await;
+
         // Initialize task manager (with unified store)
         let task_manager = Arc::new(TaskManager::with_store(
             backend.clone(),

--- a/src/store/kv.rs
+++ b/src/store/kv.rs
@@ -21,4 +21,15 @@ impl TaskStore {
     .await?;
         Ok(())
     }
+
+    /// List all (key, value) pairs where the key starts with `prefix`.
+    pub async fn kv_list_prefix(&self, prefix: &str) -> anyhow::Result<Vec<(String, String)>> {
+        let pattern = format!("{prefix}%");
+        let rows: Vec<(String, String)> =
+            sqlx::query_as("SELECT key, value FROM kv WHERE key LIKE ?")
+                .bind(&pattern)
+                .fetch_all(&self.pool)
+                .await?;
+        Ok(rows)
+    }
 }


### PR DESCRIPTION
## Summary

The changes are already committed in the latest commit (`68fcc8c`). The implementation is complete with all CI checks passing:

- **`src/store/kv.rs`**: Added `kv_list_prefix()` to scan KV entries by prefix
- **`src/engine/cooldown.rs`**: Write-through persistence — failures written to KV on record, pre-loaded from KV at startup via `init_cooldown_store()`
- **`src/engine/mod.rs`**: Calls `init_cooldown_store(store.clone())` at engine startup

849 tests pass, no clippy warnings, formatting clean. The branch is ready to push and open a PR.

Closes #873

---
*Task #873 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*