### PR TITLE
bug: push-retry path sets status to "routed" but runner maps this to NeedsReview — task never re-routed

### DIFF
--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -302,14 +302,14 @@ pub async fn handle_success(
                 "push failed {push_failures} times — blocking for human intervention"
             );
             "blocked"
-        } else {
-            tracing::warn!(
-                task_id,
-                push_failures,
-                "agent done but push failed ({push_failures}/3) — rerouting to different agent"
-            );
-            "routed"
-        }
+            } else {
+                tracing::warn!(
+                    task_id,
+                    push_failures,
+                    "agent done but push failed ({push_failures}/3) — rerouting to different agent"
+                );
+                "new"
+            }
     } else if resp.status == "done" && has_pr {
         "needs_review"
     } else if resp.status == "done" && !has_pr && has_delegations {


### PR DESCRIPTION
## Summary

Fixed push-retry path bug where failed pushes incorrectly set task status to 'routed' (mapping to NeedsReview) instead of 'new' (allowing re-routing)

### What was done

- Changed status return value from 'routed' to 'new' in src/engine/runner/response_handler.rs for push failure scenarios requiring re-routing
- Verified the fix with local test suite (all tests passed)
- Committed the fix to the feature branch


Closes #981

---
*Task #981 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/nemotron-3-super-free`*