### PR TITLE
bug: opencode timeouts & silence detection resetting tasks to 'new' — progress lost

### DIFF
--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -97,11 +97,12 @@ pub async fn handle_error(
                     ],
                 )
                 .await;
-                // Skip normal failover — we're retrying same agent with different model
-                // Apply backoff to pace retries
+                // Skip normal failover — we're retrying same agent with different model.
+                // Use "routed" (not "new") since agent/model are already stored;
+                // this avoids a redundant LLM re-routing cycle.
                 response::wait_for_fallback_backoff(task_id, store, repo).await;
                 return Ok(ErrorHandleResult::EarlyReturn {
-                    status: "new".to_string(),
+                    status: "routed".to_string(),
                 });
             }
             (
@@ -144,6 +145,7 @@ pub async fn handle_error(
         ),
         agents::AgentError::NetworkError { message } => {
             // Transient connectivity failure — retry same agent, no reroute chain update.
+            // Use "routed" so it re-dispatches without a full re-routing cycle.
             let msg = format!("{agent_name} network error: {message}");
             store::store_set(
                 store,
@@ -155,7 +157,7 @@ pub async fn handle_error(
             // Apply backoff to pace retries
             response::wait_for_fallback_backoff(task_id, store, repo).await;
             return Ok(ErrorHandleResult::EarlyReturn {
-                status: "new".to_string(),
+                status: "routed".to_string(),
             });
         }
         agents::AgentError::Unknown { exit_code, message } => {
@@ -214,10 +216,11 @@ pub async fn handle_error(
                             ],
                         )
                         .await;
-                        // Apply backoff to pace retries
+                        // Apply backoff to pace retries.
+                        // Use "routed" since agent/model are already stored.
                         response::wait_for_fallback_backoff(task_id, store, repo).await;
                         return Ok(ErrorHandleResult::EarlyReturn {
-                            status: "new".to_string(),
+                            status: "routed".to_string(),
                         });
                     }
                 }
@@ -311,7 +314,7 @@ pub async fn handle_error(
                 )
                 .await;
                 return Ok(ErrorHandleResult::EarlyReturn {
-                    status: "new".to_string(),
+                    status: "routed".to_string(),
                 });
             }
         }
@@ -430,8 +433,8 @@ mod tests {
         .unwrap();
 
         assert!(
-            matches!(result, ErrorHandleResult::EarlyReturn { ref status } if status == "new"),
-            "expected EarlyReturn{{status: new}} for simple complexity — free model should be tried first"
+            matches!(result, ErrorHandleResult::EarlyReturn { ref status } if status == "routed"),
+            "expected EarlyReturn{{status: routed}} for simple complexity — free model should be tried first"
         );
     }
 
@@ -461,8 +464,8 @@ mod tests {
         .unwrap();
 
         assert!(
-            matches!(result, ErrorHandleResult::EarlyReturn { ref status } if status == "new"),
-            "expected EarlyReturn{{status: new}} for unknown complexity — free model should be tried first"
+            matches!(result, ErrorHandleResult::EarlyReturn { ref status } if status == "routed"),
+            "expected EarlyReturn{{status: routed}} for unknown complexity — free model should be tried first"
         );
     }
 

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -382,17 +382,26 @@ impl TaskRunner {
         )
         .await;
 
-        // If silence detection (tick phase1b) already reset this task to `New` while the
+        // If silence detection (tick phase1b) already rerouted this task while the
         // session was running, skip all fallback/review processing. Without this check the
         // runner would call `fallback::handle_error` on the empty output, exhaust fallback
-        // agents, and mark the task `needs_review` — overwriting the `New` status and
-        // triggering a spurious review cycle before `review.rs::ensure_pr_exists` finally
-        // re-routes back to `New`.
+        // agents, and mark the task `needs_review` — overwriting the rerouted status and
+        // triggering a spurious review cycle.
+        // Silence detection now sets Routed (with fallback agent) or NeedsReview (no fallback).
+        // Check for both, plus New for backward compatibility.
         if let Some(stored) = store::opt_store_get_task(&self.store, &self.repo, task_id).await {
-            if stored.status == crate::store::TaskStatus::New {
+            let silence_reset = matches!(
+                stored.status,
+                crate::store::TaskStatus::New
+                    | crate::store::TaskStatus::Routed
+                    | crate::store::TaskStatus::NeedsReview
+            );
+            if silence_reset {
+                let status_str = stored.status.as_str();
                 tracing::info!(
                     task_id,
-                    "task already reset to New by silence detection — skipping fallback processing"
+                    status = status_str,
+                    "task already reset by silence detection — skipping fallback processing"
                 );
                 session::cleanup_session(task_id, &tmux, &tmux_session).await;
                 let silence_err = agents::patterns::classify_from_text(0, "silence detected");
@@ -401,17 +410,17 @@ impl TaskRunner {
                 let audit = self
                     .build_run_audit(RunAuditInput {
                         task_id,
-                        status: "new",
+                        status: status_str,
                         parse_result: &silence_parse,
                         raw_stdout: &session_output.raw_stdout,
                         raw_stderr: &session_output.raw_stderr,
                         started_at,
-                        error_override: Some("silence detection reset task to New".to_string()),
+                        error_override: Some(format!("silence detection set task to {status_str}")),
                         elapsed_secs: session_output.elapsed_secs,
                     })
                     .await;
                 return Ok(Some(RunExecution {
-                    status: "new".to_string(),
+                    status: status_str.to_string(),
                     exit_code: Some(session_output.exit_code),
                     audit,
                 }));
@@ -824,7 +833,8 @@ impl TaskRunner {
         // reroutes can happen for timeouts, auth errors, missing tools, etc.
         let is_rate_limited =
             last_error.contains("usage limit") || last_error.contains("rate limit");
-        let weight_signal = if status == "new" && is_rate_limited {
+        let is_rerouted = status == "new" || status == "routed";
+        let weight_signal = if is_rerouted && is_rate_limited {
             WeightSignal::RateLimited {
                 agent: agent_name.clone(),
             }
@@ -891,9 +901,9 @@ impl TaskRunner {
             }
         }
 
-        // If task was rerouted (status=new after run), update GitHub agent label
+        // If task was rerouted (status=routed or new after run), update GitHub agent label
         // so the router doesn't re-route back to the same failed agent.
-        if status == "new" && !is_internal_id(task_id) {
+        if is_rerouted && !is_internal_id(task_id) {
             let new_agent = self.get_field(task_id, "agent").await.unwrap_or_default();
             if !new_agent.is_empty() && new_agent != agent_name {
                 // Remove old agent label, ensure new one exists, then add it.
@@ -939,7 +949,8 @@ impl TaskRunner {
             "in_review" => Status::InReview,
             "blocked" => Status::Blocked,
             "needs_review" => Status::NeedsReview,
-            "new" => Status::New, // Rerouted
+            "routed" => Status::Routed, // Rerouted (agent/model already set)
+            "new" => Status::New,       // Legacy reroute path
             _ => Status::NeedsReview,
         };
         // Store-first: update SQLite (must succeed), then mirror to backend.
@@ -1660,7 +1671,7 @@ mod tests {
     // ── weight signal logic ───────────────────────────────────────────────────
 
     fn weight_signal_for(status: &str, is_rate_limited: bool, agent: &str) -> WeightSignal {
-        if status == "new" && is_rate_limited {
+        if (status == "new" || status == "routed") && is_rate_limited {
             WeightSignal::RateLimited {
                 agent: agent.to_string(),
             }

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -245,7 +245,7 @@ impl RetryableError {
 }
 
 /// Handle failover for any retryable error type.
-/// Returns the resulting status string: "new" if rerouted, "needs_review" otherwise.
+/// Returns the resulting status string: "routed" if rerouted, "needs_review" otherwise.
 ///
 /// Note: DB recording of rate limit events is handled by the caller (mod.rs)
 /// which has async context. This function only handles store state + cooldowns.
@@ -327,10 +327,12 @@ pub async fn handle_failover(
         )
         .await;
 
-        // Apply exponential backoff with jitter before retry
+        // Apply exponential backoff with jitter before retry.
+        // Return "routed" (not "new") since agent/model are already stored;
+        // this skips the LLM re-routing cycle and preserves progress.
         wait_for_fallback_backoff(task_id, store, repo).await;
 
-        return "new".to_string();
+        return "routed".to_string();
     }
 
     // No fallback available

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -148,7 +148,7 @@ pub(crate) async fn tick_detect_silent_agents(
             model = %model_name,
             grace_secs = config.silence_grace_period,
             cooldown_secs = config.silence_cooldown,
-            "agent silent since session start — killing session, cooling down model + agent, re-routing"
+            "agent silent since session start — killing session, cooling down model + agent, failing over"
         );
 
         // 1. Kill the tmux session
@@ -195,10 +195,51 @@ pub(crate) async fn tick_detect_silent_agents(
             );
         }
 
-        // 4. Clear routing state and reset to New for re-routing.
-        // Preserve route_attempts so the router knows this task has been routed before
-        // and can fall back to round-robin after max_route_attempts failures.
+        // 4. Pick a fallback agent and set to Routed (not New) to preserve progress.
+        // Setting to New would clear routing state and trigger a full LLM re-routing
+        // cycle, losing intermediate context. Routed skips re-routing and re-dispatches
+        // directly with the chosen fallback agent.
         let task_eid = ExternalId(task_id.clone());
+
+        // Build available agents list and reroute chain for failover
+        let available: Vec<String> = ["claude", "codex", "opencode", "kimi", "minimax"]
+            .iter()
+            .filter(|a| crate::cmd_cache::command_exists(a))
+            .map(|s| s.to_string())
+            .collect();
+        let chain = crate::engine::runner::response::get_reroute_chain(
+            &task_id,
+            &Some(Arc::clone(store)),
+            repo,
+        )
+        .await;
+        let chain = crate::engine::runner::response::update_reroute_chain(
+            &task_id,
+            &agent_name,
+            &chain,
+            &Some(Arc::clone(store)),
+            repo,
+        )
+        .await;
+
+        let (next_status, next_agent) = if let Some(fallback) =
+            crate::engine::runner::response::pick_fallback_agent(&agent_name, &chain, &available)
+        {
+            tracing::info!(
+                task_id,
+                from = %agent_name,
+                to = %fallback,
+                "silence detection: failover to different agent, setting routed"
+            );
+            (Status::Routed, Some(fallback))
+        } else {
+            tracing::warn!(
+                task_id,
+                "silence detection: no fallback agents available, marking needs_review"
+            );
+            (Status::NeedsReview, None)
+        };
+
         if use_backend {
             if let Some(ref st) = store_task {
                 for label in &st.labels {
@@ -208,27 +249,61 @@ pub(crate) async fn tick_detect_silent_agents(
                 }
             }
         }
-        store::store_set(
-            &Some(Arc::clone(store)),
-            repo,
-            &task_id,
-            &[
-                ("agent", serde_json::Value::Null),
-                ("model", serde_json::Value::Null),
-            ],
-        )
-        .await;
+
+        if let Some(ref fallback) = next_agent {
+            store::store_set(
+                &Some(Arc::clone(store)),
+                repo,
+                &task_id,
+                &[
+                    ("agent", serde_json::json!(fallback)),
+                    ("model", serde_json::json!("")),
+                    (
+                        "last_error",
+                        serde_json::json!(format!(
+                            "silence detected after {}s, rerouted from {} to {}",
+                            config.silence_grace_period, agent_name, fallback
+                        )),
+                    ),
+                ],
+            )
+            .await;
+        } else {
+            store::store_set(
+                &Some(Arc::clone(store)),
+                repo,
+                &task_id,
+                &[
+                    ("agent", serde_json::Value::Null),
+                    ("model", serde_json::Value::Null),
+                    (
+                        "last_error",
+                        serde_json::json!(format!(
+                            "silence detected after {}s, no fallback agents available",
+                            config.silence_grace_period
+                        )),
+                    ),
+                ],
+            )
+            .await;
+        }
+
         if let Err(e) = task_manager
-            .update_task_status(&task_eid, Status::New)
+            .update_task_status(&task_eid, next_status)
             .await
         {
-            tracing::warn!(task_id, ?e, "failed to reset silent task status");
+            tracing::warn!(task_id, ?e, "failed to update silent task status");
             continue;
         }
 
         // 5. Post a comment explaining what happened
+        let action = if let Some(ref fallback) = next_agent {
+            format!("failing over to {fallback}")
+        } else {
+            "marking needs_review (no fallback agents)".to_string()
+        };
         let comment = format!(
-            "[{}] agent silent for {}s since session start — killed session, cooled down model `{}:{}` for {}s{}, agent `{}` for {}s, re-routing task{}",
+            "[{}] agent silent for {}s since session start — killed session, cooled down model `{}:{}` for {}s{}, agent `{}` for {}s, {}{}",
             chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ"),
             config.silence_grace_period,
             agent_name,
@@ -237,6 +312,7 @@ pub(crate) async fn tick_detect_silent_agents(
             extended_note,
             agent_name,
             crate::engine::cooldown::SILENCE_AGENT_COOLDOWN_SECS,
+            action,
             crate::engine::orch_footer(),
         );
         if use_backend {
@@ -1641,10 +1717,16 @@ mod tests {
         );
 
         let task = store.get(internal_id).await.unwrap();
-        assert_eq!(
-            task.status,
-            crate::store::TaskStatus::New,
-            "internal task should reset to New"
+        // Silence detection now uses failover: if a fallback agent is found → Routed,
+        // otherwise → NeedsReview. Either is acceptable; the key invariant is that the
+        // task is no longer InProgress.
+        assert!(
+            matches!(
+                task.status,
+                crate::store::TaskStatus::Routed | crate::store::TaskStatus::NeedsReview
+            ),
+            "internal task should be routed to fallback or needs_review, got {:?}",
+            task.status
         );
     }
 


### PR DESCRIPTION
## Summary

All changes are complete and passing. Here's a summary of what was done:

## Summary

**Problem**: Silence detection and error recovery paths reset tasks to `new` status, which clears routing state and triggers a full LLM re-routing cycle — losing progress and wasting time.

**Fix**: Changed all silence/timeout/error recovery paths to use `routed` instead of `new`, so tasks re-dispatch directly with the chosen fallback agent without going through LLM re-routing.

### Files changed:

**`src/eng

Closes #1372

---
*Task #1372 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*