### PR TITLE
bug: silent-agent detection can unregister sessions for the wrong repo

### DIFF
--- a/src/channels/capture.rs
+++ b/src/channels/capture.rs
@@ -23,6 +23,8 @@ pub(crate) const MAX_OUTPUT_BUFFER_BYTES: usize = 1024 * 1024;
 /// Buffer for tracking session output state.
 #[derive(Debug, Clone)]
 pub struct OutputBuffer {
+    /// Repo slug (owner/repo) that owns this session.
+    pub repo: String,
     /// The tmux session name (e.g., "orch-myproject-42")
     pub session: String,
     /// The task ID this session belongs to
@@ -69,9 +71,10 @@ impl CaptureService {
     }
 
     /// Register a session to be tracked.
-    pub async fn register_session(&self, task_id: &str, session: &str) {
+    pub async fn register_session(&self, repo: &str, task_id: &str, session: &str) {
         let now = Utc::now();
         let buffer = OutputBuffer {
+            repo: repo.to_string(),
             session: session.to_string(),
             task_id: task_id.to_string(),
             last_content: String::new(),
@@ -86,13 +89,14 @@ impl CaptureService {
             .write()
             .await
             .insert(task_id.to_string(), buffer);
-        tracing::debug!(task_id, session, "session registered for capture");
+        tracing::debug!(repo, task_id, session, "session registered for capture");
     }
 
     /// Unregister a session (stop tracking).
     pub async fn unregister_session(&self, task_id: &str) {
         if let Some(buffer) = self.buffers.write().await.remove(task_id) {
             tracing::debug!(
+                repo = buffer.repo,
                 task_id = buffer.task_id,
                 session = buffer.session,
                 "session unregistered"
@@ -145,14 +149,18 @@ impl CaptureService {
     ///
     /// This intentionally does NOT flag agents that produced output then went
     /// quiet (e.g. long tool calls with sparse output).
-    pub async fn get_silent_sessions(
+    pub async fn get_silent_sessions_for_repo(
         &self,
+        repo: &str,
         grace_period: std::time::Duration,
     ) -> Vec<(String, String)> {
         let now = Utc::now();
         let buffers = self.buffers.read().await;
         let mut silent = Vec::new();
         for buf in buffers.values() {
+            if buf.repo != repo {
+                continue;
+            }
             if buf.has_output {
                 continue;
             }
@@ -301,6 +309,7 @@ mod tests {
 
     fn make_buffer() -> OutputBuffer {
         OutputBuffer {
+            repo: "owner/repo".to_string(),
             session: "test-session".to_string(),
             task_id: "task-1".to_string(),
             last_content: String::new(),
@@ -402,9 +411,10 @@ mod tests {
     async fn get_silent_sessions_returns_only_no_output_past_grace() {
         let transport = Arc::new(Transport::new());
         let svc = CaptureService::new(transport);
+        let repo = "owner/repo";
 
         // Register a session and backdate it past the grace period
-        svc.register_session("silent-task", "orch-test-silent")
+        svc.register_session(repo, "silent-task", "orch-test-silent")
             .await;
         {
             let mut buffers = svc.buffers.write().await;
@@ -413,7 +423,7 @@ mod tests {
         }
 
         // Register a session that HAS produced output (should not be returned)
-        svc.register_session("active-task", "orch-test-active")
+        svc.register_session(repo, "active-task", "orch-test-active")
             .await;
         {
             let mut buffers = svc.buffers.write().await;
@@ -423,12 +433,44 @@ mod tests {
         }
 
         // Register a fresh session within grace period (should not be returned)
-        svc.register_session("new-task", "orch-test-new").await;
+        svc.register_session(repo, "new-task", "orch-test-new")
+            .await;
 
         let grace = std::time::Duration::from_secs(120);
-        let silent = svc.get_silent_sessions(grace).await;
+        let silent = svc.get_silent_sessions_for_repo(repo, grace).await;
         assert_eq!(silent.len(), 1);
         assert_eq!(silent[0].0, "silent-task");
+    }
+
+    #[tokio::test]
+    async fn get_silent_sessions_filters_by_repo() {
+        let transport = Arc::new(Transport::new());
+        let svc = CaptureService::new(transport);
+
+        svc.register_session("owner/repo-a", "task-a", "orch-a")
+            .await;
+        svc.register_session("owner/repo-b", "task-b", "orch-b")
+            .await;
+        {
+            let mut buffers = svc.buffers.write().await;
+            let buf_a = buffers.get_mut("task-a").unwrap();
+            buf_a.registered_at = Utc::now() - chrono::Duration::seconds(200);
+            let buf_b = buffers.get_mut("task-b").unwrap();
+            buf_b.registered_at = Utc::now() - chrono::Duration::seconds(200);
+        }
+
+        let grace = std::time::Duration::from_secs(120);
+        let silent_a = svc
+            .get_silent_sessions_for_repo("owner/repo-a", grace)
+            .await;
+        assert_eq!(silent_a.len(), 1);
+        assert_eq!(silent_a[0].0, "task-a");
+
+        let silent_b = svc
+            .get_silent_sessions_for_repo("owner/repo-b", grace)
+            .await;
+        assert_eq!(silent_b.len(), 1);
+        assert_eq!(silent_b[0].0, "task-b");
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -391,7 +391,9 @@ pub async fn stream_task(task_id: &str, raw: bool) -> anyhow::Result<()> {
     // Start a CaptureService to poll the tmux session and push chunks to transport.
     // This is necessary because the CLI's Transport is isolated from the engine's.
     let capture = Arc::new(CaptureService::new(transport.clone()));
-    capture.register_session(task_id, &session_name).await;
+    capture
+        .register_session(&repo, task_id, &session_name)
+        .await;
     let capture_handle = tokio::spawn({
         let capture = capture.clone();
         async move { capture.run().await }
@@ -488,7 +490,7 @@ pub async fn stream_all(raw: bool) -> anyhow::Result<()> {
                     transport
                         .bind(&session, &session, "cli", "stream-all")
                         .await;
-                    capture.register_session(&session, &session).await;
+                    capture.register_session("cli", &session, &session).await;
                     known.insert(session.clone());
                     added.push(session);
                 }

--- a/src/engine/channel_handler.rs
+++ b/src/engine/channel_handler.rs
@@ -255,7 +255,9 @@ async fn create_and_announce_task(
             transport
                 .bind(&task_id, &session_name, channel, thread_id)
                 .await;
-            capture.register_session(&task_id, &session_name).await;
+            capture
+                .register_session(repo, &task_id, &session_name)
+                .await;
             let transport_clone = transport.clone();
             let channels_clone = channels.clone();
             let task_id_clone = task_id.clone();

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1552,7 +1552,9 @@ mod tests {
             .expect("failed to start tmux session");
 
         // Register session with capture service and transport binding
-        capture.register_session(&task_id, &session_name).await;
+        capture
+            .register_session("owner/repo", &task_id, &session_name)
+            .await;
         transport
             .bind(&task_id, &session_name, "telegram", "12345")
             .await;

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -124,7 +124,7 @@ pub(crate) async fn tick_detect_silent_agents(
 ) -> anyhow::Result<()> {
     let _span = tracing::info_span!("engine.tick.phase1b.silence").entered();
     let grace = std::time::Duration::from_secs(config.silence_grace_period);
-    let silent_sessions = capture.get_silent_sessions(grace).await;
+    let silent_sessions = capture.get_silent_sessions_for_repo(repo, grace).await;
 
     for (task_id, session_name) in silent_sessions {
         // Look up agent + model from the store so we can cooldown the right model.
@@ -731,7 +731,9 @@ pub(crate) async fn tick_dispatch_tasks(
 
         // Register session for capture
         let session_name = tmux.session_name(repo, &task_id);
-        capture.register_session(&task_id, &session_name).await;
+        capture
+            .register_session(repo, &task_id, &session_name)
+            .await;
 
         // Dispatch task
         let runner = runner.clone();

--- a/tests/capture_diff.rs
+++ b/tests/capture_diff.rs
@@ -44,6 +44,7 @@ use capture::{OutputBuffer, MAX_OUTPUT_BUFFER_BYTES};
 
 fn buffer() -> OutputBuffer {
     OutputBuffer {
+        repo: "owner/repo".to_string(),
         session: "session".to_string(),
         task_id: "task".to_string(),
         last_content: String::new(),


### PR DESCRIPTION
## Summary

Scoped silent-agent detection to repo-aware capture sessions and added coverage for per-repo filtering.

### What was done

- Added repo tracking to capture buffers and filtered silent-session detection per repo to avoid cross-repo unregistration.
- Updated capture session registration call sites to pass repo context (engine, channel handler, CLI).
- Expanded capture tests (unit + integration harness) to include repo field and per-repo silent filtering.
- Ran `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run`.


Closes #1185

---
*Task #1185 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.2-codex`*