### PR TITLE
bug: early return in runner skips tmux cleanup — leaks sessions and leaves secrets in tmux global env

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -452,8 +452,8 @@ impl TaskRunner {
                 )
                 .await?;
                 if budget_exceeded {
-                    // Token budget exceeded — store already updated, return without
-                    // tmux cleanup or metrics (preserves original behavior)
+                    // Token budget exceeded — clean up tmux session and env secrets
+                    session::cleanup_session(task_id, &tmux, &tmux_session).await;
                     let audit = self
                         .build_run_audit(RunAuditInput {
                             task_id,
@@ -487,7 +487,8 @@ impl TaskRunner {
                 .await?
                 {
                     fallback::ErrorHandleResult::EarlyReturn { status } => {
-                        // Task rerouted — return (metrics recorded in run_with_context)
+                        // Task rerouted — clean up tmux session and env secrets
+                        session::cleanup_session(task_id, &tmux, &tmux_session).await;
                         let audit = self
                             .build_run_audit(RunAuditInput {
                                 task_id,


### PR DESCRIPTION
## Summary

Done. The fix adds `session::cleanup_session(task_id, &tmux, &tmux_session).await` before both early returns in `src/engine/runner/mod.rs`:

1. **Line 455** (budget exceeded path) — was explicitly skipping cleanup per a stale comment
2. **Line 490** (error reroute path) — was returning without cleanup

This ensures tmux sessions are killed and `GH_TOKEN`/`GITHUB_TOKEN` are scrubbed from the tmux global environment in all code paths.

Closes #1142

---
*Task #1142 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch)*