### PR TITLE
bug: Discord Gateway always resumes on close frame — non-resumable auth/intent errors loop forever

### DIFF
--- a/src/channels/discord_ws.rs
+++ b/src/channels/discord_ws.rs
@@ -452,8 +452,19 @@ async fn handle_connection(
                         }
                     }
                     Message::Close(frame) => {
-                        tracing::info!(?frame, "discord gateway: close frame received");
-                        return Ok(true);
+                        let code = frame.as_ref().map(|f| u16::from(f.code)).unwrap_or(0);
+                        // Non-resumable Discord Gateway close codes per Discord docs
+                        let resumable = !matches!(code, 4004 | 4010 | 4011 | 4013 | 4014);
+                        if !resumable {
+                            state.clear();
+                            tracing::error!(
+                                code,
+                                "discord gateway: non-resumable close code — check bot token and intent configuration"
+                            );
+                        } else {
+                            tracing::info!(code, ?frame, "discord gateway: close frame, will attempt resume");
+                        }
+                        return Ok(resumable);
                     }
                     Message::Ping(data) => {
                         write


### PR DESCRIPTION
## Summary

Verified and validated the fix for non-resumable Discord Gateway close codes.

### What was done

- Confirmed fix in src/channels/discord_ws.rs handles codes 4004, 4010, 4011, 4013, 4014
- Verified state is cleared for non-resumable codes
- Passed all CI checks (fmt, clippy, nextest)
- Confirmed changes are committed to the feature branch


Closes #950

---
*Task #950 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gemini-3-flash-preview`*