### PR TITLE
bug: startup rebase destroys worktree with unstaged changes — loses agent work on service restart

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -52,10 +52,8 @@ use crate::cmd::CommandErrorContext;
 use crate::config;
 use crate::engine::cleanup::remove_worktree_and_branch;
 use crate::engine::router::Router;
-use crate::engine::runner::worktree::{
-    abort_worktree_rebase, list_project_worktrees, rebase_worktree_on_origin_main,
-    task_id_from_worktree_name,
-};
+use crate::engine::runner::git_ops::rebase_on_default;
+use crate::engine::runner::worktree::{list_project_worktrees, task_id_from_worktree_name};
 use crate::engine::tasks::TaskManager;
 use crate::github::http::{rate_limit_metrics, GhHttp};
 use crate::repo_context::REPO_CONTEXT;
@@ -381,33 +379,7 @@ async fn reconcile_startup_worktrees(project_engines: &[ProjectEngine]) -> anyho
                 | TaskStatus::NeedsReview
                 | TaskStatus::InReview => {
                     tracing::info!(repo = %engine.repo, task_id = %task_id, worktree = %worktree_dir.display(), "rebasing startup worktree");
-                    if let Err(e) =
-                        rebase_worktree_on_origin_main(&worktree_dir, &default_branch).await
-                    {
-                        tracing::warn!(repo = %engine.repo, task_id = %task_id, err = %e, "startup rebase failed, resetting task");
-                        abort_worktree_rebase(&worktree_dir).await;
-                        let keep_remote = task.pr_number.is_some();
-                        remove_worktree_and_branch(
-                            &task_id,
-                            &worktree_dir,
-                            Some(branch_name),
-                            &repo_root_path,
-                            keep_remote,
-                        )
-                        .await;
-                        if let Ok(Some(reset_id)) =
-                            engine.store.resolve_task_id(&engine.repo, &task_id).await
-                        {
-                            let _ = engine.store.reset_to_new(reset_id).await;
-                        }
-                        let _ = engine
-                            .task_manager
-                            .update_task_status(
-                                &ExternalId(task_id.clone()),
-                                crate::backends::Status::New,
-                            )
-                            .await;
-                    }
+                    rebase_on_default(&worktree_dir, &default_branch).await;
                 }
                 _ => {
                     let keep_remote =

--- a/src/engine/runner/worktree.rs
+++ b/src/engine/runner/worktree.rs
@@ -79,41 +79,6 @@ pub fn task_id_from_worktree_name(name: &str) -> Option<String> {
     None
 }
 
-/// Abort any rebase in progress for a worktree.
-pub async fn abort_worktree_rebase(worktree_dir: &Path) {
-    let _ = Command::new("git")
-        .args(["rebase", "--abort"])
-        .current_dir(worktree_dir)
-        .output_with_context()
-        .await;
-}
-
-/// Rebase a worktree on top of `origin/{default_branch}`.
-pub async fn rebase_worktree_on_origin_main(
-    worktree_dir: &Path,
-    default_branch: &str,
-) -> anyhow::Result<()> {
-    let origin_branch = format!("origin/{default_branch}");
-    let rebase = Command::new("git")
-        .args([
-            "-C",
-            &worktree_dir.to_string_lossy(),
-            "rebase",
-            &origin_branch,
-        ])
-        .output_with_context()
-        .await?;
-    if !rebase.status.success() {
-        anyhow::bail!(
-            "git rebase {} failed: {}",
-            origin_branch,
-            String::from_utf8_lossy(&rebase.stderr).trim()
-        );
-    }
-
-    Ok(())
-}
-
 /// Generate a branch name from task ID and title.
 ///
 /// Format: `internal-{id}-{slug}` for internal tasks, `gh-issue-{id}-{slug}` for external.

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -450,35 +450,6 @@ impl TaskStore {
         Ok(())
     }
 
-    /// Reset a task back to `new`.
-    pub async fn reset_to_new(&self, id: i64) -> anyhow::Result<()> {
-        let previous = sqlx::query("SELECT status, agent, model FROM tasks WHERE id = ?")
-            .bind(id)
-            .fetch_one(&self.pool)
-            .await?;
-        let from_status: String = previous.get("status");
-        let agent: Option<String> = previous.get("agent");
-        let model: Option<String> = previous.get("model");
-        sqlx::query(
-            "UPDATE tasks SET status = 'new', branch = '', worktree = '', worktree_cleaned = 0, block_reason = NULL, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
-        )
-        .bind(id)
-        .execute(&self.pool)
-        .await?;
-        let details = serde_json::json!({ "op": "reset_to_new" });
-        self.append_activity(
-            id,
-            "status_change",
-            Some(from_status.as_str()),
-            Some(TaskStatus::New.as_str()),
-            agent.as_deref(),
-            model.as_deref(),
-            Some(&details),
-        )
-        .await?;
-        Ok(())
-    }
-
     /// Update the block reason for a task.
     pub async fn set_block_reason(&self, id: i64, reason: Option<&str>) -> anyhow::Result<()> {
         let value = reason


### PR DESCRIPTION
## Summary

Done. Committed as `45ccf57`.

**Summary of changes:**

- **`src/engine/mod.rs`**: Replaced `rebase_worktree_on_origin_main` (bare `git rebase` that fails on unstaged changes) with `rebase_on_default` from `git_ops.rs` (stashes changes, rebases, restores). Removed the orphaned error-handling block that destroyed the worktree and reset the task — that path is no longer reachable since `rebase_on_default` is non-fatal.

- **`src/engine/runner/worktree.rs`**: Removed `abort_worktree_rebase` and `

Closes #1245

---
*Task #1245 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*