### PR TITLE
fix: block git push in agent sandboxes — prevents spurious needs_review when push fails

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -54,7 +54,11 @@ impl Default for PermissionRules {
         Self {
             autonomous: true,
             sandbox: SandboxLevel::WorkspaceWrite,
-            disallowed_tools: vec!["Bash(rm *)".to_string(), "Bash(rm -*)".to_string()],
+            disallowed_tools: vec![
+                "Bash(rm *)".to_string(),
+                "Bash(rm -*)".to_string(),
+                "Bash(git push*)".to_string(),
+            ],
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
         }

--- a/src/engine/runner/task_init.rs
+++ b/src/engine/runner/task_init.rs
@@ -189,7 +189,11 @@ pub async fn prepare_task(
     let output_file = attempt_dir.join("output.json");
 
     // Build sandbox disallowed tools
-    let mut disallowed_tools = vec!["Bash(rm *)".to_string(), "Bash(rm -*)".to_string()];
+    let mut disallowed_tools = vec![
+        "Bash(rm *)".to_string(),
+        "Bash(rm -*)".to_string(),
+        "Bash(git push*)".to_string(),
+    ];
 
     // Sandbox: block access to main project dir
     if wt.work_dir != wt.main_project_dir {


### PR DESCRIPTION
Resolves #1084

Auto-created by orch review gate (agent forgot to open PR)