### PR TITLE
bug: startup InReview reset silently abandoned after 3 retries — task left in stale state

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1077,8 +1077,8 @@ pub async fn serve() -> anyhow::Result<()> {
                     continue;
                 }
                 if let Err(e) = engine
-                    .backend
-                    .update_status(&task.id, Status::NeedsReview)
+                    .task_manager
+                    .update_task_status(&task.id, Status::NeedsReview)
                     .await
                 {
                     tracing::warn!(
@@ -1111,7 +1111,12 @@ pub async fn serve() -> anyhow::Result<()> {
         {
             for task in &internal_in_review {
                 let task_id = task.id.0.clone();
-                if !review_session_expected(&engine.store, &engine.repo, &task_id).await {
+                let session_expected =
+                    review_session_expected(&engine.store, &engine.repo, &task_id).await;
+                let age_minutes = chrono::DateTime::parse_from_rfc3339(&task.updated_at)
+                    .map(|dt| (chrono::Utc::now() - dt.with_timezone(&chrono::Utc)).num_minutes())
+                    .unwrap_or(0);
+                if !session_expected && age_minutes < 10 {
                     continue;
                 }
                 if let Err(e) = engine


### PR DESCRIPTION
## Summary

All 2362 tests pass. The fix is clean.

**Summary of changes to `src/engine/mod.rs`:**

1. **External loop (line 1079-1092)**: Changed `engine.backend.update_status()` → `engine.task_manager.update_task_status()`. The backend call was GitHub-labels-only and always failed for `internal:*` task IDs (no GitHub issue to update). `task_manager.update_task_status()` correctly routes: for internal IDs it updates SQLite only; for external IDs it updates SQLite first then mirrors to GitHub.

2. **Inter

Closes #1396

---
*Task #1396 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*