### PR TITLE
refactor: per-agent response extractors — eliminate generic parse false positives

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1033,74 +1033,79 @@ pub(crate) async fn review_and_merge(
     };
 
     // Stage 2: parse the ReviewResponse from the extracted text.
-    let review_response = match runner::response::parse_review_from_output(&text_for_review) {
-        Ok(r) => r,
-        Err(e) => {
-            if raw_output != text_for_review {
-                match runner::response::parse_review_from_output(&raw_output) {
-                    Ok(r) => {
-                        tracing::warn!(
-                            task_id = task.id.0,
-                            error = %e,
-                            "review response parsed from raw output fallback"
-                        );
-                        text_for_review = raw_output.clone();
-                        r
-                    }
-                    Err(fallback_err) => {
-                        let combined_error = format!(
-                            "primary parse error: {e}; raw output parse error: {fallback_err}"
-                        );
-                        tracing::error!(
-                            task_id = task.id.0,
-                            error = %combined_error,
-                            output = %text_for_review.chars().take(300).collect::<String>(),
-                            "failed to parse review response"
-                        );
-                        if let Some(rid) = run_id {
-                            let _ = store
-                                .complete_run(&CompleteRun {
-                                    run_id: rid,
-                                    exit_code: Some(exit_code),
-                                    stdout: &raw_output,
-                                    stderr: &stderr,
-                                    parsed: &text_for_review,
-                                    outcome: "failed",
-                                    error: &format!("parse error: {combined_error}"),
-                                    tokens: RunTokenUsage::default(),
-                                })
-                                .await;
+    // Use per-agent extraction to avoid false positives from generic NDJSON parsing.
+    let review_response =
+        match runner::response::parse_review_from_agent_output(&review_agent, &text_for_review) {
+            Ok(r) => r,
+            Err(e) => {
+                if raw_output != text_for_review {
+                    match runner::response::parse_review_from_agent_output(
+                        &review_agent,
+                        &raw_output,
+                    ) {
+                        Ok(r) => {
+                            tracing::warn!(
+                                task_id = task.id.0,
+                                error = %e,
+                                "review response parsed from raw output fallback"
+                            );
+                            text_for_review = raw_output.clone();
+                            r
                         }
-                        return Ok(ReviewDecision::Failed(format!(
-                            "parse error: {combined_error}"
-                        )));
+                        Err(fallback_err) => {
+                            let combined_error = format!(
+                                "primary parse error: {e}; raw output parse error: {fallback_err}"
+                            );
+                            tracing::error!(
+                                task_id = task.id.0,
+                                error = %combined_error,
+                                output = %text_for_review.chars().take(300).collect::<String>(),
+                                "failed to parse review response"
+                            );
+                            if let Some(rid) = run_id {
+                                let _ = store
+                                    .complete_run(&CompleteRun {
+                                        run_id: rid,
+                                        exit_code: Some(exit_code),
+                                        stdout: &raw_output,
+                                        stderr: &stderr,
+                                        parsed: &text_for_review,
+                                        outcome: "failed",
+                                        error: &format!("parse error: {combined_error}"),
+                                        tokens: RunTokenUsage::default(),
+                                    })
+                                    .await;
+                            }
+                            return Ok(ReviewDecision::Failed(format!(
+                                "parse error: {combined_error}"
+                            )));
+                        }
                     }
+                } else {
+                    tracing::error!(
+                        task_id = task.id.0,
+                        error = %e,
+                        output = %text_for_review.chars().take(300).collect::<String>(),
+                        "failed to parse review response"
+                    );
+                    if let Some(rid) = run_id {
+                        let _ = store
+                            .complete_run(&CompleteRun {
+                                run_id: rid,
+                                exit_code: Some(exit_code),
+                                stdout: &raw_output,
+                                stderr: &stderr,
+                                parsed: &text_for_review,
+                                outcome: "failed",
+                                error: &format!("parse error: {e}"),
+                                tokens: RunTokenUsage::default(),
+                            })
+                            .await;
+                    }
+                    return Ok(ReviewDecision::Failed(format!("parse error: {e}")));
                 }
-            } else {
-                tracing::error!(
-                    task_id = task.id.0,
-                    error = %e,
-                    output = %text_for_review.chars().take(300).collect::<String>(),
-                    "failed to parse review response"
-                );
-                if let Some(rid) = run_id {
-                    let _ = store
-                        .complete_run(&CompleteRun {
-                            run_id: rid,
-                            exit_code: Some(exit_code),
-                            stdout: &raw_output,
-                            stderr: &stderr,
-                            parsed: &text_for_review,
-                            outcome: "failed",
-                            error: &format!("parse error: {e}"),
-                            tokens: RunTokenUsage::default(),
-                        })
-                        .await;
-                }
-                return Ok(ReviewDecision::Failed(format!("parse error: {e}")));
             }
-        }
-    };
+        };
 
     // 10. Build automated review comment for the PR (before moving fields)
     let review_notes_for_comment = review_response.notes.clone();

--- a/src/engine/runner/agents/claude.rs
+++ b/src/engine/runner/agents/claude.rs
@@ -500,6 +500,113 @@ fn extract_usage(
     (None, None)
 }
 
+/// Extract a structured `AgentResult` from Claude/Kimi/MiniMax NDJSON output.
+///
+/// Finds the last `"type":"result"` line in the NDJSON stream and extracts:
+/// - `result` text (the inner content)
+/// - `is_error` flag
+/// - token usage from `usage` or `modelUsage`
+/// - `duration_ms`
+///
+/// If no `type:result` line exists (common with MiniMax), falls back to
+/// extracting the last assistant text message from the stream.
+///
+/// Returns `None` only if the input contains no recognizable NDJSON events.
+pub fn find_claude_result(ndjson: &str) -> Option<super::AgentResult> {
+    let trimmed = ndjson.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Try to find the result envelope first
+    if let Some(result_line) = find_ndjson_result_line(trimmed) {
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(result_line) {
+            if let Some(envelope) = parsed.as_object() {
+                let is_error = envelope
+                    .get("is_error")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+
+                let result_text = envelope
+                    .get("result")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+
+                let (input_tokens, output_tokens) = extract_usage(envelope);
+                let duration_ms = envelope.get("duration_ms").and_then(|v| v.as_u64());
+
+                let cost_usd = envelope
+                    .get("costUSD")
+                    .or_else(|| envelope.get("cost_usd"))
+                    .and_then(|v| v.as_f64());
+
+                return Some(super::AgentResult {
+                    is_error,
+                    result_text,
+                    input_tokens,
+                    output_tokens,
+                    cost_usd,
+                    duration_ms,
+                });
+            }
+        }
+    }
+
+    // Fallback for MiniMax/Kimi: extract last assistant text message
+    let mut last_text = None;
+    let mut input_tokens = None;
+    let mut output_tokens = None;
+
+    for line in trimmed.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(val) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if val.get("type").and_then(|v| v.as_str()) != Some("assistant") {
+            continue;
+        }
+        // Extract text from content array
+        if let Some(content) = val
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_array())
+        {
+            for item in content {
+                if item.get("type").and_then(|v| v.as_str()) == Some("text") {
+                    if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
+                        let t = text.trim();
+                        if !t.is_empty() {
+                            last_text = Some(t.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        // Extract usage (take max, as Claude reports cumulative)
+        if let Some(usage) = val.get("message").and_then(|m| m.get("usage")) {
+            if let Some(inp) = usage.get("input_tokens").and_then(|v| v.as_u64()) {
+                input_tokens = Some(input_tokens.unwrap_or(0u64).max(inp));
+            }
+            if let Some(out) = usage.get("output_tokens").and_then(|v| v.as_u64()) {
+                output_tokens = Some(output_tokens.unwrap_or(0u64).max(out));
+            }
+        }
+    }
+
+    last_text.map(|text| super::AgentResult {
+        is_error: false,
+        result_text: text,
+        input_tokens,
+        output_tokens,
+        cost_usd: None,
+        duration_ms: None,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1065,5 +1172,67 @@ mod tests {
     fn extract_text_empty_input_returns_empty_ok() {
         let text = runner().extract_text("").unwrap();
         assert!(text.is_empty());
+    }
+
+    // ── find_claude_result ──────────────────────────────────────
+
+    #[test]
+    fn find_claude_result_success_with_tokens() {
+        let ndjson = concat!(
+            r#"{"type":"system","subtype":"init","session_id":"s1"}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"working..."}]}}"#,
+            "\n",
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"{\"decision\":\"approve\",\"notes\":\"LGTM\"}","usage":{"input_tokens":1500,"output_tokens":200},"duration_ms":5000}"#,
+        );
+        let result = find_claude_result(ndjson).expect("should find result");
+        assert!(!result.is_error);
+        assert!(result.result_text.contains("approve"));
+        assert_eq!(result.input_tokens, Some(1500));
+        assert_eq!(result.output_tokens, Some(200));
+        assert_eq!(result.duration_ms, Some(5000));
+    }
+
+    #[test]
+    fn find_claude_result_error_flag() {
+        let ndjson = r#"{"type":"result","subtype":"error","is_error":true,"result":"rate limit exceeded","usage":{}}"#;
+        let result = find_claude_result(ndjson).expect("should find result");
+        assert!(result.is_error);
+        assert!(result.result_text.contains("rate limit"));
+    }
+
+    #[test]
+    fn find_claude_result_empty_returns_none() {
+        assert!(find_claude_result("").is_none());
+        assert!(find_claude_result("   ").is_none());
+    }
+
+    #[test]
+    fn find_claude_result_no_result_line_falls_back_to_assistant() {
+        // MiniMax/Kimi pattern: no type:result, just assistant messages
+        let ndjson = concat!(
+            r#"{"type":"system","subtype":"init","model":"MiniMax-M2.7"}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"analysis complete"}],"usage":{"input_tokens":800,"output_tokens":150}}}"#,
+        );
+        let result = find_claude_result(ndjson).expect("should fall back to assistant text");
+        assert!(!result.is_error);
+        assert_eq!(result.result_text, "analysis complete");
+        assert_eq!(result.input_tokens, Some(800));
+        assert_eq!(result.output_tokens, Some(150));
+    }
+
+    #[test]
+    fn find_claude_result_plain_text_returns_none() {
+        // Plain text (not NDJSON) should return None
+        assert!(find_claude_result("just some plain text output").is_none());
+    }
+
+    #[test]
+    fn find_claude_result_model_usage() {
+        let ndjson = r#"{"type":"result","subtype":"success","is_error":false,"result":"done","modelUsage":{"claude-sonnet-4-20250514":{"inputTokens":5000,"outputTokens":1000}},"duration_ms":3000}"#;
+        let result = find_claude_result(ndjson).expect("should extract modelUsage");
+        assert_eq!(result.input_tokens, Some(5000));
+        assert_eq!(result.output_tokens, Some(1000));
     }
 }

--- a/src/engine/runner/agents/codex.rs
+++ b/src/engine/runner/agents/codex.rs
@@ -390,6 +390,50 @@ fn extract_quoted(text: &str, quote: char) -> Option<String> {
     Some(rest[..end].to_string())
 }
 
+/// Extract a structured `AgentResult` from Codex NDJSON output.
+///
+/// Finds `item.completed` events with `type:agent_message` for the result text.
+/// Checks for `turn.failed`, `error`, and `item.completed` error events.
+///
+/// Returns `None` only if no parseable NDJSON events are found.
+pub fn find_codex_result(ndjson: &str) -> Option<super::AgentResult> {
+    let runner = CodexRunner;
+    let events = runner.parse_ndjson(ndjson.trim());
+    if events.is_empty() {
+        return None;
+    }
+
+    // Check for errors first
+    let is_error;
+    let error_text;
+    if let Some(err) = runner.detect_error(&events) {
+        is_error = true;
+        error_text = Some(err.to_string());
+    } else {
+        is_error = false;
+        error_text = None;
+    }
+
+    let result_text = if is_error {
+        error_text.unwrap_or_default()
+    } else {
+        runner.extract_agent_text(&events).unwrap_or_default()
+    };
+
+    if result_text.is_empty() && !is_error {
+        return None;
+    }
+
+    Some(super::AgentResult {
+        is_error,
+        result_text,
+        input_tokens: None,
+        output_tokens: None,
+        cost_usd: None,
+        duration_ms: None,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -692,5 +736,60 @@ mod tests {
     fn extract_text_empty_input_returns_empty_ok() {
         let text = runner().extract_text("").unwrap();
         assert!(text.is_empty());
+    }
+
+    // ── find_codex_result ───────────────────────────────────────
+
+    #[test]
+    fn find_codex_result_success() {
+        let ndjson = concat!(
+            r#"{"type":"thread.started","thread_id":"t1"}"#,
+            "\n",
+            r#"{"type":"turn.started"}"#,
+            "\n",
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"{\"decision\":\"approve\",\"notes\":\"LGTM\"}"}}"#,
+            "\n",
+            r#"{"type":"turn.completed"}"#,
+        );
+        let result = find_codex_result(ndjson).expect("should find result");
+        assert!(!result.is_error);
+        assert!(result.result_text.contains("approve"));
+    }
+
+    #[test]
+    fn find_codex_result_error() {
+        let ndjson = concat!(
+            r#"{"type":"error","message":"You've hit your usage limit"}"#,
+            "\n",
+            r#"{"type":"turn.failed","error":{"message":"usage limit"}}"#,
+        );
+        let result = find_codex_result(ndjson).expect("should find error result");
+        assert!(result.is_error);
+        assert!(result.result_text.contains("rate limit"));
+    }
+
+    #[test]
+    fn find_codex_result_empty_returns_none() {
+        assert!(find_codex_result("").is_none());
+        assert!(find_codex_result("   ").is_none());
+    }
+
+    #[test]
+    fn find_codex_result_plain_text_returns_none() {
+        assert!(find_codex_result("just some plain text").is_none());
+    }
+
+    #[test]
+    fn find_codex_result_skips_reasoning_and_commands() {
+        let ndjson = concat!(
+            r#"{"type":"item.completed","item":{"type":"reasoning","text":"Thinking..."}}"#,
+            "\n",
+            r#"{"type":"item.completed","item":{"type":"command_execution","command":"cargo test"}}"#,
+            "\n",
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"All tests passed"}}"#,
+        );
+        let result = find_codex_result(ndjson).expect("should find result");
+        assert!(!result.is_error);
+        assert_eq!(result.result_text, "All tests passed");
     }
 }

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -103,6 +103,41 @@ impl PermissionRules {
     }
 }
 
+/// Structured result from per-agent NDJSON extraction.
+///
+/// Each agent emits a different NDJSON format. The per-agent `find_result`
+/// functions parse agent-specific envelopes and return a unified `AgentResult`
+/// so callers (review pipeline, response handler) don't need format knowledge.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // fields read by tests and future phases
+pub struct AgentResult {
+    /// Whether the agent reported an error (e.g. `is_error: true` in Claude).
+    pub is_error: bool,
+    /// The extracted result text (inner content, stripped of envelope).
+    pub result_text: String,
+    /// Input tokens consumed (if reported by the agent).
+    pub input_tokens: Option<u64>,
+    /// Output tokens consumed (if reported by the agent).
+    pub output_tokens: Option<u64>,
+    /// Total cost in USD (if reported by the agent).
+    pub cost_usd: Option<f64>,
+    /// Wall-clock duration in milliseconds (if reported by the agent).
+    pub duration_ms: Option<u64>,
+}
+
+/// Dispatch to the appropriate per-agent result extractor.
+///
+/// Returns `None` if no structured result could be found in the output
+/// (e.g. plain text, empty output, or unrecognized format).
+pub fn find_agent_result(agent: &str, ndjson: &str) -> Option<AgentResult> {
+    match agent {
+        "claude" | "kimi" | "minimax" => claude::find_claude_result(ndjson),
+        "opencode" => opencode::find_opencode_result(ndjson),
+        "codex" => codex::find_codex_result(ndjson),
+        _ => claude::find_claude_result(ndjson),
+    }
+}
+
 /// Parsed response from an agent, including metadata extracted from the
 /// agent-specific output envelope.
 #[derive(Debug, Clone)]

--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -693,6 +693,68 @@ fn discover_free_models() -> Vec<String> {
     }
 }
 
+/// Extract a structured `AgentResult` from OpenCode NDJSON output.
+///
+/// Concatenates text from `type:text` events (both `part.text` and direct
+/// `text` field formats), extracts tokens from the last `step_finish` event,
+/// and checks for `error` / `step_finish.reason=error` events.
+///
+/// Returns `None` only if no parseable NDJSON events are found.
+pub fn find_opencode_result(ndjson: &str) -> Option<super::AgentResult> {
+    let events = parse_ndjson_events(ndjson.trim());
+    if events.is_empty() {
+        return None;
+    }
+
+    // Check for errors first
+    let is_error;
+    let error_text;
+    let runner = OpenCodeRunner::new();
+    if let Some(err) = runner.detect_error(&events) {
+        is_error = true;
+        error_text = Some(err.to_string());
+    } else {
+        is_error = false;
+        error_text = None;
+    }
+
+    // Extract text content
+    let result_text = if is_error {
+        error_text.unwrap_or_default()
+    } else {
+        extract_ndjson_text(&events).unwrap_or_default()
+    };
+
+    if result_text.is_empty() && !is_error {
+        return None;
+    }
+
+    // Extract tokens from step_finish
+    let (input_tokens, output_tokens) = runner.extract_tokens(&events);
+
+    // Extract cost from step_finish if available
+    let cost_usd = events.iter().rev().find_map(|event| {
+        if event.get("type").and_then(|v| v.as_str()) == Some("step_finish") {
+            event
+                .get("part")
+                .and_then(|p| p.get("cost"))
+                .and_then(|c| c.as_f64())
+                .filter(|&c| c > 0.0)
+        } else {
+            None
+        }
+    });
+
+    Some(super::AgentResult {
+        is_error,
+        result_text,
+        input_tokens,
+        output_tokens,
+        cost_usd,
+        duration_ms: None,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1065,5 +1127,57 @@ mod tests {
     fn extract_text_empty_input_returns_empty_ok() {
         let text = runner().extract_text("").unwrap();
         assert!(text.is_empty());
+    }
+
+    // ── find_opencode_result ────────────────────────────────────
+
+    #[test]
+    fn find_opencode_result_success_with_tokens() {
+        let ndjson = concat!(
+            r#"{"type":"step_start","timestamp":1000,"part":{"type":"step-start"}}"#,
+            "\n",
+            r#"{"type":"text","timestamp":1001,"part":{"type":"text","text":"{\"decision\":\"approve\",\"notes\":\"LGTM\"}"}}"#,
+            "\n",
+            r#"{"type":"step_finish","timestamp":1002,"part":{"type":"step-finish","reason":"stop","cost":0.05,"tokens":{"input":5000,"output":200}}}"#,
+        );
+        let result = find_opencode_result(ndjson).expect("should find result");
+        assert!(!result.is_error);
+        assert!(result.result_text.contains("approve"));
+        assert_eq!(result.input_tokens, Some(5000));
+        assert_eq!(result.output_tokens, Some(200));
+        assert_eq!(result.cost_usd, Some(0.05));
+    }
+
+    #[test]
+    fn find_opencode_result_error_event() {
+        let ndjson = r#"{"type":"error","message":"rate limit exceeded: 429"}"#;
+        let result = find_opencode_result(ndjson).expect("should find error result");
+        assert!(result.is_error);
+        assert!(result.result_text.contains("rate limit"));
+    }
+
+    #[test]
+    fn find_opencode_result_empty_returns_none() {
+        assert!(find_opencode_result("").is_none());
+        assert!(find_opencode_result("   ").is_none());
+    }
+
+    #[test]
+    fn find_opencode_result_direct_text_format() {
+        let ndjson = concat!(
+            r#"{"type":"step_start","timestamp":1000}"#,
+            "\n",
+            r#"{"type":"text","timestamp":1001,"text":"Review complete. All tests passed."}"#,
+            "\n",
+            r#"{"type":"step_finish","timestamp":1002,"part":{"type":"step-finish","reason":"stop","tokens":{"input":100,"output":10}}}"#,
+        );
+        let result = find_opencode_result(ndjson).expect("should find result");
+        assert!(!result.is_error);
+        assert!(result.result_text.contains("All tests passed"));
+    }
+
+    #[test]
+    fn find_opencode_result_plain_text_returns_none() {
+        assert!(find_opencode_result("just some plain text").is_none());
     }
 }

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -330,6 +330,7 @@ pub struct ReviewIssue {
 /// Use this in the review pipeline instead of `parse_review_response` so that
 /// raw opencode NDJSON output is handled even when the normal agent-envelope
 /// parsing chain fails (e.g. format change, empty summary).
+#[allow(dead_code)] // used by integration tests; production code uses parse_review_from_agent_output
 pub fn parse_review_from_output(output: &str) -> anyhow::Result<ReviewResponse> {
     // Step 1: direct JSON / markdown parse
     if let Ok(r) = parse_review_response(output) {
@@ -355,7 +356,59 @@ pub fn parse_review_from_output(output: &str) -> anyhow::Result<ReviewResponse> 
     anyhow::bail!("failed to parse review response from output")
 }
 
+/// Parse a review response using per-agent NDJSON extraction.
+///
+/// Unlike `parse_review_from_output`, this uses the agent-specific `find_result`
+/// extractors instead of the generic `ndjson_extract_text`. This eliminates false
+/// positives from broad substring matching when agent output contains JSON-like
+/// fragments or rate-limit keywords in normal text.
+///
+/// Parsing chain:
+/// 1. Direct JSON / markdown parse of the raw output
+/// 2. Per-agent NDJSON extraction → parse the extracted result text
+/// 3. Heuristic keyword fallback for plain-text decisions
+pub fn parse_review_from_agent_output(agent: &str, output: &str) -> anyhow::Result<ReviewResponse> {
+    // Step 1: direct JSON / markdown parse
+    if let Ok(r) = parse_review_response(output) {
+        return Ok(r);
+    }
+
+    // Step 2: per-agent NDJSON extraction
+    if let Some(result) = crate::engine::runner::agents::find_agent_result(agent, output) {
+        if !result.result_text.is_empty() {
+            if let Ok(r) = parse_review_response(&result.result_text) {
+                return Ok(r);
+            }
+            // The extracted text might itself need keyword inference
+            if let Some(r) = infer_review_response_from_text(&result.result_text) {
+                tracing::warn!(
+                    agent,
+                    output_len = output.len(),
+                    "review response parsed via keyword fallback on agent-extracted text"
+                );
+                return Ok(r);
+            }
+        }
+    }
+
+    // Step 3: heuristic fallback on the full output
+    if let Some(resp) = infer_review_response_from_text(output) {
+        tracing::warn!(
+            agent,
+            output_len = output.len(),
+            "review response parsed via keyword fallback"
+        );
+        return Ok(resp);
+    }
+
+    anyhow::bail!("failed to parse review response from {agent} output")
+}
+
 /// Extract the concatenated text content from an NDJSON event stream.
+///
+/// **Deprecated**: Prefer `parse_review_from_agent_output` which uses per-agent
+/// extractors. This generic version is retained for backward compatibility
+/// when the agent name is unknown.
 ///
 /// Handles text event formats from all agents:
 /// - opencode Format 1: `{"type":"text","part":{"type":"text","text":"..."}}`
@@ -363,6 +416,7 @@ pub fn parse_review_from_output(output: &str) -> anyhow::Result<ReviewResponse> 
 /// - codex Format:      `{"type":"item.completed","item":{"type":"agent_message","text":"..."}}`
 /// - claude stream-json: `{"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}}`
 /// - claude result:      `{"type":"result","result":"..."}`
+#[allow(dead_code)] // used by parse_review_from_output (integration tests)
 fn ndjson_extract_text(ndjson: &str) -> String {
     let texts: Vec<String> = ndjson
         .lines()
@@ -1123,6 +1177,78 @@ That's all."#;
         assert!(
             parse_review_from_output(text).is_err(),
             "negative context with backtick approve must not infer approval"
+        );
+    }
+
+    // ── parse_review_from_agent_output ──────────────────────────
+
+    #[test]
+    fn agent_output_claude_ndjson_review() {
+        let ndjson = concat!(
+            r#"{"type":"system","subtype":"init","session_id":"s1"}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Reviewing..."}]}}"#,
+            "\n",
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"{\"decision\":\"approve\",\"notes\":\"LGTM\",\"test_results\":\"pass\",\"issues\":[]}","usage":{"input_tokens":100,"output_tokens":20}}"#,
+        );
+        let resp = parse_review_from_agent_output("claude", ndjson).unwrap();
+        assert_eq!(resp.decision, "approve");
+    }
+
+    #[test]
+    fn agent_output_opencode_ndjson_review() {
+        let ndjson = concat!(
+            r#"{"type":"step_start","timestamp":1000}"#,
+            "\n",
+            r#"{"type":"text","timestamp":1001,"part":{"type":"text","text":"{\"decision\":\"request_changes\",\"notes\":\"Fix it\",\"issues\":[]}"}}"#,
+            "\n",
+            r#"{"type":"step_finish","timestamp":1002,"part":{"type":"step-finish","reason":"stop","tokens":{"input":100,"output":10}}}"#,
+        );
+        let resp = parse_review_from_agent_output("opencode", ndjson).unwrap();
+        assert_eq!(resp.decision, "request_changes");
+    }
+
+    #[test]
+    fn agent_output_codex_ndjson_review() {
+        let ndjson = concat!(
+            r#"{"type":"thread.started","thread_id":"t1"}"#,
+            "\n",
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"{\"decision\":\"approve\",\"notes\":\"All good\",\"issues\":[]}"}}"#,
+            "\n",
+            r#"{"type":"turn.completed"}"#,
+        );
+        let resp = parse_review_from_agent_output("codex", ndjson).unwrap();
+        assert_eq!(resp.decision, "approve");
+    }
+
+    #[test]
+    fn agent_output_plain_text_keyword_fallback() {
+        let text = "All checks passed, LGTM.";
+        let resp = parse_review_from_agent_output("claude", text).unwrap();
+        assert_eq!(resp.decision, "approve");
+    }
+
+    #[test]
+    fn agent_output_direct_json() {
+        let json = r#"{"decision":"approve","notes":"LGTM","test_results":"pass","issues":[]}"#;
+        let resp = parse_review_from_agent_output("opencode", json).unwrap();
+        assert_eq!(resp.decision, "approve");
+    }
+
+    /// Regression: plain text containing JSON fragments should NOT trigger false
+    /// positives. The per-agent extractor returns None for non-NDJSON text,
+    /// so we fall through to keyword inference instead of generic NDJSON parsing.
+    #[test]
+    fn agent_output_text_with_json_fragment_no_false_positive() {
+        let text = r#"I checked the file and found {"type":"text"} in the output. No issues."#;
+        // This should NOT extract a review from the JSON fragment.
+        // With the generic parser, this would match as a "text" NDJSON event.
+        // With per-agent extraction, it returns None (not valid agent NDJSON).
+        let result = parse_review_from_agent_output("claude", text);
+        // Should either fail or infer from keywords, NOT parse the JSON fragment
+        assert!(
+            result.is_err() || result.as_ref().is_ok_and(|r| r.decision != "text"),
+            "should not extract review from embedded JSON fragment"
         );
     }
 }


### PR DESCRIPTION
## Summary

All done. Here's a summary of the changes:

## Changes

### New: Per-agent result extractors

**`src/engine/runner/agents/mod.rs`**
- Added `AgentResult` struct — unified result from per-agent NDJSON extraction with `is_error`, `result_text`, tokens, cost, duration
- Added `find_agent_result(agent, ndjson)` dispatch function that routes to the correct per-agent extractor

**`src/engine/runner/agents/claude.rs`**
- Added `find_claude_result()` — extracts from `type:result` events; falls back 

Closes #1311

---
*Task #1311 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*