### PR TITLE
bug: split review parsing by agent format instead of relying on generic NDJSON fallback

### DIFF
--- a/src/engine/runner/agents/claude.rs
+++ b/src/engine/runner/agents/claude.rs
@@ -158,6 +158,39 @@ impl ClaudeRunner {
     }
 }
 
+/// Find the final `type:result` event in Claude NDJSON output and extract
+/// a uniform `AgentResult`. Handles claude, kimi, and minimax (all use the
+/// claude binary with `--output-format stream-json`).
+pub fn find_claude_result(ndjson: &str) -> Option<super::AgentResult> {
+    let line = find_ndjson_result_line(ndjson)?;
+    let parsed: serde_json::Value = serde_json::from_str(line).ok()?;
+    let envelope = parsed.as_object()?;
+
+    if envelope.get("type").and_then(|v| v.as_str()) != Some("result") {
+        return None;
+    }
+
+    let is_error = envelope
+        .get("is_error")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let result_text = envelope
+        .get("result")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let (input_tokens, output_tokens) = extract_usage(envelope);
+
+    Some(super::AgentResult {
+        is_error,
+        result_text,
+        input_tokens,
+        output_tokens,
+    })
+}
+
 pub(crate) fn extract_stream_json_result_text(raw: &str) -> Result<String, AgentError> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {

--- a/src/engine/runner/agents/codex.rs
+++ b/src/engine/runner/agents/codex.rs
@@ -350,6 +350,96 @@ impl AgentRunner for CodexRunner {
     }
 }
 
+/// Find the final result from Codex NDJSON output.
+///
+/// Looks for `item.completed` events with `item.type == "agent_message"`,
+/// and checks for error events (`turn.failed`, `error`, `item.error`).
+pub fn find_codex_result(ndjson: &str) -> Option<super::AgentResult> {
+    let events: Vec<serde_json::Value> = ndjson
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect();
+
+    if events.is_empty() {
+        return None;
+    }
+
+    // Check for errors first
+    for event in &events {
+        let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if event_type == "turn.failed" || event_type == "error" {
+            let message = if event_type == "turn.failed" {
+                event
+                    .get("error")
+                    .and_then(|e| e.get("message"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("turn failed")
+            } else {
+                event
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown error")
+            };
+            return Some(super::AgentResult {
+                is_error: true,
+                result_text: message.to_string(),
+                input_tokens: None,
+                output_tokens: None,
+            });
+        }
+        if event_type == "item.completed" {
+            if let Some(item) = event.get("item") {
+                if item.get("type").and_then(|v| v.as_str()) == Some("error") {
+                    let message = item
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("item error");
+                    return Some(super::AgentResult {
+                        is_error: true,
+                        result_text: message.to_string(),
+                        input_tokens: None,
+                        output_tokens: None,
+                    });
+                }
+            }
+        }
+    }
+
+    // Extract agent message text (prefer last JSON-looking one)
+    let mut texts = Vec::new();
+    for event in &events {
+        if event.get("type").and_then(|v| v.as_str()) == Some("item.completed") {
+            if let Some(item) = event.get("item") {
+                if item.get("type").and_then(|v| v.as_str()) == Some("agent_message") {
+                    if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
+                        texts.push(text.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    if texts.is_empty() {
+        return None;
+    }
+
+    // Prefer last JSON-looking message
+    let result_text = texts
+        .iter()
+        .rev()
+        .find(|t| t.contains('{') && t.contains("status"))
+        .cloned()
+        .unwrap_or_else(|| texts.pop().unwrap_or_default());
+
+    Some(super::AgentResult {
+        is_error: false,
+        result_text,
+        input_tokens: None,
+        output_tokens: None,
+    })
+}
+
 /// Try to extract a model name from an error message.
 ///
 /// Looks for text quoted with backticks or single quotes:

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -97,6 +97,36 @@ impl PermissionRules {
     }
 }
 
+/// Uniform result extracted from an agent's NDJSON output envelope.
+///
+/// Each agent has a different NDJSON structure. Per-agent `find_*_result()`
+/// functions extract this struct so the review pipeline and task response
+/// pipeline can share a single code path.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // input_tokens/output_tokens used by task response pipeline (Phase 3)
+pub struct AgentResult {
+    /// Whether the agent reported an error (e.g. `is_error: true` for claude).
+    pub is_error: bool,
+    /// The extracted result text (inner content, not the full envelope).
+    pub result_text: String,
+    /// Input tokens consumed (if reported).
+    pub input_tokens: Option<u64>,
+    /// Output tokens consumed (if reported).
+    pub output_tokens: Option<u64>,
+}
+
+/// Find the final result from agent NDJSON output, dispatching per agent.
+///
+/// Returns `None` if no result event is found (truly empty output).
+pub fn find_agent_result(agent_name: &str, ndjson: &str) -> Option<AgentResult> {
+    match agent_name {
+        "claude" | "kimi" | "minimax" => claude::find_claude_result(ndjson),
+        "opencode" => opencode::find_opencode_result(ndjson),
+        "codex" => codex::find_codex_result(ndjson),
+        _ => claude::find_claude_result(ndjson),
+    }
+}
+
 /// Parsed response from an agent, including metadata extracted from the
 /// agent-specific output envelope.
 #[derive(Debug, Clone)]
@@ -659,6 +689,113 @@ mod tests {
         assert_eq!(get_runner("opencode").name(), "opencode");
         // Unknown falls back to claude-compatible
         assert_eq!(get_runner("unknown-agent").name(), "unknown-agent");
+    }
+
+    // ── find_agent_result per-agent tests ──────────────────────
+
+    #[test]
+    fn find_agent_result_claude_success() {
+        let ndjson = concat!(
+            r#"{"type":"system","subtype":"init"}"#,
+            "\n",
+            r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":5000,"result":"{\"status\":\"done\",\"summary\":\"ok\"}","usage":{"input_tokens":100,"output_tokens":50}}"#,
+        );
+        let r = find_agent_result("claude", ndjson).unwrap();
+        assert!(!r.is_error);
+        assert!(r.result_text.contains("done"));
+        assert_eq!(r.input_tokens, Some(100));
+        assert_eq!(r.output_tokens, Some(50));
+    }
+
+    #[test]
+    fn find_agent_result_claude_auth_error() {
+        let ndjson = r#"{"type":"result","subtype":"error","is_error":true,"result":"credit balance too low","usage":{}}"#;
+        let r = find_agent_result("claude", ndjson).unwrap();
+        assert!(r.is_error);
+        assert!(r.result_text.contains("credit balance"));
+    }
+
+    #[test]
+    fn find_agent_result_kimi_uses_claude_extractor() {
+        let ndjson = r#"{"type":"result","subtype":"success","is_error":false,"result":"ok","usage":{"input_tokens":10,"output_tokens":5}}"#;
+        let r = find_agent_result("kimi", ndjson).unwrap();
+        assert!(!r.is_error);
+        assert_eq!(r.result_text, "ok");
+    }
+
+    #[test]
+    fn find_agent_result_minimax_uses_claude_extractor() {
+        let ndjson =
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"done","usage":{}}"#;
+        let r = find_agent_result("minimax", ndjson).unwrap();
+        assert!(!r.is_error);
+    }
+
+    #[test]
+    fn find_agent_result_opencode_success() {
+        let ndjson = concat!(
+            r#"{"type":"step_start","timestamp":1000}"#,
+            "\n",
+            r#"{"type":"text","timestamp":1001,"part":{"type":"text","text":"{\"status\":\"done\",\"summary\":\"fixed\"}}"}}"#,
+            "\n",
+            r#"{"type":"step_finish","timestamp":1002,"part":{"type":"step-finish","reason":"stop","tokens":{"input":200,"output":10}}}"#,
+        );
+        let r = find_agent_result("opencode", ndjson).unwrap();
+        assert!(!r.is_error);
+        assert!(r.result_text.contains("done"));
+        assert_eq!(r.input_tokens, Some(200));
+        assert_eq!(r.output_tokens, Some(10));
+    }
+
+    #[test]
+    fn find_agent_result_opencode_error() {
+        let ndjson = r#"{"type":"error","message":"rate limit exceeded for this model"}"#;
+        let r = find_agent_result("opencode", ndjson).unwrap();
+        assert!(r.is_error);
+        assert!(r.result_text.contains("rate limit"));
+    }
+
+    #[test]
+    fn find_agent_result_codex_success() {
+        let ndjson = concat!(
+            r#"{"type":"thread.started","thread_id":"t1"}"#,
+            "\n",
+            r#"{"type":"turn.started"}"#,
+            "\n",
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"{\"status\":\"done\",\"summary\":\"ok\"}}"}}"#,
+            "\n",
+            r#"{"type":"turn.completed"}"#,
+        );
+        let r = find_agent_result("codex", ndjson).unwrap();
+        assert!(!r.is_error);
+        assert!(r.result_text.contains("done"));
+    }
+
+    #[test]
+    fn find_agent_result_codex_rate_limit() {
+        let ndjson = concat!(
+            r#"{"type":"error","message":"You've hit your usage limit"}"#,
+            "\n",
+            r#"{"type":"turn.failed","error":{"message":"You've hit your usage limit"}}"#,
+        );
+        let r = find_agent_result("codex", ndjson).unwrap();
+        assert!(r.is_error);
+        assert!(r.result_text.contains("usage limit"));
+    }
+
+    #[test]
+    fn find_agent_result_empty_ndjson() {
+        assert!(find_agent_result("claude", "").is_none());
+        assert!(find_agent_result("opencode", "").is_none());
+        assert!(find_agent_result("codex", "").is_none());
+    }
+
+    #[test]
+    fn find_agent_result_unknown_agent_falls_back_to_claude() {
+        let ndjson = r#"{"type":"result","is_error":false,"result":"ok","usage":{}}"#;
+        let r = find_agent_result("some-new-agent", ndjson).unwrap();
+        assert!(!r.is_error);
+        assert_eq!(r.result_text, "ok");
     }
 
     #[test]

--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -116,6 +116,85 @@ fn extract_json_object(text: &str) -> Option<String> {
         .map(|_| candidate.to_string())
 }
 
+/// Find the final result from OpenCode NDJSON output.
+///
+/// Concatenates all `type:text` events, extracts tokens from `step_finish`,
+/// and checks for `type:error` events.
+pub fn find_opencode_result(ndjson: &str) -> Option<super::AgentResult> {
+    let events = parse_ndjson_events(ndjson.trim());
+    if events.is_empty() {
+        return None;
+    }
+
+    // Check for errors first
+    for event in &events {
+        let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if event_type == "error" {
+            let message = event
+                .get("message")
+                .and_then(|v| v.as_str())
+                .or_else(|| event.get("error").and_then(|v| v.as_str()))
+                .or_else(|| {
+                    event
+                        .get("error")
+                        .and_then(|e| e.get("data"))
+                        .and_then(|d| d.get("message"))
+                        .and_then(|m| m.as_str())
+                })
+                .unwrap_or("unknown error");
+            return Some(super::AgentResult {
+                is_error: true,
+                result_text: message.to_string(),
+                input_tokens: None,
+                output_tokens: None,
+            });
+        }
+        // Check step_finish for error reasons
+        if event_type == "step_finish" {
+            if let Some(part) = event.get("part") {
+                let reason = part.get("reason").and_then(|v| v.as_str()).unwrap_or("");
+                if reason == "error" || reason == "failed" {
+                    let msg = part
+                        .get("error")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("step failed");
+                    return Some(super::AgentResult {
+                        is_error: true,
+                        result_text: msg.to_string(),
+                        input_tokens: None,
+                        output_tokens: None,
+                    });
+                }
+            }
+        }
+    }
+
+    // Extract text from text events
+    let text = extract_ndjson_text(&events)?;
+
+    // Extract tokens from step_finish
+    let mut input_tokens = None;
+    let mut output_tokens = None;
+    for event in events.iter().rev() {
+        if event.get("type").and_then(|v| v.as_str()) == Some("step_finish") {
+            if let Some(part) = event.get("part") {
+                if let Some(tokens) = part.get("tokens").and_then(|v| v.as_object()) {
+                    input_tokens = tokens.get("input").and_then(|v| v.as_u64());
+                    output_tokens = tokens.get("output").and_then(|v| v.as_u64());
+                    break;
+                }
+            }
+        }
+    }
+
+    Some(super::AgentResult {
+        is_error: false,
+        result_text: text,
+        input_tokens,
+        output_tokens,
+    })
+}
+
 pub(crate) fn extract_router_text(raw: &str) -> Option<String> {
     let events = parse_ndjson_events(raw.trim());
     if events.is_empty() {

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -317,26 +317,35 @@ pub struct ReviewIssue {
 /// This is the primary entry point for review response parsing. It handles:
 /// 1. Direct JSON (`ReviewResponse` object)
 /// 2. Markdown with ` ```json ` code blocks containing a `ReviewResponse`
-/// 3. NDJSON streams (opencode `run --format json` output) — extracts text
-///    from `type:"text"` events and then applies steps 1 & 2
-///
-/// Use this in the review pipeline instead of `parse_review_response` so that
-/// raw opencode NDJSON output is handled even when the normal agent-envelope
-/// parsing chain fails (e.g. format change, empty summary).
+/// 3. Per-agent NDJSON extraction (agent-aware result event parsing)
+/// 4. Generic NDJSON fallback (legacy monolithic extraction)
+/// 5. Heuristic fallback for plain-text decisions
 pub fn parse_review_from_output(output: &str) -> anyhow::Result<ReviewResponse> {
     // Step 1: direct JSON / markdown parse
     if let Ok(r) = parse_review_response(output) {
         return Ok(r);
     }
 
-    // Step 2: NDJSON — extract text events and parse the concatenated text
+    // Step 2: per-agent NDJSON extraction — tries each known agent format
+    let agent_names = ["claude", "opencode", "codex"];
+    for agent in &agent_names {
+        if let Some(result) = super::agents::find_agent_result(agent, output) {
+            if !result.is_error && !result.result_text.is_empty() {
+                if let Ok(r) = parse_review_response(&result.result_text) {
+                    return Ok(r);
+                }
+            }
+        }
+    }
+
+    // Step 3: generic NDJSON fallback (legacy extraction for backwards compat)
     let extracted = ndjson_extract_text(output);
     if !extracted.is_empty() {
         return parse_review_response(&extracted)
             .map_err(|e| anyhow::anyhow!("parse failed after NDJSON extraction: {e}"));
     }
 
-    // Step 3: heuristic fallback for plain-text decisions
+    // Step 4: heuristic fallback for plain-text decisions
     if let Some(resp) = infer_review_response_from_text(output) {
         tracing::warn!(
             output_len = output.len(),
@@ -350,13 +359,28 @@ pub fn parse_review_from_output(output: &str) -> anyhow::Result<ReviewResponse> 
 
 /// Extract the concatenated text content from an NDJSON event stream.
 ///
-/// Handles text event formats from all agents:
-/// - opencode Format 1: `{"type":"text","part":{"type":"text","text":"..."}}`
-/// - opencode Format 2: `{"type":"text","text":"..."}`
-/// - codex Format:      `{"type":"item.completed","item":{"type":"agent_message","text":"..."}}`
-/// - claude stream-json: `{"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}}`
-/// - claude result:      `{"type":"result","result":"..."}`
+/// Delegates to per-agent extractors for agent-specific NDJSON formats,
+/// then falls back to the generic monolithic parser for unknown formats.
 fn ndjson_extract_text(ndjson: &str) -> String {
+    // Try per-agent extractors in priority order.
+    // Each returns Some(AgentResult) if it finds a recognizable result event.
+    let agent_names = ["claude", "opencode", "codex"];
+    for agent in &agent_names {
+        if let Some(result) = super::agents::find_agent_result(agent, ndjson) {
+            if !result.is_error && !result.result_text.is_empty() {
+                return result.result_text;
+            }
+        }
+    }
+
+    // Fallback: legacy monolithic extraction for backwards compatibility.
+    ndjson_extract_text_legacy(ndjson)
+}
+
+/// Legacy monolithic NDJSON text extraction (fallback).
+///
+/// Handles text event formats from all agents in a single pass.
+fn ndjson_extract_text_legacy(ndjson: &str) -> String {
     let texts: Vec<String> = ndjson
         .lines()
         .filter(|l| !l.trim().is_empty())
@@ -926,5 +950,112 @@ That's all."#;
         let extracted = ndjson_extract_text(ndjson);
         assert_eq!(extracted, "actual output");
         assert!(!extracted.contains("internal thoughts"));
+    }
+
+    // ── Per-agent review fixture tests ─────────────────────────
+
+    /// Claude NDJSON stream — review approve via fixture.
+    #[test]
+    fn parse_review_from_output_claude_review_approve() {
+        let raw = include_str!("../../../tests/fixtures/claude_review_approve.jsonl");
+        let resp = parse_review_from_output(raw).unwrap();
+        assert_eq!(resp.decision, "approve");
+        assert!(resp.notes.contains("All checks pass"));
+        assert_eq!(resp.test_results.as_deref(), Some("pass"));
+        assert!(resp.issues.is_empty());
+    }
+
+    /// Claude NDJSON stream — review request_changes via fixture.
+    #[test]
+    fn parse_review_from_output_claude_review_request_changes() {
+        let raw = include_str!("../../../tests/fixtures/claude_review_request_changes.jsonl");
+        let resp = parse_review_from_output(raw).unwrap();
+        assert_eq!(resp.decision, "request_changes");
+        assert_eq!(resp.issues.len(), 1);
+        assert_eq!(resp.issues[0].file, "src/main.rs");
+        assert_eq!(resp.issues[0].severity, "error");
+    }
+
+    /// Claude NDJSON stream — auth error must NOT parse as review.
+    #[test]
+    fn parse_review_from_output_claude_review_auth_error() {
+        let raw = include_str!("../../../tests/fixtures/claude_review_auth_error.jsonl");
+        let result = parse_review_from_output(raw);
+        // Auth error NDJSON should fail to produce a valid review response
+        // because the result is an error envelope, not a review decision.
+        assert!(result.is_err());
+    }
+
+    /// Claude NDJSON stream — rate limit must NOT parse as review.
+    #[test]
+    fn parse_review_from_output_claude_review_rate_limit() {
+        let raw = include_str!("../../../tests/fixtures/claude_review_rate_limit.jsonl");
+        let result = parse_review_from_output(raw);
+        assert!(result.is_err());
+    }
+
+    /// OpenCode NDJSON stream — review approve via fixture.
+    #[test]
+    fn parse_review_from_output_opencode_review_approve() {
+        let raw = include_str!("../../../tests/fixtures/opencode_review_approve.jsonl");
+        let resp = parse_review_from_output(raw).unwrap();
+        assert_eq!(resp.decision, "approve");
+        assert!(resp.notes.contains("solid"));
+        assert_eq!(resp.test_results.as_deref(), Some("pass"));
+    }
+
+    /// OpenCode NDJSON stream — review request_changes via fixture.
+    #[test]
+    fn parse_review_from_output_opencode_review_request_changes() {
+        let raw = include_str!("../../../tests/fixtures/opencode_review_request_changes.jsonl");
+        let resp = parse_review_from_output(raw).unwrap();
+        assert_eq!(resp.decision, "request_changes");
+        assert_eq!(resp.issues.len(), 1);
+        assert_eq!(resp.issues[0].file, "src/api.rs");
+    }
+
+    /// OpenCode NDJSON — rate limit error must NOT parse as review.
+    #[test]
+    fn parse_review_from_output_opencode_review_rate_limit() {
+        let raw = include_str!("../../../tests/fixtures/opencode_review_rate_limit.jsonl");
+        let result = parse_review_from_output(raw);
+        assert!(result.is_err());
+    }
+
+    /// Codex NDJSON stream — review approve via fixture.
+    #[test]
+    fn parse_review_from_output_codex_review_approve() {
+        let raw = include_str!("../../../tests/fixtures/codex_review_approve.jsonl");
+        let resp = parse_review_from_output(raw).unwrap();
+        assert_eq!(resp.decision, "approve");
+        assert!(resp.notes.contains("Clean implementation"));
+        assert_eq!(resp.test_results.as_deref(), Some("pass"));
+    }
+
+    /// Codex NDJSON stream — review request_changes via fixture.
+    #[test]
+    fn parse_review_from_output_codex_review_request_changes() {
+        let raw = include_str!("../../../tests/fixtures/codex_review_request_changes.jsonl");
+        let resp = parse_review_from_output(raw).unwrap();
+        assert_eq!(resp.decision, "request_changes");
+        assert_eq!(resp.issues.len(), 1);
+        assert_eq!(resp.issues[0].file, "src/handler.rs");
+        assert_eq!(resp.issues[0].severity, "error");
+    }
+
+    /// Codex NDJSON — rate limit error must NOT parse as review.
+    #[test]
+    fn parse_review_from_output_codex_review_rate_limit() {
+        let raw = include_str!("../../../tests/fixtures/codex_review_rate_limit.jsonl");
+        let result = parse_review_from_output(raw);
+        assert!(result.is_err());
+    }
+
+    /// Codex NDJSON — empty output (no agent_message) must fail.
+    #[test]
+    fn parse_review_from_output_codex_review_empty() {
+        let raw = include_str!("../../../tests/fixtures/codex_review_empty.jsonl");
+        let result = parse_review_from_output(raw);
+        assert!(result.is_err());
     }
 }

--- a/tests/fixtures/claude_review_approve.jsonl
+++ b/tests/fixtures/claude_review_approve.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","apiKeySource":"environment","cwd":"/tmp/work","model":"claude-sonnet-4-6","permissionMode":"bypassPermissions"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I'll review this PR now."}]}}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":30000,"result":"```json\n{\"decision\":\"approve\",\"notes\":\"All checks pass. Code is well-structured and tests are comprehensive.\",\"test_results\":\"pass\",\"issues\":[]}\n```","usage":{"input_tokens":12000,"output_tokens":2500},"modelUsage":{"claude-sonnet-4-6":{"inputTokens":12000,"outputTokens":2500}},"permission_denials":[]}

--- a/tests/fixtures/claude_review_auth_error.jsonl
+++ b/tests/fixtures/claude_review_auth_error.jsonl
@@ -1,0 +1,2 @@
+{"type":"system","subtype":"init","apiKeySource":"environment","cwd":"/tmp/work","model":"claude-sonnet-4-6","permissionMode":"bypassPermissions"}
+{"type":"result","subtype":"error","is_error":true,"duration_ms":500,"result":"credit balance too low","usage":{},"permission_denials":[]}

--- a/tests/fixtures/claude_review_rate_limit.jsonl
+++ b/tests/fixtures/claude_review_rate_limit.jsonl
@@ -1,0 +1,2 @@
+{"type":"system","subtype":"init","apiKeySource":"environment","cwd":"/tmp/work","model":"claude-sonnet-4-6","permissionMode":"bypassPermissions"}
+{"type":"result","subtype":"error","is_error":true,"duration_ms":1000,"result":"Error: 429 Too Many Requests - rate limit exceeded.","usage":{},"permission_denials":[]}

--- a/tests/fixtures/claude_review_request_changes.jsonl
+++ b/tests/fixtures/claude_review_request_changes.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","apiKeySource":"environment","cwd":"/tmp/work","model":"claude-sonnet-4-6","permissionMode":"bypassPermissions"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Reviewing the changes."}]}}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":25000,"result":"```json\n{\"decision\":\"request_changes\",\"notes\":\"Found issues that need fixing before merge.\",\"test_results\":\"fail\",\"issues\":[{\"file\":\"src/main.rs\",\"line\":42,\"severity\":\"error\",\"description\":\"Potential null pointer dereference\"}]}\n```","usage":{"input_tokens":10000,"output_tokens":3000},"permission_denials":[]}

--- a/tests/fixtures/codex_review_approve.jsonl
+++ b/tests/fixtures/codex_review_approve.jsonl
@@ -1,0 +1,5 @@
+{"type":"thread.started","thread_id":"thread_review_1"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"type":"reasoning","text":"I need to review the code changes carefully."}}
+{"type":"item.completed","item":{"type":"agent_message","text":"```json\n{\"decision\":\"approve\",\"notes\":\"Clean implementation with good test coverage.\",\"test_results\":\"pass\",\"issues\":[]}\n```"}}
+{"type":"turn.completed"}

--- a/tests/fixtures/codex_review_empty.jsonl
+++ b/tests/fixtures/codex_review_empty.jsonl
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"thread_review_empty"}
+{"type":"turn.started"}
+{"type":"turn.completed"}

--- a/tests/fixtures/codex_review_rate_limit.jsonl
+++ b/tests/fixtures/codex_review_rate_limit.jsonl
@@ -1,0 +1,2 @@
+{"type":"error","message":"You've hit your usage limit for this billing period"}
+{"type":"turn.failed","error":{"message":"You've hit your usage limit"}}

--- a/tests/fixtures/codex_review_request_changes.jsonl
+++ b/tests/fixtures/codex_review_request_changes.jsonl
@@ -1,0 +1,5 @@
+{"type":"thread.started","thread_id":"thread_review_2"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"type":"reasoning","text":"Let me check each file for potential issues."}}
+{"type":"item.completed","item":{"type":"agent_message","text":"```json\n{\"decision\":\"request_changes\",\"notes\":\"Race condition detected in the concurrent handler.\",\"test_results\":\"fail\",\"issues\":[{\"file\":\"src/handler.rs\",\"line\":155,\"severity\":\"error\",\"description\":\"Unprotected shared state access\"}]}\n```"}}
+{"type":"turn.completed"}

--- a/tests/fixtures/opencode_review_approve.jsonl
+++ b/tests/fixtures/opencode_review_approve.jsonl
@@ -1,0 +1,4 @@
+{"type":"step_start","timestamp":1706300000,"part":{"type":"step-start","snapshot":"Starting review..."}}
+{"type":"text","timestamp":1706300001,"part":{"type":"text","text":"Reviewing the PR changes..."}}
+{"type":"text","timestamp":1706300002,"part":{"type":"text","text":"```json\n{\"decision\":\"approve\",\"notes\":\"Implementation looks solid. Tests pass.\",\"test_results\":\"pass\",\"issues\":[]}\n```"}}
+{"type":"step_finish","timestamp":1706300010,"part":{"type":"step-finish","reason":"stop","cost":0.012,"tokens":{"total":14000,"input":13500,"output":500}}}

--- a/tests/fixtures/opencode_review_rate_limit.jsonl
+++ b/tests/fixtures/opencode_review_rate_limit.jsonl
@@ -1,0 +1,2 @@
+{"type":"step_start","timestamp":1706300000,"part":{"type":"step-start"}}
+{"type":"error","timestamp":1706300001,"message":"rate limit exceeded for this model"}

--- a/tests/fixtures/opencode_review_request_changes.jsonl
+++ b/tests/fixtures/opencode_review_request_changes.jsonl
@@ -1,0 +1,4 @@
+{"type":"step_start","timestamp":1706300000,"part":{"type":"step-start","snapshot":"Starting review..."}}
+{"type":"text","timestamp":1706300001,"part":{"type":"text","text":"Checking the diff carefully..."}}
+{"type":"text","timestamp":1706300002,"part":{"type":"text","text":"```json\n{\"decision\":\"request_changes\",\"notes\":\"Error handling is incomplete in the new function.\",\"test_results\":\"fail\",\"issues\":[{\"file\":\"src/api.rs\",\"line\":88,\"severity\":\"error\",\"description\":\"Missing error propagation for network call\"}]}\n```"}}
+{"type":"step_finish","timestamp":1706300010,"part":{"type":"step-finish","reason":"stop","cost":0.015,"tokens":{"total":15000,"input":14500,"output":500}}}


### PR DESCRIPTION
## Summary

Added per-agent review parsing with AgentResult extractors, replacing the monolithic NDJSON fallback with agent-aware parsing.

### What was done

- Added AgentResult struct and find_agent_result() dispatcher in agents/mod.rs
- Added find_claude_result() for claude/kimi/minimax (type:result envelope extraction)
- Added find_opencode_result() for opencode (type:text + step_finish events with error detection)
- Added find_codex_result() for codex (item.completed agent_message events with error detection)
- Updated parse_review_from_output() to try per-agent extraction before generic fallback
- Preserved legacy monolithic ndjson_extract_text as backwards-compat fallback
- Created 11 per-agent review fixtures (approve, request_changes, auth error, rate limit, empty)
- Added 21 new tests covering all agent formats, error cases, and edge cases
- All 947 tests pass, fmt and clippy clean


### Remaining

- Phase 3 from plan: apply same per-agent extractors to task response parsing (parse_success_output in runner/mod.rs)
- Phase 6 from plan: per-agent NDJSON rendering in orch stream


Closes #979

---
*Task #979 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2-pro-free`*