### PR TITLE
bug: cleanup deletes remote branch while task is between agent attempts — auto-closes the PR

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -378,12 +378,13 @@ async fn reconcile_startup_worktrees(project_engines: &[ProjectEngine]) -> anyho
                     {
                         tracing::warn!(repo = %engine.repo, task_id = %task_id, err = %e, "startup rebase failed, resetting task");
                         abort_worktree_rebase(&worktree_dir).await;
+                        let keep_remote = task.pr_number.is_some();
                         remove_worktree_and_branch(
                             &task_id,
                             &worktree_dir,
                             Some(branch_name),
                             &repo_root_path,
-                            false,
+                            keep_remote,
                         )
                         .await;
                         if let Ok(Some(reset_id)) =


### PR DESCRIPTION
## Summary

Done. One-line fix at `src/engine/mod.rs:381`: added `let keep_remote = task.pr_number.is_some();` and passed it to `remove_worktree_and_branch()` instead of the hardcoded `false`. This preserves the remote branch (and thus the open PR) when a startup rebase fails for a task that has a linked PR. The worktree and local branch are still cleaned up — `setup_worktree` will recreate them from the remote branch on re-dispatch.

Closes #1127

---
*Task #1127 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*