### PR TITLE
bug: auto_unblock_last_at not persisted on set_fields failure — 30-min/2-hr cooldowns silently bypassed

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -265,9 +265,13 @@ async fn auto_unblock_blocked_tasks(
             tracing::warn!(task_id = task.id, err = %e, "failed to increment auto_unblock_count");
             continue;
         }
-        let _ = store
+        if let Err(e) = store
             .set_fields(task.id, &[("auto_unblock_last_at", serde_json::json!(now))])
-            .await;
+            .await
+        {
+            tracing::warn!(task_id = task.id, err = %e, "failed to set auto_unblock_last_at — skipping unblock");
+            continue;
+        }
 
         let ext_id = task
             .external_id


### PR DESCRIPTION
## Summary

Fix committed. The change wraps the `set_fields` call with proper error handling — on failure it logs a warning and `continue`s to skip the unblock for that tick, exactly mirroring how `increment` failure is handled on the line above. All 2078 tests pass.

Closes #1214

---
*Task #1214 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*