### PR TITLE
enhancement: make event bus websocket port selection deterministic

### DIFF
--- a/src/engine/events.rs
+++ b/src/engine/events.rs
@@ -104,9 +104,10 @@ impl EventBus {
     /// Start the websocket server. Returns the bound port.
     /// Spawns a background task — does not block.
     pub async fn start_ws_server(&self) -> anyhow::Result<u16> {
-        // Bind port 0 to let the OS assign a free port (avoids TOCTOU race).
-        let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
-        let port = listener.local_addr()?.port();
+        // Select a deterministic port in the ephemeral range (49152-65535),
+        // starting from a hostname-based offset to be stable across restarts.
+        let port = select_available_port()?;
+        let listener = TcpListener::bind(("127.0.0.1", port)).await?;
 
         // Write port file
         let state_dir = crate::home::state_dir()?;
@@ -175,7 +176,7 @@ impl EventBus {
 
 /// Find an available port in the ephemeral range (49152-65535).
 /// Starts from a deterministic offset based on hostname hash, then increments.
-#[cfg(test)]
+/// This gives stable first-attempt ports across restarts on the same machine.
 pub fn select_available_port() -> anyhow::Result<u16> {
     let hostname = std::env::var("HOSTNAME").unwrap_or_else(|_| "orch".to_string());
     let hash = hostname


### PR DESCRIPTION
## Summary

I'll start by exploring the codebase to understand the current state of the event bus websocket implementation.The branch has prior work unrelated to this issue. Let me examine the event bus files:Now let me check the design spec for reference:Now I understand the issue clearly. The `select_available_port()` function exists but is gated behind `#[cfg(test)]`, and `start_ws_server()` still uses port 0. I need to:

1. Remove the `#[cfg(test)]` gate from `select_available_port()`
2. Update `start_w

Closes #1020

---
*Task #1020 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*