### PR TITLE
bug: synthesize_response_from_text marks issue-creation plain text as needs_review instead of done

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -198,6 +198,10 @@ pub fn synthesize_response_from_text(text: &str) -> Option<AgentResponse> {
     }
 
     let lower = trimmed.to_lowercase();
+    // Also accept plain-language confirmations of performed actions (issue/PR
+    // creation, comments, etc.) as a successful "done" signal. This prevents
+    // tasks from being retried when an agent reports success in free-form
+    // text instead of returning structured JSON.
     let looks_done = [
         "no changes",
         "nothing to",
@@ -210,6 +214,20 @@ pub fn synthesize_response_from_text(text: &str) -> Option<AgentResponse> {
         "no action needed",
         "complete",
         "done",
+        // Action/issue completion phrases
+        "filed",
+        "filed issue",
+        "filed issues",
+        "created issue",
+        "created issues",
+        "opened issue",
+        "opened issues",
+        "issue created",
+        "issues created",
+        "issues filed",
+        "task created",
+        "posted comment",
+        "comment posted",
     ]
     .iter()
     .any(|needle| lower.contains(needle));
@@ -828,6 +846,19 @@ mod tests {
     #[test]
     fn synthesize_response_rejects_empty_text() {
         assert!(synthesize_response_from_text("   \n\t  ").is_none());
+    }
+
+    #[test]
+    fn synthesize_response_marks_done_for_issue_creation_text() {
+        let response =
+            synthesize_response_from_text("Filed 3 high-value GitHub issues: #1037, #1038, #1039")
+                .unwrap();
+
+        assert_eq!(response.status, "done");
+        assert!(response.error.is_none());
+        assert!(response
+            .summary
+            .contains("Filed 3 high-value GitHub issues"));
     }
 
     // ── PermissionRules defaults ────────────────────────────────


### PR DESCRIPTION
## Summary

Treat plain-text confirmations of issue/comment creation as successful task completion and add a unit test.

### What was done

- Expanded the plain-text 'done' heuristics in src/engine/runner/agents/mod.rs to include issue/PR/comment/action completion phrases (e.g., 'filed', 'created issue', 'opened issue', 'posted comment', etc.) so agents that report success in free-form text are classified as done.
- Added a unit test (synthesize_response_marks_done_for_issue_creation_text) that verifies 'Filed 3 high-value GitHub issues: #1037, #1038, #1039' is marked as done and contains no error.
- Committed the change on branch gh-issue-1051-bug-synthesize-response-from-text-marks with a descriptive message.


### Remaining

- Consider expanding or consolidating the plain-text heuristics further if other success phrasings are observed in the wild.
- Follow-up: fix the prompt checklist (root cause tracked in #1050) so agents return structured JSON consistently; this change is a defensive mitigation.


Closes #1051

---
*Task #1051 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*