### PR TITLE
fix: timeout failover should switch to a different agent, not retry the same one

### DIFF
--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -147,6 +147,22 @@ pub async fn handle_error(
         ),
     };
 
+    // If this was a timeout, clear the stored agent so the router can
+    // pick a different executor on re-dispatch. Without this the same
+    // slow agent can be picked again and will timeout repeatedly.
+    if retryable == response::RetryableError::Timeout {
+        store::store_set(
+            store,
+            repo,
+            task_id,
+            &[
+                ("agent", serde_json::json!("")),
+                ("last_error", serde_json::json!(error_msg.clone())),
+            ],
+        )
+        .await;
+    }
+
     // Record rate limit in store (sqlx)
     {
         let error_type_str = match retryable {


### PR DESCRIPTION
## Summary

Ensure timeout failover clears stored agent so router can pick a different executor

### What was done

- Updated failover logic to clear the stored agent when an agent times out
- Persisted last_error alongside clearing the agent to keep context in the task store
- Ran formatter and committed the change locally


### Remaining

- Monitor CI (CI will be run by the orchestrator after push/PR creation)
- Observe runtime behavior to ensure timeouts now cause agent switching rather than repeated retries


Closes #966

---
*Task #966 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*