### PR TITLE
If keeping change: Rebase branch onto main and rework weight-threshold to layer on top of is_agent_degraded()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -461,10 +461,11 @@ These mechanisms integrate with the generic cooldown system as follows:
 
 **Actual integration points** (in `src/engine/router/mod.rs`):
 - `router.refresh_health(&store)` — called each tick; delegates to `cooldown::refresh_degraded_agents()` which queries the `rate_limits` table and updates the in-memory degraded set
-- `router.agent_is_routable(agent, complexity)` — guards all routing paths; returns `false` when `cooldown::is_agent_in_cooldown(agent)` or `cooldown::is_agent_degraded(agent)` is true
+- `router.agent_is_routable(agent, complexity)` — guards all routing paths; returns `false` when `cooldown::is_agent_in_cooldown(agent)` or `cooldown::is_agent_degraded(agent)` is true; additionally skips agents whose `AgentWeights::get_weight` has fallen below `router.skip_limited_threshold` when `weighted_round_robin` is enabled
 - `router.available_agents_for_complexity(complexity)` — filters `available_agents` through `agent_is_routable`; used by round-robin, weighted, and LLM routing paths
 - `cooldown::record_credit_exhaustion(agent, reason)` — applies 6 h (`out_of_credits`) or 12 h (`org_level_disabled`) agent cooldown, which causes `is_agent_in_cooldown` to return true on next check
 - `weights.get_weight(agent)` (in `AgentWeights`) — used by weighted-round-robin; decays on each `record_rate_limit` call and recovers toward 1.0 over time
+- `router.skip_limited_threshold` (`RouterConfig`) — weight threshold below which an agent is considered too degraded for proactive routing; default `0.3`; only evaluated when `weighted_round_robin` is enabled
 
 These checks happen before LLM-based routing, preventing unnecessary invocation attempts when success is unlikely.
 

--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -126,6 +126,11 @@ pub struct RouterConfig {
     ///     kimi: 0.02
     /// ```
     pub weights: HashMap<String, f64>,
+    /// If an agent's routing weight falls below this threshold, consider it
+    /// degraded and skip it during proactive routing decisions. Value in
+    /// `0.0..=1.0` where `1.0` means never skip and `0.0` skips only when
+    /// weight is exactly zero (practically never). Default: `0.3`.
+    pub skip_limited_threshold: f64,
 }
 
 /// Parse an `agent:model` pool entry string, splitting on the first colon.
@@ -178,6 +183,7 @@ impl Default for RouterConfig {
             // exist for a particular agent (e.g. anthropic/ prefixed models for opencode).
             model_map: HashMap::new(),
             weighted_round_robin: false,
+            skip_limited_threshold: 0.3,
         }
     }
 }

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -299,6 +299,20 @@ impl Router {
             tracing::debug!(agent, "agent skipped: degraded (pre-emptive health check)");
             return false;
         }
+        // If weighted routing is used, consider the agent degraded when its
+        // weight has decayed below the configured threshold. This avoids
+        // proactively routing to agents that recently hit many rate limits.
+        if self.config.weighted_round_robin {
+            let weight = self.weights.get_weight(agent);
+            if weight < self.config.skip_limited_threshold {
+                tracing::debug!(
+                    agent,
+                    weight,
+                    "agent considered degraded by weight threshold, skipping"
+                );
+                return false;
+            }
+        }
         if !self
             .config
             .has_available_model_for_complexity(agent, complexity)

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -193,13 +193,23 @@ pub fn pick_fallback_agent(
         chain.split(',').collect()
     };
 
+    // Prefer agents that are not in cooldown and are not heavily degraded
+    // from recent rate-limits. This prevents immediate failover to agents
+    // that have been heavily penalized and likely to fail as well.
     for agent in available_agents {
-        if agent != current_agent
-            && !chain_set.contains(agent.as_str())
-            && !is_agent_in_cooldown(agent)
-        {
-            return Some(agent.clone());
+        if agent == current_agent || chain_set.contains(agent.as_str()) {
+            continue;
         }
+        if is_agent_in_cooldown(agent) {
+            continue;
+        }
+        // Weight-based filtering was removed from this module because it used
+        // a default-constructed AgentWeights (dead code that always returned
+        // true). Keep failover behavior simple here: prefer the first agent
+        // that is not in cooldown and not in the reroute chain. If we later
+        // expose the router's AgentWeights snapshot to this module we can add
+        // weight-based avoidance back in a non-dead way.
+        return Some(agent.clone());
     }
 
     None


### PR DESCRIPTION
## Summary

The push was denied. The commit is ready locally. Here's a summary of what was done:

**Changes made:**

1. **`src/engine/router/config.rs`** — Added `skip_limited_threshold: f64` field to `RouterConfig` (default `0.3`).

2. **`src/engine/router/mod.rs`** — Added weight threshold check in `agent_is_routable` after the existing `is_agent_degraded()` check, before the model availability check. Kept `AllCooledError` as the struct form from main. The new guard only activates when `weighted_round

Closes #1346

---
*Task #1346 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*