### PR TITLE
Bug: `orch chat` with message and subcommand defaults to interactive mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -252,6 +252,10 @@ enum Commands {
         raw: bool,
     },
     /// Chat with the orchestrator control session
+    #[command(
+        subcommand_precedence_over_arg = true,
+        args_conflicts_with_subcommands = true
+    )]
     Chat {
         /// Session profile (default: "default")
         #[arg(long, short, default_value = "default")]


### PR DESCRIPTION
## Summary

Made `orch chat` reject ambiguous mixed input by letting clap treat chat subcommands and positional messages as mutually exclusive.

### What was done

- Added clap-level precedence/conflict handling to the `Chat` command in `src/main.rs`
- Verified `orch chat history` still parses as the history subcommand while mixed message+subcommand forms are rejected
- Ran `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` successfully
- Committed the fix as `fix: reject ambiguous chat input`


Closes #937

---
*Task #937 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4-mini`*