### PR TITLE
bug: review.rs and auto_merge.rs read default branch from config instead of remote — wrong branch on non-main repos

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -10,6 +10,7 @@
 use crate::backends::{ExternalBackend, ExternalTask, Status};
 use crate::config;
 use crate::engine::cleanup::cleanup_task_worktree;
+use crate::engine::runner::worktree;
 use crate::engine::tasks::TaskManager;
 use crate::github::http::GhHttp;
 use crate::github::types::GitHubReview;
@@ -443,8 +444,7 @@ pub(crate) async fn auto_merge_pr(
                         worktree = %wt,
                         "attempting rebase to resolve merge conflict"
                     );
-                    let default_branch =
-                        config::get("gh.default_branch").unwrap_or_else(|_| "main".to_string());
+                    let default_branch = worktree::detect_default_branch(&wt_path).await;
                     let fetch_result = tokio::process::Command::new("git")
                         .args(["fetch", "origin"])
                         .current_dir(&wt_path)

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -139,8 +139,7 @@ async fn ensure_pr_exists(
         }
         Ok(None) => {
             // No open PR — check if branch has commits ahead of default branch.
-            let default_branch =
-                crate::config::get("gh.default_branch").unwrap_or_else(|_| "main".to_string());
+            let default_branch = worktree::detect_default_branch(worktree_path).await;
             let worktree_str = worktree_path.to_str().ok_or_else(|| {
                 anyhow::anyhow!(
                     "worktree path contains non-UTF-8 characters: {:?}",
@@ -574,8 +573,7 @@ pub(crate) async fn review_and_merge(
     };
 
     // 3. Build diff context
-    let default_branch =
-        crate::config::get("gh.default_branch").unwrap_or_else(|_| "main".to_string());
+    let default_branch = runner::worktree::detect_default_branch(&worktree_path).await;
     let git_diff = runner::context::build_git_diff(&worktree_path, &default_branch).await;
     let git_log = runner::context::build_git_log(&worktree_path, &default_branch).await;
 


### PR DESCRIPTION
## Summary

Fixed 3 places reading default branch from config instead of remote, causing wrong branch on non-main repos

### What was done

- Replaced config::get('gh.default_branch') fallback with detect_default_branch() in review.rs:143 (ensure_pr_exists commit-count check)
- Replaced config::get('gh.default_branch') fallback with detect_default_branch() in review.rs:578 (review_and_merge diff context)
- Replaced config::get('gh.default_branch') fallback with detect_default_branch() in auto_merge.rs:447 (rebase target)
- Added use crate::engine::runner::worktree import to auto_merge.rs


Closes #1045

---
*Task #1045 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2-omni-free`*