### PR TITLE
bug: internal-only store state hides external tasks from store-first queries

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -336,12 +336,11 @@ pub(crate) async fn cleanup_done_worktrees_with_opts(
 ) -> anyhow::Result<()> {
     // Read done tasks from the store first; fall back to backend before first sync.
     let done_tasks = {
-        if store.has_tasks(repo).await {
+        if store.has_external_tasks(repo).await {
             store
-                .list_by_status(repo, crate::store::TaskStatus::Done)
+                .list_external_by_status(repo, crate::store::TaskStatus::Done)
                 .await?
                 .iter()
-                .filter(|t| t.origin != "internal")
                 .map(crate::engine::tasks::store_task_to_external)
                 .collect()
         } else {
@@ -829,23 +828,21 @@ pub(crate) async fn check_merged_prs(
     task_manager: &Arc<TaskManager>,
 ) -> anyhow::Result<()> {
     // Read from the store first; fall back to backend if the store has no data.
-    let in_review_tasks = if store.has_tasks(repo).await {
+    let in_review_tasks = if store.has_external_tasks(repo).await {
         store
-            .list_by_status(repo, crate::store::TaskStatus::InReview)
+            .list_external_by_status(repo, crate::store::TaskStatus::InReview)
             .await?
             .iter()
-            .filter(|t| t.origin != "internal")
             .map(crate::engine::tasks::store_task_to_external)
             .collect()
     } else {
         backend.list_by_status(Status::InReview).await?
     };
-    let needs_review_tasks = if store.has_tasks(repo).await {
+    let needs_review_tasks = if store.has_external_tasks(repo).await {
         store
-            .list_by_status(repo, crate::store::TaskStatus::NeedsReview)
+            .list_external_by_status(repo, crate::store::TaskStatus::NeedsReview)
             .await?
             .iter()
-            .filter(|t| t.origin != "internal")
             .map(crate::engine::tasks::store_task_to_external)
             .collect()
     } else {

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -116,15 +116,13 @@ pub(crate) async fn review_open_prs(
     // Read from the store first; fall back to backend if the store is empty.
     let mut in_review_tasks = {
         let store_tasks = store
-            .list_by_status(repo, crate::store::TaskStatus::InReview)
+            .list_external_by_status(repo, crate::store::TaskStatus::InReview)
             .await?;
-        let external: Vec<_> = store_tasks
-            .iter()
-            .filter(|t| t.origin != "internal")
-            .map(crate::engine::tasks::store_task_to_external)
-            .collect();
-        if store.has_tasks(repo).await {
-            external
+        if store.has_external_tasks(repo).await {
+            store_tasks
+                .iter()
+                .map(crate::engine::tasks::store_task_to_external)
+                .collect()
         } else {
             backend.list_by_status(Status::InReview).await?
         }

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -62,7 +62,9 @@ pub fn spawn(
 
                     // Look up the task from the store to get an ExternalTask.
                     let task = {
-                        if store.has_tasks(&repo).await {
+                        if crate::engine::tasks::is_internal_id(task_id)
+                            || store.has_external_tasks(&repo).await
+                        {
                             match store.list_by_status(&repo, TaskStatus::NeedsReview).await {
                                 Ok(tasks) => tasks
                                     .iter()

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -111,27 +111,28 @@ pub(crate) async fn sync_tick(
         // Detect stale InReview tasks (review agent crashed, no active tmux session).
         // Read from the store (includes both external and internal tasks).
         let in_review_tasks = {
-            if store.has_tasks(repo).await {
+            let mut tasks = if store.has_external_tasks(repo).await {
                 store
-                    .list_by_status(repo, TaskStatus::InReview)
+                    .list_external_by_status(repo, TaskStatus::InReview)
                     .await
                     .unwrap_or_default()
                     .iter()
                     .map(crate::engine::tasks::store_task_to_external)
                     .collect::<Vec<_>>()
             } else {
-                let mut tasks = backend
+                let tasks = backend
                     .list_by_status(Status::InReview)
                     .await
                     .unwrap_or_default();
-                if let Ok(internal_in_review) = task_manager
-                    .list_internal_by_status(TaskStatus::InReview)
-                    .await
-                {
-                    tasks.extend(internal_in_review);
-                }
                 tasks
+            };
+            if let Ok(internal_in_review) = task_manager
+                .list_internal_by_status(TaskStatus::InReview)
+                .await
+            {
+                tasks.extend(internal_in_review);
             }
+            tasks
         };
         for task in in_review_tasks {
             // Skip tasks currently being processed by the main tick (dispatch + review flow).
@@ -215,14 +216,21 @@ pub(crate) async fn sync_tick(
     // re-introducing the double-trigger race fixed in issue #857 — the subscriber is still
     // the sole spawner and uses the InReview transition as its atomic guard.
     if enable_review {
-        let needs_review_tasks = if store.has_tasks(repo).await {
-            store
-                .list_by_status(repo, TaskStatus::NeedsReview)
+        let needs_review_tasks = if store.has_external_tasks(repo).await {
+            let mut tasks = store
+                .list_external_by_status(repo, TaskStatus::NeedsReview)
                 .await
                 .unwrap_or_default()
                 .iter()
                 .map(crate::engine::tasks::store_task_to_external)
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>();
+            if let Ok(internal) = task_manager
+                .list_internal_by_status(TaskStatus::NeedsReview)
+                .await
+            {
+                tasks.extend(internal);
+            }
+            tasks
         } else {
             let mut tasks = backend
                 .list_by_status(Status::NeedsReview)

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -262,13 +262,9 @@ impl TaskManager {
     /// Reads from the store when available, falling back to the backend.
     pub async fn list_all_external_tasks(&self) -> anyhow::Result<Vec<ExternalTask>> {
         if let Some(ref store) = self.store {
-            let tasks = store.list_all(&self.repo).await?;
-            if !tasks.is_empty() {
-                return Ok(tasks
-                    .iter()
-                    .filter(|t| t.origin != "internal")
-                    .map(store_task_to_external)
-                    .collect());
+            let tasks = store.list_all_external(&self.repo).await?;
+            if store.has_external_tasks(&self.repo).await {
+                return Ok(tasks.iter().map(store_task_to_external).collect());
             }
         }
         self.backend.list_all_tasks().await
@@ -283,16 +279,10 @@ impl TaskManager {
     ) -> anyhow::Result<Vec<ExternalTask>> {
         if let Some(ref store) = self.store {
             let db_status = status_to_task_status(status);
-            let tasks = store.list_by_status(&self.repo, db_status).await?;
-            // Filter to external only (exclude internal tasks)
-            let external: Vec<ExternalTask> = tasks
-                .iter()
-                .filter(|t| t.origin != "internal")
-                .map(store_task_to_external)
-                .collect();
-            // If the store has data for this repo, trust it even if empty for this status.
-            // Only fall back to the backend if the store has no data at all (pre-first-sync).
-            if store.has_tasks(&self.repo).await {
+            let external = store.list_external_by_status(&self.repo, db_status).await?;
+            if store.has_external_tasks(&self.repo).await {
+                let external: Vec<ExternalTask> =
+                    external.iter().map(store_task_to_external).collect();
                 return Ok(external);
             }
         }
@@ -306,7 +296,7 @@ impl TaskManager {
         if let Some(ref store) = self.store {
             let all_new = store.list_routable(&self.repo).await?;
             let tasks: Vec<ExternalTask> = all_new.iter().map(store_task_to_external).collect();
-            if store.has_tasks(&self.repo).await {
+            if store.has_external_tasks(&self.repo).await {
                 return Ok(tasks);
             }
         }
@@ -581,16 +571,32 @@ mod tests {
     use async_trait::async_trait;
     use std::sync::{Arc, Mutex};
 
+    type StatusTaskMap = Arc<Mutex<Vec<(Status, Vec<ExternalTask>)>>>;
+
     /// Mock backend that records update_status calls.
     struct MockBackend {
         status_updates: Arc<Mutex<Vec<(String, Status)>>>,
+        status_tasks: StatusTaskMap,
+        routable_tasks: Arc<Mutex<Vec<ExternalTask>>>,
     }
 
     impl MockBackend {
         fn new() -> Self {
             Self {
                 status_updates: Arc::new(Mutex::new(vec![])),
+                status_tasks: Arc::new(Mutex::new(vec![])),
+                routable_tasks: Arc::new(Mutex::new(vec![])),
             }
+        }
+
+        fn with_status_tasks(self, status: Status, tasks: Vec<ExternalTask>) -> Self {
+            self.status_tasks.lock().unwrap().push((status, tasks));
+            self
+        }
+
+        fn with_routable_tasks(self, tasks: Vec<ExternalTask>) -> Self {
+            *self.routable_tasks.lock().unwrap() = tasks;
+            self
         }
     }
 
@@ -620,11 +626,18 @@ mod tests {
                 url: "".to_string(),
             })
         }
-        async fn list_by_status(&self, _s: Status) -> anyhow::Result<Vec<ExternalTask>> {
-            Ok(vec![])
+        async fn list_by_status(&self, status: Status) -> anyhow::Result<Vec<ExternalTask>> {
+            Ok(self
+                .status_tasks
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|(s, _)| *s == status)
+                .map(|(_, tasks)| tasks.clone())
+                .unwrap_or_default())
         }
         async fn list_routable(&self) -> anyhow::Result<Vec<ExternalTask>> {
-            Ok(vec![])
+            Ok(self.routable_tasks.lock().unwrap().clone())
         }
         async fn post_comment(&self, _id: &ExternalId, _b: &str) -> anyhow::Result<()> {
             Ok(())
@@ -1085,6 +1098,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_external_by_status_falls_back_when_store_has_only_internal_tasks() {
+        let store = Arc::new(TaskStore::open_memory().await.unwrap());
+        let backend = Arc::new(MockBackend::new().with_status_tasks(
+            Status::Routed,
+            vec![ExternalTask {
+                id: ExternalId("123".to_string()),
+                title: "Backend routed".to_string(),
+                body: "".to_string(),
+                state: "open".to_string(),
+                labels: vec!["status:routed".to_string()],
+                author: "bot".to_string(),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                updated_at: "2026-01-01T00:00:00Z".to_string(),
+                url: "".to_string(),
+            }],
+        ));
+        let tm = TaskManager::with_store(backend, store.clone(), "owner/repo".to_string());
+
+        let id = store
+            .create_internal("owner/repo", "Internal task", "", "cron", "1")
+            .await
+            .unwrap();
+        store.update_status(id, TaskStatus::Routed).await.unwrap();
+
+        let routed = tm.list_external_by_status(Status::Routed).await.unwrap();
+        assert_eq!(routed.len(), 1);
+        assert_eq!(routed[0].id.0, "123");
+    }
+
+    #[tokio::test]
     async fn list_routable_reads_from_store_when_populated() {
         let store = Arc::new(TaskStore::open_memory().await.unwrap());
         let backend = Arc::new(MockBackend::new());
@@ -1113,6 +1156,35 @@ mod tests {
         let routable = tm.list_routable().await.unwrap();
         // Both should appear (both are status=new)
         assert_eq!(routable.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn list_routable_falls_back_when_store_has_only_internal_tasks() {
+        let store = Arc::new(TaskStore::open_memory().await.unwrap());
+        let backend = Arc::new(MockBackend::new().with_routable_tasks(vec![ExternalTask {
+            id: ExternalId("55".to_string()),
+            title: "Backend new".to_string(),
+            body: "".to_string(),
+            state: "open".to_string(),
+            labels: vec!["status:new".to_string()],
+            author: "bot".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            url: "".to_string(),
+        }]));
+        let tm = TaskManager::with_store(backend, store.clone(), "owner/repo".to_string());
+
+        store
+            .create_internal("owner/repo", "Internal new", "", "cron", "1")
+            .await
+            .unwrap();
+
+        let routable = tm.list_routable().await.unwrap();
+        assert_eq!(routable.len(), 2);
+        assert!(routable.iter().any(|task| task.id.0 == "55"));
+        assert!(routable
+            .iter()
+            .any(|task| task.id.0.starts_with("internal:")));
     }
 
     #[tokio::test]
@@ -1162,6 +1234,35 @@ mod tests {
 
         let all = tm.list_all_external_tasks().await.unwrap();
         assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn list_all_external_tasks_falls_back_when_store_has_only_internal_tasks() {
+        let store = Arc::new(TaskStore::open_memory().await.unwrap());
+        let backend = Arc::new(MockBackend::new().with_status_tasks(
+            Status::Done,
+            vec![ExternalTask {
+                id: ExternalId("200".to_string()),
+                title: "Backend done".to_string(),
+                body: "".to_string(),
+                state: "closed".to_string(),
+                labels: vec!["status:done".to_string()],
+                author: "bot".to_string(),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                updated_at: "2026-01-01T00:00:00Z".to_string(),
+                url: "".to_string(),
+            }],
+        ));
+        let tm = TaskManager::with_store(backend, store.clone(), "owner/repo".to_string());
+
+        store
+            .create_internal("owner/repo", "Internal", "", "cron", "1")
+            .await
+            .unwrap();
+
+        let all = tm.list_all_external_tasks().await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].id.0, "200");
     }
 
     // ── store-first update_task_status ──────────────────────────────

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -379,6 +379,23 @@ impl TaskStore {
         rows.iter().map(Self::row_to_task).collect()
     }
 
+    /// List external tasks by status within a repo (origin != 'internal').
+    pub async fn list_external_by_status(
+        &self,
+        repo: &str,
+        status: TaskStatus,
+    ) -> anyhow::Result<Vec<Task>> {
+        let rows = sqlx::query(
+            "SELECT * FROM tasks WHERE repo = ? AND origin != 'internal' AND status = ? ORDER BY created_at DESC",
+        )
+        .bind(repo)
+        .bind(status.as_str())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(Self::row_to_task).collect()
+    }
+
     /// List routable tasks (status = 'new') within a repo.
     pub async fn list_routable(&self, repo: &str) -> anyhow::Result<Vec<Task>> {
         self.list_by_status(repo, TaskStatus::New).await
@@ -413,15 +430,29 @@ impl TaskStore {
         rows.iter().map(Self::row_to_task).collect()
     }
 
-    /// Check whether the store has any tasks for a repo (cheap existence check).
-    pub async fn has_tasks(&self, repo: &str) -> bool {
-        sqlx::query_scalar::<_, i32>("SELECT 1 FROM tasks WHERE repo = ? LIMIT 1")
-            .bind(repo)
-            .fetch_optional(&self.pool)
-            .await
-            .ok()
-            .flatten()
-            .is_some()
+    /// List all external tasks for a repo (origin != 'internal').
+    pub async fn list_all_external(&self, repo: &str) -> anyhow::Result<Vec<Task>> {
+        let rows = sqlx::query(
+            "SELECT * FROM tasks WHERE repo = ? AND origin != 'internal' ORDER BY created_at DESC",
+        )
+        .bind(repo)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(Self::row_to_task).collect()
+    }
+
+    /// Check whether the store has any external tasks for a repo.
+    pub async fn has_external_tasks(&self, repo: &str) -> bool {
+        sqlx::query_scalar::<_, i32>(
+            "SELECT 1 FROM tasks WHERE repo = ? AND origin != 'internal' LIMIT 1",
+        )
+        .bind(repo)
+        .fetch_optional(&self.pool)
+        .await
+        .ok()
+        .flatten()
+        .is_some()
     }
 
     /// List all tasks for a repo, ordered by creation time descending.

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -3605,24 +3605,103 @@ async fn cost_summary_returns_three_periods() {
     }
 }
 
-// ── has_tasks ────────────────────────────────────────────────────
+// ── has_external_tasks ───────────────────────────────────────────
 
 #[tokio::test]
-async fn has_tasks_returns_false_for_empty_repo() {
+async fn has_external_tasks_returns_false_for_empty_repo() {
     let store = TaskStore::open_memory().await.unwrap();
-    assert!(!store.has_tasks("owner/repo").await);
+    assert!(!store.has_external_tasks("owner/repo").await);
 }
 
 #[tokio::test]
-async fn has_tasks_returns_true_after_insert() {
+async fn has_external_tasks_returns_true_after_external_insert() {
+    let store = TaskStore::open_memory().await.unwrap();
+    store
+        .upsert_external(&UpsertExternal {
+            repo: "owner/repo",
+            ext_id: "1",
+            title: "task",
+            body: "body",
+            author: "user",
+            url: "",
+            labels: &[],
+            origin: "github",
+        })
+        .await
+        .unwrap();
+    assert!(store.has_external_tasks("owner/repo").await);
+    // Different repo should still be false
+    assert!(!store.has_external_tasks("other/repo").await);
+}
+
+#[tokio::test]
+async fn has_external_tasks_ignores_internal_rows() {
     let store = TaskStore::open_memory().await.unwrap();
     store
         .create_internal("owner/repo", "task", "body", "manual", "")
         .await
         .unwrap();
-    assert!(store.has_tasks("owner/repo").await);
-    // Different repo should still be false
-    assert!(!store.has_tasks("other/repo").await);
+
+    assert!(!store.has_external_tasks("owner/repo").await);
+
+    store
+        .upsert_external(&UpsertExternal {
+            repo: "owner/repo",
+            ext_id: "42",
+            title: "External",
+            body: "",
+            author: "user",
+            url: "",
+            labels: &[],
+            origin: "github",
+        })
+        .await
+        .unwrap();
+
+    assert!(store.has_external_tasks("owner/repo").await);
+}
+
+#[tokio::test]
+async fn list_external_scopes_ignore_internal_rows() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let internal_id = store
+        .create_internal("owner/repo", "internal", "", "manual", "")
+        .await
+        .unwrap();
+    store
+        .update_status(internal_id, TaskStatus::Routed)
+        .await
+        .unwrap();
+
+    let external_id = store
+        .upsert_external(&UpsertExternal {
+            repo: "owner/repo",
+            ext_id: "99",
+            title: "external",
+            body: "",
+            author: "user",
+            url: "",
+            labels: &[],
+            origin: "github",
+        })
+        .await
+        .unwrap();
+    store
+        .update_status(external_id, TaskStatus::Routed)
+        .await
+        .unwrap();
+
+    let routed = store
+        .list_external_by_status("owner/repo", TaskStatus::Routed)
+        .await
+        .unwrap();
+    let all = store.list_all_external("owner/repo").await.unwrap();
+
+    assert_eq!(routed.len(), 1);
+    assert_eq!(routed[0].external_id.as_deref(), Some("99"));
+    assert_eq!(all.len(), 1);
+    assert_eq!(all[0].external_id.as_deref(), Some("99"));
 }
 
 // ── list_cleanable ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

All CI checks pass (fmt, clippy, 852/852 tests). The branch has the fix committed and is ready to push. Since pushing requires permission, please run:

```bash
git push -u origin gh-issue-876-bug-internal-only-store-state-hides-exte
```

Then create a PR with:
```bash
gh pr create --title "fix: scope store existence checks to external tasks only" --body "..."
```

The fix adds `has_external_tasks()`, `list_external_by_status()`, and `list_all_external()` to `TaskStore`, then updates all 5 affected callsites (`store/tasks.rs`, `engine/tasks.rs`, `engine/review.rs`, `engine/sync.rs`, `engine/cleanup.rs`) to use these external-scoped predicates instead of `has_tasks()`. Internal-only store state no longer prevents fallback to the GitHub backend for external task queries.

Closes #876

---
*Task #876 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*