### PR TITLE
Recover orphaned PRs/branches for recoverable tasks

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -865,8 +865,39 @@ async fn apply_fixes(
                         fixed += 1;
                     }
                     Err(e) => {
-                        eprintln!("  fix failed for #{}: PR creation failed: {}", f.task_id, e);
-                        skipped += 1;
+                        // PR creation failed — it may be a transient server error. Re-check GitHub
+                        // for an existing PR for the branch and link it if found.
+                        eprintln!(
+                            "  PR creation error for #{}: {}. Re-checking for existing PR...",
+                            f.task_id, e
+                        );
+                        match gh.get_pr_number(repo, &task.branch).await {
+                            Ok(Some(pr_num)) => {
+                                let _ = store
+                                    .set_fields(
+                                        *store_id,
+                                        &[("pr_number", serde_json::json!(pr_num as i64))],
+                                    )
+                                    .await;
+                                reopen_and_set_needs_review(
+                                    store, *store_id, &task, backend, gh, repo,
+                                )
+                                .await;
+                                println!(
+                                    "  fixed #{}: PR was present on GitHub as #{} (linked) + reopened + needs_review",
+                                    f.task_id, pr_num
+                                );
+                                fixed += 1;
+                            }
+                            Ok(None) => {
+                                eprintln!("  fix failed for #{}: PR creation failed and no PR found for branch", f.task_id);
+                                skipped += 1;
+                            }
+                            Err(err2) => {
+                                eprintln!("  fix failed for #{}: PR creation failed: {}; and PR lookup failed: {}", f.task_id, e, err2);
+                                skipped += 1;
+                            }
+                        }
                     }
                 }
             }
@@ -911,8 +942,37 @@ async fn apply_fixes(
                         fixed += 1;
                     }
                     Err(e) => {
-                        eprintln!("  fix failed for #{}: PR creation failed: {}", f.task_id, e);
-                        skipped += 1;
+                        eprintln!(
+                            "  PR creation error for #{}: {}. Re-checking for existing PR...",
+                            f.task_id, e
+                        );
+                        match gh.get_pr_number(repo, &task.branch).await {
+                            Ok(Some(pr_num)) => {
+                                let _ = store
+                                    .set_fields(
+                                        *store_id,
+                                        &[("pr_number", serde_json::json!(pr_num as i64))],
+                                    )
+                                    .await;
+                                reopen_and_set_needs_review(
+                                    store, *store_id, &task, backend, gh, repo,
+                                )
+                                .await;
+                                println!(
+                                    "  fixed #{}: PR was present on GitHub as #{} (linked) + reopened + needs_review",
+                                    f.task_id, pr_num
+                                );
+                                fixed += 1;
+                            }
+                            Ok(None) => {
+                                eprintln!("  fix failed for #{}: PR creation failed and no PR found for branch", f.task_id);
+                                skipped += 1;
+                            }
+                            Err(err2) => {
+                                eprintln!("  fix failed for #{}: PR creation failed: {}; and PR lookup failed: {}", f.task_id, e, err2);
+                                skipped += 1;
+                            }
+                        }
                     }
                 }
             }
@@ -945,8 +1005,37 @@ async fn apply_fixes(
                         fixed += 1;
                     }
                     Err(e) => {
-                        eprintln!("  fix failed for #{}: PR creation failed: {}", f.task_id, e);
-                        skipped += 1;
+                        eprintln!(
+                            "  PR creation error for #{}: {}. Re-checking for existing PR...",
+                            f.task_id, e
+                        );
+                        match gh.get_pr_number(repo, &task.branch).await {
+                            Ok(Some(pr_num)) => {
+                                let _ = store
+                                    .set_fields(
+                                        *store_id,
+                                        &[("pr_number", serde_json::json!(pr_num as i64))],
+                                    )
+                                    .await;
+                                reopen_and_set_needs_review(
+                                    store, *store_id, &task, backend, gh, repo,
+                                )
+                                .await;
+                                println!(
+                                    "  fixed #{}: PR was present on GitHub as #{} (linked) + reopened + needs_review",
+                                    f.task_id, pr_num
+                                );
+                                fixed += 1;
+                            }
+                            Ok(None) => {
+                                eprintln!("  fix failed for #{}: PR creation failed and no PR found for branch", f.task_id);
+                                skipped += 1;
+                            }
+                            Err(err2) => {
+                                eprintln!("  fix failed for #{}: PR creation failed: {}; and PR lookup failed: {}", f.task_id, e, err2);
+                                skipped += 1;
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Added recovery when PR creation fails: doctor now re-checks GitHub for an existing PR for the branch and links it if found. Change committed but repo tests show unrelated failures that must be fixed before marking done.

### What was done

- Updated src/cli/doctor.rs to handle transient PR-creation failures: when gh.create_pr fails the doctor flow now queries GitHub for an existing PR for the task branch and links it if found (sets pr_number, reopens + sets needs_review).
- Committed change with message: "doctor: when PR creation fails, re-check GitHub for existing PRs and link if found (recover orphaned PRs/branches)"
- Ran the test suite locally to validate behavior: tests executed but 4 tests failed (unrelated cooldown tests)


### Remaining

- Investigate and fix the 4 failing unit tests in engine::cooldown (record_agent_success_resets_backoff, record_silence_detection_applies_extended_cooldown, clear_all_cooldowns_resets_all_failure_counts, record_model_failure_writes_to_kv).
- Run full CI locally (cargo fmt -- --check, cargo clippy --all-targets -- -D warnings, cargo nextest run) and fix any issues revealed
- Verify doctor flow end-to-end against a test repo/worktrees to confirm PR-linking behavior and that no regressions exist
- When tests pass, request review / mark needs_review as appropriate


Closes #1437

---
*Task #1437 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*