### PR TITLE
bug: handle_failover "no fallback available" path never records agent cooldown — billing-exhausted kimi loops indefinitely

### DIFF
--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -236,6 +236,13 @@ pub async fn handle_failover(
 
     // No fallback available
     tracing::warn!(task_id, agent = agent_name, "no fallback agents available");
+
+    // Record agent failure for cooldown tracking
+    // Skip cooldown for MissingTooling — it's permanent, not transient
+    if !matches!(error_type, RetryableError::MissingTooling) {
+        record_agent_failure_with_message(agent_name, error_message);
+    }
+
     let msg = format!("{error_message}, no fallback agents");
     store::store_set(
         store,


### PR DESCRIPTION
## Summary

Record agent cooldown when no fallback is available to prevent tight retry loops (fix billing-exhaustion loop).

### What was done

- Added cooldown recording in the no-fallback code path of handle_failover so failing agents are placed into cooldown when no fallback agent exists
- Ensured MissingTooling errors still skip cooldown (preserves existing behavior)
- Committed the change on branch `gh-issue-1250-bug-handle-failover-no-fallback-availabl` and ran clippy/build checks locally


### Remaining

- Push branch and open PR (orch will handle pushing and PR creation automatically after agent completes its workflow)
- Monitor tasks previously stuck in loops (e.g., tasks 23385, 23550 and issues #1227,#1232,#1235) to confirm they stop re-dispatching to the cooled agent
- Optional: add an integration test exercising billing-cycle error -> no-fallback -> cooldown behavior (not required for this small fix)


Closes #1250

---
*Task #1250 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*