### PR TITLE
bug: cooldowns recorded too late — concurrent review dispatches waste runs

### DIFF
--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -45,9 +45,18 @@ pub async fn handle_error(
     // Map AgentError to RetryableError for the existing handle_failover()
     let (retryable, error_msg) = match agent_err {
         agents::AgentError::RateLimit { message, .. } => {
-            // Check for credit exhaustion - these require longer agent-wide cooldowns
+            // Check for credit exhaustion - these require longer agent-wide cooldowns.
+            // For all other rate limits, record the agent-level cooldown immediately so
+            // the router can observe it before any concurrent tasks start their runs.
+            // handle_failover() also records the cooldown later, but setting it here
+            // means the in-memory map is updated right away — without this, concurrent
+            // dispatches that check cooldowns between now and handle_failover() will
+            // see no cooldown and waste another run against the same rate-limited agent.
             if let Some(reason) = crate::engine::cooldown::detect_credit_exhaustion(message) {
                 crate::engine::cooldown::record_credit_exhaustion(agent_name, reason).await;
+            } else {
+                crate::engine::cooldown::record_agent_failure_with_message(agent_name, message)
+                    .await;
             }
             (
                 response::RetryableError::UsageLimit,
@@ -405,6 +414,48 @@ mod tests {
         ) -> anyhow::Result<tokio::process::Command> {
             anyhow::bail!("not implemented")
         }
+    }
+
+    /// Verify that a generic (non-credit-exhaustion) rate limit error sets the agent
+    /// cooldown immediately in `handle_error()`, before `handle_failover()` is called.
+    ///
+    /// This prevents concurrent dispatches from starting new runs against the same
+    /// rate-limited agent while the first task is still in its error-handling path.
+    #[tokio::test]
+    async fn rate_limit_sets_agent_cooldown_immediately() {
+        let runner = MockRunner { free: vec![] };
+        let agent = "test-agent-1371-early-cooldown";
+
+        // Confirm no cooldown before the error.
+        assert!(
+            !crate::engine::cooldown::is_agent_in_cooldown(agent),
+            "agent should not be in cooldown before handle_error"
+        );
+
+        let err = AgentError::RateLimit {
+            message: "429 Too Many Requests".to_string(),
+        };
+
+        // Run handle_error — no store so handle_failover will find no agents and return Continue.
+        let _result = handle_error(
+            "test-1371-a",
+            &err,
+            agent,
+            &runner,
+            Some("sonnet"),
+            Some("medium"),
+            1,
+            &None,
+            "owner/repo",
+        )
+        .await
+        .unwrap();
+
+        // Cooldown must be set immediately after handle_error returns, not deferred.
+        assert!(
+            crate::engine::cooldown::is_agent_in_cooldown(agent),
+            "agent should be in cooldown immediately after handle_error for RateLimit"
+        );
     }
 
     #[tokio::test]

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -211,6 +211,61 @@ pub fn spawn(
                             Block,
                             Ok,
                         }
+
+                        // Re-check agent cooldowns inside the spawned task. A concurrent
+                        // review that ran between the outer dispatch check and now may have
+                        // set a cooldown — bail early rather than burning a review run
+                        // against a rate-limited agent.
+                        let pre_check_all_cooled = {
+                            let agents = router_c.read().await.available_agents.clone();
+                            !agents.is_empty()
+                                && agents
+                                    .iter()
+                                    .all(|a| crate::engine::cooldown::is_agent_in_cooldown(a))
+                        };
+                        if pre_check_all_cooled {
+                            tracing::info!(
+                                task_id = tid,
+                                "all agents cooled at review spawn time — deferring without running agent"
+                            );
+                            // Fall through to RateLimited outcome handling below, which
+                            // waits for the cooldown to expire and resets to NeedsReview.
+                            crate::store::set_review_session_expected(
+                                &store_c,
+                                &repo_s,
+                                &tid,
+                                false,
+                            )
+                            .await;
+                            let wait_secs = {
+                                let agents = router_c.read().await.available_agents.clone();
+                                let now = chrono::Utc::now().timestamp();
+                                agents
+                                    .iter()
+                                    .filter_map(|a| crate::engine::cooldown::cooldown_until(a))
+                                    .min()
+                                    .map(|until| ((until - now).max(1)) as u64)
+                                    .unwrap_or(crate::engine::cooldown::AGENT_COOLDOWN_SECS as u64)
+                            };
+                            tracing::info!(
+                                task_id = tid,
+                                wait_secs,
+                                "pre-check: deferring review retry due to agent rate limit cooldown"
+                            );
+                            tokio::time::sleep(std::time::Duration::from_secs(wait_secs)).await;
+                            if let Err(e) = task_manager_c
+                                .update_task_status(
+                                    &ExternalId(tid.clone()),
+                                    Status::NeedsReview,
+                                )
+                                .await
+                            {
+                                tracing::error!(task_id = %tid, err = %e, "pre-check: update_task_status(NeedsReview) failed — task may be stuck in InReview");
+                            }
+                            drop(permit);
+                            return;
+                        }
+
                         let outcome = match review_and_merge(
                             &task,
                             &backend_c,


### PR DESCRIPTION
## Summary

All tests pass (2348/2348) and the fix is committed. Here's a summary of what was done:

## Fix: Cooldowns recorded too late — concurrent review dispatches waste runs

**Root cause**: Agent cooldowns were only written to the in-memory map after `handle_failover()` completed. In high-concurrency windows, multiple concurrent review dispatches would all pass `is_agent_in_cooldown()` before the first failure set the cooldown, causing N wasted runs against the same rate-limited agent.

**Changes ma

Closes #1371

---
*Task #1371 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*