### PR TITLE
Review cooldown trigger uses string matching instead of AgentError enum — misses opencode/codex errors

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -785,19 +785,20 @@ pub(crate) async fn review_and_merge(
             "review agent: entering error path"
         );
         let err = agent_runner.classify_error(exit_code, &raw_output, &stderr);
-        let err_str = err.to_string();
-        if err_str.contains("rate limit")
-            || err_str.contains("usage limit")
-            || err_str.contains("rate_limit")
-            || err_str.contains("auth error")
-            || err_str.contains("Auth")
-        {
-            tracing::warn!(
-                task_id = task.id.0,
-                agent = %review_agent,
-                "review agent hit rate limit — adding to cooldown"
-            );
-            runner::response::record_agent_failure_with_message(&review_agent, &err_str);
+        match &err {
+            runner::agents::AgentError::RateLimit { .. }
+            | runner::agents::AgentError::Auth { .. } => {
+                tracing::warn!(
+                    task_id = task.id.0,
+                    agent = %review_agent,
+                    "review agent hit rate limit — adding to cooldown"
+                );
+                runner::response::record_agent_failure_with_message(
+                    &review_agent,
+                    &err.to_string(),
+                );
+            }
+            _ => {}
         }
         tracing::error!(task_id = task.id.0, error = %err, "review agent failed");
         if let Some(rid) = run_id {
@@ -838,6 +839,21 @@ pub(crate) async fn review_and_merge(
         }
         Err(e) => {
             tracing::error!(task_id = task.id.0, error = %e, "review agent error");
+            match &e {
+                runner::agents::AgentError::RateLimit { .. }
+                | runner::agents::AgentError::Auth { .. } => {
+                    tracing::warn!(
+                        task_id = task.id.0,
+                        agent = %review_agent,
+                        "review agent hit rate limit — adding to cooldown"
+                    );
+                    runner::response::record_agent_failure_with_message(
+                        &review_agent,
+                        &e.to_string(),
+                    );
+                }
+                _ => {}
+            }
             if let Some(rid) = run_id {
                 let _ = store
                     .complete_run(&CompleteRun {


### PR DESCRIPTION
## Summary

Replaced fragile string matching with AgentError enum variant matching for cooldown triggers in the review pipeline, and added missing cooldown trigger in the parse_response error path.

### What was done

- Replaced string.contains() checks with match on AgentError::RateLimit and AgentError::Auth in the is_hard_failure path (line 787)
- Added cooldown trigger in the parse_response Err(e) branch (line 840) — previously missing, so OpenCode/Codex errors never entered cooldown
- All 927 tests pass, clippy clean, formatting clean


Closes #974

---
*Task #974 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2-pro-free`*