### PR TITLE
Code review

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -1582,10 +1582,15 @@ impl GhHttp {
                 .unwrap_or("queued");
 
             match status {
-                "completed" => match conclusion {
-                    "success" | "neutral" | "skipped" => passing += 1,
-                    _ => failing += 1,
-                },
+                "completed" => {
+                    if conclusion.is_empty() {
+                        pending += 1;
+                    } else if matches!(conclusion, "success" | "neutral" | "skipped") {
+                        passing += 1;
+                    } else {
+                        failing += 1;
+                    }
+                }
                 _ => pending += 1,
             }
         }


### PR DESCRIPTION
## Summary

Reviewed the CI status handling path and filed one bug for a merge-race in auto-merge.

### What was done

- Confirmed the recent fix in `src/github/http.rs` and traced its impact into `src/engine/auto_merge.rs`
- Filed GitHub issue #1010 for the CI-success race when no check data is present yet
- Verified the branch already contains the local commit `b377572`


### Remaining

- Decide whether the CI wait loop should distinguish 'no checks configured' from 'no checks observed yet'


---
*Task internal-13509 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4-mini`*