### PR TITLE
bug: worktree path silently falls back to "." on non-UTF8 path — review agent runs git in wrong directory

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -708,14 +708,21 @@ mod tests {
             .args([
                 "init",
                 "--initial-branch=main",
-                repo_dir.to_str().unwrap_or("."),
+                repo_dir
+                    .to_str()
+                    .expect("test repo path contains non-UTF-8 characters"),
             ])
             .output()
             .ok()?;
         if !init.status.success() {
             // Older git may not have --initial-branch; fall back.
             let _ = std::process::Command::new("git")
-                .args(["init", repo_dir.to_str().unwrap_or(".")])
+                .args([
+                    "init",
+                    repo_dir
+                        .to_str()
+                        .expect("test repo path contains non-UTF-8 characters"),
+                ])
                 .output()
                 .ok()?;
         }

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -140,10 +140,16 @@ async fn ensure_pr_exists(
             // No open PR — check if branch has commits ahead of default branch.
             let default_branch =
                 crate::config::get("gh.default_branch").unwrap_or_else(|_| "main".to_string());
+            let worktree_str = worktree_path.to_str().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "worktree path contains non-UTF-8 characters: {:?}",
+                    worktree_path
+                )
+            })?;
             let has_commits = tokio::process::Command::new("git")
                 .args([
                     "-C",
-                    worktree_path.to_str().unwrap_or("."),
+                    worktree_str,
                     "rev-list",
                     "--count",
                     &format!("origin/{default_branch}..HEAD"),
@@ -169,14 +175,7 @@ async fn ensure_pr_exists(
                 );
                 // Push first in case agent forgot
                 let _ = tokio::process::Command::new("git")
-                    .args([
-                        "-C",
-                        worktree_path.to_str().unwrap_or("."),
-                        "push",
-                        "-u",
-                        "origin",
-                        branch_name,
-                    ])
+                    .args(["-C", worktree_str, "push", "-u", "origin", branch_name])
                     .output()
                     .await;
 


### PR DESCRIPTION
## Summary

Fixed the silent `.to_str().unwrap_or(".")` fallback so non-UTF8 worktree paths now error instead of running git in the wrong directory.

### What was done

- Replaced the review path fallback with an explicit UTF-8 validation error in `src/engine/review.rs`
- Kept the cleanup test helper on explicit path handling instead of silently defaulting to `.`
- Ran `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` successfully


Closes #951

---
*Task #951 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4-mini`*