### PR TITLE
bug: is_rate_limited check in run_with_context treats any rerouted task as rate-limited — incorrectly degrades agent weights

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -776,8 +776,8 @@ impl TaskRunner {
         // Only treat explicit rate-limit messages (or usage limit) as rate-limited.
         // Do NOT consider generic "rerouted" text as evidence of a rate limit —
         // reroutes can happen for timeouts, auth errors, missing tools, etc.
-        let is_rate_limited = last_error.contains("usage limit")
-            || last_error.contains("rate limit");
+        let is_rate_limited =
+            last_error.contains("usage limit") || last_error.contains("rate limit");
         let weight_signal = if status == "new" && is_rate_limited {
             WeightSignal::RateLimited {
                 agent: agent_name.clone(),


### PR DESCRIPTION
Resolves #1226

Auto-created by orch review gate (agent forgot to open PR)

---
*Task #1226 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*