### PR TITLE
Decide & implement alignment between router pre-emptive routability and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,12 +459,12 @@ These mechanisms integrate with the generic cooldown system as follows:
 - Track the frequency and duration of extended cooldowns for `out_of_credits` and `org_level_disabled` events
 - Review router logs for messages indicating skipped agents due to weight decay or circuit-breaker activation
 
-**Example integration points**:
-In `src/engine/router/selection.rs`, the router calls:
-- `cooldown.is_agent_available(agent)` to check standard cooldown state
-- `cooldown.is_model_available(agent, model)` to check model-specific cooldown
-- `weight_calculator.get_weight(agent, model)` to assess routing weight decay
-- `cooldown.get_extended_cooldown_reason()` to detect if special event cooldowns apply
+**Actual integration points** (in `src/engine/router/mod.rs`):
+- `router.refresh_health(&store)` — called each tick; delegates to `cooldown::refresh_degraded_agents()` which queries the `rate_limits` table and updates the in-memory degraded set
+- `router.agent_is_routable(agent, complexity)` — guards all routing paths; returns `false` when `cooldown::is_agent_in_cooldown(agent)` or `cooldown::is_agent_degraded(agent)` is true
+- `router.available_agents_for_complexity(complexity)` — filters `available_agents` through `agent_is_routable`; used by round-robin, weighted, and LLM routing paths
+- `cooldown::record_credit_exhaustion(agent, reason)` — applies 6 h (`out_of_credits`) or 12 h (`org_level_disabled`) agent cooldown, which causes `is_agent_in_cooldown` to return true on next check
+- `weights.get_weight(agent)` (in `AgentWeights`) — used by weighted-round-robin; decays on each `record_rate_limit` call and recovers toward 1.0 over time
 
 These checks happen before LLM-based routing, preventing unnecessary invocation attempts when success is unlikely.
 


### PR DESCRIPTION
## Summary

The commit is ready locally but Bash tool calls to push/create the PR are being blocked by your permission settings. Here's a summary of what was done:

**Decision: Option A (Document)**

The pre-emptive routability and circuit-breaker behavior is architecturally sound, well-tested (2312/2312 tests pass), and correctly integrated with the generic cooldown system. Reverting it (Option B) would remove valuable protection against futile routing attempts.

**What was fixed:**

The only misalignment 

Closes #1343

---
*Task #1343 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*