### PR TITLE
fix: review prompt should not hardcode project-specific CI check names

### DIFF
--- a/prompts/review_task.md
+++ b/prompts/review_task.md
@@ -30,7 +30,7 @@ timeout 300 gh pr checks {{PR_NUMBER}} --watch --fail-fast --required || true
 
 **Do NOT request changes for local-only test failures when required checks are green.**
 
-**Non-required checks** (e.g. `review-gate`, `deploy`, `release`, `build-macos`, `check-release`) are informational — ignore their pass/fail status. Do NOT request changes based on non-required check failures.
+**Non-required checks** are informational — the `--required` flag filters to required checks only. The only non-required check orch installs is `review-gate`. Ignore pass/fail status of non-required checks. Do NOT request changes based on non-required check failures.
 
 ### Step 3: Check architecture alignment
 
@@ -93,4 +93,4 @@ Do NOT respond with prose summaries.
 Decision rules:
 - **approve**: Required GitHub CI checks pass, branch is rebased, code meets requirements, no major issues
 - **request_changes**: Required GitHub CI checks fail on PR-related code, there are bugs, scope creep, or the code doesn't meet requirements
-- **Do NOT** request changes solely because non-required checks (e.g. `review-gate`, `deploy`, `release`) are failing
+- **Do NOT** request changes solely because non-required checks are failing


### PR DESCRIPTION
## Summary

I see the two places with hardcoded check names. Let me fix both.Wait, line 96 also has hardcoded check names. Let me fix that too:Let me verify the final file and run the required checks:Now let me commit:This is a prompt-only change (markdown), so no Rust quality gates apply. Let me verify:Done. Removed hardcoded check names (`deploy`, `release`, `build-macos`, `check-release`) from both places in `prompts/review_task.md`. The `--required` flag handles filtering — the prompt now just mention

Closes #1193

---
*Task #1193 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2-pro-free`*