### PR TITLE
bug: reconcile_startup_worktrees never runs git worktree prune — orphaned .git/worktrees entries persist across restarts

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -48,6 +48,7 @@ use crate::channels::telegram::TelegramChannel;
 use crate::channels::tmux::TmuxChannel;
 use crate::channels::transport::Transport;
 use crate::channels::{Channel, ChannelRegistry, IncomingMessage, OutgoingMessage};
+use crate::cmd::CommandErrorContext;
 use crate::config;
 use crate::engine::cleanup::remove_worktree_and_branch;
 use crate::engine::router::Router;
@@ -64,6 +65,7 @@ use crate::tmux::TmuxManager;
 use runner::WeightSignal;
 // AtomicBool/Ordering removed — shutdown is now immediate (reset tasks + break)
 use std::sync::Arc;
+use tokio::process::Command;
 use tokio::sync::{mpsc, Notify, RwLock, Semaphore};
 
 use crate::backends::Status;
@@ -414,6 +416,25 @@ async fn reconcile_startup_worktrees(project_engines: &[ProjectEngine]) -> anyho
                     )
                     .await;
                 }
+            }
+        }
+
+        // Prune stale .git/worktrees/ entries whose directories no longer exist.
+        // This handles entries left behind by crashes or manual directory removal.
+        let prune = Command::new("git")
+            .args(["-C", &repo_root.to_string_lossy(), "worktree", "prune"])
+            .output_with_context()
+            .await;
+        match prune {
+            Ok(output) if output.status.success() => {
+                tracing::debug!(repo = %engine.repo, "startup worktree prune completed");
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                tracing::warn!(repo = %engine.repo, err = %stderr, "startup worktree prune failed");
+            }
+            Err(e) => {
+                tracing::warn!(repo = %engine.repo, err = %e, "startup worktree prune failed");
             }
         }
     }


### PR DESCRIPTION
## Summary

Added `git worktree prune` to `reconcile_startup_worktrees` so orphaned `.git/worktrees/` metadata entries are cleaned up on every restart.

### What was done

- Added `git worktree prune` call at the end of each project engine's startup reconciliation loop in `src/engine/mod.rs:424`
- Matched the error-handling pattern from `cleanup.rs` (success debug log, stderr warning, io error warning)
- All checks pass: cargo fmt, cargo clippy, 2096 tests


Closes #1225

---
*Task #1225 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2-pro-free`*