### PR TITLE
bug: handle_review_changes reads auto_unblock_count as ci_recovery_count — two independent mechanisms share one counter

### DIFF
--- a/migrations/013_ci_recovery_count.sql
+++ b/migrations/013_ci_recovery_count.sql
@@ -1,0 +1,4 @@
+-- Add dedicated ci_recovery_count column for CI-based auto-recovery tracking.
+-- Previously, handle_review_changes incorrectly used auto_unblock_count for this purpose,
+-- conflating two independent mechanisms (recoverable-failure auto-unblock and CI auto-recovery).
+ALTER TABLE tasks ADD COLUMN ci_recovery_count INTEGER DEFAULT 0;

--- a/src/cli/events.rs
+++ b/src/cli/events.rs
@@ -356,6 +356,7 @@ mod tests {
             delegations: Vec::new(),
             auto_unblock_count: 0,
             auto_unblock_last_at: String::new(),
+            ci_recovery_count: 0,
             created_at: String::new(),
             updated_at: String::new(),
         };
@@ -417,6 +418,7 @@ mod tests {
             delegations: Vec::new(),
             auto_unblock_count: 0,
             auto_unblock_last_at: String::new(),
+            ci_recovery_count: 0,
             created_at: String::new(),
             updated_at: String::new(),
         };

--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -798,7 +798,7 @@ pub(crate) async fn handle_review_changes(
         // the review cycle counter and re-trigger the review agent.
         let ci_recovery_count: i32 = task_store_record
             .as_ref()
-            .map(|t| t.auto_unblock_count)
+            .map(|t| t.ci_recovery_count)
             .unwrap_or(0);
 
         if ci_recovery_count < 1 {
@@ -820,7 +820,7 @@ pub(crate) async fn handle_review_changes(
                         &Some(Arc::clone(store)),
                         repo,
                         &task.id.0,
-                        "auto_unblock_count",
+                        "ci_recovery_count",
                     )
                     .await;
                     if let Err(e) = task_manager

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -112,6 +112,9 @@ pub struct Task {
     pub auto_unblock_count: i32,
     pub auto_unblock_last_at: String,
 
+    // CI-based auto-recovery tracking (separate from auto_unblock_count)
+    pub ci_recovery_count: i32,
+
     // Timestamps
     pub created_at: String,
     pub updated_at: String,
@@ -665,6 +668,7 @@ impl TaskStore {
             "labels",
             "auto_unblock_count",
             "auto_unblock_last_at",
+            "ci_recovery_count",
         ];
 
         for (col, _) in updates {
@@ -717,6 +721,7 @@ impl TaskStore {
             "review_cycles",
             "review_invocations",
             "auto_unblock_count",
+            "ci_recovery_count",
         ];
 
         anyhow::ensure!(
@@ -749,6 +754,7 @@ impl TaskStore {
             review_session_expected = 0,
             auto_unblock_count = 0,
             auto_unblock_last_at = '',
+            ci_recovery_count = 0,
             updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
          WHERE id = ?",
         )
@@ -777,6 +783,7 @@ impl TaskStore {
             review_session_expected = 0,
             auto_unblock_count = 0,
             auto_unblock_last_at = '',
+            ci_recovery_count = 0,
             updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
          WHERE id = ?",
         )
@@ -1228,6 +1235,7 @@ impl TaskStore {
                 .unwrap_or_default(),
             auto_unblock_count: row.get("auto_unblock_count"),
             auto_unblock_last_at: row.get("auto_unblock_last_at"),
+            ci_recovery_count: row.get("ci_recovery_count"),
             created_at: row.get("created_at"),
             updated_at: row.get("updated_at"),
         })


### PR DESCRIPTION
## Summary

All done. Here's a summary of the changes:

## Summary

Fixed the bug where `handle_review_changes` incorrectly used `auto_unblock_count` as a proxy for CI recovery tracking, conflating two independent mechanisms.

### Changes

**New file: `migrations/013_ci_recovery_count.sql`**
- Adds `ci_recovery_count INTEGER DEFAULT 0` column to the `tasks` table

**`src/store/tasks.rs`**
- Added `ci_recovery_count: i32` field to the `Task` struct (after `auto_unblock_last_at`)
- Added `"ci_recovery_count"`

Closes #1232

---
*Task #1232 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*