### PR TITLE
bug: closed-issue reconciliation aborts on GitHub JSON decode errors

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -7,6 +7,7 @@ use super::{ExternalBackend, ExternalId, ExternalTask, Mention, Status};
 use crate::github::http::{status_label_color, GhHttp};
 use crate::github::projects::ProjectSync;
 use async_trait::async_trait;
+use chrono::{Duration, Utc};
 
 /// Author associations that are allowed to create tasks.
 /// Issues from other authors are silently ignored during ingestion.
@@ -221,6 +222,29 @@ impl ExternalBackend for GitHubBackend {
         let issues = self.gh.list_all_issues(&self.repo).await?;
         Ok(issues
             .into_iter()
+            .filter(|issue| issue.pull_request.is_none()) // Exclude PRs
+            .filter(is_trusted_author) // Only trusted authors
+            .map(|issue| ExternalTask {
+                id: ExternalId(issue.number.to_string()),
+                title: issue.title,
+                body: issue.body.unwrap_or_default(),
+                state: issue.state,
+                labels: issue.labels.into_iter().map(|l| l.name).collect(),
+                author: issue.user.login,
+                created_at: issue.created_at,
+                updated_at: issue.updated_at,
+                url: issue.html_url,
+            })
+            .collect())
+    }
+
+    async fn list_reconciliation_candidates(&self) -> anyhow::Result<Vec<ExternalTask>> {
+        let since = (Utc::now() - Duration::days(30)).to_rfc3339();
+        let open = self.gh.list_all_open_issues(&self.repo).await?;
+        let closed = self.gh.list_closed_issues_since(&self.repo, &since).await?;
+        let issues = open.into_iter().chain(closed);
+
+        Ok(issues
             .filter(|issue| issue.pull_request.is_none()) // Exclude PRs
             .filter(is_trusted_author) // Only trusted authors
             .map(|issue| ExternalTask {

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -190,6 +190,14 @@ pub trait ExternalBackend: Send + Sync {
         Ok(all_tasks)
     }
 
+    /// List tasks for closed-issue reconciliation fallback.
+    ///
+    /// Used when `list_all_tasks` fails (e.g., transient API issues).
+    /// Default implementation returns an empty list, meaning no fallback data.
+    async fn list_reconciliation_candidates(&self) -> anyhow::Result<Vec<ExternalTask>> {
+        Ok(Vec::new())
+    }
+
     /// List open tasks that are routable — no `status:*` label yet, or `status:new`.
     ///
     /// Default implementation falls back to `list_by_status(New)`.

--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -4,7 +4,7 @@
 //! deleting local/remote branches, pulling main, and detecting
 //! already-merged PRs so their tasks can be marked done.
 
-use crate::backends::{ExternalBackend, ExternalId, Status};
+use crate::backends::{ExternalBackend, ExternalId, ExternalTask, Status};
 use crate::cmd::CommandErrorContext;
 use crate::engine::tasks::TaskManager;
 use crate::store;
@@ -75,6 +75,73 @@ pub(crate) async fn cleanup_done_worktrees(
     cleanup_done_worktrees_with_opts(backend, repo, task_manager, store, &opts).await
 }
 
+async fn reconcile_closed_tasks(
+    task_ids: &mut Vec<String>,
+    all_tasks: &[ExternalTask],
+    task_manager: &TaskManager,
+) {
+    let done_set: std::collections::HashSet<String> = task_ids.iter().cloned().collect();
+    let closed_not_in_store: Vec<_> = all_tasks
+        .iter()
+        .filter(|t| t.state == "closed" && !done_set.contains(&t.id.0))
+        .collect();
+
+    // Split: issues that already have status:done label just need worktree
+    // cleanup (no API call needed), vs those needing label reconciliation.
+    let mut already_labeled: Vec<String> = Vec::new();
+    let mut needs_reconcile: Vec<&ExternalTask> = Vec::new();
+    for task in &closed_not_in_store {
+        if task.labels.iter().any(|l| l == "status:done") {
+            already_labeled.push(task.id.0.clone());
+        } else {
+            needs_reconcile.push(task);
+        }
+    }
+
+    // Add already-labeled issues directly (no API call).
+    if !already_labeled.is_empty() {
+        tracing::debug!(
+            count = already_labeled.len(),
+            "closed issues already labeled status:done — adding to cleanup set"
+        );
+        task_ids.extend(already_labeled);
+    }
+
+    // Reconcile issues missing the done label — cap to avoid rate-limit
+    // exhaustion. Remaining issues will be picked up in subsequent cycles.
+    const MAX_RECONCILE_PER_CYCLE: usize = 10;
+    if needs_reconcile.len() > MAX_RECONCILE_PER_CYCLE {
+        tracing::info!(
+            total = needs_reconcile.len(),
+            batch = MAX_RECONCILE_PER_CYCLE,
+            "capping closed-issue reconciliation to avoid rate-limit exhaustion"
+        );
+    }
+    for task in needs_reconcile.iter().take(MAX_RECONCILE_PER_CYCLE) {
+        tracing::info!(
+            task_id = task.id.0,
+            labels = ?task.labels,
+            "closed issue with stale status label — reconciling to done and cleaning up"
+        );
+        if let Err(e) = task_manager
+            .update_task_status(&task.id, Status::Done)
+            .await
+        {
+            tracing::warn!(
+                task_id = task.id.0,
+                err = %e,
+                "failed to reconcile closed issue status to done"
+            );
+        }
+    }
+    task_ids.extend(
+        needs_reconcile
+            .iter()
+            .take(MAX_RECONCILE_PER_CYCLE)
+            .map(|t| t.id.0.clone()),
+    );
+}
+
 /// Cleanup worktrees for completed tasks with explicit options.
 ///
 /// Separated from `cleanup_done_worktrees` so that integration tests can
@@ -113,69 +180,28 @@ pub(crate) async fn cleanup_done_worktrees_with_opts(
     // is backend-specific and not tracked in the store.
     match backend.list_all_tasks().await {
         Ok(all_tasks) => {
-            let done_set: std::collections::HashSet<String> = task_ids.iter().cloned().collect();
-            let closed_not_in_store: Vec<_> = all_tasks
-                .iter()
-                .filter(|t| t.state == "closed" && !done_set.contains(&t.id.0))
-                .collect();
-
-            // Split: issues that already have status:done label just need worktree
-            // cleanup (no API call needed), vs those needing label reconciliation.
-            let mut already_labeled: Vec<String> = Vec::new();
-            let mut needs_reconcile: Vec<&crate::backends::ExternalTask> = Vec::new();
-            for task in &closed_not_in_store {
-                if task.labels.iter().any(|l| l == "status:done") {
-                    already_labeled.push(task.id.0.clone());
-                } else {
-                    needs_reconcile.push(task);
-                }
-            }
-
-            // Add already-labeled issues directly (no API call).
-            if !already_labeled.is_empty() {
-                tracing::debug!(
-                    count = already_labeled.len(),
-                    "closed issues already labeled status:done — adding to cleanup set"
-                );
-                task_ids.extend(already_labeled);
-            }
-
-            // Reconcile issues missing the done label — cap to avoid rate-limit
-            // exhaustion. Remaining issues will be picked up in subsequent cycles.
-            const MAX_RECONCILE_PER_CYCLE: usize = 10;
-            if needs_reconcile.len() > MAX_RECONCILE_PER_CYCLE {
-                tracing::info!(
-                    total = needs_reconcile.len(),
-                    batch = MAX_RECONCILE_PER_CYCLE,
-                    "capping closed-issue reconciliation to avoid rate-limit exhaustion"
-                );
-            }
-            for task in needs_reconcile.iter().take(MAX_RECONCILE_PER_CYCLE) {
-                tracing::info!(
-                    task_id = task.id.0,
-                    labels = ?task.labels,
-                    "closed issue with stale status label — reconciling to done and cleaning up"
-                );
-                if let Err(e) = task_manager
-                    .update_task_status(&task.id, Status::Done)
-                    .await
-                {
-                    tracing::warn!(
-                        task_id = task.id.0,
-                        err = %e,
-                        "failed to reconcile closed issue status to done"
-                    );
-                }
-            }
-            task_ids.extend(
-                needs_reconcile
-                    .iter()
-                    .take(MAX_RECONCILE_PER_CYCLE)
-                    .map(|t| t.id.0.clone()),
-            );
+            reconcile_closed_tasks(&mut task_ids, &all_tasks, task_manager).await;
         }
         Err(e) => {
             tracing::warn!(err = %e, "failed to list all tasks for closed-issue reconciliation");
+            match backend.list_reconciliation_candidates().await {
+                Ok(fallback_tasks) if !fallback_tasks.is_empty() => {
+                    tracing::info!(
+                        count = fallback_tasks.len(),
+                        "using fallback tasks for closed-issue reconciliation"
+                    );
+                    reconcile_closed_tasks(&mut task_ids, &fallback_tasks, task_manager).await;
+                }
+                Ok(_) => {
+                    tracing::debug!("no fallback tasks available for closed-issue reconciliation");
+                }
+                Err(fallback_err) => {
+                    tracing::warn!(
+                        err = %fallback_err,
+                        "failed to list fallback tasks for closed-issue reconciliation"
+                    );
+                }
+            }
         }
     }
 

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -539,44 +539,79 @@ impl GhHttp {
         let mut all: Vec<T> = Vec::new();
         let mut next_url: Option<String> = None;
         let mut is_first = true;
+        const MAX_JSON_DECODE_RETRIES: u32 = 2;
+        const JSON_DECODE_RETRY_BACKOFF_MS: u64 = 200;
 
         loop {
-            let resp = if is_first {
+            let (request_url, request_query) = if is_first {
                 is_first = false;
-                let auth = self.auth_header().await?;
-                self.client
-                    .get(url)
-                    .query(query)
-                    .header(header::AUTHORIZATION, auth)
-                    .header(header::ACCEPT, "application/vnd.github+json")
-                    .header("X-GitHub-Api-Version", "2022-11-28")
-                    .send()
-                    .await?
+                (url, Some(query))
             } else {
                 let Some(u) = next_url.as_ref() else { break };
+                (u.as_str(), None)
+            };
+
+            let mut decode_attempt = 0;
+            let (page, next) = loop {
                 let auth = self.auth_header().await?;
-                self.client
-                    .get(u)
+                let mut req = self
+                    .client
+                    .get(request_url)
                     .header(header::AUTHORIZATION, auth)
                     .header(header::ACCEPT, "application/vnd.github+json")
-                    .header("X-GitHub-Api-Version", "2022-11-28")
-                    .send()
-                    .await?
+                    .header("X-GitHub-Api-Version", "2022-11-28");
+                if let Some(q) = request_query {
+                    req = req.query(q);
+                }
+
+                let resp = req.send().await?;
+                Self::record_response(&resp);
+                let status = resp.status();
+                let next_from_headers = parse_link_next(resp.headers());
+                let content_type = resp
+                    .headers()
+                    .get(header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "<missing>".to_string());
+
+                if !status.is_success() {
+                    let body = resp.text().await.unwrap_or_default();
+                    Self::maybe_record_rate_limit_from_body(status, &body);
+                    anyhow::bail!("GitHub API GET (paginated) failed ({status}): {body}");
+                }
+
+                let text = resp.text().await?;
+                match serde_json::from_str::<Vec<T>>(&text) {
+                    Ok(page) => break (page, next_from_headers),
+                    Err(err) => {
+                        let snippet: String = text.chars().take(200).collect();
+                        let decode_error = anyhow::anyhow!(
+                            "GitHub API GET (paginated) JSON decode failed ({status}, content-type={content_type}): {snippet}"
+                        )
+                        .context(err);
+                        if decode_attempt < MAX_JSON_DECODE_RETRIES {
+                            decode_attempt += 1;
+                            tracing::warn!(
+                                attempt = decode_attempt,
+                                max_attempts = MAX_JSON_DECODE_RETRIES,
+                                status = %status,
+                                content_type,
+                                err = %decode_error,
+                                "json decode failed; retrying paginated GET"
+                            );
+                            tokio::time::sleep(Duration::from_millis(
+                                JSON_DECODE_RETRY_BACKOFF_MS * u64::from(decode_attempt),
+                            ))
+                            .await;
+                            continue;
+                        }
+                        return Err(decode_error);
+                    }
+                }
             };
-            Self::record_response(&resp);
-            let status = resp.status();
 
-            // Parse Link header for next page
-            next_url = parse_link_next(resp.headers());
-
-            if !status.is_success() {
-                let body = resp.text().await.unwrap_or_default();
-                Self::maybe_record_rate_limit_from_body(status, &body);
-                anyhow::bail!("GitHub API GET (paginated) failed ({status}): {body}");
-            }
-
-            let text = resp.text().await?;
-            let page: Vec<T> = serde_json::from_str(&text)?;
+            next_url = next;
             all.extend(page);
 
             if next_url.is_none() {
@@ -741,6 +776,25 @@ impl GhHttp {
                     ("since", since),
                     ("per_page", "100"),
                 ],
+            )
+            .await?;
+        Ok(all
+            .into_iter()
+            .filter(|i| i.pull_request.is_none())
+            .collect())
+    }
+
+    /// List closed issues updated since `since` (ISO 8601), no label filter.
+    pub async fn list_closed_issues_since(
+        &self,
+        repo: &str,
+        since: &str,
+    ) -> anyhow::Result<Vec<GitHubIssue>> {
+        let url = format!("{GITHUB_API}/repos/{repo}/issues");
+        let all: Vec<GitHubIssue> = self
+            .get_all_pages(
+                &url,
+                &[("state", "closed"), ("since", since), ("per_page", "100")],
             )
             .await?;
         Ok(all


### PR DESCRIPTION
## Summary

All done. Here's a summary of the changes made:

**`src/github/http.rs` — two changes:**

1. **`get_all_pages` — better error context on JSON decode failure** (lines ~580-595): Captures the `Content-Type` header before consuming the response body, then wraps any `serde_json` decode error with a descriptive message including the HTTP status, content-type, and first 200 chars of the body. The log that was failing (`error decoding response body`) will now say something like:
   ```
   JSON deco

Closes #1117

---
*Task #1117 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*