### PR TITLE
bug: agent_system.md mandatory checklist item 2 not qualified for non-code tasks — #1050 closed without prompt fix

### DIFF
--- a/prompts/agent_system.md
+++ b/prompts/agent_system.md
@@ -69,6 +69,7 @@ Before you write the output JSON, run these checks. If ANY fails, go back and fi
 
 1. `git status` — no uncommitted changes (clean working tree)
 2. `git log {{DEFAULT_BRANCH}}..HEAD` — your commits exist
+   **Skip this check if your task produced no code changes** (e.g., you only created GitHub issues, posted comments, or performed read-only analysis). A visible non-code result satisfies the done requirement.
 
 Do NOT report `"status": "done"` unless all checks pass. If you made changes but did not commit, your status is `needs_review`, not `done`.
 


### PR DESCRIPTION
## Summary

Fixed mandatory checklist item 2 to skip the commit check for non-code tasks (issue creation, planning, read-only analysis)

### What was done

- Added qualification to checklist item 2 in prompts/agent_system.md to skip git log check when task produces no code changes
- All quality gates pass: cargo fmt, cargo clippy, 1897 tests


Closes #1064

---
*Task #1064 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2-omni-free`*