### PR TITLE
feat: startup worktree reconciliation — rebase active branches, clean up stale worktrees

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -383,7 +383,13 @@ pub(crate) async fn cleanup_task_worktree_with_opts(
             );
         } else {
             tracing::info!(task_id, worktree = %wt.display(), "removing worktree");
-            remove_worktree_and_branch(task_id, &wt, branch.as_deref(), &repo_root).await;
+            remove_worktree_and_branch(
+                task_id,
+                &wt,
+                branch.as_deref(),
+                std::path::Path::new(&repo_root),
+            )
+            .await;
             did_clean = true;
         }
     } else if let Some(ref br) = branch {
@@ -391,7 +397,7 @@ pub(crate) async fn cleanup_task_worktree_with_opts(
         // on the remote. Delete it to avoid orphaned branches.
         if !opts.dry_run {
             tracing::debug!(task_id, branch = %br, "no worktree on disk, cleaning up branch only");
-            delete_branches(task_id, br, &repo_root).await;
+            delete_branches(task_id, br, std::path::Path::new(&repo_root)).await;
             did_clean = true;
         }
     }
@@ -407,18 +413,26 @@ pub(crate) async fn cleanup_task_worktree_with_opts(
 }
 
 /// Remove a git worktree directory and its local + remote branches.
-async fn remove_worktree_and_branch(
+pub(crate) async fn remove_worktree_and_branch(
     task_id: &str,
     wt: &std::path::Path,
     branch: Option<&str>,
-    repo_root: &str,
+    repo_root: &std::path::Path,
 ) {
     let wt_str = wt.to_string_lossy().to_string();
+    let repo_root_str = repo_root.to_string_lossy();
 
     // Remove worktree FIRST, then delete the branch.
     // Git refuses to remove a worktree if its branch is already deleted.
     let remove_result = Command::new("git")
-        .args(["-C", repo_root, "worktree", "remove", &wt_str, "--force"])
+        .args([
+            "-C",
+            repo_root_str.as_ref(),
+            "worktree",
+            "remove",
+            &wt_str,
+            "--force",
+        ])
         .output_with_context()
         .await;
 
@@ -442,9 +456,10 @@ async fn remove_worktree_and_branch(
 }
 
 /// Delete local and remote branches for a task.
-async fn delete_branches(task_id: &str, br: &str, repo_root: &str) {
+pub(crate) async fn delete_branches(task_id: &str, br: &str, repo_root: &std::path::Path) {
+    let repo_root_str = repo_root.to_string_lossy();
     let branch_delete_result = Command::new("git")
-        .args(["-C", repo_root, "branch", "-D", br])
+        .args(["-C", repo_root_str.as_ref(), "branch", "-D", br])
         .output_with_context()
         .await;
 
@@ -467,7 +482,14 @@ async fn delete_branches(task_id: &str, br: &str, repo_root: &str) {
 
     // Delete remote branch
     let remote_delete = Command::new("git")
-        .args(["-C", repo_root, "push", "origin", "--delete", br])
+        .args([
+            "-C",
+            repo_root_str.as_ref(),
+            "push",
+            "origin",
+            "--delete",
+            br,
+        ])
         .output_with_context()
         .await;
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -49,12 +49,17 @@ use crate::channels::tmux::TmuxChannel;
 use crate::channels::transport::Transport;
 use crate::channels::{Channel, ChannelRegistry, IncomingMessage, OutgoingMessage};
 use crate::config;
+use crate::engine::cleanup::remove_worktree_and_branch;
 use crate::engine::router::Router;
+use crate::engine::runner::worktree::{
+    abort_worktree_rebase, list_project_worktrees, rebase_worktree_on_origin_main,
+    task_id_from_worktree_name,
+};
 use crate::engine::tasks::TaskManager;
 use crate::github::http::{rate_limit_metrics, GhHttp};
 use crate::repo_context::REPO_CONTEXT;
-use crate::store::TaskStore;
 use crate::store::{review_session_expected, set_review_session_expected};
+use crate::store::{TaskStatus, TaskStore};
 use crate::tmux::TmuxManager;
 use runner::WeightSignal;
 // AtomicBool/Ordering removed — shutdown is now immediate (reset tasks + break)
@@ -297,6 +302,88 @@ async fn init_project_engines() -> anyhow::Result<Vec<ProjectEngine>> {
     Ok(engines)
 }
 
+async fn reconcile_startup_worktrees(project_engines: &[ProjectEngine]) -> anyhow::Result<()> {
+    for engine in project_engines {
+        let repo_root =
+            crate::engine::runner::worktree::resolve_main_repo(&engine.project_dir).await;
+        let repo_root_path = std::path::PathBuf::from(&repo_root);
+        let worktrees = list_project_worktrees(&repo_root_path)?;
+
+        for worktree_dir in worktrees {
+            let Some(name) = worktree_dir.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+
+            let Some(task_id) = task_id_from_worktree_name(name) else {
+                tracing::info!(repo = %engine.repo, worktree = %worktree_dir.display(), "orphan worktree without task id, removing");
+                remove_worktree_and_branch(name, &worktree_dir, Some(name), &repo_root_path).await;
+                continue;
+            };
+
+            let Some(store_id) = engine.store.resolve_task_id(&engine.repo, &task_id).await? else {
+                tracing::info!(repo = %engine.repo, task_id = %task_id, worktree = %worktree_dir.display(), "worktree has no matching task, removing");
+                remove_worktree_and_branch(&task_id, &worktree_dir, Some(name), &repo_root_path)
+                    .await;
+                continue;
+            };
+
+            let task = engine.store.get(store_id).await?;
+            let branch_name = if task.branch.is_empty() {
+                name
+            } else {
+                task.branch.as_str()
+            };
+
+            match task.status {
+                TaskStatus::New
+                | TaskStatus::Routed
+                | TaskStatus::InProgress
+                | TaskStatus::NeedsReview
+                | TaskStatus::InReview => {
+                    tracing::info!(repo = %engine.repo, task_id = %task_id, worktree = %worktree_dir.display(), "rebasing startup worktree");
+                    if let Err(e) =
+                        rebase_worktree_on_origin_main(&worktree_dir, &repo_root_path).await
+                    {
+                        tracing::warn!(repo = %engine.repo, task_id = %task_id, err = %e, "startup rebase failed, resetting task");
+                        abort_worktree_rebase(&worktree_dir).await;
+                        remove_worktree_and_branch(
+                            &task_id,
+                            &worktree_dir,
+                            Some(branch_name),
+                            &repo_root_path,
+                        )
+                        .await;
+                        if let Ok(Some(reset_id)) =
+                            engine.store.resolve_task_id(&engine.repo, &task_id).await
+                        {
+                            let _ = engine.store.reset_to_new(reset_id).await;
+                        }
+                        let _ = engine
+                            .task_manager
+                            .update_task_status(
+                                &ExternalId(task_id.clone()),
+                                crate::backends::Status::New,
+                            )
+                            .await;
+                    }
+                }
+                _ => {
+                    tracing::info!(repo = %engine.repo, task_id = %task_id, worktree = %worktree_dir.display(), status = ?task.status, "terminal task worktree, removing");
+                    remove_worktree_and_branch(
+                        &task_id,
+                        &worktree_dir,
+                        Some(branch_name),
+                        &repo_root_path,
+                    )
+                    .await;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Read per-project channel configuration from `.orch.yml`.
 fn read_project_channel_config(project_dir: &std::path::Path) -> ProjectChannelConfig {
     let config_path = project_dir.join(".orch.yml");
@@ -396,6 +483,10 @@ pub async fn serve() -> anyhow::Result<()> {
             engine.repo.clone(),
             event_bus.sender(),
         ));
+    }
+
+    if let Err(e) = reconcile_startup_worktrees(&project_engines).await {
+        tracing::warn!(err = %e, "startup worktree reconciliation failed");
     }
 
     // Build ChannelRouter from global config + per-project configs

--- a/src/engine/runner/worktree.rs
+++ b/src/engine/runner/worktree.rs
@@ -22,6 +22,108 @@ pub struct WorktreeSetup {
     pub main_project_dir: PathBuf,
 }
 
+/// Canonical project name used under `~/.orch/worktrees/`.
+pub fn project_name(project_dir: &Path) -> String {
+    project_dir
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| "project".to_string())
+        .trim_end_matches(".git")
+        .to_string()
+}
+
+/// Base worktrees directory for a project.
+pub fn project_worktrees_dir(project_dir: &Path) -> PathBuf {
+    crate::home::worktrees_dir()
+        .unwrap_or_default()
+        .join(project_name(project_dir))
+}
+
+/// List all worktree directories for a project.
+pub fn list_project_worktrees(project_dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let base = project_worktrees_dir(project_dir);
+    let mut worktrees = Vec::new();
+
+    if !base.exists() {
+        return Ok(worktrees);
+    }
+
+    for entry in std::fs::read_dir(&base)? {
+        let entry = entry?;
+        if entry.path().is_dir() {
+            worktrees.push(entry.path());
+        }
+    }
+
+    Ok(worktrees)
+}
+
+/// Extract a task ID from a worktree directory name.
+pub fn task_id_from_worktree_name(name: &str) -> Option<String> {
+    if let Some(rest) = name.strip_prefix("internal-") {
+        let num = rest.split('-').next()?;
+        return num.parse::<u64>().ok().map(|n| format!("internal:{n}"));
+    }
+
+    for prefix in ["gh-issue-", "gh-task-"] {
+        if let Some(rest) = name.strip_prefix(prefix) {
+            let task_part = rest.split('-').next()?;
+            if task_part == "internal" {
+                let num = rest.split('-').nth(1)?;
+                return num.parse::<u64>().ok().map(|n| format!("internal:{n}"));
+            }
+            return Some(task_part.to_string());
+        }
+    }
+
+    None
+}
+
+/// Abort any rebase in progress for a worktree.
+pub async fn abort_worktree_rebase(worktree_dir: &Path) {
+    let _ = Command::new("git")
+        .args(["rebase", "--abort"])
+        .current_dir(worktree_dir)
+        .output_with_context()
+        .await;
+}
+
+/// Rebase a worktree on top of `origin/main`.
+pub async fn rebase_worktree_on_origin_main(
+    worktree_dir: &Path,
+    repo_root: &Path,
+) -> anyhow::Result<()> {
+    let repo_root_str = repo_root.to_string_lossy();
+    let fetch = Command::new("git")
+        .args(["-C", repo_root_str.as_ref(), "fetch", "origin"])
+        .output_with_context()
+        .await?;
+    if !fetch.status.success() {
+        anyhow::bail!(
+            "git fetch origin failed: {}",
+            String::from_utf8_lossy(&fetch.stderr).trim()
+        );
+    }
+
+    let rebase = Command::new("git")
+        .args([
+            "-C",
+            &worktree_dir.to_string_lossy(),
+            "rebase",
+            "origin/main",
+        ])
+        .output_with_context()
+        .await?;
+    if !rebase.status.success() {
+        anyhow::bail!(
+            "git rebase origin/main failed: {}",
+            String::from_utf8_lossy(&rebase.stderr).trim()
+        );
+    }
+
+    Ok(())
+}
+
 /// Generate a branch name from task ID and title.
 ///
 /// Format: `internal-{id}-{slug}` for internal tasks, `gh-issue-{id}-{slug}` for external.
@@ -153,16 +255,7 @@ pub async fn setup_worktree(
     let main_dir = resolve_main_repo(project_dir).await;
     let default_branch = detect_default_branch(&main_dir).await;
 
-    let project_name = main_dir
-        .file_name()
-        .map(|s| s.to_string_lossy().to_string())
-        .unwrap_or_else(|| "project".to_string())
-        .trim_end_matches(".git")
-        .to_string();
-
-    let worktrees_base = crate::home::worktrees_dir()
-        .unwrap_or_default()
-        .join(&project_name);
+    let worktrees_base = project_worktrees_dir(&main_dir);
     std::fs::create_dir_all(&worktrees_base)?;
 
     // Check if we have a saved branch/worktree in store
@@ -510,6 +603,35 @@ mod tests {
         let slug = name.strip_prefix("gh-issue-265-").unwrap();
         assert!(slug.len() <= 40, "slug too long: {}", slug.len());
         assert!(slug.is_ascii(), "slug contains non-ASCII: {slug}");
+    }
+
+    #[test]
+    fn task_id_from_worktree_name_parses_issue_branches() {
+        assert_eq!(
+            task_id_from_worktree_name("gh-issue-42-fix-login"),
+            Some("42".to_string())
+        );
+        assert_eq!(
+            task_id_from_worktree_name("gh-task-42-fix-login"),
+            Some("42".to_string())
+        );
+    }
+
+    #[test]
+    fn task_id_from_worktree_name_parses_internal_branches() {
+        assert_eq!(
+            task_id_from_worktree_name("internal-8-fix-login"),
+            Some("internal:8".to_string())
+        );
+        assert_eq!(
+            task_id_from_worktree_name("gh-issue-internal-8-fix-login"),
+            Some("internal:8".to_string())
+        );
+    }
+
+    #[test]
+    fn task_id_from_worktree_name_returns_none_for_unknown_names() {
+        assert!(task_id_from_worktree_name("random-worktree").is_none());
     }
 
     #[test]

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -354,6 +354,17 @@ impl TaskStore {
         Ok(())
     }
 
+    /// Reset a task back to `new`.
+    pub async fn reset_to_new(&self, id: i64) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE tasks SET status = 'new', branch = '', worktree = '', worktree_cleaned = 0, block_reason = NULL, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+        )
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Update the block reason for a task.
     pub async fn set_block_reason(&self, id: i64, reason: Option<&str>) -> anyhow::Result<()> {
         let value = reason


### PR DESCRIPTION
## Summary

Added startup worktree reconciliation so active tasks are rebased on boot and stale/orphaned worktrees are removed.

### What was done

- Hooked reconciliation into engine startup after project initialization
- Added worktree listing, task-id parsing, and rebase helpers in `src/engine/runner/worktree.rs`
- Reused cleanup paths to delete worktrees/branches for terminal or orphaned tasks
- Added store reset support for failed rebases and covered the new helpers with tests
- Verified with `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run`


Closes #960

---
*Task #960 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4-mini`*