### PR TITLE
bug: push-retry path sets status to "routed" but runner maps this to NeedsReview — task never re-routed

### DIFF
--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -308,7 +308,7 @@ pub async fn handle_success(
                 push_failures,
                 "agent done but push failed ({push_failures}/3) — rerouting to different agent"
             );
-            "routed"
+            "new"
         }
     } else if resp.status == "done" && has_pr {
         "needs_review"


### PR DESCRIPTION
## Summary

Fixed the push-retry status bug by changing the return value from 'routed' to 'new' in response_handler.rs line 311

### What was done

- Changed status string from 'routed' to 'new' in handle_success for push-retry path
- This fixes the bug where push failures (1-2/3) incorrectly set task status to NeedsReview instead of re-routing


Closes #981

---
*Task #981 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*