### PR TITLE
Self-improvement: debug agent errors and fix root causes

### DIFF
--- a/src/engine/runner/agents/claude.rs
+++ b/src/engine/runner/agents/claude.rs
@@ -220,7 +220,9 @@ impl AgentRunner for ClaudeRunner {
         msg_file: &str,
         permissions: &PermissionRules,
     ) -> String {
-        let model_flag = model.map(|m| format!("--model {m}")).unwrap_or_default();
+        let model_flag = model
+            .map(|m| format!("--model {}", super::shell_single_quote(m)))
+            .unwrap_or_default();
 
         // Claude permission mode: autonomous → bypassPermissions, supervised → acceptEdits
         let permission_mode = if permissions.autonomous {

--- a/src/engine/runner/agents/codex.rs
+++ b/src/engine/runner/agents/codex.rs
@@ -238,7 +238,9 @@ impl AgentRunner for CodexRunner {
         msg_file: &str,
         permissions: &PermissionRules,
     ) -> String {
-        let model_flag = model.map(|m| format!("--model {m}")).unwrap_or_default();
+        let model_flag = model
+            .map(|m| format!("--model {}", super::shell_single_quote(m)))
+            .unwrap_or_default();
 
         // Codex permission mode:
         // - autonomous → --full-auto (auto-approval + workspace-write sandbox)

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -251,6 +251,11 @@ pub fn synthesize_response_from_text(text: &str) -> Option<AgentResponse> {
     })
 }
 
+/// Quote a string for safe insertion into a POSIX shell command.
+pub(crate) fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
 /// Find the largest byte index <= `max_bytes` that lies on a UTF-8 char
 /// boundary.  Used for safe string truncation in error messages.
 fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> usize {

--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -229,7 +229,9 @@ impl AgentRunner for OpenCodeRunner {
         msg_file: &str,
         permissions: &PermissionRules,
     ) -> String {
-        let model_flag = model.map(|m| format!("--model {m}")).unwrap_or_default();
+        let model_flag = model
+            .map(|m| format!("--model {}", super::shell_single_quote(m)))
+            .unwrap_or_default();
 
         // OpenCode permission control via XDG_CONFIG_HOME override.
         //


### PR DESCRIPTION
## Summary

Fixed shell quoting for agent model flags, eliminating the opencode/codex/claude command-splitting failure mode.

### What was done

- Added a shared POSIX shell quoting helper for agent commands
- Updated Claude, Codex, and OpenCode runner command builders to quote model values safely
- Verified formatting, clippy, and tests passed
- Committed the fix in `c69bd77`


---
*Task internal-13011 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4-mini`*