### PR TITLE
bug: required_checks_state treats completed check run with null conclusion as failing — blocks auto-merge

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -62,7 +62,7 @@ fn required_checks_state(
 
         if let Some((status, conclusion)) = check_run_match {
             matched = true;
-            if status != "completed" {
+            if status != "completed" || conclusion.is_none() {
                 pending += 1;
             } else if matches!(conclusion, Some("success" | "neutral" | "skipped")) {
                 passing += 1;


### PR DESCRIPTION
## Summary

Fixed required_checks_state to treat a completed check run with null conclusion as pending rather than failing

### What was done

- Changed condition in src/engine/auto_merge.rs:65 from `status != "completed"` to `status != "completed" || conclusion.is_none()`, so a completed check with no conclusion increments pending instead of failing
- All 926 tests pass (cargo fmt, clippy, nextest)


Closes #990

---
*Task #990 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*