### PR TITLE
bug: review_poll.rs never increments review_cycles — max_review_cycles guard bypassed for human CHANGES_REQUESTED reviews

### DIFF
--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -5,7 +5,7 @@
 //! are requested.
 
 use crate::backends::{ExternalBackend, Status};
-use crate::engine::auto_merge::{dedup_reviews, MAX_MERGE_CONFLICT_RETRIES};
+use crate::engine::auto_merge::{dedup_reviews, handle_review_changes, MAX_MERGE_CONFLICT_RETRIES};
 use crate::engine::tasks::TaskManager;
 use crate::engine::EngineConfig;
 use crate::github::http::GhHttp;
@@ -432,29 +432,42 @@ pub(crate) async fn review_open_prs(
                 repo,
                 task_id,
                 &[(
-                    "pr_review_context",
-                    serde_json::json!(review_context.clone()),
-                )],
-            )
-            .await;
-
-            store_set(
-                &Some(Arc::clone(store)),
-                repo,
-                task_id,
-                &[(
                     "last_review_ts",
                     serde_json::json!(latest_review_ts.clone()),
                 )],
             )
             .await;
 
-            if let Err(e) = task_manager
-                .update_task_status(&task.id, Status::Routed)
-                .await
+            let task_agent = stored_task
+                .agent
+                .clone()
+                .unwrap_or_else(|| "orch".to_string());
+            let task_model = stored_task
+                .model
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string());
+            let review_cycles = stored_task.review_cycles.max(0) as u32;
+            let max_cycles: u32 = crate::config::get("workflow.max_review_cycles")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(2);
+
+            if let Err(e) = handle_review_changes(
+                &task,
+                &review_context,
+                &[],
+                backend,
+                repo,
+                pr_number,
+                &task_agent,
+                &task_model,
+                task_manager,
+                store,
+            )
+            .await
             {
-                tracing::warn!(task_id, err = %e, "failed to set status to routed for re-dispatch");
-            } else {
+                tracing::warn!(task_id, err = %e, "failed to handle review feedback");
+            } else if review_cycles < max_cycles {
                 tracing::info!(task_id, "re-dispatching task to address review feedback");
                 store_reset_failure_counters(&Some(Arc::clone(store)), repo, task_id).await;
             }


### PR DESCRIPTION
## Summary

Fixed review polling so human CHANGES_REQUESTED reviews now go through the shared review-change flow and respect the review-cycle cap.

### What was done

- Updated `src/engine/review_poll.rs` to call `handle_review_changes` instead of directly routing the task.
- Preserved review context/timestamp handling while reusing the existing max-cycle enforcement path.
- Verified formatting, clippy, and the full test suite pass.
- Committed the fix as `1a05629` (`fix: enforce review cycle cap in review poll`).


Closes #998

---
*Task #998 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4-mini`*