### PR TITLE
bug: synthesized needs_review response skips git ops — agent work lost

### DIFF
--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -114,7 +114,7 @@ pub async fn handle_success(
     let mut has_pr = false;
     let mut has_pushed = false;
     let mut has_commits = false;
-    if resp.status == "done" || resp.status == "in_progress" {
+    if resp.status == "done" || resp.status == "in_progress" || resp.status == "needs_review" {
         if let Err(e) =
             git_ops::auto_commit(&wt.work_dir, task_id, task_title, agent_name, new_attempts).await
         {


### PR DESCRIPTION
## Summary

All 2362 tests pass. The fix is a one-line change: adding `|| resp.status == "needs_review"` to the git ops gate condition at line 117. Now when a synthesized response has `needs_review` status, the agent's work is committed, pushed, and a PR created before the task enters the review stage — nothing is lost.

Closes #1400

---
*Task #1400 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*