### PR TITLE
bug: orch log includes stale legacy orchestrator logs by default

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -158,26 +158,55 @@ fn install_review_workflow(project_dir: &std::path::Path) -> anyhow::Result<()> 
 }
 
 /// Show orch logs.
-pub fn log(lines: &str) -> anyhow::Result<()> {
+pub fn log(lines: &str, include_legacy_flag: bool) -> anyhow::Result<()> {
     let state_dir = crate::home::state_dir().unwrap_or_default();
     let brew_prefix = std::env::var("HOMEBREW_PREFIX").unwrap_or_else(|_| "/opt/homebrew".into());
 
     let mut log_files = Vec::new();
 
-    let candidates = [
+    // Always prefer current orch logs (state dir + brew prefix).
+    let mut current_candidates = vec![
         state_dir.join("orch.log"),
         state_dir.join("orch.error.log"),
         std::path::PathBuf::from(&brew_prefix).join("var/log/orch.log"),
         std::path::PathBuf::from(&brew_prefix).join("var/log/orch.error.log"),
     ];
 
-    for path in &candidates {
+    for path in &current_candidates {
         if path.exists()
             && std::fs::metadata(path)
                 .map(|m| m.len() > 0)
                 .unwrap_or(false)
         {
             log_files.push(path.clone());
+        }
+    }
+
+    // Legacy orchestrator logs are noisy on upgraded installs. Include them
+    // only when explicitly requested via the CLI flag or the environment
+    // variable ORCH_INCLUDE_LEGACY_LOGS (for backward compatibility).
+    let include_legacy_env = std::env::var("ORCH_INCLUDE_LEGACY_LOGS")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    let include_legacy = include_legacy_flag || include_legacy_env;
+
+    if include_legacy {
+        let legacy_candidates = [
+            state_dir.join("orchestrator.log"),
+            state_dir.join("orchestrator.error.log"),
+            std::path::PathBuf::from(&brew_prefix).join("var/log/orchestrator.log"),
+            std::path::PathBuf::from(&brew_prefix).join("var/log/orchestrator.error.log"),
+        ];
+
+        for path in &legacy_candidates {
+            if path.exists()
+                && std::fs::metadata(path)
+                    .map(|m| m.len() > 0)
+                    .unwrap_or(false)
+            {
+                log_files.push(path.clone());
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,6 +223,9 @@ enum Commands {
         /// Number of lines to show, or "watch" for live follow
         #[arg(default_value = "50")]
         lines: String,
+        /// Include legacy Homebrew "orchestrator" logs (opt-in)
+        #[arg(long, default_value_t = false)]
+        include_legacy: bool,
     },
     /// List installed agent CLIs
     Agents,
@@ -627,8 +630,8 @@ async fn main() -> anyhow::Result<()> {
         Commands::Init { repo } => {
             cli::init(repo)?;
         }
-        Commands::Log { lines } => {
-            cli::log(&lines)?;
+        Commands::Log { lines, include_legacy } => {
+            cli::log(&lines, include_legacy)?;
         }
         Commands::Agents => {
             cli::agents();


### PR DESCRIPTION
## Summary

**Fix Logs**

- Changed `orch log` to stop including legacy Homebrew `orchestrator*` logs by default; now only current `orch.log`/`orch.error.log` are shown.
- Added an opt-in CLI flag `--include-legacy` and support for an environment variable `ORCH_INCLUDE_LEGACY_LOGS=1|true` for backwards compatibility.
- Wired the new flag into the CLI and made `cli::log` accept the flag.

What I changed
- src/main.rs: added `include_legacy` boolean flag to the `Log` CLI subcommand and pass it to `cli::log`.


Closes #1124

---
*Task #1124 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*