### PR TITLE
bug: auto_unblock failure analysis includes review runs — review parse failures can trigger incorrect auto-unblock

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -233,8 +233,9 @@ async fn auto_unblock_blocked_tasks(
         }
 
         let runs = store.get_runs(task.id).await.unwrap_or_default();
+        let agent_runs: Vec<_> = runs.into_iter().filter(|r| r.run_type == "agent").collect();
         let mut failures = Vec::new();
-        for run in runs.iter().rev() {
+        for run in agent_runs.iter().rev() {
             if let Some(category) = classify_failure_from_run(run) {
                 failures.push(category);
             }


### PR DESCRIPTION
## Summary

Fixed auto-unblock to filter agent runs only - review runs no longer incorrectly trigger auto-unblock

### What was done

- Filtered runs to only include agent runs (run_type == "agent") in auto_unblock_blocked_tasks() failure analysis
- This prevents review parse errors from being treated as recoverable and incorrectly triggering auto-unblock for legitimately blocked tasks


Closes #1210

---
*Task #1210 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*