### PR TITLE
feat: agent should read issue comments when picking up a task — not just the body

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -391,4 +391,21 @@ impl ExternalBackend for GitHubBackend {
             })
             .collect())
     }
+
+    async fn list_issue_comments(&self, id: &ExternalId) -> anyhow::Result<Vec<Mention>> {
+        let issue_number: u64 =
+            id.0.parse()
+                .map_err(|_| anyhow::anyhow!("invalid issue number: {}", id.0))?;
+        let comments = self.gh.get_issue_comments(&self.repo, issue_number).await?;
+        Ok(comments
+            .into_iter()
+            .map(|c| Mention {
+                id: c.id.to_string(),
+                body: c.body,
+                author: c.user.login,
+                created_at: c.created_at,
+                issue_url: c.issue_url,
+            })
+            .collect())
+    }
 }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -281,6 +281,13 @@ pub trait ExternalBackend: Send + Sync {
     async fn get_mentions(&self, _since: &str) -> anyhow::Result<Vec<Mention>> {
         Ok(vec![])
     }
+
+    /// Get all comments for a specific task/issue.
+    ///
+    /// Returns empty by default (backends that don't support per-issue comment listing).
+    async fn list_issue_comments(&self, _id: &ExternalId) -> anyhow::Result<Vec<Mention>> {
+        Ok(vec![])
+    }
 }
 
 #[cfg(test)]

--- a/src/engine/runner/context.rs
+++ b/src/engine/runner/context.rs
@@ -241,38 +241,53 @@ pub async fn build_git_log(project_dir: &Path, default_branch: &str) -> String {
     }
 }
 
-/// Fetch recent issue comments for agent context.
+/// Returns true if the comment is from an automated bot and should be skipped.
+fn is_bot_comment(mention: &crate::backends::Mention) -> bool {
+    // Skip GitHub Actions bots and other automated accounts
+    if mention.author.ends_with("[bot]") {
+        return true;
+    }
+    // Skip automated review comments posted by orch itself
+    if mention.body.starts_with("## Automated Review") {
+        return true;
+    }
+    false
+}
+
+/// Fetch issue comments for agent context.
+///
+/// Fetches all comments for the specific issue using the per-issue API endpoint,
+/// then returns the last `limit` non-bot comments formatted for the prompt.
 pub async fn fetch_issue_comments(
     backend: &dyn ExternalBackend,
     task_id: &str,
     limit: usize,
 ) -> String {
-    let since = chrono::Utc::now() - chrono::Duration::days(30);
-    let since_str = since.format("%Y-%m-%dT%H:%M:%SZ").to_string();
-
-    let mentions = match backend.get_mentions(&since_str).await {
-        Ok(m) => m,
-        Err(_) => return String::new(),
+    let id = crate::backends::ExternalId(task_id.to_string());
+    let all_comments = match backend.list_issue_comments(&id).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!(task_id, error = %e, "failed to fetch issue comments");
+            return String::new();
+        }
     };
 
-    // Filter to comments on this task
-    let mut comments = String::new();
-    let mut count = 0;
-    for mention in mentions.iter().rev() {
-        if count >= limit {
-            break;
-        }
-        // Include if the mention references this task
-        if mention.id.contains(task_id) || mention.body.contains(&format!("#{task_id}")) {
-            comments.push_str(&format!(
-                "**@{}** ({}):\n{}\n\n",
-                mention.author, mention.created_at, mention.body
-            ));
-            count += 1;
-        }
+    // Filter bot comments, then take the last `limit` entries
+    let human_comments: Vec<_> = all_comments
+        .into_iter()
+        .filter(|c| !is_bot_comment(c))
+        .collect();
+
+    let start = human_comments.len().saturating_sub(limit);
+    let mut formatted = String::new();
+    for comment in &human_comments[start..] {
+        formatted.push_str(&format!(
+            "**@{}** ({}):\n{}\n\n",
+            comment.author, comment.created_at, comment.body
+        ));
     }
 
-    comments
+    formatted
 }
 
 /// Build memory context from previous attempts.

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -960,6 +960,16 @@ impl GhHttp {
             .await
     }
 
+    /// Get all comments for a specific issue number.
+    pub async fn get_issue_comments(
+        &self,
+        repo: &str,
+        issue_number: u64,
+    ) -> anyhow::Result<Vec<GitHubComment>> {
+        let url = format!("{GITHUB_API}/repos/{repo}/issues/{issue_number}/comments");
+        self.get_all_pages(&url, &[("per_page", "100")]).await
+    }
+
     /// Get the current authenticated username.
     pub async fn get_whoami(&self) -> anyhow::Result<String> {
         let user: serde_json::Value = self.get_json(&format!("{GITHUB_API}/user")).await?;


### PR DESCRIPTION
## Summary

Done. Here's a summary of what was implemented:

**Problem**: `fetch_issue_comments` used `get_mentions()` (repo-wide, since 30 days) with broken filtering — it checked if the comment's numeric ID contained the task ID string, which is unreliable and mostly fails.

**Fix** (4 files):
- `src/github/http.rs` — added `get_issue_comments(repo, issue_number)` using `GET /repos/{repo}/issues/{issue_number}/comments`
- `src/backends/mod.rs` — added `list_issue_comments(id)` to `ExternalBackend` t

Closes #1160

---
*Task #1160 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*