### PR TITLE
docs: add link to orch's own .orch.yml as example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ git:
 
 Place in your project root. Values here override global defaults.
 
+See [`.orch.yml`](.orch.yml) for a real-world example — orch uses itself to build, review, and improve its own codebase.
+
 ```yaml
 # Required — identifies this project on GitHub
 gh:


### PR DESCRIPTION
## Summary

Added a link to orch's own `.orch.yml` as a living example in the README's Project config section.

### What was done

- Added link to `.orch.yml` with dogfooding context in README.md


Closes #1191

---
*Task #1191 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2-pro-free`*