### PR TITLE
bug: pricing_for_model misses current codex/opencode model names — orch cost reports wrong estimates

### DIFF
--- a/src/store/pricing.rs
+++ b/src/store/pricing.rs
@@ -37,9 +37,34 @@ pub struct CostEstimate {
     pub output_cost_usd: f64,
     pub total_cost_usd: f64,
 }
+/// Zero-cost pricing (subscription-based or free-tier models).
+const FREE: ModelPricing = ModelPricing {
+    input_per_million_usd: 0.0,
+    output_per_million_usd: 0.0,
+};
+
 /// Resolve model pricing using a built-in table and normalized model aliases.
 pub fn pricing_for_model(model: &str) -> ModelPricing {
     let normalized = model.trim().to_lowercase();
+
+    // GitHub Copilot subscription models — billed to Copilot account, not per-token.
+    if normalized.starts_with("github-copilot/") {
+        return FREE;
+    }
+
+    // Free-tier models (e.g. minimax-m2.5-free, nemotron-3-super-free).
+    if normalized.contains("-free") || normalized.ends_with("free") {
+        return FREE;
+    }
+
+    // DeepSeek models (e.g. deepseek-r1, deepseek-v3).
+    if normalized.starts_with("deepseek") {
+        return ModelPricing {
+            input_per_million_usd: 0.55,
+            output_per_million_usd: 2.19,
+        };
+    }
+
     // OpenAI models
     if normalized == "o3" {
         return ModelPricing {
@@ -59,6 +84,22 @@ pub fn pricing_for_model(model: &str) -> ModelPricing {
             output_per_million_usd: 8.0,
         };
     }
+    // Codex v5 mini variants (gpt-5.1-codex-mini, gpt-5.4-mini, etc.).
+    if normalized.starts_with("gpt-5") && normalized.contains("mini") {
+        return ModelPricing {
+            input_per_million_usd: 0.15,
+            output_per_million_usd: 0.6,
+        };
+    }
+    // Codex v5 full variants (gpt-5.2-codex, gpt-5.3-codex, etc.).
+    if normalized.starts_with("gpt-5") {
+        return ModelPricing {
+            input_per_million_usd: 2.0,
+            output_per_million_usd: 8.0,
+        };
+    }
+
+    // Claude models matched by family substring.
     if normalized.contains("opus") {
         return ModelPricing {
             input_per_million_usd: 15.0,

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -4027,6 +4027,41 @@ fn pricing_unknown_model_returns_fallback() {
     assert!((unknown.output_per_million_usd - 4.0).abs() < 0.01);
 }
 
+#[test]
+fn pricing_free_and_subscription_models() {
+    use super::pricing_for_model;
+
+    // GitHub Copilot subscription — $0
+    let copilot_sonnet = pricing_for_model("github-copilot/claude-sonnet-4-6");
+    assert_eq!(copilot_sonnet.input_per_million_usd, 0.0);
+    assert_eq!(copilot_sonnet.output_per_million_usd, 0.0);
+
+    let copilot_gpt = pricing_for_model("github-copilot/gpt-5.4-mini");
+    assert_eq!(copilot_gpt.input_per_million_usd, 0.0);
+
+    // Free-tier suffix — $0
+    let minimax_free = pricing_for_model("minimax-m2.5-free");
+    assert_eq!(minimax_free.input_per_million_usd, 0.0);
+
+    let nemotron_free = pricing_for_model("nemotron-3-super-free");
+    assert_eq!(nemotron_free.input_per_million_usd, 0.0);
+
+    // DeepSeek
+    let deepseek = pricing_for_model("deepseek-r1");
+    assert!((deepseek.input_per_million_usd - 0.55).abs() < 0.01);
+    assert!((deepseek.output_per_million_usd - 2.19).abs() < 0.01);
+
+    // Codex v5 mini
+    let codex_mini = pricing_for_model("gpt-5.1-codex-mini");
+    assert!((codex_mini.input_per_million_usd - 0.15).abs() < 0.01);
+    assert!((codex_mini.output_per_million_usd - 0.6).abs() < 0.01);
+
+    // Codex v5 full
+    let codex_full = pricing_for_model("gpt-5.2-codex");
+    assert!((codex_full.input_per_million_usd - 2.0).abs() < 0.01);
+    assert!((codex_full.output_per_million_usd - 8.0).abs() < 0.01);
+}
+
 // ── cost_summary static queries ──────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Done. Changes made to `src/store/pricing.rs`:

- `github-copilot/*` prefix → `$0` (subscription billing, not per-token)
- `-free` suffix → `$0` (minimax-m2.5-free, nemotron-3-super-free, etc.)
- `deepseek*` → `$0.55/$2.19` per 1M tokens
- `gpt-5*-mini` → `$0.15/$0.60` (codex mini tier)
- `gpt-5*` → `$2.00/$8.00` (codex full tier)

All 6 pricing tests pass (both new and existing).

Closes #1061

---
*Task #1061 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*