### PR TITLE
bug: git fetch failure before review context is silently discarded — review uses stale diff/log with no warning

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -629,11 +629,18 @@ pub(crate) async fn review_and_merge(
     // 3. Fetch latest remote refs before building diff context.
     // Without this, build_git_diff and build_git_log operate on stale
     // origin/{default_branch}, producing false diffs and incorrect baselines.
-    let _ = Command::new("git")
+    if let Err(e) = Command::new("git")
         .args(["fetch", "origin", "--prune"])
         .current_dir(&worktree_path)
         .output_with_context()
-        .await;
+        .await
+    {
+        tracing::warn!(
+            task_id = task.id.0,
+            error = %e,
+            "review: git fetch failed — diff/log may use stale remote refs"
+        );
+    }
 
     // 4. Build diff context
     let default_branch = runner::worktree::detect_default_branch(&worktree_path).await;


### PR DESCRIPTION
## Summary

Log a warning if `git fetch origin --prune` fails before building review diff/log so review decisions don't silently use stale remote refs.

### What was done

- Replaced the silently-discarded git fetch in `src/engine/review.rs` with error handling that emits a warning when the fetch fails
- Committed the change on the current feature branch with message: "review: warn on git fetch failure before building review diff/log to avoid silent stale refs"


### Remaining

- Monitor CI and review logs to ensure the new warning appears when fetch failures occur in relevant environments
- Consider adding a unit/integration test covering behavior when git fetch fails (optional)


Closes #1129

---
*Task #1129 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*