### PR TITLE
bug: parse_retry_at indexes error_message using byte offset from lowercased string — can panic or produce wrong date on non-ASCII input

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -284,7 +284,7 @@ fn parse_retry_at(error_message: &str) -> Option<i64> {
     let lower = error_message.to_lowercase();
     let retry_marker = "try again at ";
     if let Some(idx) = lower.find(retry_marker) {
-        let date_str = &error_message[idx + retry_marker.len()..];
+        let date_str = &lower[idx + retry_marker.len()..];
         // Take until period, newline, or end
         let date_str = date_str
             .split(['.', '\n'])


### PR DESCRIPTION
## Summary

Done! I've fixed the bug in `src/engine/cooldown.rs:287`.

**The Problem:**
The code was computing a byte offset from a lowercased string but applying it to slice the original string. When Unicode characters like `ẞ` shrink during lowercasing (3 bytes → 2 bytes), the byte index becomes incorrect relative to the original string, causing either a panic ("byte index is not a char boundary") or silently returning the wrong date substring.

**The Fix:**
Changed line 287 from:
```rust
let date_str

Closes #1205

---
*Task #1205 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*