### PR TITLE
bug: review_task.md blocks PRs for pre-existing test failures — no baseline check before request_changes

### DIFF
--- a/prompts/review_task.md
+++ b/prompts/review_task.md
@@ -24,7 +24,23 @@ If ANY check fails, try to fix it yourself:
 - Apply auto-fixers if available (e.g. formatter --fix, linter --fix)
 - Fix errors directly if straightforward
 
-Commit your fixes and re-run checks. If you cannot fix a failure, decision = `request_changes`. Do NOT push — the orchestrator handles that.
+Commit your fixes and re-run checks.
+
+If you cannot fix a failure, **before setting `request_changes`, check whether it pre-exists on `{{DEFAULT_BRANCH}}`**:
+
+1. List files changed by this PR: `git diff origin/{{DEFAULT_BRANCH}} --name-only`
+2. If the failing test/check does not touch any of those files, verify on the base branch:
+   ```bash
+   git stash
+   cargo nextest run <failing_test_name>   # or the equivalent failing command
+   git stash pop
+   ```
+3. If the failure reproduces on `{{DEFAULT_BRANCH}}` (pre-existing) → it is **not** caused by this PR.
+   - Do NOT block the PR for a pre-existing failure.
+   - Note it in your review summary and proceed with the rest of the review.
+4. If the failure only occurs with the PR changes → it is a regression. Set decision = `request_changes`.
+
+Do NOT push — the orchestrator handles that.
 
 ### Step 2b: Verify GitHub CI status on the PR
 


### PR DESCRIPTION
## Summary

Done. The fix adds a 4-step baseline check to `prompts/review_task.md` Step 2:

1. List files changed by the PR
2. If the failing test doesn't touch those files, stash → re-run on base branch → pop
3. Pre-existing failure → don't block, just note it and continue
4. Regression (only fails with PR) → `request_changes`

This directly addresses the root cause: PR #1047 was rejected because `build_runner_script_*` tests were already failing on `main` but the review agent had no way to disting

Closes #1069

---
*Task #1069 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*