### PR TITLE
bug: github-copilot models on opencode have ~99% failure rate — silent exit 0 loops waste hours per day

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -62,25 +62,29 @@ model_map:
   simple:
     claude: haiku
     codex: gpt-5.1-codex-mini
-    opencode: github-copilot/gpt-5-mini
+    opencode:
+      - opencode:free
     kimi: haiku
     minimax: haiku
   medium:
     claude: sonnet
     codex: gpt-5.2
-    opencode: github-copilot/gpt-5.1-codex
+    opencode:
+      - opencode:free
     kimi: sonnet
     minimax: sonnet
   complex:
     claude: opus
     codex: gpt-5.3-codex
-    opencode: github-copilot/claude-opus-4.5
+    opencode:
+      - opencode:free
     kimi: opus
     minimax: opus
   review:
     claude: sonnet
     codex: gpt-5.2
-    opencode: github-copilot/gpt-5.1-codex
+    opencode:
+      - opencode:free
     kimi: sonnet
     minimax: sonnet
   # Free models used as fallback when hitting usage limits (round-robin)


### PR DESCRIPTION
## Summary

Config example now routes every opencode complexity tier through the discovered free-model pool instead of the failing GitHub Copilot models.

### What was done

- Updated `config.example.yml` so each opencode entry under simple/medium/complex/review is defined as a list containing `opencode:free`, ensuring only the locally discoverable free models are used for those tiers.


Closes #1169

---
*Task #1169 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.1-codex-mini`*