### PR TITLE
bug: auto_unblock_count >= 3 early exit fires before reason-change reset — tasks permanently stuck on new failure types

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -265,10 +265,6 @@ async fn auto_unblock_blocked_tasks(
             continue;
         }
 
-        if task.auto_unblock_count >= 3 {
-            continue;
-        }
-
         let dispatch_key = format!("{}/{}", repo, task.external_id.clone().unwrap_or_default());
         {
             let guard = dispatching.lock().unwrap_or_else(|e| e.into_inner());
@@ -324,6 +320,14 @@ async fn auto_unblock_blocked_tasks(
         } else {
             task.auto_unblock_count
         };
+
+        // Gate on attempt count using the effective count — if the reason changed, the
+        // counter was reset above so cooldown_count is 0 and a new reason always gets a
+        // fresh attempt regardless of how many times the old reason fired.
+        if cooldown_count >= 3 {
+            continue;
+        }
+
         if !auto_unblock_cooldown_elapsed(cooldown_count, &task.auto_unblock_last_at) {
             continue;
         }


### PR DESCRIPTION
## Summary

All 2362 tests pass. The fix is clean and correct.

**Summary:** Removed the premature `auto_unblock_count >= 3` early-exit guard (lines 268-270) that fired before reason-change detection. Moved the count gate to after `cooldown_count` is computed, so it correctly uses the effective count (0 when reason changed). A task that exhausted attempts for one failure reason (e.g. `RateLimit`) will now get a fresh attempt when a different recoverable failure type is detected.

Closes #1392

---
*Task #1392 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*