### PR TITLE
fix: router LLM has bias toward its own agent — add self-routing penalty weight

### DIFF
--- a/prompts/route.md
+++ b/prompts/route.md
@@ -1,5 +1,7 @@
 You are a routing and profiling agent. Decide which executor should handle the task, assess its complexity, create a specialized agent profile, and select relevant skills.
 
+You are being invoked as the **{{ROUTER_AGENT}}** executor. When executors have similar capabilities for a task, prefer routing to executors OTHER than yourself to distribute load and avoid self-routing bias.
+
 Installed executors (only pick from these):
 {{AVAILABLE_AGENTS}}
 

--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -45,6 +45,14 @@ pub struct RouterConfig {
     /// Fallback `agent:model` when all pool entries are cooled or fail.
     /// When empty, defaults to `router_agent:router_model`.
     pub fallback: String,
+    /// Penalty weight applied when the LLM routes a task to itself (the routing agent).
+    ///
+    /// Range: `0.0` (always redirect away from router agent) to `1.0` (no penalty, default).
+    /// When `< 1.0` and the LLM selects its own agent, the router probabilistically
+    /// redirects to another available agent, reducing self-routing bias.
+    ///
+    /// Example: `0.5` means ~50% of self-routed tasks are redirected to another agent.
+    pub self_routing_penalty: f64,
 }
 
 /// Parse an `agent:model` pool entry string, splitting on the first colon.
@@ -134,6 +142,7 @@ impl Default for RouterConfig {
             max_route_attempts: 3,
             pool: vec![],
             fallback: String::new(),
+            self_routing_penalty: 1.0,
             allowed_tools: vec![
                 "yq".to_string(),
                 "jq".to_string(),
@@ -265,6 +274,13 @@ impl RouterConfig {
         // Parse weighted_round_robin
         if let Ok(val) = crate::config::get("router.weighted_round_robin") {
             config.weighted_round_robin = val == "true" || val == "1";
+        }
+
+        // Parse self_routing_penalty
+        if let Ok(val) = crate::config::get("router.self_routing_penalty") {
+            if let Ok(penalty) = val.parse::<f64>() {
+                config.self_routing_penalty = penalty.clamp(0.0, 1.0);
+            }
         }
 
         // Parse pool: list of "agent:model" entries.
@@ -458,6 +474,30 @@ mod tests {
     fn cwd_mutex() -> &'static Mutex<()> {
         static CWD_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
         CWD_MUTEX.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn default_self_routing_penalty_is_one() {
+        let config = RouterConfig::default();
+        assert_eq!(
+            config.self_routing_penalty, 1.0,
+            "default penalty must be 1.0 (no penalty = full self-routing allowed)"
+        );
+    }
+
+    #[test]
+    fn from_config_reads_self_routing_penalty() {
+        let _lock = cwd_mutex().lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".orch.yml"),
+            "router:\n  self_routing_penalty: 0.5\n",
+        )
+        .unwrap();
+        let _guard = CurrentDirGuard::set(dir.path());
+
+        let config = RouterConfig::from_config();
+        assert_eq!(config.self_routing_penalty, 0.5);
     }
 
     #[test]

--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -47,6 +47,50 @@ pub(crate) struct LlmAgentProfile {
     pub(crate) constraints: Vec<String>,
 }
 
+/// Apply self-routing penalty: if the LLM chose the same agent that's running the router,
+/// probabilistically redirect to another agent.
+///
+/// Returns `Some(agent)` with the redirected agent, or `None` if no redirect is needed.
+///
+/// - `penalty = 1.0` → never redirect (no penalty, default)
+/// - `penalty = 0.0` → always redirect (maximum penalty)
+/// - `penalty = 0.5` → redirect ~50% of self-routed tasks
+pub(super) fn apply_self_routing_penalty(
+    chosen_agent: &str,
+    router_agent: &str,
+    available_agents: &[String],
+    penalty: f64,
+    task_id: &str,
+) -> Option<String> {
+    // No penalty configured, or LLM chose a different agent — nothing to do
+    if penalty >= 1.0 || chosen_agent != router_agent {
+        return None;
+    }
+
+    // Collect alternative agents (everyone except the router)
+    let alternatives: Vec<&String> = available_agents
+        .iter()
+        .filter(|a| a.as_str() != router_agent)
+        .collect();
+
+    if alternatives.is_empty() {
+        return None;
+    }
+
+    // Probabilistically override: keep original if rand < penalty, else redirect.
+    // Using simple_hash_fraction_for gives deterministic-ish behavior per task_id
+    // so the same task always routes consistently.
+    let rand = super::selection::simple_hash_fraction_for(task_id);
+    if rand < penalty {
+        return None; // Keep the LLM's choice
+    }
+
+    // Redirect to an alternative agent chosen by hash
+    let idx =
+        super::selection::simple_hash_index_for(alternatives.len(), &format!("penalty:{task_id}"));
+    Some(alternatives[idx].clone())
+}
+
 /// Handles LLM-based task routing.
 ///
 /// `LlmRouter` is a self-contained unit: it builds a prompt from the task and
@@ -88,7 +132,7 @@ impl LlmRouter {
         }
 
         // Build the routing prompt
-        let prompt = self.build_routing_prompt(task, available_agents)?;
+        let prompt = self.build_routing_prompt(task, available_agents, router_agent)?;
 
         // Save prompt and response to per-task routing dir for debugging
         let routing_dir = crate::home::task_dir(repo, &task.id.0)
@@ -131,6 +175,24 @@ impl LlmRouter {
                 "selected agent not available, using fallback"
             );
             agent = first_available;
+        }
+
+        // Apply self-routing penalty: reduce bias toward the router's own agent
+        if let Some(redirected) = apply_self_routing_penalty(
+            &agent,
+            router_agent,
+            available_agents,
+            config.self_routing_penalty,
+            &task.id.0,
+        ) {
+            tracing::info!(
+                original_agent = %agent,
+                redirected_agent = %redirected,
+                router_agent,
+                penalty = config.self_routing_penalty,
+                "self-routing penalty applied — redirecting to alternate agent"
+            );
+            agent = redirected;
         }
 
         // Build the profile
@@ -192,6 +254,7 @@ impl LlmRouter {
         &self,
         task: &ExternalTask,
         available_agents: &[String],
+        router_agent: &str,
     ) -> anyhow::Result<String> {
         let template = include_str!("../../../prompts/route.md");
 
@@ -206,6 +269,7 @@ impl LlmRouter {
 
         // Simple template substitution
         let prompt = template
+            .replace("{{ROUTER_AGENT}}", router_agent)
             .replace("{{AVAILABLE_AGENTS}}", &available_agents_str)
             .replace("{{SKILLS_CATALOG}}", &skills_catalog)
             .replace("{{TASK_ID}}", &task.id.0)
@@ -783,5 +847,78 @@ mod tests {
             warning.is_some(),
             "label matching should be case-insensitive"
         );
+    }
+
+    // ── apply_self_routing_penalty ────────────────────────────────────────────
+
+    #[test]
+    fn self_routing_penalty_zero_always_redirects() {
+        let agents = vec![
+            "opencode".to_string(),
+            "claude".to_string(),
+            "codex".to_string(),
+        ];
+        // penalty=0.0: any hash ∈ [0,1) is never < 0.0, so always redirects
+        let result = apply_self_routing_penalty("opencode", "opencode", &agents, 0.0, "task-42");
+        assert!(result.is_some(), "penalty=0.0 must redirect self-routing");
+        assert_ne!(
+            result.unwrap(),
+            "opencode",
+            "redirected agent must not be the router agent"
+        );
+    }
+
+    #[test]
+    fn self_routing_penalty_one_keeps_self_routing() {
+        let agents = vec!["opencode".to_string(), "claude".to_string()];
+        // penalty=1.0: any hash ∈ [0,1) is always < 1.0, so never redirects
+        let result = apply_self_routing_penalty("opencode", "opencode", &agents, 1.0, "task-42");
+        assert!(result.is_none(), "penalty=1.0 must not redirect");
+    }
+
+    #[test]
+    fn self_routing_penalty_no_redirect_when_different_agent_chosen() {
+        let agents = vec!["opencode".to_string(), "claude".to_string()];
+        // LLM chose claude, router is opencode — no self-routing, no penalty
+        let result = apply_self_routing_penalty("claude", "opencode", &agents, 0.0, "task-42");
+        assert!(
+            result.is_none(),
+            "no redirect when LLM chose a different agent than the router"
+        );
+    }
+
+    #[test]
+    fn self_routing_penalty_no_redirect_when_no_alternatives() {
+        // Only one agent available — can't redirect anywhere else
+        let agents = vec!["opencode".to_string()];
+        let result = apply_self_routing_penalty("opencode", "opencode", &agents, 0.0, "task-42");
+        assert!(
+            result.is_none(),
+            "no redirect when no alternative agents are available"
+        );
+    }
+
+    #[test]
+    fn self_routing_penalty_redirects_only_to_non_router_agents() {
+        let agents = vec![
+            "opencode".to_string(),
+            "claude".to_string(),
+            "codex".to_string(),
+        ];
+        // penalty=0.0 always redirects — verify the redirected agent is never "opencode"
+        for suffix in &["1", "2", "3", "4", "5", "42", "100", "999"] {
+            let task_id = format!("task-{suffix}");
+            let result = apply_self_routing_penalty("opencode", "opencode", &agents, 0.0, &task_id);
+            if let Some(agent) = result {
+                assert_ne!(
+                    agent, "opencode",
+                    "redirected agent must not be router agent"
+                );
+                assert!(
+                    agents.contains(&agent),
+                    "redirected agent must be in available_agents"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

All done. Here's what was implemented:

**`src/engine/router/config.rs`**
- Added `self_routing_penalty: f64` to `RouterConfig` (default `1.0` = no penalty)
- Loads from `router.self_routing_penalty` in config, clamped to `[0.0, 1.0]`
- 2 new tests: `default_self_routing_penalty_is_one`, `from_config_reads_self_routing_penalty`

**`src/engine/router/llm.rs`**
- Added `apply_self_routing_penalty(chosen, router, agents, penalty, task_id) -> Option<String>`
  - `penalty=1.0` → never redirect (bac

Closes #1115

---
*Task #1115 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*