### PR TITLE
bug: gh pr checks --watch in review_task.md has no timeout — blocks review agent indefinitely if CI is slow

### DIFF
--- a/prompts/review_task.md
+++ b/prompts/review_task.md
@@ -31,7 +31,7 @@ Commit your fixes and re-run checks. If you cannot fix a failure, decision = `re
 Local checks can diverge from CI (e.g. different toolchain versions). After local checks pass, also verify GitHub CI:
 
 ```bash
-gh pr checks {{PR_NUMBER}} --watch --fail-fast
+timeout 300 gh pr checks {{PR_NUMBER}} --watch --fail-fast || true
 ```
 
 If GitHub CI has failures that your local checks missed, fix them, commit, and re-run. If CI is still pending after 5 minutes, proceed with local results but note it in your review.


### PR DESCRIPTION
## Summary

Added timeout to gh pr checks watch command in review prompt to prevent indefinite blocking

### What was done

- Wrapped gh pr checks --watch command with timeout 300 and || true in prompts/review_task.md


Closes #1060

---
*Task #1060 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2-omni-free`*