### PR TITLE
feat: write service version to state at startup so orch version can detect CLI/service drift

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,8 +21,29 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 
 /// Print version information.
+///
+/// Shows CLI version and, if the service is running, the service version.
+/// Warns when they differ so operators can detect CLI/service drift.
 pub fn version() {
-    println!("orch {}", env!("ORCH_VERSION"));
+    let cli_version = env!("ORCH_VERSION");
+    println!("CLI:     {cli_version}");
+
+    match crate::home::service_version_path()
+        .ok()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+    {
+        Some(svc) => {
+            let svc = svc.trim();
+            if svc == cli_version {
+                println!("Service: {svc}  ✓ in sync");
+            } else {
+                println!("Service: {svc}  ✗ mismatch — run: brew upgrade orch && brew services restart orch");
+            }
+        }
+        None => {
+            println!("Service: not running (no service.version file)");
+        }
+    }
 }
 
 /// Initialize orchestrator for a project.

--- a/src/engine/events.rs
+++ b/src/engine/events.rs
@@ -128,6 +128,11 @@ impl EventBus {
         // Write port file
         std::fs::write(ws_port_path()?, port.to_string())?;
 
+        // Write service version file so `orch version` can detect CLI/service drift
+        if let Ok(path) = crate::home::service_version_path() {
+            let _ = std::fs::write(path, env!("ORCH_VERSION"));
+        }
+
         let tx = self.tx.clone();
         tokio::spawn(async move {
             loop {
@@ -233,6 +238,13 @@ pub fn select_available_listener() -> anyhow::Result<(std::net::TcpListener, u16
 /// Remove the ws.port file on shutdown.
 pub fn cleanup_port_file() {
     if let Ok(path) = ws_port_path() {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Remove the service.version file on shutdown.
+pub fn cleanup_version_file() {
+    if let Ok(path) = crate::home::service_version_path() {
         let _ = std::fs::remove_file(path);
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1412,8 +1412,9 @@ pub async fn serve() -> anyhow::Result<()> {
         }
     }
 
-    // Clean up event bus port file
+    // Clean up event bus port file and service version file
     events::cleanup_port_file();
+    events::cleanup_version_file();
 
     // transport and channels drop here at end of scope
     let _ = transport;

--- a/src/home.rs
+++ b/src/home.rs
@@ -93,6 +93,14 @@ pub fn db_path() -> anyhow::Result<PathBuf> {
     Ok(new_path)
 }
 
+/// Get the path to the service version file (~/.orch/state/service.version).
+///
+/// Written by the engine at startup, deleted on graceful shutdown.
+/// Used by `orch version` to detect CLI/service drift.
+pub fn service_version_path() -> anyhow::Result<std::path::PathBuf> {
+    Ok(state_dir()?.join("service.version"))
+}
+
 /// Get the path to the worktrees directory (~/.orch/worktrees/).
 pub fn worktrees_dir() -> anyhow::Result<PathBuf> {
     let dir = orch_home()?.join("worktrees");


### PR DESCRIPTION
## Summary

Done. Here's what was implemented:

**`src/home.rs`** — added `service_version_path()` helper returning `~/.orch/state/service.version`

**`src/engine/events.rs`** — at startup (alongside `ws.port` write), writes `env!("ORCH_VERSION")` to `service.version`; added `cleanup_version_file()` that removes it on shutdown

**`src/engine/mod.rs`** — calls `cleanup_version_file()` on graceful shutdown alongside `cleanup_port_file()`

**`src/cli/mod.rs`** — `version()` now reads `service.version` 

Closes #1037

---
*Task #1037 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*