### PR TITLE
Pre-emptive agent health check and skip degraded agents during routing

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -372,6 +372,109 @@ fn is_in_cooldown(key: &str) -> bool {
     false
 }
 
+// ---------------------------------------------------------------------------
+// Degraded-agent tracking (pre-emptive health check)
+// ---------------------------------------------------------------------------
+
+/// Default health check window for recent rate-limit events (hours).
+pub const DEFAULT_HEALTH_CHECK_WINDOW_HOURS: u32 = 6;
+
+/// Default threshold: minimum rate-limit events within the window to consider
+/// an agent degraded.  A single transient 429 shouldn't mark an agent; we need
+/// a pattern of repeated failures.
+pub const DEFAULT_DEGRADED_RATE_LIMIT_THRESHOLD: i64 = 3;
+
+/// In-memory set of agents currently flagged as degraded.
+fn degraded_agents() -> &'static Mutex<std::collections::HashSet<String>> {
+    static DEGRADED: OnceLock<Mutex<std::collections::HashSet<String>>> = OnceLock::new();
+    DEGRADED.get_or_init(|| Mutex::new(std::collections::HashSet::new()))
+}
+
+/// Check if an agent is currently flagged as degraded by the health check.
+///
+/// Degraded means: all configured models are cooled **or** the agent has
+/// exceeded the rate-limit/out_of_credits threshold within the configured
+/// lookback window.
+pub fn is_agent_degraded(agent: &str) -> bool {
+    let set = degraded_agents().lock().unwrap_or_else(|e| e.into_inner());
+    set.contains(agent)
+}
+
+/// Mark an agent as degraded (called by [`refresh_degraded_agents`]).
+pub fn mark_agent_degraded(agent: &str) {
+    let mut set = degraded_agents().lock().unwrap_or_else(|e| e.into_inner());
+    set.insert(agent.to_string());
+}
+
+/// Clear the degraded flag for an agent.
+pub fn clear_agent_degraded(agent: &str) {
+    let mut set = degraded_agents().lock().unwrap_or_else(|e| e.into_inner());
+    set.remove(agent);
+}
+
+/// Refresh the degraded-agent set from the rate_limits table and cooldown state.
+///
+/// An agent is marked degraded when:
+/// 1. It is in agent-level cooldown, **or**
+/// 2. All its configured models are in cooldown, **or**
+/// 3. It has >= `threshold` rate_limit/out_of_credits events within `window_hours`.
+///
+/// Agents that no longer meet these criteria are cleared.
+pub async fn refresh_degraded_agents(
+    store: &Arc<crate::store::TaskStore>,
+    available_agents: &[String],
+    model_checker: &dyn Fn(&str) -> bool,
+    window_hours: u32,
+    threshold: i64,
+) {
+    let counts = match store.recent_rate_limit_counts(window_hours).await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(err = %e, "failed to query recent rate limit counts for health check");
+            return;
+        }
+    };
+
+    for agent in available_agents {
+        let in_cooldown = is_agent_in_cooldown(agent);
+        let no_models = !model_checker(agent);
+        let rate_limit_count = counts.get(agent.as_str()).copied().unwrap_or(0);
+        let over_threshold = rate_limit_count >= threshold;
+
+        let degraded = in_cooldown || no_models || over_threshold;
+
+        if degraded {
+            if !is_agent_degraded(agent) {
+                let reason = if in_cooldown {
+                    "agent in cooldown"
+                } else if no_models {
+                    "all models cooled"
+                } else {
+                    "rate limit threshold exceeded"
+                };
+                tracing::warn!(
+                    agent,
+                    reason,
+                    rate_limit_count,
+                    window_hours,
+                    threshold,
+                    "pre-emptive health check: marking agent as degraded"
+                );
+            }
+            mark_agent_degraded(agent);
+        } else {
+            if is_agent_degraded(agent) {
+                tracing::info!(
+                    agent,
+                    rate_limit_count,
+                    "pre-emptive health check: agent recovered, clearing degraded flag"
+                );
+            }
+            clear_agent_degraded(agent);
+        }
+    }
+}
+
 /// Clear expired cooldowns from the in-memory map.
 pub fn clear_expired_cooldowns() {
     let mut map = cooldowns().lock().unwrap_or_else(|e| e.into_inner());
@@ -754,6 +857,126 @@ mod tests {
         assert_eq!(
             CreditExhaustionReason::OrgLevelDisabled.cooldown_secs(),
             ORG_LEVEL_DISABLED_COOLDOWN_SECS
+        );
+    }
+
+    // ---- Degraded-agent tracking tests ----
+
+    #[test]
+    fn mark_and_check_agent_degraded() {
+        let agent = "test_degraded_mark";
+        assert!(!is_agent_degraded(agent));
+        mark_agent_degraded(agent);
+        assert!(is_agent_degraded(agent));
+        clear_agent_degraded(agent);
+        assert!(!is_agent_degraded(agent));
+    }
+
+    #[tokio::test]
+    async fn refresh_degraded_agents_marks_cooled_agent() {
+        let store = test_store().await;
+        let agent = "test_refresh_cooled";
+
+        // Put agent in cooldown
+        record_agent_failure_with_message(agent, "");
+        assert!(is_agent_in_cooldown(agent));
+
+        // model_checker always returns true (agent has models)
+        let agents = vec![agent.to_string()];
+        refresh_degraded_agents(&store, &agents, &|_| true, 6, 3).await;
+
+        assert!(
+            is_agent_degraded(agent),
+            "agent in cooldown should be marked degraded"
+        );
+
+        // Cleanup
+        clear_agent_degraded(agent);
+    }
+
+    #[tokio::test]
+    async fn refresh_degraded_agents_marks_no_models_agent() {
+        let store = test_store().await;
+        let agent = "test_refresh_no_models";
+
+        // model_checker returns false (no available models)
+        let agents = vec![agent.to_string()];
+        refresh_degraded_agents(&store, &agents, &|_| false, 6, 3).await;
+
+        assert!(
+            is_agent_degraded(agent),
+            "agent with no available models should be marked degraded"
+        );
+
+        // Cleanup
+        clear_agent_degraded(agent);
+    }
+
+    #[tokio::test]
+    async fn refresh_degraded_agents_marks_rate_limited_agent() {
+        let store = test_store().await;
+        let agent = "test_refresh_rate_limited";
+
+        // Insert rate limit events exceeding threshold
+        for _ in 0..4 {
+            store
+                .record_rate_limit(agent, "rate_limit", None)
+                .await
+                .unwrap();
+        }
+
+        let agents = vec![agent.to_string()];
+        // threshold=3, window=6h — 4 events should trigger degraded
+        refresh_degraded_agents(&store, &agents, &|_| true, 6, 3).await;
+
+        assert!(
+            is_agent_degraded(agent),
+            "agent with rate limit count >= threshold should be marked degraded"
+        );
+
+        // Cleanup
+        clear_agent_degraded(agent);
+    }
+
+    #[tokio::test]
+    async fn refresh_degraded_agents_clears_healthy_agent() {
+        let store = test_store().await;
+        let agent = "test_refresh_healthy";
+
+        // Pre-mark as degraded
+        mark_agent_degraded(agent);
+        assert!(is_agent_degraded(agent));
+
+        // No cooldown, has models, no rate limit events
+        let agents = vec![agent.to_string()];
+        refresh_degraded_agents(&store, &agents, &|_| true, 6, 3).await;
+
+        assert!(
+            !is_agent_degraded(agent),
+            "healthy agent should have degraded flag cleared"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_degraded_agents_below_threshold_not_degraded() {
+        let store = test_store().await;
+        let agent = "test_refresh_below_threshold";
+
+        // Insert rate limit events below threshold
+        for _ in 0..2 {
+            store
+                .record_rate_limit(agent, "rate_limit", None)
+                .await
+                .unwrap();
+        }
+
+        let agents = vec![agent.to_string()];
+        // threshold=3, only 2 events — should NOT be degraded
+        refresh_degraded_agents(&store, &agents, &|_| true, 6, 3).await;
+
+        assert!(
+            !is_agent_degraded(agent),
+            "agent with rate limit count < threshold should not be degraded"
         );
     }
 }

--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -19,6 +19,28 @@ pub fn sequential_dispatch_delay_ms() -> u64 {
         .unwrap_or(1000)
 }
 
+/// Lookback window (in hours) for the pre-emptive agent health check.
+///
+/// The health check queries `rate_limits` for events within this window.
+/// Configurable via `dispatch.health_check_window_hours` (default: 6).
+pub fn health_check_window_hours() -> u32 {
+    crate::config::get("dispatch.health_check_window_hours")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(crate::engine::cooldown::DEFAULT_HEALTH_CHECK_WINDOW_HOURS)
+}
+
+/// Minimum number of rate-limit events within the health check window to
+/// consider an agent degraded.
+///
+/// Configurable via `dispatch.degraded_rate_limit_threshold` (default: 3).
+pub fn degraded_rate_limit_threshold() -> i64 {
+    crate::config::get("dispatch.degraded_rate_limit_threshold")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(crate::engine::cooldown::DEFAULT_DEGRADED_RATE_LIMIT_THRESHOLD)
+}
+
 /// Base delay in milliseconds for exponential backoff between fallback retries.
 pub fn retry_base_delay_ms() -> u64 {
     crate::config::get("dispatch.retry_base_delay_ms")

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -256,17 +256,57 @@ impl Router {
         }
     }
 
+    /// Run the pre-emptive health check, refreshing the degraded-agent set.
+    ///
+    /// Queries the `rate_limits` table for recent events and combines with
+    /// cooldown state to mark agents as degraded before routing attempts them.
+    pub async fn refresh_health(&self, store: &std::sync::Arc<crate::store::TaskStore>) {
+        let config_ref = &self.config;
+        let agents = self.available_agents.clone();
+        let model_checker = |agent: &str| -> bool {
+            // Agent has at least one available model across any complexity tier
+            for comp in &["simple", "medium", "complex", "review"] {
+                if config_ref.has_available_model_for_complexity(agent, comp) {
+                    return true;
+                }
+            }
+            false
+        };
+        crate::engine::cooldown::refresh_degraded_agents(
+            store,
+            &agents,
+            &model_checker,
+            config::health_check_window_hours(),
+            config::degraded_rate_limit_threshold(),
+        )
+        .await;
+    }
+
     /// Check if an agent is available.
     pub fn is_agent_available(&self, agent: &str) -> bool {
         self.available_agents.contains(&agent.to_string())
     }
 
     fn agent_is_routable(&self, agent: &str, complexity: &str) -> bool {
-        self.is_agent_available(agent)
-            && !crate::engine::cooldown::is_agent_in_cooldown(agent)
-            && self
-                .config
-                .has_available_model_for_complexity(agent, complexity)
+        if !self.is_agent_available(agent) {
+            return false;
+        }
+        if crate::engine::cooldown::is_agent_in_cooldown(agent) {
+            tracing::debug!(agent, "agent skipped: in cooldown");
+            return false;
+        }
+        if crate::engine::cooldown::is_agent_degraded(agent) {
+            tracing::debug!(agent, "agent skipped: degraded (pre-emptive health check)");
+            return false;
+        }
+        if !self
+            .config
+            .has_available_model_for_complexity(agent, complexity)
+        {
+            tracing::debug!(agent, complexity, "agent skipped: no available model");
+            return false;
+        }
+        true
     }
 
     fn available_agents_for_complexity(&self, complexity: &str) -> Vec<String> {
@@ -385,6 +425,9 @@ impl Router {
         store: &std::sync::Arc<crate::store::TaskStore>,
         repo: &str,
     ) -> anyhow::Result<RouteResult> {
+        // Pre-emptive health check: refresh degraded-agent flags before routing.
+        self.refresh_health(store).await;
+
         loop {
             // 1. Check store agent field first (set by failover, authoritative over labels)
             let store_agent = match store.resolve_task_id(repo, &task.id.0).await {
@@ -2114,5 +2157,106 @@ Hope that helps!"#;
         router.advance_pool_index_after_attempt(2, router.router_pool.len());
 
         assert_eq!(router.pool_index, 0);
+    }
+
+    // ---- Pre-emptive health check: degraded agent exclusion ----
+
+    #[test]
+    fn degraded_agent_excluded_from_routing() {
+        let mut config = RouterConfig::default();
+        config
+            .model_map
+            .entry("medium".to_string())
+            .or_default()
+            .insert(
+                "test_degraded_routing".to_string(),
+                vec!["model-a".to_string()],
+            );
+
+        let mut router = Router::new(config);
+        router.available_agents = vec!["test_degraded_routing".to_string()];
+
+        // Agent is routable before degradation
+        assert!(router.agent_is_routable("test_degraded_routing", "medium"));
+
+        // Mark as degraded
+        crate::engine::cooldown::mark_agent_degraded("test_degraded_routing");
+
+        // Now excluded from routing
+        assert!(!router.agent_is_routable("test_degraded_routing", "medium"));
+
+        // available_agents_for_complexity returns empty
+        assert!(
+            router.available_agents_for_complexity("medium").is_empty(),
+            "degraded agent should be excluded from available agents"
+        );
+
+        // healthy_agent_count reflects exclusion
+        assert_eq!(router.healthy_agent_count("medium"), 0);
+
+        // Cleanup
+        crate::engine::cooldown::clear_agent_degraded("test_degraded_routing");
+    }
+
+    #[test]
+    fn healthy_agents_skips_degraded_but_keeps_healthy() {
+        let mut config = RouterConfig::default();
+        for agent in &["agent_healthy", "agent_degraded"] {
+            config
+                .model_map
+                .entry("medium".to_string())
+                .or_default()
+                .insert(agent.to_string(), vec!["model-x".to_string()]);
+        }
+
+        let mut router = Router::new(config);
+        router.available_agents = vec!["agent_healthy".to_string(), "agent_degraded".to_string()];
+
+        crate::engine::cooldown::mark_agent_degraded("agent_degraded");
+
+        let candidates = router.available_agents_for_complexity("medium");
+        assert_eq!(candidates, vec!["agent_healthy".to_string()]);
+        assert_eq!(router.healthy_agent_count("medium"), 1);
+
+        // Cleanup
+        crate::engine::cooldown::clear_agent_degraded("agent_degraded");
+    }
+
+    #[tokio::test]
+    async fn refresh_health_marks_degraded_from_rate_limits() {
+        let store = test_store().await;
+        let agent = "test_refresh_health_agent";
+
+        let mut config = RouterConfig::default();
+        config
+            .model_map
+            .entry("medium".to_string())
+            .or_default()
+            .insert(agent.to_string(), vec!["model-z".to_string()]);
+
+        let mut router = Router::new(config);
+        router.available_agents = vec![agent.to_string()];
+
+        // Insert rate limit events exceeding default threshold (3)
+        for _ in 0..4 {
+            store
+                .record_rate_limit(agent, "rate_limit", None)
+                .await
+                .unwrap();
+        }
+
+        router.refresh_health(&store).await;
+
+        assert!(
+            crate::engine::cooldown::is_agent_degraded(agent),
+            "agent should be degraded after exceeding rate limit threshold"
+        );
+        assert!(
+            !router.agent_is_routable(agent, "medium"),
+            "degraded agent should not be routable"
+        );
+
+        // Cleanup
+        crate::engine::cooldown::clear_agent_degraded(agent);
     }
 }

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -730,6 +730,12 @@ pub(crate) async fn sync_tick(
         }
     }
 
+    // Pre-emptive health check: refresh degraded-agent flags from rate_limits table.
+    {
+        let r = router.read().await;
+        r.refresh_health(store).await;
+    }
+
     // Emit degraded-agents metric/log if needed (best-effort)
     let r = router.read().await;
     emit_degraded_agents_if_needed(&r, Some(store)).await;

--- a/src/store/metrics.rs
+++ b/src/store/metrics.rs
@@ -431,6 +431,38 @@ impl TaskStore {
         Ok(row.get("id"))
     }
 
+    /// Count recent rate limit events per agent within the given window (in hours).
+    ///
+    /// Returns a map of `agent -> count` for agents that have rate_limit or
+    /// out_of_credits events in the `rate_limits` table within the window.
+    /// Used by the pre-emptive health check to detect degraded agents.
+    pub async fn recent_rate_limit_counts(
+        &self,
+        window_hours: u32,
+    ) -> anyhow::Result<std::collections::HashMap<String, i64>> {
+        // SQLite datetime modifiers don't support parameterised intervals, so
+        // we build the interval string and embed it directly.  The value comes
+        // from a config integer, not user input, so this is safe.
+        let interval = format!("-{window_hours} hours");
+        let rows = sqlx::query(
+            "SELECT agent, COUNT(*) as cnt
+             FROM rate_limits
+             WHERE occurred_at >= datetime('now', ?)
+             GROUP BY agent",
+        )
+        .bind(&interval)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut map = std::collections::HashMap::new();
+        for row in &rows {
+            let agent: String = row.get("agent");
+            let cnt: i64 = row.get("cnt");
+            map.insert(agent, cnt);
+        }
+        Ok(map)
+    }
+
     /// Get slow tasks (top 10 longest running) from the last 7 days.
     pub async fn get_slow_tasks_7d(&self) -> anyhow::Result<Vec<SlowTaskInfo>> {
         let rows = sqlx::query(

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -5081,3 +5081,34 @@ async fn migrations_are_idempotent() {
     let _ = std::fs::remove_file(tmp.with_extension("db-shm"));
     let _ = std::fs::remove_file(tmp.with_extension("db-wal"));
 }
+
+// ── Recent rate limit counts (health check query) ───────────────
+
+#[tokio::test]
+async fn recent_rate_limit_counts_empty() {
+    let store = TaskStore::open_memory().await.unwrap();
+    let counts = store.recent_rate_limit_counts(6).await.unwrap();
+    assert!(counts.is_empty());
+}
+
+#[tokio::test]
+async fn recent_rate_limit_counts_groups_by_agent() {
+    let store = TaskStore::open_memory().await.unwrap();
+    store
+        .record_rate_limit("claude", "rate_limit", None)
+        .await
+        .unwrap();
+    store
+        .record_rate_limit("claude", "out_of_credits", None)
+        .await
+        .unwrap();
+    store
+        .record_rate_limit("codex", "rate_limit", None)
+        .await
+        .unwrap();
+
+    let counts = store.recent_rate_limit_counts(6).await.unwrap();
+    assert_eq!(counts.get("claude"), Some(&2));
+    assert_eq!(counts.get("codex"), Some(&1));
+    assert_eq!(counts.get("opencode"), None);
+}


### PR DESCRIPTION
## Summary

Added a pre-emptive agent health check that marks degraded agents (cooled, out-of-credits, or rate-limited) and skips them during routing; exposed configuration, integrated refresh into router, and added unit tests.

### What was done

- Added degraded-agent tracking and health-check logic to `src/engine/cooldown.rs` (mark/clear/is checks, refresh_degraded_agents, tests).
- Added router dispatch configuration helpers in `src/engine/router/config.rs` (`health_check_window_hours` and `degraded_rate_limit_threshold`).
- Integrated pre-emptive health refresh into `Router::refresh_health()` and used `is_agent_degraded()` in `Router::agent_is_routable()` to skip degraded agents with clear debug log lines in `src/engine/router/mod.rs`.
- Added router-side unit tests covering degraded-agent exclusion and an integration-style test that exercises `refresh_health()` using the in-memory store.
- Ran the full test suite locally: 1124 tests passed, 3 ignored.


### Remaining

- If desired, add integration tests that simulate sync tick calling `Router::refresh_health()` in `src/engine/sync.rs` (current changes refresh health from router before routing).
- Consider adding structured metrics (counter/gauge) for number of degraded agents for monitoring dashboards.
- Decide whether to persist degraded-agent state to KV (currently in-memory) for cross-process visibility across restarts.


Closes #1335

---
*Task #1335 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*