### PR TITLE
feat: self-review job — add review loop and high-cycle detection pattern

### DIFF
--- a/src/engine/jobs.rs
+++ b/src/engine/jobs.rs
@@ -15,7 +15,9 @@
 
 use crate::backends::{ExternalBackend, ExternalId};
 use crate::cmd::CommandErrorContext;
-use crate::store::{ErrorStat, JobState, MetricsSummary, SlowTaskInfo, TaskStatus};
+use crate::store::{
+    ErrorStat, HighReviewCycleTask, JobState, MetricsSummary, SlowTaskInfo, TaskStatus,
+};
 use anyhow::Context;
 use cron::Schedule;
 use serde::{Deserialize, Serialize};
@@ -503,10 +505,11 @@ async fn run_self_review(
     }
 
     // Gather metrics data
-    let (summary, slow_tasks, error_distribution) = (
+    let (summary, slow_tasks, error_distribution, high_cycle_tasks) = (
         s.get_metrics_summary_24h().await?,
         s.get_slow_tasks_7d().await?,
         s.get_error_distribution_7d().await?,
+        s.get_high_review_cycle_tasks_7d().await?,
     );
 
     // Analyze and create issues for each pattern
@@ -541,6 +544,19 @@ async fn run_self_review(
     // Issue 3: Slow tasks pattern
     if issues_created < remaining_slots {
         if let Some(issue) = detect_slow_tasks(&slow_tasks, &summary) {
+            if create_self_improvement_issue(backend, &issue.title, &issue.body)
+                .await
+                .is_ok()
+            {
+                s.increment_self_improvement_counter().await?;
+                issues_created += 1;
+            }
+        }
+    }
+
+    // Issue 4: Persistent review loops
+    if issues_created < remaining_slots {
+        if let Some(issue) = detect_review_loops(&high_cycle_tasks) {
             if create_self_improvement_issue(backend, &issue.title, &issue.body)
                 .await
                 .is_ok()
@@ -715,6 +731,57 @@ fn detect_slow_tasks(
 
     Some(ImprovementIssue {
         title: "[Self-Improvement] Slow task execution patterns detected".to_string(),
+        body,
+    })
+}
+
+/// Detect persistent review loop patterns (tasks cycling through review repeatedly).
+fn detect_review_loops(high_cycle_tasks: &[HighReviewCycleTask]) -> Option<ImprovementIssue> {
+    if high_cycle_tasks.is_empty() {
+        return None;
+    }
+
+    // Only flag if there are 3+ tasks with review cycles >= 2 (avoids noise)
+    if high_cycle_tasks.len() < 3 {
+        return None;
+    }
+
+    let mut body = String::from("## Persistent Review Loops Detected (Last 7 Days)\n\n");
+    body.push_str(
+        "Multiple tasks have been sent back for rework 2+ times, indicating a systematic issue.\n\n",
+    );
+    body.push_str("| External ID | Agent | Review Cycles | Title |\n");
+    body.push_str("|-------------|-------|---------------|-------|\n");
+    for task in high_cycle_tasks.iter().take(10) {
+        body.push_str(&format!(
+            "| {} | {} | {} | {} |\n",
+            task.external_id.as_deref().unwrap_or("internal"),
+            task.agent.as_deref().unwrap_or("unknown"),
+            task.review_cycles,
+            task.title,
+        ));
+    }
+
+    body.push_str("\n## Recommendation\n\n");
+    body.push_str("Review loops suggest the agent isn't addressing review feedback effectively:\n");
+    body.push_str(
+        "- Check if the agent is reading and incorporating review comments before retrying\n",
+    );
+    body.push_str(
+        "- Consider if the review agent has overly strict criteria for specific task types\n",
+    );
+    body.push_str(
+        "- Investigate whether a specific agent or task pattern consistently fails quality checks\n",
+    );
+    body.push_str(
+        "- Review the agent memory system — are learnings from failed attempts being persisted?\n",
+    );
+    body.push_str(
+        "\n## Evidence\n\nThis issue was automatically created by the orchestrator's self-review job.\n",
+    );
+
+    Some(ImprovementIssue {
+        title: "[Self-Improvement] Persistent review loop patterns detected".to_string(),
         body,
     })
 }
@@ -1265,6 +1332,67 @@ mod tests {
         };
 
         let issue = detect_slow_tasks(&slow_tasks, &summary);
+        assert!(issue.is_none());
+    }
+
+    #[test]
+    fn detect_review_loops_with_enough_tasks() {
+        let tasks = vec![
+            HighReviewCycleTask {
+                external_id: Some("101".to_string()),
+                agent: Some("claude".to_string()),
+                review_cycles: 3,
+                title: "Fix auth".to_string(),
+            },
+            HighReviewCycleTask {
+                external_id: Some("102".to_string()),
+                agent: Some("codex".to_string()),
+                review_cycles: 2,
+                title: "Add tests".to_string(),
+            },
+            HighReviewCycleTask {
+                external_id: None,
+                agent: Some("claude".to_string()),
+                review_cycles: 2,
+                title: "Internal review".to_string(),
+            },
+        ];
+
+        let issue = detect_review_loops(&tasks);
+        assert!(issue.is_some());
+        let issue = issue.unwrap();
+        assert!(issue.title.contains("review loop"));
+        assert!(issue.body.contains("101"));
+        assert!(issue.body.contains("3"));
+        assert!(issue.body.contains("internal")); // None external_id renders as "internal"
+    }
+
+    #[test]
+    fn detect_review_loops_ignores_fewer_than_three() {
+        let tasks = vec![
+            HighReviewCycleTask {
+                external_id: Some("101".to_string()),
+                agent: Some("claude".to_string()),
+                review_cycles: 5,
+                title: "Fix auth".to_string(),
+            },
+            HighReviewCycleTask {
+                external_id: Some("102".to_string()),
+                agent: Some("codex".to_string()),
+                review_cycles: 2,
+                title: "Add tests".to_string(),
+            },
+        ];
+
+        // Only 2 tasks — below threshold of 3
+        let issue = detect_review_loops(&tasks);
+        assert!(issue.is_none());
+    }
+
+    #[test]
+    fn detect_review_loops_empty() {
+        let tasks: Vec<HighReviewCycleTask> = vec![];
+        let issue = detect_review_loops(&tasks);
         assert!(issue.is_none());
     }
 }

--- a/src/store/metrics.rs
+++ b/src/store/metrics.rs
@@ -62,6 +62,15 @@ pub struct ErrorStat {
     pub count: i64,
 }
 
+/// Task with high review cycle count (persistent review loop).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HighReviewCycleTask {
+    pub external_id: Option<String>,
+    pub agent: Option<String>,
+    pub review_cycles: i64,
+    pub title: String,
+}
+
 /// Cost summary across multiple time periods.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CostSummary {
@@ -599,6 +608,30 @@ impl TaskStore {
         let key = self_improvement_key();
         let count = self.kv_get(&key).await?;
         Ok(count.and_then(|c| c.parse().ok()).unwrap_or(0))
+    }
+
+    /// Get tasks with high review cycle counts (persistent review loops) from the last 7 days.
+    pub async fn get_high_review_cycle_tasks_7d(&self) -> anyhow::Result<Vec<HighReviewCycleTask>> {
+        let rows = sqlx::query(
+            "SELECT external_id, agent, review_cycles, title
+         FROM tasks
+         WHERE review_cycles >= 2
+           AND updated_at >= datetime('now', '-7 days')
+         ORDER BY review_cycles DESC
+         LIMIT 10",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .iter()
+            .map(|row| HighReviewCycleTask {
+                external_id: row.get("external_id"),
+                agent: row.get("agent"),
+                review_cycles: row.get("review_cycles"),
+                title: row.get("title"),
+            })
+            .collect())
     }
 
     /// Increment the self-improvement issue counter for the current week.

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -32,8 +32,8 @@ pub use helpers::{
 pub use jobs::JobState;
 #[allow(unused_imports)]
 pub use metrics::{
-    AgentStat, CostByGroup, CostPeriod, CostSummary, ErrorStat, InsertTaskMetric, MetricsSummary,
-    SlowTaskInfo,
+    AgentStat, CostByGroup, CostPeriod, CostSummary, ErrorStat, HighReviewCycleTask,
+    InsertTaskMetric, MetricsSummary, SlowTaskInfo,
 };
 #[allow(unused_imports)]
 pub use pricing::{pricing_for_model, CostEstimate, ModelPricing, TokenUsage};

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -3838,6 +3838,83 @@ async fn error_distribution_empty() {
 }
 
 #[tokio::test]
+async fn high_review_cycle_tasks_empty() {
+    let store = TaskStore::open_memory().await.unwrap();
+    let tasks = store.get_high_review_cycle_tasks_7d().await.unwrap();
+    assert!(tasks.is_empty());
+}
+
+#[tokio::test]
+async fn high_review_cycle_tasks_filters_by_threshold() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    // Create tasks with different review_cycles values
+    let id_low = store
+        .create_internal("owner/repo", "Low cycles", "", "manual", "")
+        .await
+        .unwrap();
+    let id_high = store
+        .create_internal("owner/repo", "High cycles", "", "manual", "")
+        .await
+        .unwrap();
+    let id_boundary = store
+        .create_internal("owner/repo", "At boundary", "", "manual", "")
+        .await
+        .unwrap();
+
+    // Set review_cycles: 0, 2, 3
+    store.increment(id_low, "review_cycles").await.unwrap();
+    // id_low has review_cycles=1, should be excluded
+
+    store.increment(id_high, "review_cycles").await.unwrap();
+    store.increment(id_high, "review_cycles").await.unwrap();
+    store.increment(id_high, "review_cycles").await.unwrap();
+    // id_high has review_cycles=3, should be included
+
+    store.increment(id_boundary, "review_cycles").await.unwrap();
+    store.increment(id_boundary, "review_cycles").await.unwrap();
+    // id_boundary has review_cycles=2, should be included (>=2)
+
+    let tasks = store.get_high_review_cycle_tasks_7d().await.unwrap();
+    assert_eq!(tasks.len(), 2);
+    // Should be sorted by review_cycles DESC
+    assert_eq!(tasks[0].title, "High cycles");
+    assert_eq!(tasks[0].review_cycles, 3);
+    assert_eq!(tasks[1].title, "At boundary");
+    assert_eq!(tasks[1].review_cycles, 2);
+}
+
+#[tokio::test]
+async fn high_review_cycle_tasks_excludes_old_tasks() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let id_old = store
+        .create_internal("owner/repo", "Old task", "", "manual", "")
+        .await
+        .unwrap();
+    store.increment(id_old, "review_cycles").await.unwrap();
+    store.increment(id_old, "review_cycles").await.unwrap();
+
+    // Backdate to 10 days ago (outside 7d window)
+    sqlx::query("UPDATE tasks SET updated_at = datetime('now', '-10 days') WHERE id = ?")
+        .bind(id_old)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+
+    let id_recent = store
+        .create_internal("owner/repo", "Recent task", "", "manual", "")
+        .await
+        .unwrap();
+    store.increment(id_recent, "review_cycles").await.unwrap();
+    store.increment(id_recent, "review_cycles").await.unwrap();
+
+    let tasks = store.get_high_review_cycle_tasks_7d().await.unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].title, "Recent task");
+}
+
+#[tokio::test]
 async fn error_distribution_groups_by_type() {
     use chrono::Utc;
     let store = TaskStore::open_memory().await.unwrap();


### PR DESCRIPTION
## Summary

Added review loop detection to the self-review job. New 4th detection pattern flags tasks with review_cycles >= 2 when 3+ such tasks exist in 7 days, indicating agents aren't addressing review feedback effectively.

### What was done

- Added HighReviewCycleTask struct to store/metrics.rs
- Added get_high_review_cycle_tasks_7d() query
- Added detect_review_loops() function in jobs.rs
- Wired into run_self_review() as 4th detection pattern
- Added 5 tests (3 unit + 2 integration)
- All 882 tests pass, clippy clean, fmt clean


Closes #926

---
*Task #926 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2-pro-free`*