### PR TITLE
bug: build_git_log uses bare branch name instead of origin/${default_branch} — fails silently on bare repos and is inconsistent with build_git_diff

### DIFF
--- a/src/engine/runner/context.rs
+++ b/src/engine/runner/context.rs
@@ -213,7 +213,11 @@ pub async fn build_git_diff(project_dir: &Path, default_branch: &str) -> String 
 /// Shows commit history for the feature branch.
 pub async fn build_git_log(project_dir: &Path, default_branch: &str) -> String {
     let output = Command::new("git")
-        .args(["log", "--oneline", &format!("{}..HEAD", default_branch)])
+        .args([
+            "log",
+            "--oneline",
+            &format!("origin/{default_branch}..HEAD"),
+        ])
         .current_dir(project_dir)
         .output_with_context()
         .await;


### PR DESCRIPTION
Resolves #1041

Auto-created by orch review gate (agent forgot to open PR)