### PR TITLE
Reviewer should auto merge if PR approved and required CI checks passes

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -36,6 +36,71 @@ fn ci_poll_semaphore() -> &'static Arc<Semaphore> {
     CI_POLL_SEMAPHORE.get_or_init(|| Arc::new(Semaphore::new(3)))
 }
 
+fn required_checks_state(
+    required_contexts: &[String],
+    check_runs: &[(String, String, Option<String>)],
+    statuses: &[(String, String)],
+) -> (String, u64, u64, u64, u64) {
+    if required_contexts.is_empty() {
+        return ("success".to_string(), 0, 0, 0, 0);
+    }
+
+    let mut passing = 0u64;
+    let mut failing = 0u64;
+    let mut pending = 0u64;
+
+    for context in required_contexts {
+        let mut matched = false;
+
+        let mut check_run_match = None;
+        for (name, status, conclusion) in check_runs {
+            if name == context {
+                check_run_match = Some((status.as_str(), conclusion.as_deref()));
+                break;
+            }
+        }
+
+        if let Some((status, conclusion)) = check_run_match {
+            matched = true;
+            if status != "completed" {
+                pending += 1;
+            } else if matches!(conclusion, Some("success" | "neutral" | "skipped")) {
+                passing += 1;
+            } else {
+                failing += 1;
+            }
+        } else {
+            for (name, state) in statuses {
+                if name != context {
+                    continue;
+                }
+                matched = true;
+                match state.as_str() {
+                    "success" | "neutral" | "skipped" => passing += 1,
+                    "failure" | "error" => failing += 1,
+                    _ => pending += 1,
+                }
+                break;
+            }
+        }
+
+        if !matched {
+            pending += 1;
+        }
+    }
+
+    let total = required_contexts.len() as u64;
+    let state = if failing > 0 {
+        "failure".to_string()
+    } else if pending > 0 {
+        "pending".to_string()
+    } else {
+        "success".to_string()
+    };
+
+    (state, total, passing, failing, pending)
+}
+
 /// Build a standard attribution footer for GitHub comments posted by orch bots.
 ///
 /// `verb` is "Reviewed" or "Commented" depending on context.
@@ -142,10 +207,31 @@ pub(crate) async fn auto_merge_pr(
 
     // Acquire a global permit to limit concurrent CI polling loops across tasks.
     let _permit = ci_poll_semaphore().clone().acquire_owned().await;
+    let pr = gh.get_pr(repo, pr_number).await?;
+    if pr.mergeable == Some(false) {
+        anyhow::bail!("PR is not mergeable (merge conflicts present)");
+    }
+    let head_sha = pr.head.sha.clone();
+    let required_contexts = gh
+        .get_required_status_check_contexts(repo, branch)
+        .await
+        .unwrap_or_default();
 
     loop {
-        let (state, total, passing, failing, pending) =
-            gh.get_combined_status(repo, branch).await?;
+        let (state, total, passing, failing, pending) = if required_contexts.is_empty() {
+            gh.get_combined_status(repo, &head_sha).await?
+        } else {
+            let check_runs = gh.get_check_runs(repo, &head_sha).await.unwrap_or_default();
+            let statuses = gh
+                .get_commit_status_contexts(repo, &head_sha)
+                .await
+                .unwrap_or_default();
+            let check_runs = check_runs
+                .into_iter()
+                .map(|run| (run.name, run.status, run.conclusion))
+                .collect::<Vec<_>>();
+            required_checks_state(&required_contexts, &check_runs, &statuses)
+        };
 
         tracing::info!(
             task_id = task.id.0,
@@ -575,6 +661,33 @@ mod tests {
             submitted_at: submitted_at.to_string(),
             commit_id: None,
         }
+    }
+
+    #[test]
+    fn required_checks_state_uses_required_contexts() {
+        let required = vec!["ci".to_string(), "lint".to_string()];
+        let check_runs = vec![
+            (
+                "ci".to_string(),
+                "completed".to_string(),
+                Some("success".to_string()),
+            ),
+            (
+                "lint".to_string(),
+                "completed".to_string(),
+                Some("failure".to_string()),
+            ),
+        ];
+        let statuses = vec![("unused".to_string(), "success".to_string())];
+
+        let (state, total, passing, failing, pending) =
+            required_checks_state(&required, &check_runs, &statuses);
+
+        assert_eq!(state, "failure");
+        assert_eq!(total, 2);
+        assert_eq!(passing, 1);
+        assert_eq!(failing, 1);
+        assert_eq!(pending, 0);
     }
 
     #[test]

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -11,7 +11,8 @@
 
 use super::token;
 use super::types::{
-    GitHubComment, GitHubIssue, GitHubPullRequest, GitHubReview, GitHubReviewComment,
+    GitHubCheckRun, GitHubComment, GitHubIssue, GitHubPullRequest, GitHubReview,
+    GitHubReviewComment,
 };
 use reqwest::{header, Client, Response, StatusCode};
 use serde::Serialize;
@@ -1011,6 +1012,77 @@ impl GhHttp {
     pub async fn get_pr(&self, repo: &str, pr_number: u64) -> anyhow::Result<GitHubPullRequest> {
         let url = format!("{GITHUB_API}/repos/{repo}/pulls/{pr_number}");
         self.get_json(&url).await
+    }
+
+    /// Get the required status check contexts for a branch.
+    pub async fn get_required_status_check_contexts(
+        &self,
+        repo: &str,
+        branch: &str,
+    ) -> anyhow::Result<Vec<String>> {
+        let branch = urlencoding::encode(branch);
+        let url = format!("{GITHUB_API}/repos/{repo}/branches/{branch}/protection");
+        let resp = self.get_json::<serde_json::Value>(&url).await;
+        match resp {
+            Ok(value) => Ok(value
+                .pointer("/required_status_checks/contexts")
+                .and_then(|v| v.as_array())
+                .map(|contexts| {
+                    contexts
+                        .iter()
+                        .filter_map(|context| context.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default()),
+            Err(e) => {
+                let err = e.to_string();
+                if err.contains("404") {
+                    Ok(vec![])
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
+
+    /// Get commit status contexts for a SHA.
+    pub async fn get_commit_status_contexts(
+        &self,
+        repo: &str,
+        sha: &str,
+    ) -> anyhow::Result<Vec<(String, String)>> {
+        let url = format!("{GITHUB_API}/repos/{repo}/commits/{sha}/status");
+        let resp = self.get_json::<serde_json::Value>(&url).await?;
+        Ok(resp
+            .get("statuses")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|status| {
+                let context = status.get("context").and_then(|v| v.as_str())?;
+                let state = status.get("state").and_then(|v| v.as_str())?;
+                Some((context.to_string(), state.to_string()))
+            })
+            .collect())
+    }
+
+    /// Get check runs for a PR head SHA.
+    pub async fn get_check_runs(
+        &self,
+        repo: &str,
+        sha: &str,
+    ) -> anyhow::Result<Vec<GitHubCheckRun>> {
+        let url = format!("{GITHUB_API}/repos/{repo}/commits/{sha}/check-runs");
+        let resp: serde_json::Value = self.get_json(&url).await?;
+        Ok(resp
+            .get("check_runs")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|run| serde_json::from_value(run).ok())
+            .collect())
     }
 
     /// Get reviews for a PR.

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -47,12 +47,21 @@ pub struct GitHubPullRequest {
     pub head: GitHubBranchRef,
     pub base: GitHubBranchRef,
     pub mergeable: Option<bool>,
+    pub mergeable_state: Option<String>,
     pub merged: Option<bool>,
     pub html_url: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubCheckRun {
+    pub name: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitHubBranchRef {
+    #[serde(rename = "ref")]
     pub ref_field: String,
     pub sha: String,
 }


### PR DESCRIPTION
## Summary

Auto-merge now evaluates the PR's head SHA against required checks and only considers the checks that branch protection requires.

### What was done

- Added required-check aggregation so auto-merge can ignore non-required failing checks.
- Switched merge readiness polling to use PR head SHA check runs/statuses and reject unmergeable PRs with conflicts.
- Added coverage for required-check evaluation behavior.


Closes #970

---
*Task #970 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4-mini`*