### PR TITLE
feat: use task_runs table for agent debugging — populate stdout/stderr/parsed_response on every run

### DIFF
--- a/.orch.yml
+++ b/.orch.yml
@@ -192,15 +192,18 @@ jobs:
          ```
       2. Check recent task run audit trails:
          ```
-         sqlite3 ~/.orch/orch.db "SELECT task_id, agent, model, outcome, error, started_at FROM task_runs WHERE started_at > datetime('now', '-12 hours') AND outcome != 'success' ORDER BY started_at DESC LIMIT 30;"
+         sqlite3 ~/.orch/orch.db "SELECT agent, model, outcome, COUNT(*) AS count FROM task_runs WHERE started_at > datetime('now', '-12 hours') AND outcome != 'success' GROUP BY agent, model, outcome ORDER BY count DESC;"
+         sqlite3 ~/.orch/orch.db "SELECT agent, started_at, error FROM task_runs WHERE outcome = 'rate_limit' AND started_at > datetime('now', '-24 hours') ORDER BY started_at;"
+         sqlite3 ~/.orch/orch.db "SELECT agent, outcome, SUM(total_cost_usd) AS total_cost, COUNT(*) AS runs FROM task_runs WHERE started_at > datetime('now', '-24 hours') GROUP BY agent, outcome;"
          ```
       3. Read the service log for errors:
          ```
          tail -500 /opt/homebrew/var/log/orch.log | grep -i 'error\|warn' | grep -v 'error sending request\|kill-session failed' | tail -30
          ```
-      4. Check recent attempt directories for raw outputs:
+      4. Inspect task-specific run history when a task needs more context:
          ```
-         find ~/.orch/state -name 'output.json' -newer ~/.orch/state -mmin -720 | head -10
+         orch task runs <id>
+         orch task runs <id> --verbose
          ```
 
       ## Step 2: Classify failures

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -44,9 +44,35 @@ fn format_age(updated_at: &str) -> String {
 /// Truncate an error message to a maximum length, appending an ellipsis when truncated.
 fn truncate_err(err: &str, max: usize) -> String {
     if err.len() > max {
-        format!("{}…", &err[..max])
+        format!("{}...", &err[..max])
     } else {
         err.to_string()
+    }
+}
+
+fn format_run_duration(duration_secs: f64) -> String {
+    if duration_secs < 60.0 {
+        format!("{duration_secs:.0}s")
+    } else {
+        format!("{:.1}m", duration_secs / 60.0)
+    }
+}
+
+fn format_run_cost(cost: f64) -> String {
+    if cost <= 0.0 {
+        "-".to_string()
+    } else {
+        format!("${cost:.2}")
+    }
+}
+
+fn format_run_text(text: &str, verbose: bool, max: usize) -> String {
+    if verbose {
+        text.to_string()
+    } else if text.is_empty() {
+        String::new()
+    } else {
+        truncate_err(text, max)
     }
 }
 
@@ -650,6 +676,7 @@ pub async fn run(id: Option<String>) -> anyhow::Result<()> {
 
     // Mark in progress
     let ext_id = ExternalId(task_id.clone());
+    let started_at = Utc::now();
     update_status_store_first(
         &Some(store.clone()),
         &backend,
@@ -667,6 +694,7 @@ pub async fn run(id: Option<String>) -> anyhow::Result<()> {
             agent.as_deref(),
             model.as_deref(),
             Some(&*backend),
+            &started_at,
         )
         .await?;
 
@@ -1261,6 +1289,61 @@ pub async fn logs(id: &str) -> anyhow::Result<()> {
             Err(e) => {
                 println!("(tmux capture failed: {})", e);
             }
+        }
+    }
+
+    Ok(())
+}
+
+/// Show run history for a task.
+pub async fn runs(id: &str, verbose: bool) -> anyhow::Result<()> {
+    let store = crate::cli::init_store().await?;
+    let repo = config::get_current_repo().unwrap_or_default();
+    let Some(task_id) = store.resolve_task_id(&repo, id).await? else {
+        anyhow::bail!("task not found: {id}");
+    };
+
+    let runs = store.get_runs(task_id).await?;
+    if runs.is_empty() {
+        println!("No runs found for task {id}.");
+        return Ok(());
+    }
+
+    println!(
+        "{:<4} {:<8} {:<18} {:<12} {:<8} {:<8} ERROR",
+        "RUN", "AGENT", "MODEL", "OUTCOME", "DURATION", "COST"
+    );
+    println!("{}", "-".repeat(90));
+
+    for run in runs {
+        let model = if run.model.is_empty() {
+            "-"
+        } else {
+            &run.model
+        };
+        let error = format_run_text(&run.error, verbose, 48);
+        println!(
+            "{:<4} {:<8} {:<18} {:<12} {:<8} {:<8} {}",
+            run.attempt,
+            run.agent,
+            model,
+            run.outcome,
+            format_run_duration(run.duration_secs),
+            format_run_cost(run.total_cost_usd),
+            error,
+        );
+
+        if verbose {
+            if !run.stdout.is_empty() {
+                println!("  stdout:\n{}", run.stdout);
+            }
+            if !run.stderr.is_empty() {
+                println!("  stderr:\n{}", run.stderr);
+            }
+            if !run.parsed_response.is_empty() {
+                println!("  parsed_response:\n{}", run.parsed_response);
+            }
+            println!();
         }
     }
 

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -41,6 +41,93 @@ pub use response::WeightSignal;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+/// Fully materialized task-run audit data.
+#[derive(Debug, Clone)]
+pub struct RunAudit {
+    pub stdout: String,
+    pub stderr: String,
+    pub parsed_response: String,
+    pub outcome: String,
+    pub error: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub total_cost_usd: f64,
+    pub duration_secs: f64,
+}
+
+/// Result returned by `run()` so callers can persist the audit trail.
+#[derive(Debug, Clone)]
+pub struct RunExecution {
+    pub status: String,
+    pub exit_code: Option<i32>,
+    pub audit: RunAudit,
+}
+
+fn serialize_parsed_response(
+    parse_result: &Result<agents::ParsedResponse, agents::AgentError>,
+    raw_stdout: &str,
+) -> String {
+    match parse_result {
+        Ok(parsed) => serde_json::json!({
+            "response": parsed.response,
+            "input_tokens": parsed.input_tokens,
+            "output_tokens": parsed.output_tokens,
+            "duration_ms": parsed.duration_ms,
+        })
+        .to_string(),
+        Err(agents::AgentError::InvalidResponse { raw }) => {
+            serde_json::json!({"raw": raw}).to_string()
+        }
+        Err(_) => serde_json::json!({"raw": raw_stdout}).to_string(),
+    }
+}
+
+fn classify_run_outcome(
+    status: &str,
+    parse_result: &Result<agents::ParsedResponse, agents::AgentError>,
+) -> &'static str {
+    match parse_result {
+        Err(agents::AgentError::Timeout { .. }) => "timeout",
+        Err(agents::AgentError::RateLimit { .. }) => "rate_limit",
+        Err(agents::AgentError::InvalidResponse { .. }) => "parse_error",
+        Err(_) => "failed",
+        Ok(_) if matches!(status, "done" | "in_progress" | "in_review" | "blocked") => "success",
+        Ok(_) => "failed",
+    }
+}
+
+fn extract_run_tokens(
+    parse_result: &Result<agents::ParsedResponse, agents::AgentError>,
+) -> (i64, i64) {
+    match parse_result {
+        Ok(parsed) => (
+            parsed
+                .input_tokens
+                .or(parsed.response.input_tokens)
+                .unwrap_or(0) as i64,
+            parsed
+                .output_tokens
+                .or(parsed.response.output_tokens)
+                .unwrap_or(0) as i64,
+        ),
+        Err(_) => (0, 0),
+    }
+}
+
+fn run_duration_secs(started_at: &chrono::DateTime<Utc>) -> f64 {
+    (Utc::now() - *started_at).num_milliseconds() as f64 / 1000.0
+}
+
+struct RunAuditInput<'a> {
+    task_id: &'a str,
+    status: &'a str,
+    parse_result: &'a Result<agents::ParsedResponse, agents::AgentError>,
+    raw_stdout: &'a str,
+    raw_stderr: &'a str,
+    started_at: &'a chrono::DateTime<Utc>,
+    error_override: Option<String>,
+}
+
 fn parse_success_output(
     task_id: &str,
     agent_name: &str,
@@ -115,6 +202,41 @@ impl TaskRunner {
         }
     }
 
+    async fn build_run_audit(&self, input: RunAuditInput<'_>) -> RunAudit {
+        let last_error = self.get_field(input.task_id, "last_error").await;
+        let error =
+            input
+                .error_override
+                .or(last_error)
+                .unwrap_or_else(|| match input.parse_result {
+                    Ok(parsed) => parsed.response.error.clone().unwrap_or_default(),
+                    Err(err) => err.to_string(),
+                });
+
+        let total_cost_usd = match &self.store {
+            Some(_) => {
+                store::get_cost_estimate(&self.store, &self.repo, input.task_id)
+                    .await
+                    .total_cost_usd
+            }
+            None => 0.0,
+        };
+
+        let (input_tokens, output_tokens) = extract_run_tokens(input.parse_result);
+
+        RunAudit {
+            stdout: input.raw_stdout.to_string(),
+            stderr: input.raw_stderr.to_string(),
+            parsed_response: serialize_parsed_response(input.parse_result, input.raw_stdout),
+            outcome: classify_run_outcome(input.status, input.parse_result).to_string(),
+            error,
+            input_tokens,
+            output_tokens,
+            total_cost_usd,
+            duration_secs: run_duration_secs(input.started_at),
+        }
+    }
+
     /// Run a task through the full execution pipeline.
     ///
     /// Returns `Ok(None)` if the runner guard skipped the task (caller should not
@@ -125,7 +247,8 @@ impl TaskRunner {
         agent: Option<&str>,
         model: Option<&str>,
         backend: Option<&dyn ExternalBackend>,
-    ) -> anyhow::Result<Option<(String, Option<i32>)>> {
+        started_at: &chrono::DateTime<Utc>,
+    ) -> anyhow::Result<Option<RunExecution>> {
         tracing::info!(
             task_id,
             agent = agent.unwrap_or("default"),
@@ -163,7 +286,21 @@ impl TaskRunner {
                         }
                     }
                 }
-                return Ok(Some(("needs_review".to_string(), None)));
+                return Ok(Some(RunExecution {
+                    status: "needs_review".to_string(),
+                    exit_code: None,
+                    audit: RunAudit {
+                        stdout: String::new(),
+                        stderr: String::new(),
+                        parsed_response: String::new(),
+                        outcome: "failed".to_string(),
+                        error: "max attempts reached".to_string(),
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        total_cost_usd: 0.0,
+                        duration_secs: 0.0,
+                    },
+                }));
             }
             Err(e) => return Err(e),
         };
@@ -264,10 +401,10 @@ impl TaskRunner {
 
         // Handle outcome: success or error recovery
         let final_status = match parse_result {
-            Ok(parsed) => {
+            Ok(ref parsed) => {
                 let (status, budget_exceeded) = response_handler::handle_success(
                     task_id,
-                    parsed,
+                    parsed.clone(),
                     &init.wt,
                     &init.task_title,
                     &init.agent_name,
@@ -280,14 +417,29 @@ impl TaskRunner {
                 if budget_exceeded {
                     // Token budget exceeded — store already updated, return without
                     // tmux cleanup or metrics (preserves original behavior)
-                    return Ok(Some((status, Some(session_output.exit_code))));
+                    let audit = self
+                        .build_run_audit(RunAuditInput {
+                            task_id,
+                            status: &status,
+                            parse_result: &parse_result,
+                            raw_stdout: &session_output.raw_stdout,
+                            raw_stderr: &session_output.raw_stderr,
+                            started_at,
+                            error_override: None,
+                        })
+                        .await;
+                    return Ok(Some(RunExecution {
+                        status,
+                        exit_code: Some(session_output.exit_code),
+                        audit,
+                    }));
                 }
                 status
             }
-            Err(agent_err) => {
+            Err(ref agent_err) => {
                 match fallback::handle_error(
                     task_id,
-                    &agent_err,
+                    agent_err,
                     &init.agent_name,
                     &*agent_runner,
                     init.model_name.as_deref(),
@@ -299,7 +451,22 @@ impl TaskRunner {
                 {
                     fallback::ErrorHandleResult::EarlyReturn { status } => {
                         // Task rerouted — return (metrics recorded in run_with_context)
-                        return Ok(Some((status, Some(session_output.exit_code))));
+                        let audit = self
+                            .build_run_audit(RunAuditInput {
+                                task_id,
+                                status: &status,
+                                parse_result: &parse_result,
+                                raw_stdout: &session_output.raw_stdout,
+                                raw_stderr: &session_output.raw_stderr,
+                                started_at,
+                                error_override: Some(agent_err.to_string()),
+                            })
+                            .await;
+                        return Ok(Some(RunExecution {
+                            status,
+                            exit_code: Some(session_output.exit_code),
+                            audit,
+                        }));
                     }
                     fallback::ErrorHandleResult::Continue { status } => status,
                 }
@@ -323,7 +490,23 @@ impl TaskRunner {
         }
 
         // Return final status and the session exit code so callers can record it.
-        Ok(Some((final_status, Some(session_output.exit_code))))
+        let audit = self
+            .build_run_audit(RunAuditInput {
+                task_id,
+                status: &final_status,
+                parse_result: &parse_result,
+                raw_stdout: &session_output.raw_stdout,
+                raw_stderr: &session_output.raw_stderr,
+                started_at,
+                error_override: None,
+            })
+            .await;
+
+        Ok(Some(RunExecution {
+            status: final_status,
+            exit_code: Some(session_output.exit_code),
+            audit,
+        }))
     }
 
     /// Record task execution metrics to the database.
@@ -493,11 +676,13 @@ impl TaskRunner {
         };
 
         // Run the task
-        let run_result = self.run(task_id, agent, model, Some(&**backend)).await?;
+        let run_result = self
+            .run(task_id, agent, model, Some(&**backend), &started_at)
+            .await?;
 
         // If the runner guard skipped the task, do not re-post stale data as a new comment.
-        let (status, exit_code_opt) = match run_result {
-            Some(result) => result,
+        let (status, exit_code_opt, run_audit) = match run_result {
+            Some(result) => (result.status, result.exit_code, result.audit),
             None => {
                 tracing::info!(task_id, "guard skipped task — not posting stale result");
                 return Ok(WeightSignal::None);
@@ -580,29 +765,20 @@ impl TaskRunner {
         // Complete run in task_runs audit trail (include exit code from runner when available)
         if let Some(run_id) = run_audit_id {
             if let Some(ref store) = self.store {
-                let duration = (Utc::now() - started_at).num_milliseconds() as f64 / 1000.0;
-                let usage = store::get_token_usage(&self.store, &self.repo, task_id).await;
-                let outcome = if status == "done" || status == "in_progress" {
-                    "success"
-                } else if is_rate_limited {
-                    "rate_limit"
-                } else {
-                    "failed"
-                };
                 let _ = store
                     .complete_run(&crate::store::CompleteRun {
                         run_id,
                         exit_code: exit_code_opt,
-                        stdout: &summary,
-                        stderr: "",
-                        parsed: "",
-                        outcome,
-                        error: &last_error,
+                        stdout: &run_audit.stdout,
+                        stderr: &run_audit.stderr,
+                        parsed: &run_audit.parsed_response,
+                        outcome: &run_audit.outcome,
+                        error: &run_audit.error,
                         tokens: crate::store::RunTokenUsage {
-                            input_tokens: usage.input_tokens as i64,
-                            output_tokens: usage.output_tokens as i64,
-                            total_cost_usd: 0.0, // computed by store
-                            duration_secs: duration,
+                            input_tokens: run_audit.input_tokens,
+                            output_tokens: run_audit.output_tokens,
+                            total_cost_usd: run_audit.total_cost_usd,
+                            duration_secs: run_audit.duration_secs,
                         },
                     })
                     .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -454,6 +454,14 @@ enum TaskAction {
         /// Task ID (e.g. "internal:8" or issue number)
         id: String,
     },
+    /// Show task run history and audit details
+    Runs {
+        /// Task ID (e.g. "internal:8" or issue number)
+        id: String,
+        /// Show full stdout/stderr/parsed response for each run
+        #[arg(long)]
+        verbose: bool,
+    },
     /// Mark a task as done (without running an agent)
     Close {
         /// Task ID (e.g. "internal:8" or issue number)
@@ -685,6 +693,9 @@ async fn main() -> anyhow::Result<()> {
             }
             TaskAction::Logs { id } => {
                 cli::task::logs(&id).await?;
+            }
+            TaskAction::Runs { id, verbose } => {
+                cli::task::runs(&id, verbose).await?;
             }
             TaskAction::Close { id, note } => {
                 cli::task::close(&id, note.as_deref()).await?;


### PR DESCRIPTION
## Summary

Added task run auditing and a CLI to inspect it, with run data now captured for debugging and job queries updated to use SQL.

### What was done

- Populated `task_runs` audit fields for run outcomes, stdout/stderr, parsed responses, tokens, cost, and completion timestamps
- Added `orch task runs <id>` with a `--verbose` mode for full run details
- Updated the agent-debugger job queries in `.orch.yml` to read from `task_runs` instead of filesystem scans
- Committed the changes in `5619e96 feat: expose task run audit history`


Closes #921

---
*Task #921 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4-mini`*