### PR TITLE
parser: silently ignore malformed 'delegations' field instead of surfacing error

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -351,11 +351,15 @@ fn map_generic_response(val: &serde_json::Value) -> anyhow::Result<AgentResponse
         .or_else(|| extract_u64(obj.get("tokens_output")))
         .or_else(|| extract_usage_tokens(obj.get("usage"), false));
 
-    // Extract delegations
-    let delegations = obj
-        .get("delegations")
-        .and_then(|v| serde_json::from_value::<Vec<Delegation>>(v.clone()).ok())
-        .unwrap_or_default();
+    // Extract delegations. If the `delegations` field is present but malformed,
+    // return an error instead of silently ignoring it so callers can surface
+    // and debug malformed agent output.
+    let delegations = if let Some(v) = obj.get("delegations") {
+        serde_json::from_value::<Vec<Delegation>>(v.clone())
+            .with_context(|| format!("invalid delegations field: {}", v))?
+    } else {
+        Vec::new()
+    };
 
     Ok(AgentResponse {
         status,


### PR DESCRIPTION
## Summary

Fail on malformed `delegations` instead of silently ignoring it

### What was done

- Replaced silent .ok().unwrap_or_default() for delegations with explicit deserialization and contextual error
- Ensured parser surfaces malformed delegations with helpful context
- Ran test suite; all tests passed locally


### Remaining

- Optionally add a unit test that asserts malformed delegations produce an error
- Decide whether to log & continue with raw payload instead of returning an error (alternate behavior)


Closes #1314

---
*Task #1314 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*