### PR TITLE
bug: rebase_worktree_on_origin_main hardcodes origin/main — startup rebase always fails on non-main repos

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -307,6 +307,8 @@ async fn reconcile_startup_worktrees(project_engines: &[ProjectEngine]) -> anyho
         let repo_root =
             crate::engine::runner::worktree::resolve_main_repo(&engine.project_dir).await;
         let repo_root_path = std::path::PathBuf::from(&repo_root);
+        let default_branch =
+            crate::engine::runner::worktree::detect_default_branch(&repo_root_path).await;
         let worktrees = list_project_worktrees(&repo_root_path)?;
 
         for worktree_dir in worktrees {
@@ -341,8 +343,12 @@ async fn reconcile_startup_worktrees(project_engines: &[ProjectEngine]) -> anyho
                 | TaskStatus::NeedsReview
                 | TaskStatus::InReview => {
                     tracing::info!(repo = %engine.repo, task_id = %task_id, worktree = %worktree_dir.display(), "rebasing startup worktree");
-                    if let Err(e) =
-                        rebase_worktree_on_origin_main(&worktree_dir, &repo_root_path).await
+                    if let Err(e) = rebase_worktree_on_origin_main(
+                        &worktree_dir,
+                        &repo_root_path,
+                        &default_branch,
+                    )
+                    .await
                     {
                         tracing::warn!(repo = %engine.repo, task_id = %task_id, err = %e, "startup rebase failed, resetting task");
                         abort_worktree_rebase(&worktree_dir).await;

--- a/src/engine/runner/worktree.rs
+++ b/src/engine/runner/worktree.rs
@@ -88,10 +88,11 @@ pub async fn abort_worktree_rebase(worktree_dir: &Path) {
         .await;
 }
 
-/// Rebase a worktree on top of `origin/main`.
+/// Rebase a worktree on top of `origin/{default_branch}`.
 pub async fn rebase_worktree_on_origin_main(
     worktree_dir: &Path,
     repo_root: &Path,
+    default_branch: &str,
 ) -> anyhow::Result<()> {
     let repo_root_str = repo_root.to_string_lossy();
     let fetch = Command::new("git")
@@ -105,18 +106,20 @@ pub async fn rebase_worktree_on_origin_main(
         );
     }
 
+    let origin_branch = format!("origin/{default_branch}");
     let rebase = Command::new("git")
         .args([
             "-C",
             &worktree_dir.to_string_lossy(),
             "rebase",
-            "origin/main",
+            &origin_branch,
         ])
         .output_with_context()
         .await?;
     if !rebase.status.success() {
         anyhow::bail!(
-            "git rebase origin/main failed: {}",
+            "git rebase {} failed: {}",
+            origin_branch,
             String::from_utf8_lossy(&rebase.stderr).trim()
         );
     }


### PR DESCRIPTION
## Summary

All checks passed and changes committed. The task is complete.

Closes #1044

---
*Task #1044 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*