### PR TITLE
bug: minimax review agent produces unparseable output — 4 parse errors in 24h stall review cycles

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -917,7 +917,7 @@ pub(crate) async fn review_and_merge(
     }
 
     // Stage 1: strip the agent-specific output envelope to get the review text.
-    let text_for_review = match agent_runner.extract_text(&raw_output) {
+    let mut text_for_review = match agent_runner.extract_text(&raw_output) {
         Ok(text) if !text.is_empty() => text,
         Ok(_) => {
             tracing::debug!(
@@ -966,27 +966,69 @@ pub(crate) async fn review_and_merge(
     let review_response = match runner::response::parse_review_from_output(&text_for_review) {
         Ok(r) => r,
         Err(e) => {
-            tracing::error!(
-                task_id = task.id.0,
-                error = %e,
-                output = %text_for_review.chars().take(300).collect::<String>(),
-                "failed to parse review response"
-            );
-            if let Some(rid) = run_id {
-                let _ = store
-                    .complete_run(&CompleteRun {
-                        run_id: rid,
-                        exit_code: Some(exit_code),
-                        stdout: &raw_output,
-                        stderr: &stderr,
-                        parsed: &text_for_review,
-                        outcome: "failed",
-                        error: &format!("parse error: {e}"),
-                        tokens: RunTokenUsage::default(),
-                    })
-                    .await;
+            if raw_output != text_for_review {
+                match runner::response::parse_review_from_output(&raw_output) {
+                    Ok(r) => {
+                        tracing::warn!(
+                            task_id = task.id.0,
+                            error = %e,
+                            "review response parsed from raw output fallback"
+                        );
+                        text_for_review = raw_output.clone();
+                        r
+                    }
+                    Err(fallback_err) => {
+                        let combined_error = format!(
+                            "primary parse error: {e}; raw output parse error: {fallback_err}"
+                        );
+                        tracing::error!(
+                            task_id = task.id.0,
+                            error = %combined_error,
+                            output = %text_for_review.chars().take(300).collect::<String>(),
+                            "failed to parse review response"
+                        );
+                        if let Some(rid) = run_id {
+                            let _ = store
+                                .complete_run(&CompleteRun {
+                                    run_id: rid,
+                                    exit_code: Some(exit_code),
+                                    stdout: &raw_output,
+                                    stderr: &stderr,
+                                    parsed: &text_for_review,
+                                    outcome: "failed",
+                                    error: &format!("parse error: {combined_error}"),
+                                    tokens: RunTokenUsage::default(),
+                                })
+                                .await;
+                        }
+                        return Ok(ReviewDecision::Failed(format!(
+                            "parse error: {combined_error}"
+                        )));
+                    }
+                }
+            } else {
+                tracing::error!(
+                    task_id = task.id.0,
+                    error = %e,
+                    output = %text_for_review.chars().take(300).collect::<String>(),
+                    "failed to parse review response"
+                );
+                if let Some(rid) = run_id {
+                    let _ = store
+                        .complete_run(&CompleteRun {
+                            run_id: rid,
+                            exit_code: Some(exit_code),
+                            stdout: &raw_output,
+                            stderr: &stderr,
+                            parsed: &text_for_review,
+                            outcome: "failed",
+                            error: &format!("parse error: {e}"),
+                            tokens: RunTokenUsage::default(),
+                        })
+                        .await;
+                }
+                return Ok(ReviewDecision::Failed(format!("parse error: {e}")));
             }
-            return Ok(ReviewDecision::Failed(format!("parse error: {e}")));
         }
     };
 

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -443,6 +443,10 @@ pub fn parse_review_response(text: &str) -> anyhow::Result<ReviewResponse> {
         }
     }
 
+    if let Some(resp) = extract_review_response_object(text) {
+        return Ok(resp);
+    }
+
     anyhow::bail!("failed to parse review response")
 }
 
@@ -512,6 +516,58 @@ fn extract_json_block(text: &str) -> Option<String> {
         }
         search_from = end + 3;
     }
+    None
+}
+
+/// Extract a ReviewResponse JSON object from arbitrary text.
+///
+/// Scans for balanced JSON objects and tries to parse them as ReviewResponse.
+fn extract_review_response_object(text: &str) -> Option<ReviewResponse> {
+    let mut start: Option<usize> = None;
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    let mut escape = false;
+
+    for (idx, ch) in text.char_indices() {
+        if start.is_some() {
+            if in_string {
+                if escape {
+                    escape = false;
+                } else if ch == '\\' {
+                    escape = true;
+                } else if ch == '"' {
+                    in_string = false;
+                }
+                continue;
+            }
+
+            match ch {
+                '"' => in_string = true,
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        let start_idx = start.unwrap();
+                        let candidate = &text[start_idx..=idx];
+                        if let Ok(resp) = serde_json::from_str::<ReviewResponse>(candidate) {
+                            return Some(resp);
+                        }
+                        start = None;
+                    }
+                }
+                _ => {}
+            }
+            continue;
+        }
+
+        if ch == '{' {
+            start = Some(idx);
+            depth = 1;
+            in_string = false;
+            escape = false;
+        }
+    }
+
     None
 }
 
@@ -753,6 +809,14 @@ That's all."#;
         assert_eq!(resp.decision, "request_changes");
         assert_eq!(resp.issues.len(), 1);
         assert_eq!(resp.issues[0].file, "src/main.rs");
+    }
+
+    #[test]
+    fn parse_review_response_embedded_json_object() {
+        let text = "Review complete.\n\n{\"decision\":\"approve\",\"notes\":\"LGTM\",\"test_results\":\"pass\",\"issues\":[]}\nThanks!";
+        let resp = parse_review_response(text).unwrap();
+        assert_eq!(resp.decision, "approve");
+        assert_eq!(resp.notes, "LGTM");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Hardened review response parsing with embedded JSON extraction and a raw-output fallback, plus added coverage for embedded JSON responses.

### What was done

- Added balanced-brace JSON extraction to parse ReviewResponse objects embedded in non-JSON text
- Added a review parsing fallback to retry against raw output when envelope-extracted text fails
- Added test coverage for embedded ReviewResponse JSON parsing
- Ran `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run`


Closes #1171

---
*Task #1171 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.2-codex`*