### PR TITLE
bug: review router uses hardcoded anthropic/ model for opencode instead of config values

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -684,16 +684,18 @@ pub(crate) async fn review_and_merge(
         let agent = r
             .next_round_robin_agent(&exclude_refs)
             .unwrap_or_else(|| "claude".to_string());
-        let model = r
-            .config
-            .model_for_complexity_or_default(&agent, "review", &task.id.0);
+        let model = r.config.model_for_complexity(&agent, "review", &task.id.0);
         (agent, model)
     };
+    // Derive a &str view for call sites that require a concrete string (e.g. attribution,
+    // activity logging). An empty string is used when no model is configured so that
+    // downstream code does not silently use a hardcoded model name.
+    let review_model_str = review_model.as_deref().unwrap_or("");
 
     tracing::info!(
         task_id = task.id.0,
         agent = %review_agent,
-        model = %review_model,
+        model = ?review_model,
         "spawning review agent"
     );
 
@@ -721,7 +723,7 @@ pub(crate) async fn review_and_merge(
 
     let invocation = runner::agent::AgentInvocation {
         agent: review_agent.clone(),
-        model: Some(review_model.clone()),
+        model: review_model.clone(),
         work_dir: worktree_path.clone(),
         system_prompt,
         agent_message: review_prompt,
@@ -743,7 +745,7 @@ pub(crate) async fn review_and_merge(
                 attempt: review_attempt as i32,
                 run_type: "review",
                 agent: &review_agent,
-                model: &review_model,
+                model: review_model.as_deref().unwrap_or(""),
                 command: "",
                 prompt: "",
             })
@@ -762,7 +764,7 @@ pub(crate) async fn review_and_merge(
         }
     };
 
-    let start_comment = review_started_comment(&review_agent, &review_model);
+    let start_comment = review_started_comment(&review_agent, review_model_str);
     match GhHttp::new() {
         Ok(gh) => {
             if let Err(e) = gh
@@ -1066,7 +1068,7 @@ pub(crate) async fn review_and_merge(
         None,
         None,
         Some(&review_agent),
-        Some(&review_model),
+        review_model.as_deref(),
         Some(&serde_json::json!({
             "decision": decision_name,
             "pr_number": pr_number_early,
@@ -1086,7 +1088,7 @@ pub(crate) async fn review_and_merge(
                 None,
                 None,
                 Some(&review_agent),
-                Some(&review_model),
+                review_model.as_deref(),
                 Some(&serde_json::json!({
                     "status": "ok",
                     "branch": branch_name.clone(),
@@ -1122,7 +1124,7 @@ pub(crate) async fn review_and_merge(
                 None,
                 None,
                 Some(&review_agent),
-                Some(&review_model),
+                review_model.as_deref(),
                 Some(&serde_json::json!({
                     "status": "error",
                     "branch": branch_name.clone(),
@@ -1184,7 +1186,7 @@ pub(crate) async fn review_and_merge(
     };
 
     if !pr_comment.is_empty() {
-        let footer = attribution_footer("Reviewed", &review_agent, &review_model);
+        let footer = attribution_footer("Reviewed", &review_agent, review_model_str);
         let pr_comment_with_footer = format!("{}{}", pr_comment, footer);
         if let Err(e) = gh
             .add_comment(repo, &pr_number_early.to_string(), &pr_comment_with_footer)
@@ -1267,7 +1269,7 @@ pub(crate) async fn review_and_merge(
                     backend,
                     repo,
                     &review_agent,
-                    &review_model,
+                    review_model_str,
                     task_manager,
                     store,
                 )
@@ -1313,7 +1315,7 @@ pub(crate) async fn review_and_merge(
                 repo,
                 pr_number_early,
                 &review_agent,
-                &review_model,
+                review_model_str,
                 task_manager,
                 store,
             )
@@ -1462,27 +1464,15 @@ mod tests {
     }
 
     #[test]
-    fn test_router_config_model_for_complexity_returns_nonempty() {
+    fn test_router_config_model_for_complexity_returns_none_without_config() {
+        // With no model_map configured, model_for_complexity must return None rather than
+        // silently using a hardcoded model that may not exist for the given agent.
         let cfg = RouterConfig::default();
-        assert!(!cfg
-            .model_for_complexity_or_default("claude", "simple", "")
-            .is_empty());
-        assert!(!cfg
-            .model_for_complexity_or_default("claude", "medium", "")
-            .is_empty());
-        assert!(!cfg
-            .model_for_complexity_or_default("claude", "complex", "")
-            .is_empty());
-        assert!(!cfg
-            .model_for_complexity_or_default("claude", "review", "")
-            .is_empty());
-    }
-
-    #[test]
-    fn test_router_config_model_for_complexity_unknown_agent() {
-        let cfg = RouterConfig::default();
-        let model = cfg.model_for_complexity_or_default("unknown_agent_xyz", "simple", "");
-        assert!(!model.is_empty());
+        assert!(cfg.model_for_complexity("claude", "simple", "").is_none());
+        assert!(cfg.model_for_complexity("opencode", "review", "").is_none());
+        assert!(cfg
+            .model_for_complexity("unknown_agent_xyz", "simple", "")
+            .is_none());
     }
 
     #[test]

--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -73,65 +73,6 @@ pub fn parse_pool_entry(entry: &str) -> (String, String) {
 
 impl Default for RouterConfig {
     fn default() -> Self {
-        let mut model_map = HashMap::new();
-
-        // Simple tasks — fast, cheap models
-        let mut simple = HashMap::new();
-        simple.insert(
-            "claude".to_string(),
-            vec!["claude-haiku-4-5-20251001".to_string()],
-        );
-        simple.insert("codex".to_string(), vec!["o4-mini".to_string()]);
-        simple.insert(
-            "opencode".to_string(),
-            vec!["openai/gpt-4.1-mini".to_string()],
-        );
-        simple.insert(
-            "kimi".to_string(),
-            vec!["claude-haiku-4-5-20251001".to_string()],
-        );
-        simple.insert(
-            "minimax".to_string(),
-            vec!["claude-haiku-4-5-20251001".to_string()],
-        );
-        model_map.insert("simple".to_string(), simple);
-
-        // Medium tasks — balanced cost/capability
-        let mut medium = HashMap::new();
-        medium.insert("claude".to_string(), vec!["claude-sonnet-4-6".to_string()]);
-        medium.insert("codex".to_string(), vec!["gpt-4.1".to_string()]);
-        medium.insert(
-            "opencode".to_string(),
-            vec!["anthropic/claude-sonnet-4-6".to_string()],
-        );
-        medium.insert("kimi".to_string(), vec!["claude-sonnet-4-6".to_string()]);
-        medium.insert("minimax".to_string(), vec!["claude-sonnet-4-6".to_string()]);
-        model_map.insert("medium".to_string(), medium);
-
-        // Complex tasks — most capable models
-        let mut complex = HashMap::new();
-        complex.insert("claude".to_string(), vec!["claude-opus-4-6".to_string()]);
-        complex.insert("codex".to_string(), vec!["o3".to_string()]);
-        complex.insert(
-            "opencode".to_string(),
-            vec!["anthropic/claude-opus-4-6".to_string()],
-        );
-        complex.insert("kimi".to_string(), vec!["claude-opus-4-6".to_string()]);
-        complex.insert("minimax".to_string(), vec!["claude-opus-4-6".to_string()]);
-        model_map.insert("complex".to_string(), complex);
-
-        // Review tasks — strong reasoning, moderate cost
-        let mut review = HashMap::new();
-        review.insert("claude".to_string(), vec!["claude-sonnet-4-6".to_string()]);
-        review.insert("codex".to_string(), vec!["gpt-4.1".to_string()]);
-        review.insert(
-            "opencode".to_string(),
-            vec!["anthropic/claude-sonnet-4-6".to_string()],
-        );
-        review.insert("kimi".to_string(), vec!["claude-sonnet-4-6".to_string()]);
-        review.insert("minimax".to_string(), vec!["claude-sonnet-4-6".to_string()]);
-        model_map.insert("review".to_string(), review);
-
         Self {
             mode: "llm".to_string(),
             router_agent: "claude".to_string(),
@@ -158,7 +99,10 @@ impl Default for RouterConfig {
                 "bun".to_string(),
             ],
             default_skills: vec!["gh".to_string(), "git-worktree".to_string()],
-            model_map,
+            // model_map is intentionally empty — config.yml is the sole source of truth.
+            // Hardcoded models cause "Model not found" failures when the model does not
+            // exist for a particular agent (e.g. anthropic/ prefixed models for opencode).
+            model_map: HashMap::new(),
             weighted_round_robin: false,
         }
     }
@@ -314,8 +258,11 @@ impl RouterConfig {
 
         // Load model_map overrides from config (model_map.{complexity}.{agent})
         // Value may be a single string ("model-name") or a JSON array (["m1","m2"]).
+        // Iterate over all known complexity tiers regardless of what is in model_map —
+        // the Default impl has no hardcoded entries, so iterating over keys() would be a no-op.
         let known_agents = ["claude", "codex", "opencode", "kimi", "minimax"];
-        for complexity in config.model_map.keys().cloned().collect::<Vec<_>>() {
+        let known_complexities = ["simple", "medium", "complex", "review"];
+        for complexity in known_complexities {
             for agent in &known_agents {
                 let key = format!("model_map.{complexity}.{agent}");
                 // Try as list first (YAML arrays), fall back to single string
@@ -323,7 +270,7 @@ impl RouterConfig {
                     if !list.is_empty() {
                         config
                             .model_map
-                            .entry(complexity.clone())
+                            .entry(complexity.to_string())
                             .or_default()
                             .insert(agent.to_string(), list);
                     }
@@ -331,7 +278,7 @@ impl RouterConfig {
                     if !val.is_empty() {
                         config
                             .model_map
-                            .entry(complexity.clone())
+                            .entry(complexity.to_string())
                             .or_default()
                             .insert(agent.to_string(), vec![val]);
                     }
@@ -423,25 +370,6 @@ impl RouterConfig {
         }
         // All models cooled — return None so the caller can fall back to a different agent
         None
-    }
-
-    /// Get the model for a given agent and complexity level, falling back to built-in defaults.
-    ///
-    /// Unlike [`model_for_complexity`], this always returns a non-empty `String`.
-    /// Use this instead of hardcoding fallback model names at call sites.
-    pub fn model_for_complexity_or_default(
-        &self,
-        agent: &str,
-        complexity: &str,
-        task_id: &str,
-    ) -> String {
-        self.model_for_complexity(agent, complexity, task_id)
-            .or_else(|| Self::default().model_for_complexity(agent, complexity, task_id))
-            .unwrap_or_else(|| match agent {
-                "codex" => "o3".to_string(),
-                "opencode" => "anthropic/claude-sonnet-4-6".to_string(),
-                _ => "claude-sonnet-4-6".to_string(),
-            })
     }
 }
 
@@ -567,6 +495,19 @@ mod tests {
 
         let config = RouterConfig::from_config();
         assert_eq!(config.self_routing_penalty, 0.5);
+    }
+
+    #[test]
+    fn default_config_model_map_is_empty() {
+        // model_map must be empty — config.yml is the sole source of truth for models.
+        // Hardcoded defaults (especially anthropic/ prefixed opencode models) cause
+        // "Model not found" failures when the model does not exist for a given agent.
+        let config = RouterConfig::default();
+        assert!(
+            config.model_map.is_empty(),
+            "Default RouterConfig must have no hardcoded models; got {:?}",
+            config.model_map
+        );
     }
 
     #[test]

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -829,41 +829,35 @@ mod tests {
     }
 
     #[test]
-    fn model_map_lookup() {
+    fn model_map_lookup_returns_none_without_config() {
+        // Default config has no hardcoded models — config.yml is the source of truth.
         let config = RouterConfig::default();
+        assert!(config
+            .model_for_complexity("claude", "simple", "")
+            .is_none());
+        assert!(config
+            .model_for_complexity("claude", "medium", "")
+            .is_none());
+        assert!(config
+            .model_for_complexity("claude", "complex", "")
+            .is_none());
+        assert!(config
+            .model_for_complexity("opencode", "review", "")
+            .is_none());
+    }
 
+    #[test]
+    fn model_map_lookup_returns_configured_value() {
+        // When model_map is populated (from config), it is returned correctly.
+        let mut config = RouterConfig::default();
+        config
+            .model_map
+            .entry("simple".to_string())
+            .or_default()
+            .insert("claude".to_string(), vec!["haiku".to_string()]);
         assert_eq!(
             config.model_for_complexity("claude", "simple", ""),
-            Some("claude-haiku-4-5-20251001".to_string())
-        );
-        assert_eq!(
-            config.model_for_complexity("claude", "medium", ""),
-            Some("claude-sonnet-4-6".to_string())
-        );
-        assert_eq!(
-            config.model_for_complexity("claude", "complex", ""),
-            Some("claude-opus-4-6".to_string())
-        );
-        assert_eq!(
-            config.model_for_complexity("codex", "simple", ""),
-            Some("o4-mini".to_string())
-        );
-        // Verify kimi and minimax use same models as claude
-        assert_eq!(
-            config.model_for_complexity("kimi", "simple", ""),
-            Some("claude-haiku-4-5-20251001".to_string())
-        );
-        assert_eq!(
-            config.model_for_complexity("kimi", "complex", ""),
-            Some("claude-opus-4-6".to_string())
-        );
-        assert_eq!(
-            config.model_for_complexity("minimax", "medium", ""),
-            Some("claude-sonnet-4-6".to_string())
-        );
-        assert_eq!(
-            config.model_for_complexity("minimax", "complex", ""),
-            Some("claude-opus-4-6".to_string())
+            Some("haiku".to_string())
         );
     }
 
@@ -912,11 +906,16 @@ mod tests {
 
     #[test]
     fn model_pool_single_string_backward_compat() {
-        // Single-item pools behave identically to the old string format
-        let config = RouterConfig::default();
-        // All default entries are single-item pools
+        // Single-item pools behave identically to the old string format.
+        // Manually insert a single-item pool and verify it is returned correctly.
+        let mut config = RouterConfig::default();
+        config
+            .model_map
+            .entry("simple".to_string())
+            .or_default()
+            .insert("claude".to_string(), vec!["haiku".to_string()]);
         let m = config.model_for_complexity("claude", "simple", "any-task");
-        assert_eq!(m, Some("claude-haiku-4-5-20251001".to_string()));
+        assert_eq!(m, Some("haiku".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

All 2080 tests pass. Here's a summary of what was done:

**Changes:**

1. **`src/engine/router/config.rs`**
   - `Default` impl: removed all hardcoded model_map entries (the `anthropic/claude-sonnet-4-6`, `anthropic/claude-opus-4-6`, etc.). `model_map` is now `HashMap::new()`.
   - `from_config`: changed model_map loading to iterate over `known_complexities = ["simple", "medium", "complex", "review"]` instead of `config.model_map.keys()` (which would be empty with the new default).
   - Deleted 

Closes #1201

---
*Task #1201 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*