### PR TITLE
bug: auto-unblock ignores review-run failures — tasks blocked by review agent rate limits stuck forever

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -278,10 +278,17 @@ async fn auto_unblock_blocked_tasks(
         }
 
         let runs = store.get_runs(task.id).await.unwrap_or_default();
-        let agent_runs: Vec<_> = runs.into_iter().filter(|r| r.run_type == "agent").collect();
+        let relevant_runs: Vec<_> = runs
+            .into_iter()
+            .filter(|r| r.run_type == "agent" || r.run_type == "review")
+            .collect();
         let mut failures = Vec::new();
-        for run in agent_runs.iter().rev() {
+        let mut has_review_failure = false;
+        for run in relevant_runs.iter().rev() {
             if let Some(category) = classify_failure_from_run(run) {
+                if run.run_type == "review" {
+                    has_review_failure = true;
+                }
                 failures.push(category);
             }
             if failures.len() >= 3 {
@@ -338,6 +345,18 @@ async fn auto_unblock_blocked_tasks(
                 .await;
         }
 
+        if has_review_failure {
+            let _ = store
+                .set_fields(
+                    task.id,
+                    &[
+                        ("review_agent_failures", serde_json::json!(0)),
+                        ("review_invocations", serde_json::json!(0)),
+                    ],
+                )
+                .await;
+        }
+
         let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
         if do_increment {
             if let Err(e) = store.increment(task.id, "auto_unblock_count").await {
@@ -373,12 +392,22 @@ async fn auto_unblock_blocked_tasks(
             .external_id
             .clone()
             .unwrap_or_else(|| format!("internal:{}", task.id));
+        let new_status = if has_review_failure {
+            Status::NeedsReview
+        } else {
+            Status::New
+        };
+        let new_status_str = if has_review_failure {
+            "needs_review"
+        } else {
+            "new"
+        };
         let _ = store
             .append_activity(
                 task.id,
                 "auto_unblock",
                 Some("blocked"),
-                Some("new"),
+                Some(new_status_str),
                 None,
                 None,
                 Some(&serde_json::json!({
@@ -390,7 +419,7 @@ async fn auto_unblock_blocked_tasks(
             .await;
 
         if let Err(e) = task_manager
-            .update_task_status(&crate::backends::ExternalId(ext_id), Status::New)
+            .update_task_status(&crate::backends::ExternalId(ext_id), new_status)
             .await
         {
             tracing::warn!(
@@ -402,6 +431,7 @@ async fn auto_unblock_blocked_tasks(
             tracing::info!(
                 task_id = task.id,
                 failures = ?failures,
+                review_failure = has_review_failure,
                 "auto-unblocked task with recoverable failures"
             );
         }


### PR DESCRIPTION
## Summary

Fixed auto-unblock to consider review runs and properly reset review counters

### What was done

- Modified auto_unblock_blocked_tasks() to include review runs in failure classification (line 281-284)
- Added tracking of has_review_failure flag when failures come from review runs (lines 286-291)
- Added reset of review_agent_failures and review_invocations counters on unblock (lines 348-358)
- Changed status to needs_review (instead of new) when unblocking from review failures (lines 395-404)
- All tests pass (2249 tests)


Closes #1318

---
*Task #1318 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*