### PR TITLE
bug: review gate loops tasks after failover exhaustion by forcing Status::New when no PR/commits

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -481,6 +481,24 @@ async fn ensure_pr_exists(
                     return Ok(EnsurePrResult::EarlyReturn(ReviewDecision::Skipped));
                 }
 
+                if last_error.contains("no fallback agents")
+                    || last_error.contains("all agents exhausted")
+                {
+                    tracing::warn!(
+                        task_id = task.id.0,
+                        branch = %branch_name,
+                        last_error = %last_error,
+                        "no PR and no commits after failover exhaustion — marking blocked to stop loop"
+                    );
+                    if let Err(e) = task_manager
+                        .update_task_status(&task.id, Status::Blocked)
+                        .await
+                    {
+                        tracing::error!(task_id = task.id.0, err = %e, "update_task_status(Blocked) failed — task may be stuck in NeedsReview");
+                    }
+                    return Ok(EnsurePrResult::EarlyReturn(ReviewDecision::Skipped));
+                }
+
                 tracing::warn!(
                     task_id = task.id.0,
                     branch = %branch_name,


### PR DESCRIPTION
## Summary

Fix committed. The change adds a guard in `ensure_pr_exists()` at `src/engine/review.rs:483` that checks `last_error` for `"no fallback agents"` or `"all agents exhausted"` before the fallthrough that was unconditionally setting `Status::New`. When either string is found, the task is now marked `Status::Blocked` instead, stopping the retry loop and surfacing the task for human attention.

Closes #1234

---
*Task #1234 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch)*