### PR TITLE
bug: ensure_pr_exists returns Skipped instead of Ready when PR already exists — automated review never runs

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -232,7 +232,7 @@ async fn ensure_pr_exists(
                                     &[("pr_number", serde_json::json!(n as i64))],
                                 )
                                 .await;
-                                return Ok(EnsurePrResult::EarlyReturn(ReviewDecision::Skipped));
+                                return Ok(EnsurePrResult::Ready(n));
                             }
                         }
                         tracing::warn!(
@@ -293,28 +293,26 @@ async fn ensure_pr_exists(
                                         stderr.lines().find(|l| l.trim().starts_with("https://"))
                                     {
                                         let pr_url = pr_url.trim();
-                                        if let Some(pr_num) = pr_url
+                                        let pr_num = pr_url
                                             .rsplit('/')
                                             .next()
-                                            .and_then(|n| n.parse::<i64>().ok())
-                                        {
+                                            .and_then(|n| n.parse::<u64>().ok());
+                                        if let Some(pr_num) = pr_num {
                                             store_set(
                                                 &Some(Arc::clone(store)),
                                                 repo,
                                                 &task.id.0,
-                                                &[("pr_number", serde_json::json!(pr_num))],
+                                                &[("pr_number", serde_json::json!(pr_num as i64))],
                                             )
                                             .await;
+                                            tracing::info!(
+                                                task_id = task.id.0,
+                                                branch = %branch_name,
+                                                pr_url = %pr_url,
+                                                "PR already exists (from CLI stderr) — retrying review"
+                                            );
+                                            return Ok(EnsurePrResult::Ready(pr_num));
                                         }
-                                        tracing::info!(
-                                            task_id = task.id.0,
-                                            branch = %branch_name,
-                                            pr_url = %pr_url,
-                                            "PR already exists (from CLI stderr) — retrying review"
-                                        );
-                                        return Ok(EnsurePrResult::EarlyReturn(
-                                            ReviewDecision::Skipped,
-                                        ));
                                     }
                                 }
                                 tracing::error!(


### PR DESCRIPTION
## Summary

Fixed PR recovery in `src/engine/review.rs` so existing PRs now continue into automated review instead of short-circuiting as skipped.

### What was done

- Changed the 422/already-exists recovery path to return `EnsurePrResult::Ready(n)` after persisting the PR number
- Changed the CLI stderr fallback path to return `EnsurePrResult::Ready(pr_num)` when it extracts an existing PR URL
- Validated the change with `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run`
- Committed the fix in `d55ce8c fix(review): return ready when PR exists`


Closes #1000

---
*Task #1000 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4-mini`*