### PR TITLE
bug: review_task.md blocks PRs for pre-existing test failures — no baseline check before request_changes

### DIFF
--- a/prompts/review_task.md
+++ b/prompts/review_task.md
@@ -14,9 +14,35 @@ Keep the branch up to date — other PRs may have merged since this was created:
 
 **Do NOT push** — the orchestrator handles pushing after review completes.
 
-### Step 2: Check GitHub CI status
+### Step 2: Run local checks and fix failures
 
-GitHub CI is the authoritative test environment. Check it first:
+1. Read `.github/workflows/` to identify what the CI pipeline runs (lint, format, test, build, etc.)
+2. Execute those exact commands locally — do not guess or hardcode language-specific commands
+3. Run only the checks that apply to the changed code (skip deploy/publish steps)
+
+If ANY check fails, try to fix it yourself:
+- Apply auto-fixers if available (e.g. formatter --fix, linter --fix)
+- Fix errors directly if straightforward
+
+Commit your fixes and re-run checks.
+
+If you cannot fix a failure, **before setting `request_changes`, check whether it pre-exists on `{{DEFAULT_BRANCH}}`**:
+
+1. List files changed by this PR: `git diff origin/{{DEFAULT_BRANCH}} --name-only`
+2. If the failing test/check does not touch any of those files, verify on the base branch:
+   ```bash
+   git stash
+   cargo nextest run <failing_test_name>   # or the equivalent failing command
+   git stash pop
+   ```
+3. If the failure reproduces on `{{DEFAULT_BRANCH}}` (pre-existing) → it is **not** caused by this PR.
+   - Do NOT block the PR for a pre-existing failure.
+   - Note it in your review summary and proceed with the rest of the review.
+4. If the failure only occurs with the PR changes → it is a regression. Set decision = `request_changes`.
+
+Do NOT push — the orchestrator handles that.
+
+### Step 2b: Verify GitHub CI status on the PR
 
 ```bash
 timeout 300 gh pr checks {{PR_NUMBER}} --watch --fail-fast || true


### PR DESCRIPTION
## Summary

The fix is already committed. The `prompts/review_task.md` has the baseline pre-existing failure check added in Step 2 (lines 29-41), which directly addresses the issue described in #1069.

The branch has 3 local commits that haven't been pushed to origin yet — the orchestrator will handle pushing and PR creation. The task is complete.

**Summary of what was done (in a previous attempt):**
- Added a baseline check step to `prompts/review_task.md` Step 2
- When a CI check fails, the review agen

Closes #1069

---
*Task #1069 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*