### PR TITLE
fix: atomic SQL increment for failure counts (#1363)

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -180,16 +180,7 @@ async fn read_and_increment_failure_count(
 ) -> u32 {
     let kv_key = format!("{FAILURE_COUNT_PREFIX}{key}");
     if let Some(store) = store_opt {
-        let count: u32 = store
-            .kv_get(&kv_key)
-            .await
-            .ok()
-            .flatten()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(0);
-        let new_count = count.saturating_add(1);
-        let _ = store.kv_set(&kv_key, &new_count.to_string()).await;
-        new_count
+        store.kv_increment(&kv_key).await.unwrap_or(1)
     } else {
         1
     }

--- a/src/store/kv.rs
+++ b/src/store/kv.rs
@@ -22,6 +22,25 @@ impl TaskStore {
         Ok(())
     }
 
+    /// Atomically increment an integer counter in the KV store, inserting it as 1 if absent.
+    ///
+    /// Executes a single SQL statement (`INSERT … ON CONFLICT … DO UPDATE`) so concurrent
+    /// callers cannot race — SQLite's serialised write lock ensures the read-modify-write is
+    /// indivisible.  Returns the new value after the increment.
+    pub async fn kv_increment(&self, key: &str) -> anyhow::Result<u32> {
+        let row: (i64,) = sqlx::query_as(
+            "INSERT INTO kv (key, value, updated_at) VALUES (?1, '1', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+             ON CONFLICT(key) DO UPDATE
+               SET value = CAST(value AS INTEGER) + 1,
+                   updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+             RETURNING CAST(value AS INTEGER)",
+        )
+        .bind(key)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0.max(1) as u32)
+    }
+
     /// List all (key, value) pairs where the key starts with `prefix`.
     pub async fn kv_list_prefix(&self, prefix: &str) -> anyhow::Result<Vec<(String, String)>> {
         let pattern = format!("{prefix}%");

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -3482,6 +3482,29 @@ async fn kv_multiple_keys() {
     assert_eq!(store.kv_get("b").await.unwrap(), Some("2".to_string()));
 }
 
+#[tokio::test]
+async fn kv_increment_missing_starts_at_one() {
+    let store = TaskStore::open_memory().await.unwrap();
+    assert_eq!(store.kv_increment("counter").await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn kv_increment_existing_adds_one() {
+    let store = TaskStore::open_memory().await.unwrap();
+    assert_eq!(store.kv_increment("counter").await.unwrap(), 1);
+    assert_eq!(store.kv_increment("counter").await.unwrap(), 2);
+    assert_eq!(store.kv_increment("counter").await.unwrap(), 3);
+}
+
+#[tokio::test]
+async fn kv_increment_independent_keys() {
+    let store = TaskStore::open_memory().await.unwrap();
+    assert_eq!(store.kv_increment("a").await.unwrap(), 1);
+    assert_eq!(store.kv_increment("b").await.unwrap(), 1);
+    assert_eq!(store.kv_increment("a").await.unwrap(), 2);
+    assert_eq!(store.kv_get("b").await.unwrap(), Some("1".to_string()));
+}
+
 // ── Task Metrics ─────────────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `read_and_increment_failure_count()` was non-atomic (read/increment/write)
- Concurrent failures under-counted, producing shorter cooldowns
- Replaced with `kv_increment()` using `INSERT...ON CONFLICT...DO UPDATE...RETURNING`
- Added 3 tests for the new atomic operation

Fixes #1363

🤖 Generated with [Claude Code](https://claude.com/claude-code)