### PR TITLE
refactor: deduplicate NDJSON parsing and error classification across agent runners

### DIFF
--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -12,7 +12,7 @@
 //! - Loading and caching the skills catalog from disk
 
 use crate::backends::ExternalTask;
-use crate::engine::runner::agents::{claude, opencode, AgentError};
+use crate::engine::runner::agents::{self, claude, opencode, AgentError};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -678,7 +678,7 @@ impl LlmRouter {
     fn extract_agent_text(&self, agent: &str, raw: &str) -> anyhow::Result<String> {
         match agent {
             "opencode" => {
-                let events = opencode::parse_ndjson_events(raw.trim());
+                let events = agents::parse_ndjson(raw.trim());
                 if events.is_empty() {
                     // No parseable NDJSON lines — treat as plain text
                     Ok(raw.to_string())

--- a/src/engine/runner/agents/codex.rs
+++ b/src/engine/runner/agents/codex.rs
@@ -42,20 +42,6 @@ use crate::parser;
 pub struct CodexRunner;
 
 impl CodexRunner {
-    /// Parse an NDJSON stream from Codex into structured events.
-    fn parse_ndjson(&self, raw: &str) -> Vec<serde_json::Value> {
-        raw.lines()
-            .filter(|line| !line.trim().is_empty())
-            .filter_map(|line| match serde_json::from_str(line) {
-                Ok(val) => Some(val),
-                Err(e) => {
-                    tracing::debug!(line, error = %e, "codex: skipping unparseable NDJSON line");
-                    None
-                }
-            })
-            .collect()
-    }
-
     /// Extract the agent's response text from NDJSON events.
     ///
     /// Looks for `item.completed` events with `item.type == "agent_message"`.
@@ -236,7 +222,7 @@ impl AgentRunner for CodexRunner {
             return Ok(String::new());
         }
 
-        let events = self.parse_ndjson(trimmed);
+        let events = super::parse_ndjson(trimmed);
         if events.is_empty() {
             return Ok(trimmed.to_string());
         }
@@ -304,7 +290,7 @@ impl AgentRunner for CodexRunner {
             return Err(AgentError::InvalidResponse { raw: String::new() });
         }
 
-        let events = self.parse_ndjson(trimmed);
+        let events = super::parse_ndjson(trimmed);
 
         if events.is_empty() {
             // Maybe it's direct JSON, not NDJSON
@@ -348,7 +334,7 @@ impl AgentRunner for CodexRunner {
 
     fn classify_error(&self, exit_code: i32, stdout: &str, stderr: &str) -> AgentError {
         // Try parsing NDJSON events from stdout for structured errors
-        let events = self.parse_ndjson(stdout);
+        let events = super::parse_ndjson(stdout);
         if let Some(err) = self.detect_error(&events) {
             return err;
         }
@@ -398,7 +384,7 @@ fn extract_quoted(text: &str, quote: char) -> Option<String> {
 /// Returns `None` only if no parseable NDJSON events are found.
 pub fn find_codex_result(ndjson: &str) -> Option<super::AgentResult> {
     let runner = CodexRunner;
-    let events = runner.parse_ndjson(ndjson.trim());
+    let events = super::parse_ndjson(ndjson.trim());
     if events.is_empty() {
         return None;
     }

--- a/src/engine/runner/agents/kimi.rs
+++ b/src/engine/runner/agents/kimi.rs
@@ -9,7 +9,7 @@
 //! output format differences from native Claude.
 
 use super::minimax::MiniMaxClaudeRunner;
-use super::{AgentError, AgentRunner, ParsedResponse, PermissionRules};
+use super::{delegate_agent_runner, AgentError, AgentRunner, ParsedResponse, PermissionRules};
 
 /// Runner for Kimi-via-Claude agents (same output handling as MiniMaxClaude).
 /// Named `KimiClaudeRunner` to distinguish from a future native Kimi CLI runner.
@@ -25,44 +25,7 @@ impl KimiClaudeRunner {
     }
 }
 
-impl AgentRunner for KimiClaudeRunner {
-    #[cfg(test)]
-    fn name(&self) -> &str {
-        self.inner.name()
-    }
-
-    fn build_command(
-        &self,
-        model: Option<&str>,
-        timeout_cmd: &str,
-        sys_file: &str,
-        msg_file: &str,
-        permissions: &PermissionRules,
-    ) -> String {
-        self.inner
-            .build_command(model, timeout_cmd, sys_file, msg_file, permissions)
-    }
-
-    fn parse_response(&self, raw: &str) -> Result<ParsedResponse, AgentError> {
-        self.inner.parse_response(raw)
-    }
-
-    fn extract_text(&self, raw: &str) -> Result<String, AgentError> {
-        self.inner.extract_text(raw)
-    }
-
-    fn classify_error(&self, exit_code: i32, stdout: &str, stderr: &str) -> AgentError {
-        self.inner.classify_error(exit_code, stdout, stderr)
-    }
-
-    fn router_command(
-        &self,
-        prompt: &str,
-        model: Option<&str>,
-    ) -> anyhow::Result<tokio::process::Command> {
-        self.inner.router_command(prompt, model)
-    }
-}
+delegate_agent_runner!(KimiClaudeRunner, inner);
 
 #[cfg(test)]
 mod tests {

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -485,6 +485,76 @@ pub fn get_runner(agent_name: &str) -> Box<dyn AgentRunner> {
     }
 }
 
+/// Parse an NDJSON stream into a list of JSON values.
+///
+/// Shared by all agents that emit NDJSON output (Codex, OpenCode, etc.).
+/// Lines that are empty or unparseable are silently skipped with a debug log.
+pub(crate) fn parse_ndjson(raw: &str) -> Vec<serde_json::Value> {
+    raw.lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| match serde_json::from_str(line) {
+            Ok(val) => Some(val),
+            Err(e) => {
+                tracing::debug!(line, error = %e, "skipping unparseable NDJSON line");
+                None
+            }
+        })
+        .collect()
+}
+
+/// Generate a complete, delegating `AgentRunner` impl for a wrapper struct.
+///
+/// Use this for runner types that delegate every `AgentRunner` method to an
+/// inner field (e.g., `KimiClaudeRunner → MiniMaxClaudeRunner`).
+///
+/// ```ignore
+/// delegate_agent_runner!(KimiClaudeRunner, inner);
+/// ```
+macro_rules! delegate_agent_runner {
+    ($runner:ty, $inner:ident) => {
+        impl AgentRunner for $runner {
+            #[cfg(test)]
+            fn name(&self) -> &str {
+                self.$inner.name()
+            }
+
+            fn build_command(
+                &self,
+                model: Option<&str>,
+                timeout_cmd: &str,
+                sys_file: &str,
+                msg_file: &str,
+                permissions: &PermissionRules,
+            ) -> String {
+                self.$inner
+                    .build_command(model, timeout_cmd, sys_file, msg_file, permissions)
+            }
+
+            fn parse_response(&self, raw: &str) -> Result<ParsedResponse, AgentError> {
+                self.$inner.parse_response(raw)
+            }
+
+            fn extract_text(&self, raw: &str) -> Result<String, AgentError> {
+                self.$inner.extract_text(raw)
+            }
+
+            fn classify_error(&self, exit_code: i32, stdout: &str, stderr: &str) -> AgentError {
+                self.$inner.classify_error(exit_code, stdout, stderr)
+            }
+
+            fn router_command(
+                &self,
+                prompt: &str,
+                model: Option<&str>,
+            ) -> anyhow::Result<tokio::process::Command> {
+                self.$inner.router_command(prompt, model)
+            }
+        }
+    };
+}
+
+pub(crate) use delegate_agent_runner;
+
 /// Shared error pattern detection utilities used by multiple agent runners.
 pub(crate) mod patterns {
     use super::AgentError;

--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -38,19 +38,6 @@ pub struct OpenCodeRunner {
     free_models_cache: Mutex<Option<(Vec<String>, std::time::Instant)>>,
 }
 
-pub(crate) fn parse_ndjson_events(raw: &str) -> Vec<serde_json::Value> {
-    raw.lines()
-        .filter(|line| !line.trim().is_empty())
-        .filter_map(|line| match serde_json::from_str(line) {
-            Ok(val) => Some(val),
-            Err(e) => {
-                tracing::debug!(line, error = %e, "opencode: skipping unparseable NDJSON line");
-                None
-            }
-        })
-        .collect()
-}
-
 pub(crate) fn extract_ndjson_text(events: &[serde_json::Value]) -> Option<String> {
     let mut texts = Vec::new();
 
@@ -224,7 +211,7 @@ fn extract_json_object(text: &str) -> Option<String> {
 }
 
 pub(crate) fn extract_router_text(raw: &str) -> Option<String> {
-    let events = parse_ndjson_events(raw.trim());
+    let events = super::parse_ndjson(raw.trim());
     if events.is_empty() {
         return None;
     }
@@ -270,11 +257,6 @@ impl OpenCodeRunner {
         Self {
             free_models_cache: Mutex::new(None),
         }
-    }
-
-    /// Parse NDJSON stream into events.
-    fn parse_ndjson(&self, raw: &str) -> Vec<serde_json::Value> {
-        parse_ndjson_events(raw)
     }
 
     /// Extract text from `text` events.
@@ -395,7 +377,7 @@ impl AgentRunner for OpenCodeRunner {
             return Ok(String::new());
         }
 
-        let events = self.parse_ndjson(trimmed);
+        let events = super::parse_ndjson(trimmed);
         if events.is_empty() {
             return Ok(trimmed.to_string());
         }
@@ -466,7 +448,7 @@ printf '%s\n' '{permission_json}' > .orch-opencode/opencode/opencode.json || {{ 
             return Err(AgentError::InvalidResponse { raw: String::new() });
         }
 
-        let events = self.parse_ndjson(trimmed);
+        let events = super::parse_ndjson(trimmed);
 
         if events.is_empty() {
             // Maybe direct JSON
@@ -512,7 +494,7 @@ printf '%s\n' '{permission_json}' > .orch-opencode/opencode/opencode.json || {{ 
 
     fn classify_error(&self, exit_code: i32, stdout: &str, stderr: &str) -> AgentError {
         // Try parsing NDJSON events from stdout for structured errors
-        let events = self.parse_ndjson(stdout);
+        let events = super::parse_ndjson(stdout);
         if let Some(err) = self.detect_error(&events) {
             return err;
         }
@@ -730,7 +712,7 @@ fn discover_free_models() -> Vec<String> {
 ///
 /// Returns `None` only if no parseable NDJSON events are found.
 pub fn find_opencode_result(ndjson: &str) -> Option<super::AgentResult> {
-    let events = parse_ndjson_events(ndjson.trim());
+    let events = super::parse_ndjson(ndjson.trim());
     if events.is_empty() {
         return None;
     }


### PR DESCRIPTION
## Summary

Deduplicated NDJSON parsing and extracted delegation macro across agent runners

### What was done

- Extracted shared `parse_ndjson()` into `agents/mod.rs`; removed identical copies from `codex.rs` and `opencode.rs`
- Updated all call sites in codex.rs, opencode.rs, and router/llm.rs to use the shared function
- Added `delegate_agent_runner!(Type, field)` macro in `mod.rs` that generates fully-forwarding `AgentRunner` impls
- Replaced 37-line boilerplate `AgentRunner` impl in `kimi.rs` with a single macro invocation
- All 2380 tests pass, clippy clean


Closes #1426

---
*Task #1426 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*