### PR TITLE
bug: review agent posts approval before orchestrator pushes rebased branch — approval comment references unpushed code

### DIFF
--- a/prompts/review_task.md
+++ b/prompts/review_task.md
@@ -12,7 +12,7 @@ Keep the branch up to date — other PRs may have merged since this was created:
    - `git add <resolved files>` then `git rebase --continue`
    - If a conflict is too complex to resolve safely, set decision = `request_changes`
 
-**Do NOT push** — the orchestrator handles pushing after review completes.
+**Do NOT push** — the orchestrator handles pushing after review completes and before posting the review decision.
 
 ### Step 2: Verify CI status
 
@@ -23,7 +23,7 @@ timeout 300 gh pr checks {{PR_NUMBER}} --watch --fail-fast || true
 ```
 
 - **CI passes AND branch is up to date** (Step 1 rebase was a no-op or already applied) → proceed to Step 3 (skip local test runs)
-- **CI passes BUT branch was rebased** (Step 1 changed commits) → CI results are stale. Note in your review that CI needs to re-run post-rebase and proceed with code review. The orchestrator will push the rebased branch and CI will re-run before merging.
+- **CI passes BUT branch was rebased** (Step 1 changed commits) → CI results are stale. Note in your review that CI needs to re-run post-rebase and proceed with code review. The orchestrator will push the rebased branch (before posting the review decision) and CI will re-run before merging.
 - **CI fails** → check if the failure is related to files in this PR. If not, it's pre-existing — note it and proceed. If it is, set decision = `request_changes`
 - **CI not run yet or pending** → run local checks as fallback: read `.github/workflows/` to identify what CI runs and execute those commands. Do NOT hardcode language-specific commands
 

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1002,7 +1002,47 @@ pub(crate) async fn review_and_merge(
         "review agent decision received"
     );
 
-    // 12. Post automated review comment on the PR
+    // 12. Push the rebased branch before posting the review decision so the
+    // comment references code that's already on the PR.
+    match runner::git_ops::push_branch(&worktree_path, &branch_name, &default_branch).await {
+        Ok(_) => {
+            if opt_store_get_task(&Some(Arc::clone(store)), repo, &task.id.0)
+                .await
+                .map(|t| t.last_error)
+                .unwrap_or_default()
+                .contains("push failed")
+            {
+                store_set(
+                    &Some(Arc::clone(store)),
+                    repo,
+                    &task.id.0,
+                    &[
+                        ("last_error", serde_json::json!("")),
+                        ("push_failures", serde_json::json!(0)),
+                    ],
+                )
+                .await;
+            }
+        }
+        Err(e) => {
+            tracing::error!(
+                task_id = task.id.0,
+                branch = %branch_name,
+                error = %e,
+                "review push failed"
+            );
+            store_set(
+                &Some(Arc::clone(store)),
+                repo,
+                &task.id.0,
+                &[("last_error", serde_json::json!(format!("push failed: {e}")))],
+            )
+            .await;
+            return Ok(ReviewDecision::Failed(format!("push failed: {e}")));
+        }
+    }
+
+    // 13. Post automated review comment on the PR
     let gh = GhHttp::new()?;
     let pr_comment = match &decision {
         ReviewDecision::Approve => {
@@ -1052,7 +1092,7 @@ pub(crate) async fn review_and_merge(
         }
     }
 
-    // 13. Complete run tracking
+    // 14. Complete run tracking
     if let Some(run_id) = run_id {
         let outcome = match &decision {
             ReviewDecision::Approve => "success",
@@ -1080,14 +1120,14 @@ pub(crate) async fn review_and_merge(
             .await;
     }
 
-    // 14. Check for push failures before acting on the decision.
+    // 15. Check for push failures before acting on the decision.
     let has_push_failure = opt_store_get_task(&Some(Arc::clone(store)), repo, &task.id.0)
         .await
         .map(|t| t.last_error)
         .unwrap_or_default()
         .contains("push failed");
 
-    // 15. Handle the decision
+    // 16. Handle the decision
     match decision {
         ReviewDecision::Approve => {
             if has_push_failure {


### PR DESCRIPTION
## Summary

Push rebased review branches before posting automated review decisions, and aligned the review prompt guidance with the new behavior.

### What was done

- Added a pre-comment push step in review flow, including push-failure handling and clearing stale push errors
- Updated review prompt to reflect orchestrator push timing before review comments
- Ran `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run`


Closes #1119

---
*Task #1119 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.2-codex`*