### PR TITLE
bug: required_checks_state uses oldest check run when name matches multiple runs — re-ran CI never seen as passing

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -1176,7 +1176,11 @@ impl GhHttp {
         repo: &str,
         sha: &str,
     ) -> anyhow::Result<Vec<GitHubCheckRun>> {
-        let url = format!("{GITHUB_API}/repos/{repo}/commits/{sha}/check-runs");
+        // Use `filter=latest` so GitHub returns only the most recent check run
+        // per check name. Without this, the API returns all runs (oldest
+        // first) and callers that pick the first match may observe a stale
+        // failed run when a newer run with the same name has succeeded.
+        let url = format!("{GITHUB_API}/repos/{repo}/commits/{sha}/check-runs?filter=latest");
         let resp: serde_json::Value = self.get_json(&url).await?;
         Ok(resp
             .get("check_runs")


### PR DESCRIPTION
## Summary

**Change Made**

- Updated `src/github/http.rs` to request only the latest check run per name from GitHub by adding `?filter=latest` to the check-runs endpoint.

What I changed:
- File: `src/github/http.rs`
- Edited line where check runs are fetched:
  - Before: `GET /repos/{repo}/commits/{sha}/check-runs`
  - After:  `GET /repos/{repo}/commits/{sha}/check-runs?filter=latest`
- Added a short comment explaining the rationale.

Why:
- GitHub returns check runs in oldest-first order by default. Whe

Closes #1282

---
*Task #1282 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*