### PR TITLE
Fallback model in model_for_complexity_or_default is hardcoded to claude-sonnet-4-6 for all agents

### DIFF
--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -356,7 +356,11 @@ impl RouterConfig {
     ) -> String {
         self.model_for_complexity(agent, complexity, task_id)
             .or_else(|| Self::default().model_for_complexity(agent, complexity, task_id))
-            .unwrap_or_else(|| "claude-sonnet-4-6".to_string())
+            .unwrap_or_else(|| match agent {
+                "codex" => "o3".to_string(),
+                "opencode" => "anthropic/claude-sonnet-4-6".to_string(),
+                _ => "claude-sonnet-4-6".to_string(),
+            })
     }
 }
 


### PR DESCRIPTION
## Summary

Updated `model_for_complexity_or_default` to use agent-aware fallback models instead of a hardcoded Claude model.

### What was done

- Modified `src/engine/router/config.rs` to use agent-specific fallback models.
- Codex now falls back to `o3`.
- OpenCode now falls back to `anthropic/claude-sonnet-4-6`.
- Other agents continue to fall back to `claude-sonnet-4-6`.


Closes #975

---
*Task #975 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gemini-3-flash-preview`*