### PR TITLE
feat: detect silent agents via tmux capture — cooldown model and re-route after 120s of no output

### DIFF
--- a/src/channels/capture.rs
+++ b/src/channels/capture.rs
@@ -39,6 +39,13 @@ pub struct OutputBuffer {
     /// Prevents firing "session ended" for sessions that were registered
     /// before the tmux session was actually created.
     pub seen_alive: bool,
+    /// When this session was registered for capture.
+    pub registered_at: DateTime<Utc>,
+    /// Whether the agent has produced any meaningful output since session start.
+    /// Used for silence detection: only agents that never produced output are
+    /// considered silent. Agents that produced output then go quiet are NOT
+    /// killed (they may be running long tool calls with sparse output).
+    pub has_output: bool,
 }
 
 /// Service that captures tmux pane output and broadcasts to transport.
@@ -63,14 +70,17 @@ impl CaptureService {
 
     /// Register a session to be tracked.
     pub async fn register_session(&self, task_id: &str, session: &str) {
+        let now = Utc::now();
         let buffer = OutputBuffer {
             session: session.to_string(),
             task_id: task_id.to_string(),
             last_content: String::new(),
             last_len: 0,
             last_hash: None,
-            last_capture: Utc::now(),
+            last_capture: now,
             seen_alive: false,
+            registered_at: now,
+            has_output: false,
         };
         self.buffers
             .write()
@@ -125,6 +135,33 @@ impl CaptureService {
 
             self.tick().await;
         }
+    }
+
+    /// Return task IDs of sessions that have been silent since registration.
+    ///
+    /// A session is "silent" when:
+    /// 1. It has been registered for longer than `grace_period`
+    /// 2. It has NEVER produced any meaningful output (`has_output == false`)
+    ///
+    /// This intentionally does NOT flag agents that produced output then went
+    /// quiet (e.g. long tool calls with sparse output).
+    pub async fn get_silent_sessions(
+        &self,
+        grace_period: std::time::Duration,
+    ) -> Vec<(String, String)> {
+        let now = Utc::now();
+        let buffers = self.buffers.read().await;
+        let mut silent = Vec::new();
+        for buf in buffers.values() {
+            if buf.has_output {
+                continue;
+            }
+            let age = now.signed_duration_since(buf.registered_at);
+            if age.num_seconds() > grace_period.as_secs() as i64 {
+                silent.push((buf.task_id.clone(), buf.session.clone()));
+            }
+        }
+        silent
     }
 
     /// Run one tick of the capture loop.
@@ -233,6 +270,7 @@ impl OutputBuffer {
         if new_content.trim().is_empty() {
             None
         } else {
+            self.has_output = true;
             Some(new_content)
         }
     }
@@ -259,6 +297,7 @@ fn cap_content(content: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::channels::transport::Transport;
 
     fn make_buffer() -> OutputBuffer {
         OutputBuffer {
@@ -269,6 +308,8 @@ mod tests {
             last_hash: None,
             last_capture: Utc::now(),
             seen_alive: false,
+            registered_at: Utc::now(),
+            has_output: false,
         }
     }
 
@@ -330,6 +371,64 @@ mod tests {
         let mut buf = make_buffer();
         let result = buf.diff_and_update("");
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn has_output_set_on_meaningful_content() {
+        let mut buf = make_buffer();
+        assert!(!buf.has_output);
+        buf.diff_and_update("hello");
+        assert!(buf.has_output);
+    }
+
+    #[test]
+    fn has_output_not_set_on_empty_content() {
+        let mut buf = make_buffer();
+        buf.diff_and_update("");
+        assert!(!buf.has_output, "empty content should not set has_output");
+    }
+
+    #[test]
+    fn has_output_stays_true_after_silence() {
+        let mut buf = make_buffer();
+        buf.diff_and_update("hello");
+        assert!(buf.has_output);
+        // Same content (no new output) — has_output should remain true
+        buf.diff_and_update("hello");
+        assert!(buf.has_output, "has_output should not revert once set");
+    }
+
+    #[tokio::test]
+    async fn get_silent_sessions_returns_only_no_output_past_grace() {
+        let transport = Arc::new(Transport::new());
+        let svc = CaptureService::new(transport);
+
+        // Register a session and backdate it past the grace period
+        svc.register_session("silent-task", "orch-test-silent")
+            .await;
+        {
+            let mut buffers = svc.buffers.write().await;
+            let buf = buffers.get_mut("silent-task").unwrap();
+            buf.registered_at = Utc::now() - chrono::Duration::seconds(200);
+        }
+
+        // Register a session that HAS produced output (should not be returned)
+        svc.register_session("active-task", "orch-test-active")
+            .await;
+        {
+            let mut buffers = svc.buffers.write().await;
+            let buf = buffers.get_mut("active-task").unwrap();
+            buf.registered_at = Utc::now() - chrono::Duration::seconds(200);
+            buf.has_output = true;
+        }
+
+        // Register a fresh session within grace period (should not be returned)
+        svc.register_session("new-task", "orch-test-new").await;
+
+        let grace = std::time::Duration::from_secs(120);
+        let silent = svc.get_silent_sessions(grace).await;
+        assert_eq!(silent.len(), 1);
+        assert_eq!(silent[0].0, "silent-task");
     }
 
     #[test]

--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -105,6 +105,16 @@ pub fn record_model_failure(agent_name: &str, model: &str) {
     set_cooldown(&key, cooldown_until, "model_error");
 }
 
+/// Set a model cooldown with a custom duration (in seconds).
+///
+/// Used by silence detection to cooldown the specific model that failed to
+/// produce any output, with a configurable duration.
+pub fn set_model_cooldown(agent_name: &str, model: &str, duration_secs: u64) {
+    let key = format!("{agent_name}:{model}");
+    let cooldown_until = chrono::Utc::now().timestamp() + duration_secs as i64;
+    set_cooldown(&key, cooldown_until, "silence_detected");
+}
+
 /// Check if a specific agent+model combo is in cooldown.
 pub fn is_model_in_cooldown(agent_name: &str, model: &str) -> bool {
     let key = format!("{agent_name}:{model}");

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -111,6 +111,11 @@ pub struct EngineConfig {
     pub auto_close_task_on_approval: bool,
     /// Graceful shutdown timeout — how long to wait for running agents before exiting.
     pub graceful_shutdown_timeout: std::time::Duration,
+    /// Grace period before silence detection kicks in (seconds).
+    /// Allows time for agent startup, model download, API handshake.
+    pub silence_grace_period: u64,
+    /// Cooldown duration for a model detected as silent (seconds).
+    pub silence_cooldown: u64,
 }
 
 impl Default for EngineConfig {
@@ -125,6 +130,8 @@ impl Default for EngineConfig {
             auto_create_followup_on_changes: true,
             auto_close_task_on_approval: false,
             graceful_shutdown_timeout: std::time::Duration::from_secs(600),
+            silence_grace_period: 120,
+            silence_cooldown: 3600,
         }
     }
 }
@@ -190,6 +197,18 @@ impl EngineConfig {
         if let Ok(val) = crate::config::get("engine.graceful_shutdown_timeout") {
             if let Ok(secs) = val.parse::<u64>() {
                 config.graceful_shutdown_timeout = std::time::Duration::from_secs(secs);
+            }
+        }
+
+        if let Ok(val) = crate::config::get("engine.silence_grace_period") {
+            if let Ok(secs) = val.parse::<u64>() {
+                config.silence_grace_period = secs;
+            }
+        }
+
+        if let Ok(val) = crate::config::get("engine.silence_cooldown") {
+            if let Ok(secs) = val.parse::<u64>() {
+                config.silence_cooldown = secs;
             }
         }
 

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -105,6 +105,118 @@ async fn stuck_task_timing(
     })
 }
 
+/// Phase 1b of tick: detect agents that have produced no output since session start
+/// and have exceeded the silence grace period.
+///
+/// Only triggers on complete silence (agent never produced any output). Agents that
+/// produced output then went quiet (e.g. long tool calls) are NOT affected.
+///
+/// On silence: kills the tmux session, applies model-level cooldown, resets the task
+/// to `New` so the router picks a different agent/model.
+pub(crate) async fn tick_detect_silent_agents(
+    tmux: &Arc<TmuxManager>,
+    repo: &str,
+    capture: &Arc<CaptureService>,
+    backend: &Arc<dyn ExternalBackend>,
+    task_manager: &Arc<TaskManager>,
+    config: &EngineConfig,
+    store: &Arc<TaskStore>,
+) -> anyhow::Result<()> {
+    let _span = tracing::info_span!("engine.tick.phase1b.silence").entered();
+    let grace = std::time::Duration::from_secs(config.silence_grace_period);
+    let silent_sessions = capture.get_silent_sessions(grace).await;
+
+    for (task_id, session_name) in silent_sessions {
+        // Look up agent + model from the store so we can cooldown the right model.
+        let store_task = match store.resolve_task_id(repo, &task_id).await {
+            Ok(Some(store_id)) => store.get(store_id).await.ok(),
+            _ => None,
+        };
+        let agent_name = store_task
+            .as_ref()
+            .and_then(|t| t.agent.clone())
+            .unwrap_or_default();
+        let model_name = store_task
+            .as_ref()
+            .and_then(|t| t.model.clone())
+            .unwrap_or_default();
+
+        tracing::warn!(
+            task_id,
+            agent = %agent_name,
+            model = %model_name,
+            grace_secs = config.silence_grace_period,
+            cooldown_secs = config.silence_cooldown,
+            "agent silent since session start — killing session, cooling down model, re-routing"
+        );
+
+        // 1. Kill the tmux session
+        if let Err(e) = tmux.kill_session(&session_name).await {
+            tracing::debug!(
+                task_id,
+                ?e,
+                "kill_session failed for silent agent (may already be gone)"
+            );
+        }
+
+        // 2. Unregister from capture
+        capture.unregister_session(&task_id).await;
+
+        // 3. Cooldown the specific model (not the whole agent)
+        if !agent_name.is_empty() && !model_name.is_empty() {
+            crate::engine::cooldown::set_model_cooldown(
+                &agent_name,
+                &model_name,
+                config.silence_cooldown,
+            );
+        }
+
+        // 4. Clear routing state and reset to New for re-routing
+        let task_eid = ExternalId(task_id.clone());
+        if let Some(ref st) = store_task {
+            for label in &st.labels {
+                if label.starts_with("agent:") || label.starts_with("complexity:") {
+                    backend.remove_label(&task_eid, label).await.ok();
+                }
+            }
+        }
+        store::store_set(
+            &Some(Arc::clone(store)),
+            repo,
+            &task_id,
+            &[
+                ("agent", serde_json::Value::Null),
+                ("model", serde_json::Value::Null),
+                ("route_attempts", serde_json::json!(0)),
+            ],
+        )
+        .await;
+        if let Err(e) = task_manager
+            .update_task_status(&task_eid, Status::New)
+            .await
+        {
+            tracing::warn!(task_id, ?e, "failed to reset silent task status");
+            continue;
+        }
+
+        // 5. Post a comment explaining what happened
+        let comment = format!(
+            "[{}] agent silent for {}s since session start — killed session, cooled down model `{}:{}` for {}s, re-routing task{}",
+            chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ"),
+            config.silence_grace_period,
+            agent_name,
+            model_name,
+            config.silence_cooldown,
+            crate::engine::orch_footer(),
+        );
+        if let Err(e) = backend.post_comment(&task_eid, &comment).await {
+            tracing::warn!(task_id, ?e, "failed to post silence detection comment");
+        }
+    }
+
+    Ok(())
+}
+
 /// Phase 2 of tick: detect tasks stuck in_progress or in_review without an active tmux session and reset them.
 /// - `in_progress` tasks → reset to `New` (clears routing state so the LLM router re-routes)
 /// - `in_review` tasks   → reset to `NeedsReview` (keeps routing state; review agent re-triggers)
@@ -860,6 +972,7 @@ pub(crate) async fn tick(
 ) -> anyhow::Result<()> {
     let _tick_span = tracing::info_span!("engine.tick").entered();
     tick_check_session_completions(tmux, repo, capture).await?;
+    tick_detect_silent_agents(tmux, repo, capture, backend, task_manager, config, store).await?;
     tick_recover_stuck_tasks(backend, tmux, repo, task_manager, config, store).await?;
     tick_route_tasks(backend, task_manager, router, store, repo).await?;
     tick_dispatch_tasks(

--- a/tests/capture_diff.rs
+++ b/tests/capture_diff.rs
@@ -23,6 +23,10 @@ mod channels {
         pub struct Transport;
 
         impl Transport {
+            pub fn new() -> Self {
+                Self
+            }
+
             pub async fn get_session_output(&self, _task_id: &str) -> Option<String> {
                 None
             }
@@ -47,6 +51,8 @@ fn buffer() -> OutputBuffer {
         last_hash: None,
         last_capture: chrono::Utc::now(),
         seen_alive: false,
+        registered_at: chrono::Utc::now(),
+        has_output: false,
     }
 }
 


### PR DESCRIPTION
## Summary

The background clippy run also completed clean — no output means no errors or warnings.

The implementation is complete and all checks pass (fmt ✓, clippy ✓, 1991/1991 tests ✓).

Closes #1113

---
*Task #1113 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*