### PR TITLE
bug: block_reason and last_error empty when task blocked via max review cycles

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -907,6 +907,25 @@ pub(crate) async fn handle_review_changes(
             );
             return Ok(());
         }
+        store_set(
+            &Some(Arc::clone(store)),
+            repo,
+            &task.id.0,
+            &[
+                (
+                    "block_reason",
+                    serde_json::json!(format!("max review cycles ({}) exceeded", max_cycles)),
+                ),
+                (
+                    "last_error",
+                    serde_json::json!(format!(
+                        "review agent requested changes {} times — escalated to human review",
+                        review_cycles
+                    )),
+                ),
+            ],
+        )
+        .await;
         let escalation = format!(
             "🔍 Review agent requested changes after {} cycles. Escalating to human.\n\n**Review Notes:**\n{}",
             review_cycles, notes

--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -298,6 +298,28 @@ pub(crate) async fn review_open_prs(
                             retries,
                             "PR approved but merge conflict retry limit reached — blocking for human review"
                         );
+                        store_set(
+                            &Some(Arc::clone(store)),
+                            repo,
+                            task_id,
+                            &[
+                                (
+                                    "block_reason",
+                                    serde_json::json!(format!(
+                                        "merge conflict retry limit ({}) reached",
+                                        MAX_MERGE_CONFLICT_RETRIES
+                                    )),
+                                ),
+                                (
+                                    "last_error",
+                                    serde_json::json!(format!(
+                                        "PR approved but has unresolved merge conflicts after {} retries",
+                                        retries
+                                    )),
+                                ),
+                            ],
+                        )
+                        .await;
                         if let Err(e) = task_manager
                             .update_task_status(&task.id, Status::Blocked)
                             .await

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -8,7 +8,7 @@ use crate::engine::router::Router;
 use crate::engine::tasks::TaskManager;
 use crate::github::http::GhHttp;
 use crate::repo_context::REPO_CONTEXT;
-use crate::store::{opt_store_get_task, TaskStatus, TaskStore};
+use crate::store::{opt_store_get_task, store_set, TaskStatus, TaskStore};
 use crate::tmux::TmuxManager;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -208,7 +208,7 @@ pub fn spawn(
                         enum ReviewOutcome {
                             Reset,
                             RateLimited,
-                            Block,
+                            Block(String),
                             Ok,
                         }
 
@@ -283,7 +283,9 @@ pub fn spawn(
                                     reason,
                                     "review gate blocked after repeated failures — marking task blocked"
                                 );
-                                ReviewOutcome::Block
+                                ReviewOutcome::Block(format!(
+                                    "review gate blocked after repeated failures: {reason}"
+                                ))
                             }
                             Ok(ReviewDecision::Failed(reason)) => {
                                 // Rate-limit failures are not real review failures — don't count
@@ -316,7 +318,9 @@ pub fn spawn(
                                             failures,
                                             "review agent failed too many times — blocking task"
                                         );
-                                        ReviewOutcome::Block
+                                        ReviewOutcome::Block(format!(
+                                            "review agent failed {failures} times: {reason}"
+                                        ))
                                     } else {
                                         tracing::error!(
                                             task_id = tid,
@@ -357,7 +361,9 @@ pub fn spawn(
                                             failures,
                                             "review_and_merge failed too many times — blocking task"
                                         );
-                                        ReviewOutcome::Block
+                                        ReviewOutcome::Block(format!(
+                                            "review_and_merge failed {failures} times: {reason}"
+                                        ))
                                     } else {
                                         tracing::error!(
                                             task_id = tid,
@@ -463,7 +469,20 @@ pub fn spawn(
                                     tracing::error!(task_id = %tid, err = %e, "update_task_status(NeedsReview) failed after rate limit backoff — task may be stuck in InReview");
                                 }
                             }
-                            ReviewOutcome::Block => {
+                            ReviewOutcome::Block(reason) => {
+                                store_set(
+                                    &Some(store_c.clone()),
+                                    &repo_s,
+                                    &tid,
+                                    &[
+                                        (
+                                            "block_reason",
+                                            serde_json::json!("review agent blocked — exceeded failure threshold"),
+                                        ),
+                                        ("last_error", serde_json::json!(reason)),
+                                    ],
+                                )
+                                .await;
                                 if let Err(e) = task_manager_c
                                     .update_task_status(
                                         &ExternalId(tid.clone()),


### PR DESCRIPTION
## Summary

All 2362 tests pass. Here's a summary of the changes made:

**3 files changed:**

1. **`src/engine/auto_merge.rs`** — After successfully blocking for max review cycles, sets:
   - `block_reason`: `"max review cycles (N) exceeded"`
   - `last_error`: `"review agent requested changes N times — escalated to human review"`

2. **`src/engine/review_poll.rs`** — Before blocking for merge conflict retry limit, sets:
   - `block_reason`: `"merge conflict retry limit (N) reached"`
   - `last_error`

Closes #1395

---
*Task #1395 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*