### PR TITLE
bug: opencode silence detection resets tasks to New instead of applying cooldown

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -195,7 +195,9 @@ pub(crate) async fn tick_detect_silent_agents(
             );
         }
 
-        // 4. Clear routing state and reset to New for re-routing
+        // 4. Clear routing state and reset to New for re-routing.
+        // Preserve route_attempts so the router knows this task has been routed before
+        // and can fall back to round-robin after max_route_attempts failures.
         let task_eid = ExternalId(task_id.clone());
         if use_backend {
             if let Some(ref st) = store_task {
@@ -213,7 +215,6 @@ pub(crate) async fn tick_detect_silent_agents(
             &[
                 ("agent", serde_json::Value::Null),
                 ("model", serde_json::Value::Null),
-                ("route_attempts", serde_json::json!(0)),
             ],
         )
         .await;


### PR DESCRIPTION
## Summary

Let me understand the issue better by looking at how `route_attempts` is used and the runner's silence detection handling.I understand the issue. The silence detection in `tick_detect_silent_agents` resets `route_attempts` to 0 (line 216-217), which means the router loses all memory of previous routing attempts. This causes the same agent/model to potentially be selected again, creating a loop.

The fix: preserve `route_attempts` when silence detection triggers, so the router knows this task has

Closes #1320

---
*Task #1320 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*