### PR TITLE
perf: sync.rs — batch get_runs(), tmux checks, and mention filtering

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -251,6 +251,10 @@ async fn auto_unblock_blocked_tasks(
         return Ok(());
     }
 
+    // Batch-load all runs for blocked tasks in a single query instead of N individual queries.
+    let task_ids: Vec<i64> = blocked.iter().map(|t| t.id).collect();
+    let mut runs_by_task = store.get_runs_batch(&task_ids).await.unwrap_or_default();
+
     for task in blocked {
         if task.block_reason.is_some() {
             continue;
@@ -273,7 +277,7 @@ async fn auto_unblock_blocked_tasks(
             }
         }
 
-        let runs = store.get_runs(task.id).await.unwrap_or_default();
+        let runs = runs_by_task.remove(&task.id).unwrap_or_default();
         let relevant_runs: Vec<_> = runs
             .into_iter()
             .filter(|r| r.run_type == "agent" || r.run_type == "review")
@@ -335,62 +339,31 @@ async fn auto_unblock_blocked_tasks(
         // Always increment after cooldown check. When reason changed, count was reset to 0
         // above — incrementing after that gives count=1 (first time with this new reason).
         // When reason is the same, increment advances from current count for exponential backoff.
-        let do_increment = true;
-
-        if failures.contains(&FailureCategory::MaxAttempts) {
-            let _ = store
-                .set_fields(
-                    task.id,
-                    &[
-                        ("attempts", serde_json::json!(0)),
-                        ("route_attempts", serde_json::json!(0)),
-                    ],
-                )
-                .await;
-        }
-
-        if has_review_failure {
-            let _ = store
-                .set_fields(
-                    task.id,
-                    &[
-                        ("review_agent_failures", serde_json::json!(0)),
-                        ("review_invocations", serde_json::json!(0)),
-                    ],
-                )
-                .await;
-        }
-
         let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
-        if do_increment {
-            if let Err(e) = store.increment(task.id, "auto_unblock_count").await {
-                tracing::warn!(task_id = task.id, err = %e, "failed to increment auto_unblock_count");
-                continue;
-            }
-        }
-        if let Err(e) = store
-            .set_fields(
-                task.id,
-                &[
-                    ("auto_unblock_last_at", serde_json::json!(now)),
-                    ("auto_unblock_last_reason", serde_json::json!(reason_key)),
-                ],
-            )
-            .await
-        {
-            tracing::warn!(task_id = task.id, err = %e, "failed to set auto_unblock_last_at — skipping unblock");
+        if let Err(e) = store.increment(task.id, "auto_unblock_count").await {
+            tracing::warn!(task_id = task.id, err = %e, "failed to increment auto_unblock_count");
             continue;
         }
 
-        let _ = store
-            .set_fields(
-                task.id,
-                &[
-                    ("agent", serde_json::Value::Null),
-                    ("model", serde_json::Value::Null),
-                ],
-            )
-            .await;
+        // Combine all remaining field updates into a single set_fields call.
+        let mut fields: Vec<(&str, serde_json::Value)> = vec![
+            ("auto_unblock_last_at", serde_json::json!(now)),
+            ("auto_unblock_last_reason", serde_json::json!(reason_key)),
+            ("agent", serde_json::Value::Null),
+            ("model", serde_json::Value::Null),
+        ];
+        if failures.contains(&FailureCategory::MaxAttempts) {
+            fields.push(("attempts", serde_json::json!(0)));
+            fields.push(("route_attempts", serde_json::json!(0)));
+        }
+        if has_review_failure {
+            fields.push(("review_agent_failures", serde_json::json!(0)));
+            fields.push(("review_invocations", serde_json::json!(0)));
+        }
+        if let Err(e) = store.set_fields(task.id, &fields).await {
+            tracing::warn!(task_id = task.id, err = %e, "failed to set auto_unblock fields — skipping unblock");
+            continue;
+        }
 
         let ext_id = task
             .external_id
@@ -534,6 +507,14 @@ pub(crate) async fn sync_tick(
             }
             tasks
         };
+        // Fetch all live tmux sessions once instead of one subprocess call per task.
+        let live_sessions: std::collections::HashSet<String> = tmux
+            .list_sessions()
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
         for task in in_review_tasks {
             // Skip tasks currently being processed by the main tick (dispatch + review flow).
             let dispatch_key = format!("{}/{}", repo, task.id.0);
@@ -575,7 +556,7 @@ pub(crate) async fn sync_tick(
 
             let review_task_id = format!("{}-review", task.id.0);
             let review_session = tmux.session_name(repo, &review_task_id);
-            if tmux.session_exists(&review_session).await {
+            if live_sessions.contains(&review_session) {
                 // Review agent is still alive — skip.
                 continue;
             }
@@ -785,12 +766,12 @@ async fn scan_mentions(
     };
 
     // Get existing mention tasks across ALL statuses to avoid duplicates.
+    // Uses a SQL-filtered query instead of loading all internal tasks.
     let existing_mentions: std::collections::HashSet<String> = if let Some(s) = store {
-        s.list_all_internal(repo)
+        s.list_internal_by_source(repo, "mention")
             .await
             .unwrap_or_default()
             .into_iter()
-            .filter(|t| t.source == "mention")
             .map(|t| t.source_id.clone())
             .collect()
     } else {
@@ -1101,33 +1082,39 @@ pub(crate) async fn ingest_external_tasks(
         }
     }
 
-    // 3. Upsert into the store.
+    // 3. Upsert into the store, collecting store IDs for batch status check.
+    let mut id_status_pairs: Vec<(i64, crate::backends::Status)> = Vec::new();
     for (task, status) in &all_tasks {
         match store.ensure_external_task(repo, task).await {
             Ok(store_id) => {
-                // Only sync status from backend → store for NEW tasks (first ingest).
-                // Once a task exists in the store, its status is authoritative —
-                // re-ingestion must not overwrite store-first status changes
-                // (e.g., store has Routed but GitHub still shows New labels).
-                if let Some(status) = status {
-                    if let Ok(existing) = store.get(store_id).await {
-                        if existing.status == crate::store::TaskStatus::New {
-                            let db_status = crate::engine::tasks::status_to_task_status(*status);
-                            if db_status != crate::store::TaskStatus::New {
-                                if let Err(e) = store.update_status(store_id, db_status).await {
-                                    tracing::debug!(
-                                        task_id = task.id.0,
-                                        ?e,
-                                        "ingest: status sync failed"
-                                    );
-                                }
-                            }
-                        }
-                    }
+                if let Some(s) = status {
+                    id_status_pairs.push((store_id, *s));
                 }
             }
             Err(e) => {
                 tracing::debug!(task_id = task.id.0, ?e, "ingest: upsert failed");
+            }
+        }
+    }
+
+    // Batch-fetch all upserted tasks in a single query, then sync status for NEW tasks.
+    // Only sync status from backend → store for NEW tasks (first ingest).
+    // Once a task exists in the store, its status is authoritative —
+    // re-ingestion must not overwrite store-first status changes
+    // (e.g., store has Routed but GitHub still shows New labels).
+    if !id_status_pairs.is_empty() {
+        let all_ids: Vec<i64> = id_status_pairs.iter().map(|(id, _)| *id).collect();
+        let existing_map = store.get_batch(&all_ids).await.unwrap_or_default();
+        for (store_id, status) in id_status_pairs {
+            if let Some(existing) = existing_map.get(&store_id) {
+                if existing.status == crate::store::TaskStatus::New {
+                    let db_status = crate::engine::tasks::status_to_task_status(status);
+                    if db_status != crate::store::TaskStatus::New {
+                        if let Err(e) = store.update_status(store_id, db_status).await {
+                            tracing::debug!(?e, "ingest: status sync failed");
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -559,6 +559,24 @@ impl TaskStore {
         rows.iter().map(Self::row_to_task).collect()
     }
 
+    /// List internal tasks with a specific source value (origin = 'internal' AND source = ?).
+    /// More efficient than `list_all_internal` + in-memory filter when only a subset is needed.
+    pub async fn list_internal_by_source(
+        &self,
+        repo: &str,
+        source: &str,
+    ) -> anyhow::Result<Vec<Task>> {
+        let rows = sqlx::query(
+            "SELECT * FROM tasks WHERE repo = ? AND origin = 'internal' AND source = ? ORDER BY created_at DESC",
+        )
+        .bind(repo)
+        .bind(source)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(Self::row_to_task).collect()
+    }
+
     /// List all external tasks for a repo (origin != 'internal').
     pub async fn list_all_external(&self, repo: &str) -> anyhow::Result<Vec<Task>> {
         let rows = sqlx::query(
@@ -1122,6 +1140,57 @@ impl TaskStore {
         .await?;
 
         rows.iter().map(Self::row_to_run).collect()
+    }
+
+    /// Get all runs for a batch of task IDs in a single query, grouped by task ID.
+    /// Returns an empty map if `task_ids` is empty.
+    pub async fn get_runs_batch(
+        &self,
+        task_ids: &[i64],
+    ) -> anyhow::Result<std::collections::HashMap<i64, Vec<TaskRun>>> {
+        if task_ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let placeholders = task_ids.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let sql = format!(
+            "SELECT * FROM task_runs WHERE task_id IN ({placeholders}) ORDER BY task_id ASC, attempt ASC, run_type ASC"
+        );
+        let mut query = sqlx::query(&sql);
+        for id in task_ids {
+            query = query.bind(*id);
+        }
+        let rows = query.fetch_all(&self.pool).await?;
+        let mut result: std::collections::HashMap<i64, Vec<TaskRun>> =
+            std::collections::HashMap::new();
+        for row in &rows {
+            let run = Self::row_to_run(row)?;
+            result.entry(run.task_id).or_default().push(run);
+        }
+        Ok(result)
+    }
+
+    /// Get multiple tasks by ID in a single query, returning a map from task ID to Task.
+    /// Returns an empty map if `ids` is empty.
+    pub async fn get_batch(
+        &self,
+        ids: &[i64],
+    ) -> anyhow::Result<std::collections::HashMap<i64, Task>> {
+        if ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let sql = format!("SELECT * FROM tasks WHERE id IN ({placeholders})");
+        let mut query = sqlx::query(&sql);
+        for id in ids {
+            query = query.bind(*id);
+        }
+        let rows = query.fetch_all(&self.pool).await?;
+        let mut result = std::collections::HashMap::new();
+        for row in &rows {
+            let task = Self::row_to_task(row)?;
+            result.insert(task.id, task);
+        }
+        Ok(result)
     }
 
     /// Get the last run of a specific type for a task.


### PR DESCRIPTION
## Summary

Batched get_runs(), tmux checks, mention filtering, set_fields calls, and ingest status checks in sync.rs — all 2362 tests pass

### What was done

- Batch-load runs for blocked tasks via store.get_runs_batch() — N queries → 1
- Single tmux list-sessions call for in-review checks — N process spawns → 1
- SQL-filtered mention query via store.list_internal_by_source() — loads only mention tasks
- Merged multiple set_fields calls per unblock into one — 3N writes → N
- Batch-fetch tasks during ingest via store.get_batch() — N queries → 1
- cargo fmt, cargo clippy, cargo nextest all pass (2362/2362)


Closes #1405

---
*Task #1405 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*