### PR TITLE
bug: self-improvement failure query uses removed tasks.last_response column

### DIFF
--- a/.orch.yml
+++ b/.orch.yml
@@ -198,7 +198,7 @@ jobs:
 
       1. Check recent task run logs for failures:
          ```
-         sqlite3 ~/.orch/orch.db "SELECT id, external_id, status, agent, last_error, last_response FROM tasks WHERE status IN ('blocked', 'needs_review') AND updated_at > datetime('now', '-12 hours') ORDER BY updated_at DESC LIMIT 20;"
+          sqlite3 ~/.orch/orch.db "SELECT id, external_id, status, agent, model, last_error, block_reason, updated_at FROM tasks WHERE status IN ('blocked', 'needs_review') AND updated_at > datetime('now', '-12 hours') ORDER BY updated_at DESC LIMIT 20;"
          ```
       2. Check recent task run audit trails:
          ```


### PR DESCRIPTION
## Summary

Fixed self-improvement failure-triage query that referenced non-existent tasks.last_response column

### What was done

- Replaced `last_response` with `model`, `block_reason`, and `updated_at` in the Step 1 query — all columns exist in the current tasks schema


Closes #1236

---
*Task #1236 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2-pro-free`*