### PR TITLE
bug: synthesize_response_from_text misses "committed" as a done signal — write-commit tasks stuck in review

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -234,6 +234,7 @@ pub fn synthesize_response_from_text(text: &str) -> Option<AgentResponse> {
         "not yet complete",
         "not completed",
         "not yet completed",
+        "not committed",
         "incomplete",
         "undone",
     ]
@@ -266,10 +267,14 @@ pub fn synthesize_response_from_text(text: &str) -> Option<AgentResponse> {
             "task created",
             "posted comment",
             "comment posted",
+            "changes committed",
+            "commit created",
+            "the commit",
         ]
         .iter()
         .any(|needle| lower.contains(needle))
-            || contains_word(&lower, "done"));
+            || contains_word(&lower, "done")
+            || contains_word(&lower, "committed"));
 
     let looks_error = [
         "error:",
@@ -947,6 +952,31 @@ mod tests {
         assert!(response
             .summary
             .contains("Filed 3 high-value GitHub issues"));
+    }
+
+    #[test]
+    fn synthesize_response_marks_done_for_committed() {
+        let response =
+            synthesize_response_from_text("I've committed the changes to the repository").unwrap();
+        assert_eq!(response.status, "done");
+    }
+
+    #[test]
+    fn synthesize_response_marks_done_for_commit_created() {
+        let response = synthesize_response_from_text(
+            "The commit is created locally. The push is being blocked by permissions.",
+        )
+        .unwrap();
+        assert_eq!(response.status, "done");
+    }
+
+    #[test]
+    fn synthesize_response_does_not_mark_done_for_not_committed() {
+        let response = synthesize_response_from_text("The changes are not committed yet").unwrap();
+        assert_eq!(
+            response.status, "needs_review",
+            "\"not committed\" should not match \"committed\""
+        );
     }
 
     // ── PermissionRules defaults ────────────────────────────────


### PR DESCRIPTION
## Summary

Expanded synthesize_response completion detection for commit phrasing with tests covering positive and negative cases.

### What was done

- Added commit-related completion phrases plus a committed word-boundary check and a not-committed negative guard in synthesize_response_from_text.
- Added unit tests for committed, commit created, and not committed scenarios.
- Ran cargo fmt -- --check, cargo clippy --all-targets -- -D warnings, and cargo nextest run.


Closes #1082

---
*Task #1082 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.2-codex`*