### PR TITLE
fix: orch log includes orchestrator logs (different project)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -169,9 +169,6 @@ pub fn log(lines: &str) -> anyhow::Result<()> {
         state_dir.join("orch.error.log"),
         std::path::PathBuf::from(&brew_prefix).join("var/log/orch.log"),
         std::path::PathBuf::from(&brew_prefix).join("var/log/orch.error.log"),
-        // Legacy paths
-        std::path::PathBuf::from(&brew_prefix).join("var/log/orchestrator.log"),
-        std::path::PathBuf::from(&brew_prefix).join("var/log/orchestrator.error.log"),
     ];
 
     for path in &candidates {


### PR DESCRIPTION
## Summary

Removed the legacy orchestrator log candidates from `orch log` so it only shows orch logs.

### What was done

- Dropped the brew-installed `orchestrator.log` and `orchestrator.error.log` paths from the candidate list in `src/cli/mod.rs:160-166`, leaving only the orch log files.


Closes #1180

---
*Task #1180 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.1-codex-mini`*