### PR TITLE
feat: save raw agent responses to SQLite and add graceful parser fallback for non-JSON output

### DIFF
--- a/migrations/009_last_response.sql
+++ b/migrations/009_last_response.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tasks ADD COLUMN last_response TEXT DEFAULT '';

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -224,6 +224,18 @@ impl TaskRunner {
             "agent raw output"
         );
 
+        // Store raw response in SQLite BEFORE parsing (for debugging parse failures)
+        crate::engine::cleanup::store_set(
+            &self.store,
+            &self.repo,
+            task_id,
+            &[(
+                "last_response",
+                serde_json::json!(session_output.raw_stdout),
+            )],
+        )
+        .await;
+
         // Use agent-specific parsing when exit code is 0, fall back to classify_error
         let agent_runner = agents::get_runner(&init.agent_name);
         let parse_result = if session_output.exit_code == 0 && !session_output.raw_stdout.is_empty()

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -75,6 +75,7 @@ pub struct Task {
     pub worktree_cleaned: bool,
     pub summary: String,
     pub last_error: String,
+    pub last_response: String,
     pub parent_id: Option<i64>,
     pub block_reason: Option<String>,
 
@@ -513,6 +514,7 @@ impl TaskStore {
             "worktree_cleaned",
             "summary",
             "last_error",
+            "last_response",
             "parent_id",
             "block_reason",
             "pr_number",
@@ -953,6 +955,7 @@ impl TaskStore {
             worktree_cleaned: row.get::<i32, _>("worktree_cleaned") != 0,
             summary: row.get("summary"),
             last_error: row.get("last_error"),
+            last_response: row.get("last_response"),
             parent_id: row.get("parent_id"),
             block_reason: row.get("block_reason"),
             pr_number: row.get("pr_number"),


### PR DESCRIPTION
Resolves #888

Auto-created by orch review gate (agent forgot to open PR)