### PR TITLE
bug: review agent starts with stale remote refs — no git fetch before build_git_diff or rebase

### DIFF
--- a/prompts/review_task.md
+++ b/prompts/review_task.md
@@ -5,7 +5,7 @@ You are reviewing a PR created by an AI agent. Complete ALL steps in order.
 ### Step 1: Rebase onto default branch
 
 Keep the branch up to date — other PRs may have merged since this was created:
-1. Ensure the service has pre-fetched remote refs, then rebase onto the default branch:
+1. The service has pre-fetched remote refs. Rebase onto the default branch:
    - `git rebase origin/{{DEFAULT_BRANCH}}`
 2. If there are conflicts:
    - Resolve each conflict by understanding both sides of the change

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -576,6 +576,16 @@ pub(crate) async fn review_and_merge(
     // 3. Build diff context
     let default_branch =
         crate::config::get("gh.default_branch").unwrap_or_else(|_| "main".to_string());
+
+    // Refresh remote refs before building diff context.
+    // The review agent is instructed to rebase on origin/{default_branch};
+    // this ensures the ref is current, mirroring what rebase_on_default() does for task agents.
+    let _ = tokio::process::Command::new("git")
+        .args(["fetch", "origin"])
+        .current_dir(&worktree_path)
+        .output()
+        .await;
+
     let git_diff = runner::context::build_git_diff(&worktree_path, &default_branch).await;
     let git_log = runner::context::build_git_log(&worktree_path, &default_branch).await;
 


### PR DESCRIPTION
## Summary

The background test run also completed successfully (exit code 0). The fix is committed and ready.

Closes #1039

---
*Task #1039 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*