### PR TITLE
fix: parser fallback for plain text agent output — treat valid summaries as done instead of looping

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -187,6 +187,70 @@ pub fn error_class_name(err: &AgentError) -> &'static str {
     }
 }
 
+/// Build a synthetic agent response from plain text when structured parsing fails.
+///
+/// Returns `None` for empty/whitespace-only text so callers can preserve the
+/// original `InvalidResponse` behavior.
+pub fn synthesize_response_from_text(text: &str) -> Option<AgentResponse> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let lower = trimmed.to_lowercase();
+    let looks_done = [
+        "no changes",
+        "nothing to",
+        "nothing to do",
+        "nothing to execute",
+        "no positions",
+        "no open positions",
+        "no trades",
+        "no trade",
+        "no action needed",
+        "complete",
+        "done",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle));
+
+    let looks_error = [
+        "error:",
+        "failed to",
+        "cannot",
+        "permission denied",
+        "unable to",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle));
+
+    let status = if looks_error {
+        "needs_review"
+    } else if looks_done {
+        "done"
+    } else {
+        "needs_review"
+    };
+
+    let summary_end = truncate_at_char_boundary(trimmed, 500);
+    let summary = trimmed[..summary_end].to_string();
+    let error =
+        (status == "needs_review").then(|| "agent returned plain text instead of JSON".to_string());
+
+    Some(AgentResponse {
+        status: status.to_string(),
+        summary,
+        accomplished: vec![],
+        remaining: vec![],
+        files: vec![],
+        error,
+        input_tokens: None,
+        output_tokens: None,
+        learnings: vec![],
+        delegations: vec![],
+    })
+}
+
 /// Find the largest byte index <= `max_bytes` that lies on a UTF-8 char
 /// boundary.  Used for safe string truncation in error messages.
 fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> usize {
@@ -709,6 +773,38 @@ mod tests {
     fn classify_from_text_worktree_missing() {
         let err = patterns::classify_from_text(1, "worktree directory does not exist: /tmp/wt");
         assert!(matches!(err, AgentError::AgentFailed { .. }));
+    }
+
+    #[test]
+    fn synthesize_response_marks_done_for_plain_text_no_op() {
+        let response = synthesize_response_from_text(
+            "No open positions, no trade executions, no conditions change. Full cash, holding.",
+        )
+        .unwrap();
+
+        assert_eq!(response.status, "done");
+        assert_eq!(
+            response.summary,
+            "No open positions, no trade executions, no conditions change. Full cash, holding."
+        );
+        assert!(response.error.is_none());
+    }
+
+    #[test]
+    fn synthesize_response_marks_needs_review_for_plain_text_error() {
+        let response =
+            synthesize_response_from_text("Failed to update branch: permission denied").unwrap();
+
+        assert_eq!(response.status, "needs_review");
+        assert_eq!(
+            response.error.as_deref(),
+            Some("agent returned plain text instead of JSON")
+        );
+    }
+
+    #[test]
+    fn synthesize_response_rejects_empty_text() {
+        assert!(synthesize_response_from_text("   \n\t  ").is_none());
     }
 
     // ── PermissionRules defaults ────────────────────────────────

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -40,6 +40,35 @@ pub use response::WeightSignal;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+fn parse_success_output(
+    task_id: &str,
+    agent_name: &str,
+    agent_runner: &dyn agents::AgentRunner,
+    raw_stdout: &str,
+) -> Result<agents::ParsedResponse, agents::AgentError> {
+    match agent_runner.parse_response(raw_stdout) {
+        Ok(parsed) => Ok(parsed),
+        Err(agents::AgentError::InvalidResponse { raw }) => {
+            if let Some(response) = agents::synthesize_response_from_text(&raw) {
+                tracing::warn!(
+                    task_id,
+                    agent = agent_name,
+                    "parse failed, synthesizing response from plain text"
+                );
+                Ok(agents::ParsedResponse {
+                    response,
+                    input_tokens: None,
+                    output_tokens: None,
+                    duration_ms: None,
+                })
+            } else {
+                Err(agents::AgentError::InvalidResponse { raw })
+            }
+        }
+        Err(err) => Err(err),
+    }
+}
+
 /// Task runner configuration.
 pub struct TaskRunner {
     /// Repository slug (owner/repo)
@@ -186,7 +215,12 @@ impl TaskRunner {
         let agent_runner = agents::get_runner(&init.agent_name);
         let parse_result = if session_output.exit_code == 0 && !session_output.raw_stdout.is_empty()
         {
-            agent_runner.parse_response(&session_output.raw_stdout)
+            parse_success_output(
+                task_id,
+                &init.agent_name,
+                &*agent_runner,
+                &session_output.raw_stdout,
+            )
         } else if session_output.exit_code != 0 {
             Err(agent_runner.classify_error(
                 session_output.exit_code,
@@ -923,6 +957,45 @@ mod tests {
         let s = "abcdef"; // 6 bytes
         assert_eq!(safe_utf8_tail(s, 6), "abcdef"); // exactly fits
         assert_eq!(safe_utf8_tail(s, 0), ""); // empty tail
+    }
+
+    #[test]
+    fn parse_success_output_synthesizes_done_from_plain_text() {
+        let runner = agents::get_runner("claude");
+        let parsed = parse_success_output(
+            "123",
+            "claude",
+            &*runner,
+            "No open positions, no trade executions, no conditions change.",
+        )
+        .unwrap();
+
+        assert_eq!(parsed.response.status, "done");
+        assert_eq!(
+            parsed.response.summary,
+            "No open positions, no trade executions, no conditions change."
+        );
+    }
+
+    #[test]
+    fn parse_success_output_synthesizes_needs_review_from_error_text() {
+        let runner = agents::get_runner("claude");
+        let parsed =
+            parse_success_output("123", "claude", &*runner, "Failed to update branch").unwrap();
+
+        assert_eq!(parsed.response.status, "needs_review");
+        assert_eq!(
+            parsed.response.error.as_deref(),
+            Some("agent returned plain text instead of JSON")
+        );
+    }
+
+    #[test]
+    fn parse_success_output_keeps_empty_text_invalid() {
+        let runner = agents::get_runner("claude");
+        let err = parse_success_output("123", "claude", &*runner, "").unwrap_err();
+
+        assert!(matches!(err, agents::AgentError::InvalidResponse { .. }));
     }
 
     // ── resolve_project_dir ──────────────────────────────────────────────────


### PR DESCRIPTION
Resolves #889

Auto-created by orch review gate (agent forgot to open PR)