### PR TITLE
fix: make orch events fall back when the websocket port file is stale

### DIFF
--- a/src/cli/events.rs
+++ b/src/cli/events.rs
@@ -1,8 +1,14 @@
 //! CLI handler for `orch events` and `orch task watch` — connects to the
 //! event bus websocket server and prints task status transitions in real-time.
+//!
+//! If the websocket is unreachable (stale port file after service restart/crash),
+//! falls back to polling the SQLite store for status changes.
 
 use anyhow::Context;
 use futures::StreamExt;
+use std::collections::HashMap;
+use std::net::TcpStream;
+use std::net::{Ipv4Addr, SocketAddrV4};
 use tokio_tungstenite::connect_async;
 
 /// Read the websocket port from `~/.orch/state/ws.port`.
@@ -16,11 +22,43 @@ fn read_ws_port() -> anyhow::Result<u16> {
         .context("invalid port number in ws.port")
 }
 
-/// Stream events from the event bus, optionally filtered by repo and/or task ID.
+/// Probe whether a TCP socket is reachable on the given port.
+///
+/// Uses a short timeout (500ms) so the CLI doesn't hang on stale ports.
+fn probe_ws_port(port: u16) -> bool {
+    let addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port);
+    TcpStream::connect_timeout(
+        &std::net::SocketAddr::V4(addr),
+        std::time::Duration::from_millis(500),
+    )
+    .is_ok()
+}
+
+/// Stream events from the event bus websocket. Falls back to store polling
+/// when the websocket port is stale or unreachable.
 ///
 /// Output format: `HH:MM:SS task_id old_status → new_status agent PR: #N`
 pub async fn stream(repo: Option<&str>, task: Option<&str>) -> anyhow::Result<()> {
-    let port = read_ws_port()?;
+    // Try to read and probe the websocket port.
+    match read_ws_port() {
+        Ok(port) if probe_ws_port(port) => {
+            // Port is alive — connect via websocket.
+            stream_from_ws(port, repo, task).await
+        }
+        Ok(port) => {
+            eprintln!("Event bus port {port} is not reachable — falling back to store polling.");
+            stream_from_store(repo, task).await
+        }
+        Err(_) => {
+            // No port file at all — service probably isn't running.
+            eprintln!("Event bus not available — falling back to store polling.");
+            stream_from_store(repo, task).await
+        }
+    }
+}
+
+/// Connect to the event bus websocket and stream events.
+async fn stream_from_ws(port: u16, repo: Option<&str>, task: Option<&str>) -> anyhow::Result<()> {
     let url = format!("ws://127.0.0.1:{port}/events");
 
     let (ws, _) = connect_async(&url)
@@ -50,25 +88,264 @@ pub async fn stream(repo: Option<&str>, task: Option<&str>) -> anyhow::Result<()
                 }
             }
 
-            // Format output
-            let time = if event.timestamp.len() >= 19 {
-                &event.timestamp[11..19]
-            } else {
-                &event.timestamp
-            };
-            let agent_str = event.agent.as_deref().unwrap_or("");
-            let pr_str = event
-                .pr_number
-                .as_ref()
-                .map(|p| format!(" PR: #{p}"))
-                .unwrap_or_default();
-
-            println!(
-                "{time} {} {} \u{2192} {} {agent_str}{pr_str}",
-                event.task_id, event.old_status, event.new_status,
-            );
+            print_event(&event);
         }
     }
 
     Ok(())
+}
+
+/// Format and print a single task event.
+fn print_event(event: &crate::engine::events::TaskEvent) {
+    let time = if event.timestamp.len() >= 19 {
+        &event.timestamp[11..19]
+    } else {
+        &event.timestamp
+    };
+    let agent_str = event.agent.as_deref().unwrap_or("");
+    let pr_str = event
+        .pr_number
+        .as_ref()
+        .map(|p| format!(" PR: #{p}"))
+        .unwrap_or_default();
+
+    println!(
+        "{time} {} {} \u{2192} {} {agent_str}{pr_str}",
+        event.task_id, event.old_status, event.new_status,
+    );
+}
+
+/// Fallback: poll the SQLite store for task status changes.
+///
+/// When watching a specific task (`task` is Some), polls that task's status
+/// every 3 seconds and prints transitions. When watching all tasks, polls
+/// all active tasks and prints any status changes.
+async fn stream_from_store(
+    repo_filter: Option<&str>,
+    task_filter: Option<&str>,
+) -> anyhow::Result<()> {
+    let store = match crate::cli::init_store().await {
+        Ok(s) => s,
+        Err(e) => {
+            anyhow::bail!(
+                "Cannot stream events: store unavailable ({e:#}). Is the service running?"
+            );
+        }
+    };
+
+    println!("Watching store for status changes (polling every 3s)...\n");
+
+    // Snapshot of last known statuses: task_key -> (status, agent, pr_number)
+    let mut last_status: HashMap<String, (String, Option<String>, Option<i32>)> = HashMap::new();
+
+    // Seed initial state
+    let tasks = store.list_all_active_global().await.unwrap_or_default();
+    for t in &tasks {
+        let key = task_key(t);
+        last_status.insert(
+            key,
+            (t.status.as_str().to_string(), t.agent.clone(), t.pr_number),
+        );
+    }
+
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(3));
+    loop {
+        interval.tick().await;
+
+        let tasks = match store.list_all_active_global().await {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+
+        for t in &tasks {
+            let key = task_key(t);
+
+            // Apply filters
+            if let Some(ref rf) = repo_filter {
+                if !t.repo.contains(rf) {
+                    continue;
+                }
+            }
+            if let Some(tf) = task_filter {
+                if key != tf && t.external_id.as_deref() != Some(tf) {
+                    continue;
+                }
+            }
+
+            let new_status = t.status.as_str().to_string();
+
+            match last_status.get(&key) {
+                Some((old_status, _, _)) if *old_status == new_status => {
+                    // No change
+                }
+                Some((old_status, _, _)) => {
+                    // Status changed — print transition
+                    let now = chrono::Utc::now().format("%H:%M:%S");
+                    let agent_str = t.agent.as_deref().unwrap_or("");
+                    let pr_str = t
+                        .pr_number
+                        .map(|p| format!(" PR: #{p}"))
+                        .unwrap_or_default();
+
+                    println!("{now} {key} {old_status} \u{2192} {new_status} {agent_str}{pr_str}",);
+                    last_status.insert(key, (new_status, t.agent.clone(), t.pr_number));
+                }
+                None => {
+                    // New task appeared
+                    let now = chrono::Utc::now().format("%H:%M:%S");
+                    let agent_str = t.agent.as_deref().unwrap_or("");
+                    println!("{now} {key} - \u{2192} {new_status} {agent_str}");
+                    last_status.insert(key, (new_status, t.agent.clone(), t.pr_number));
+                }
+            }
+        }
+
+        // Check for tasks that were removed (completed + cleaned up)
+        let active_keys: std::collections::HashSet<String> = tasks.iter().map(task_key).collect();
+        let disappeared: Vec<String> = last_status
+            .keys()
+            .filter(|k| !active_keys.contains(*k))
+            .cloned()
+            .collect();
+        for key in disappeared {
+            if let Some((old_status, _, _)) = last_status.remove(&key) {
+                if old_status != "done" {
+                    let now = chrono::Utc::now().format("%H:%M:%S");
+                    println!("{now} {key} {old_status} \u{2192} done");
+                }
+            }
+        }
+    }
+}
+
+/// Derive a display key for a task: prefer external_id, fall back to internal id.
+fn task_key(t: &crate::store::Task) -> String {
+    t.external_id
+        .clone()
+        .unwrap_or_else(|| format!("internal:{}", t.id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_ws_port_unreachable() {
+        // Port 1 should be unreachable (reserved).
+        assert!(!probe_ws_port(1));
+    }
+
+    #[test]
+    fn task_key_prefers_external_id() {
+        let t = crate::store::Task {
+            id: 42,
+            external_id: Some("123".to_string()),
+            repo: "o/r".into(),
+            origin: "external".into(),
+            title: "t".into(),
+            body: String::new(),
+            status: crate::store::TaskStatus::New,
+            source: String::new(),
+            source_id: String::new(),
+            author: String::new(),
+            url: String::new(),
+            labels: Vec::new(),
+            agent: None,
+            model: None,
+            complexity: String::new(),
+            route_reason: String::new(),
+            agent_profile: String::new(),
+            selected_skills: String::new(),
+            route_attempts: 0,
+            attempts: 0,
+            branch: String::new(),
+            worktree: String::new(),
+            worktree_cleaned: false,
+            summary: String::new(),
+            last_error: String::new(),
+            parent_id: None,
+            block_reason: None,
+            pr_number: None,
+            pr_review_context: String::new(),
+            last_review_ts: String::new(),
+            last_comment_review_ts: String::new(),
+            merge_conflict_retries: 0,
+            ci_merge_failures: 0,
+            pr_create_failures: 0,
+            review_agent_failures: 0,
+            review_cycles: 0,
+            review_session_expected: false,
+            input_tokens: 0,
+            output_tokens: 0,
+            input_cost_usd: 0.0,
+            output_cost_usd: 0.0,
+            total_cost_usd: 0.0,
+            model_reroute_chain: String::new(),
+            limit_reroute_chain: String::new(),
+            budget_warning: String::new(),
+            budget_exceeded: false,
+            memory: Vec::new(),
+            delegations: Vec::new(),
+            created_at: String::new(),
+            updated_at: String::new(),
+        };
+        assert_eq!(task_key(&t), "123");
+    }
+
+    #[test]
+    fn task_key_falls_back_to_internal() {
+        let t = crate::store::Task {
+            id: 7,
+            external_id: None,
+            repo: "o/r".into(),
+            origin: "internal".into(),
+            title: "t".into(),
+            body: String::new(),
+            status: crate::store::TaskStatus::InProgress,
+            source: String::new(),
+            source_id: String::new(),
+            author: String::new(),
+            url: String::new(),
+            labels: Vec::new(),
+            agent: Some("claude".to_string()),
+            model: None,
+            complexity: String::new(),
+            route_reason: String::new(),
+            agent_profile: String::new(),
+            selected_skills: String::new(),
+            route_attempts: 0,
+            attempts: 1,
+            branch: String::new(),
+            worktree: String::new(),
+            worktree_cleaned: false,
+            summary: String::new(),
+            last_error: String::new(),
+            parent_id: None,
+            block_reason: None,
+            pr_number: None,
+            pr_review_context: String::new(),
+            last_review_ts: String::new(),
+            last_comment_review_ts: String::new(),
+            merge_conflict_retries: 0,
+            ci_merge_failures: 0,
+            pr_create_failures: 0,
+            review_agent_failures: 0,
+            review_cycles: 0,
+            review_session_expected: false,
+            input_tokens: 0,
+            output_tokens: 0,
+            input_cost_usd: 0.0,
+            output_cost_usd: 0.0,
+            total_cost_usd: 0.0,
+            model_reroute_chain: String::new(),
+            limit_reroute_chain: String::new(),
+            budget_warning: String::new(),
+            budget_exceeded: false,
+            memory: Vec::new(),
+            delegations: Vec::new(),
+            created_at: String::new(),
+            updated_at: String::new(),
+        };
+        assert_eq!(task_key(&t), "internal:7");
+    }
 }


### PR DESCRIPTION
## Summary

Fixed orch events to gracefully fall back when the websocket port file is stale

### What was done

- Added probe_ws_port() function that performs a TCP connect check with 500ms timeout before attempting websocket connection
- Added stream_from_store() fallback that polls the SQLite store every 3 seconds for task status changes
- Refactored stream() into three paths: websocket (port alive), fallback (port stale), and fallback (no port file)
- Extracted print_event() helper to share output formatting between websocket and store paths
- Added 3 tests: probe_ws_port_unreachable, task_key_prefers_external_id, task_key_falls_back_to_internal
- All 879 tests pass, cargo fmt and cargo clippy clean


Closes #932

---
*Task #932 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2-pro-free`*