### PR TITLE
bug: split review parsing by agent format instead of relying on generic NDJSON fallback

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -817,21 +817,13 @@ pub(crate) async fn review_and_merge(
     }
 
     // Stage 1: strip the agent-specific output envelope to get the review text.
-    let text_for_review = match agent_runner.parse_response(&raw_output) {
-        Ok(p) if !p.response.summary.is_empty() => p.response.summary,
+    let text_for_review = match agent_runner.extract_text(&raw_output) {
+        Ok(text) if !text.is_empty() => text,
         Ok(_) => {
             tracing::debug!(
                 task_id = task.id.0,
                 agent = %review_agent,
-                "review agent: empty summary after parse, falling back to raw output"
-            );
-            raw_output.clone()
-        }
-        Err(runner::agents::AgentError::InvalidResponse { .. }) => {
-            tracing::warn!(
-                task_id = task.id.0,
-                agent = %review_agent,
-                "review agent: envelope parse failed (InvalidResponse), falling back to raw output"
+                "review agent: empty text after envelope extraction, falling back to raw output"
             );
             raw_output.clone()
         }

--- a/src/engine/runner/agents/claude.rs
+++ b/src/engine/runner/agents/claude.rs
@@ -212,6 +212,56 @@ impl AgentRunner for ClaudeRunner {
         &self.binary
     }
 
+    fn extract_text(&self, raw: &str) -> Result<String, super::AgentError> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Ok(String::new());
+        }
+
+        // For NDJSON (stream-json format): find the final "type":"result" line.
+        let envelope_str = find_ndjson_result_line(trimmed).unwrap_or(trimmed);
+        let Ok(parsed_json) = serde_json::from_str::<serde_json::Value>(envelope_str) else {
+            // Not a recognizable JSON envelope — return raw text as-is.
+            return Ok(trimmed.to_string());
+        };
+
+        let Some(envelope) = parsed_json.as_object() else {
+            return Ok(trimmed.to_string());
+        };
+
+        if envelope.get("type").and_then(|v| v.as_str()) != Some("result") {
+            return Ok(trimmed.to_string());
+        }
+
+        let is_error = envelope
+            .get("is_error")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let result_text = envelope
+            .get("result")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        if is_error {
+            let combined = format!("{result_text} {envelope_str}");
+            if let Some(e) = super::patterns::detect_auth_error(&combined) {
+                return Err(e);
+            }
+            if let Some(e) = super::patterns::detect_rate_limit(&combined) {
+                return Err(e);
+            }
+            if let Some(e) = super::patterns::detect_context_overflow(&combined) {
+                return Err(e);
+            }
+            return Err(super::AgentError::AgentFailed {
+                message: result_text.to_string(),
+            });
+        }
+
+        Ok(result_text.to_string())
+    }
+
     fn build_command(
         &self,
         model: Option<&str>,
@@ -893,5 +943,80 @@ mod tests {
             matches!(err, AgentError::ContextOverflow { .. }),
             "got: {err:?}"
         );
+    }
+
+    // ── extract_text ─────────────────────────────────────────────
+
+    /// Claude stream-json: extract_text returns the inner result text for review parsing.
+    #[test]
+    fn extract_text_stream_json_returns_result_field() {
+        let raw = concat!(
+            r#"{"type":"system","subtype":"init","session_id":"s1"}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Reviewing..."}]}}"#,
+            "\n",
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"{\"decision\":\"approve\",\"notes\":\"LGTM\",\"test_results\":\"pass\",\"issues\":[]}","usage":{"input_tokens":100,"output_tokens":20}}"#,
+        );
+        let text = runner().extract_text(raw).unwrap();
+        assert_eq!(
+            text,
+            r#"{"decision":"approve","notes":"LGTM","test_results":"pass","issues":[]}"#
+        );
+    }
+
+    /// Claude stream-json with markdown-wrapped ReviewResponse in result field.
+    #[test]
+    fn extract_text_stream_json_markdown_result() {
+        let review_json =
+            r#"```json\n{"decision":"request_changes","notes":"Fix it","issues":[]}\n```"#;
+        let result_line = format!(
+            r#"{{"type":"result","subtype":"success","is_error":false,"result":"{review_json}","usage":{{"input_tokens":10,"output_tokens":5}}}}"#
+        );
+        let raw = format!(
+            "{}\n{}",
+            r#"{"type":"system","subtype":"init","session_id":"s1"}"#, result_line
+        );
+        let text = runner().extract_text(&raw).unwrap();
+        assert!(
+            text.contains("request_changes"),
+            "expected review JSON in result, got: {text}"
+        );
+    }
+
+    /// Claude stream-json error (is_error=true, rate limit): extract_text propagates RateLimit.
+    #[test]
+    fn extract_text_stream_json_rate_limit_propagates() {
+        let raw = concat!(
+            r#"{"type":"system","subtype":"init","session_id":"s1"}"#,
+            "\n",
+            r#"{"type":"result","subtype":"error","is_error":true,"result":"rate limit exceeded: 429 Too Many Requests","usage":{"input_tokens":0,"output_tokens":0}}"#,
+        );
+        let err = runner().extract_text(raw).unwrap_err();
+        assert!(
+            matches!(err, AgentError::RateLimit { .. }),
+            "expected RateLimit, got: {err:?}"
+        );
+    }
+
+    /// Claude stream-json error (is_error=true, auth): extract_text propagates Auth.
+    #[test]
+    fn extract_text_stream_json_auth_error_propagates() {
+        let raw = concat!(
+            r#"{"type":"system","subtype":"init","session_id":"s1"}"#,
+            "\n",
+            r#"{"type":"result","subtype":"error","is_error":true,"result":"401 Unauthorized: invalid api key","usage":{"input_tokens":0,"output_tokens":0}}"#,
+        );
+        let err = runner().extract_text(raw).unwrap_err();
+        assert!(
+            matches!(err, AgentError::Auth { .. }),
+            "expected Auth, got: {err:?}"
+        );
+    }
+
+    /// extract_text on empty input returns empty string (not an error).
+    #[test]
+    fn extract_text_empty_input_returns_empty_ok() {
+        let text = runner().extract_text("").unwrap();
+        assert!(text.is_empty());
     }
 }

--- a/src/engine/runner/agents/codex.rs
+++ b/src/engine/runner/agents/codex.rs
@@ -230,6 +230,29 @@ impl AgentRunner for CodexRunner {
         "codex"
     }
 
+    fn extract_text(&self, raw: &str) -> Result<String, AgentError> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Ok(String::new());
+        }
+
+        let events = self.parse_ndjson(trimmed);
+        if events.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+
+        // Propagate terminal errors (rate limit, auth) so the review pipeline
+        // can record cooldowns and abort cleanly.
+        if let Some(err) = self.detect_error(&events) {
+            return Err(err);
+        }
+
+        // Return agent_message text, or fall back to the raw output.
+        Ok(self
+            .extract_agent_text(&events)
+            .unwrap_or_else(|| trimmed.to_string()))
+    }
+
     fn build_command(
         &self,
         model: Option<&str>,
@@ -605,5 +628,69 @@ mod tests {
         if let AgentError::ModelUnavailable { model, .. } = &err {
             assert_eq!(model, "gpt-4.1");
         }
+    }
+
+    // ── extract_text ─────────────────────────────────────────────
+
+    /// Codex: extract_text returns the agent_message text for review parsing.
+    #[test]
+    fn extract_text_returns_agent_message() {
+        let raw = concat!(
+            r#"{"type":"thread.started","thread_id":"t1"}"#,
+            "\n",
+            r#"{"type":"turn.started"}"#,
+            "\n",
+            r#"{"type":"item.completed","item":{"type":"reasoning","text":"Thinking..."}}"#,
+            "\n",
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"{\"decision\":\"approve\",\"notes\":\"LGTM\",\"test_results\":\"pass\",\"issues\":[]}"}}"#,
+            "\n",
+            r#"{"type":"turn.completed"}"#,
+        );
+        let text = runner().extract_text(raw).unwrap();
+        assert_eq!(
+            text,
+            r#"{"decision":"approve","notes":"LGTM","test_results":"pass","issues":[]}"#
+        );
+    }
+
+    /// Codex: extract_text propagates RateLimit for terminal errors.
+    #[test]
+    fn extract_text_rate_limit_propagates() {
+        let raw = concat!(
+            r#"{"type":"thread.started","thread_id":"t1"}"#,
+            "\n",
+            r#"{"type":"error","message":"You've hit your usage limit. Upgrade to continue."}"#,
+            "\n",
+            r#"{"type":"turn.failed","error":{"message":"usage limit exceeded"}}"#,
+        );
+        let err = runner().extract_text(raw).unwrap_err();
+        assert!(
+            matches!(err, AgentError::RateLimit { .. }),
+            "expected RateLimit, got: {err:?}"
+        );
+    }
+
+    /// Codex: extract_text propagates Auth error.
+    #[test]
+    fn extract_text_auth_error_propagates() {
+        let raw = concat!(
+            r#"{"type":"thread.started","thread_id":"t1"}"#,
+            "\n",
+            r#"{"type":"error","message":"401 Unauthorized: invalid api key"}"#,
+            "\n",
+            r#"{"type":"turn.failed","error":{"message":"auth failed"}}"#,
+        );
+        let err = runner().extract_text(raw).unwrap_err();
+        assert!(
+            matches!(err, AgentError::Auth { .. }),
+            "expected Auth, got: {err:?}"
+        );
+    }
+
+    /// Codex: extract_text on empty input returns empty string (not an error).
+    #[test]
+    fn extract_text_empty_input_returns_empty_ok() {
+        let text = runner().extract_text("").unwrap();
+        assert!(text.is_empty());
     }
 }

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -299,6 +299,24 @@ pub trait AgentRunner: Send + Sync {
     /// output indicates an error or cannot be parsed.
     fn parse_response(&self, raw: &str) -> Result<ParsedResponse, AgentError>;
 
+    /// Extract the raw inner text from an agent output envelope, without
+    /// attempting to parse it as an `AgentResponse`.
+    ///
+    /// Use this in the review pipeline so that a `ReviewResponse` JSON can be
+    /// recovered even when the text doesn't match the task `AgentResponse` schema.
+    ///
+    /// - For Claude/Kimi/MiniMax: strips the `--output-format stream-json` NDJSON
+    ///   wrapper and returns the `"result"` field of the final `"type":"result"` line.
+    /// - For Codex: returns the text of the last `agent_message` item.
+    /// - For OpenCode: concatenates all `text` events.
+    /// - Default: returns `raw` unchanged (safe fallback for unknown agents).
+    ///
+    /// Returns `Err(AgentError)` only for terminal errors (rate limit, auth, etc.)
+    /// that should abort the review pipeline entirely.
+    fn extract_text(&self, raw: &str) -> Result<String, AgentError> {
+        Ok(raw.to_string())
+    }
+
     /// Classify an error from exit code + stdout + stderr into an AgentError.
     ///
     /// Called when the agent process exits with a non-zero code, or when

--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -146,7 +146,7 @@ impl OpenCodeRunner {
     /// Handles two text event formats emitted by different opencode versions:
     /// - Format 1 (current): `{"type":"text","part":{"type":"text","text":"..."}}`
     /// - Format 2 (newer):   `{"type":"text","text":"..."}`
-    fn extract_text(&self, events: &[serde_json::Value]) -> Option<String> {
+    fn extract_text_from_events(&self, events: &[serde_json::Value]) -> Option<String> {
         extract_ndjson_text(events)
     }
 
@@ -248,6 +248,26 @@ impl AgentRunner for OpenCodeRunner {
         "opencode"
     }
 
+    fn extract_text(&self, raw: &str) -> Result<String, AgentError> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Ok(String::new());
+        }
+
+        let events = self.parse_ndjson(trimmed);
+        if events.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+
+        // Propagate terminal errors so the review pipeline records cooldowns.
+        if let Some(err) = self.detect_error(&events) {
+            return Err(err);
+        }
+
+        // Concatenate all text events; fall back to raw output if none found.
+        Ok(extract_ndjson_text(&events).unwrap_or_else(|| trimmed.to_string()))
+    }
+
     fn build_command(
         &self,
         model: Option<&str>,
@@ -328,11 +348,11 @@ printf '%s\n' '{permission_json}' > .orch-opencode/opencode/opencode.json || {{ 
         }
 
         // Extract text
-        let text = self
-            .extract_text(&events)
-            .ok_or_else(|| AgentError::InvalidResponse {
-                raw: trimmed.to_string(),
-            })?;
+        let text =
+            self.extract_text_from_events(&events)
+                .ok_or_else(|| AgentError::InvalidResponse {
+                    raw: trimmed.to_string(),
+                })?;
 
         // Extract tokens
         let (input_tokens, output_tokens) = self.extract_tokens(&events);
@@ -860,5 +880,78 @@ mod tests {
         if let AgentError::ModelUnavailable { model, .. } = &err {
             assert_eq!(model, "anthropic/claude-sonnet-4-6");
         }
+    }
+
+    // ── extract_text ─────────────────────────────────────────────
+
+    /// OpenCode: extract_text concatenates text events for review parsing.
+    #[test]
+    fn extract_text_returns_text_events() {
+        let raw = concat!(
+            r#"{"type":"step_start","timestamp":1000,"sessionID":"ses_abc"}"#,
+            "\n",
+            r#"{"type":"text","timestamp":1001,"part":{"type":"text","text":"{\"decision\":\"approve\",\"notes\":\"LGTM\",\"test_results\":\"pass\",\"issues\":[]}"}}"#,
+            "\n",
+            r#"{"type":"step_finish","timestamp":1002,"part":{"type":"step-finish","reason":"stop","cost":0,"tokens":{"total":100,"input":90,"output":10}}}"#,
+        );
+        let text = runner().extract_text(raw).unwrap();
+        assert_eq!(
+            text,
+            r#"{"decision":"approve","notes":"LGTM","test_results":"pass","issues":[]}"#
+        );
+    }
+
+    /// OpenCode: extract_text with newer direct-text format.
+    #[test]
+    fn extract_text_direct_text_event_format() {
+        let raw = concat!(
+            r#"{"type":"step_start","timestamp":1000,"sessionID":"ses_abc"}"#,
+            "\n",
+            r#"{"type":"text","timestamp":1001,"sessionID":"ses_abc","text":"Here is my review:\n\n```json\n{\"decision\":\"request_changes\",\"notes\":\"Fix the bug\",\"test_results\":\"fail\",\"issues\":[]}\n```\n"}"#,
+            "\n",
+            r#"{"type":"step_finish","timestamp":1002,"sessionID":"ses_abc"}"#,
+        );
+        let text = runner().extract_text(raw).unwrap();
+        assert!(
+            text.contains("request_changes"),
+            "expected review JSON, got: {text}"
+        );
+    }
+
+    /// OpenCode: extract_text propagates RateLimit for terminal errors.
+    #[test]
+    fn extract_text_rate_limit_propagates() {
+        let raw = concat!(
+            r#"{"type":"step_start","timestamp":1000}"#,
+            "\n",
+            r#"{"type":"error","message":"rate limit exceeded: 429 Too Many Requests"}"#,
+        );
+        let err = runner().extract_text(raw).unwrap_err();
+        assert!(
+            matches!(err, AgentError::RateLimit { .. }),
+            "expected RateLimit, got: {err:?}"
+        );
+    }
+
+    /// OpenCode: extract_text propagates Auth error.
+    #[test]
+    fn extract_text_auth_error_propagates() {
+        let raw = concat!(
+            r#"{"type":"step_start","timestamp":1000}"#,
+            "\n",
+            r#"{"type":"error","message":"401 Unauthorized: invalid api key"}"#,
+        );
+        let err = runner().extract_text(raw).unwrap_err();
+        assert!(
+            matches!(err, AgentError::Auth { .. }),
+            "expected Auth, got: {err:?}"
+        );
+    }
+
+    /// OpenCode: extract_text on empty input returns empty string (not an error).
+    #[test]
+    fn extract_text_empty_input_returns_empty_ok() {
+        let text = runner().extract_text("").unwrap();
+        assert!(text.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Per-agent review parsing implemented via extract_text() trait method. ClaudeRunner strips stream-json NDJSON envelope, CodexRunner extracts last agent_message, OpenCodeRunner concatenates text events. review.rs Stage 1 now uses agent-aware extraction instead of generic parse_response() fallback.

### What was done

- Added extract_text() to AgentRunner trait with safe default fallback
- Implemented ClaudeRunner::extract_text() for stream-json NDJSON envelope stripping
- Implemented CodexRunner::extract_text() for last agent_message extraction
- Implemented OpenCodeRunner::extract_text() for text event concatenation
- Updated review.rs Stage 1 to call extract_text() instead of parse_response()
- Added terminal error (rate limit/auth) propagation from extract_text()
- Added empty-output fallback to raw output in review.rs
- 14 unit tests covering success, rate limit, auth, empty-input per agent


Closes #979

---
*Task #979 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*