### PR TITLE
fix: orch dashboard should be global

### DIFF
--- a/src/cli/dashboard.rs
+++ b/src/cli/dashboard.rs
@@ -6,11 +6,24 @@ use crate::store::TaskStatus;
 use crate::store::TaskStore;
 use crate::tmux::TmuxManager;
 use chrono::{DateTime, Duration, Utc};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Simple dashboard command combining task status, active sessions, and recent activity.
-pub async fn dashboard() -> anyhow::Result<()> {
-    let task_manager = init_task_manager().await?;
+pub async fn dashboard(global: bool, project: Option<String>) -> anyhow::Result<()> {
+    // Use global store when --global flag is set, a project filter is given,
+    // or when no project context is available (running outside a project dir).
+    if global || project.is_some() {
+        return dashboard_from_global_store(project.as_deref()).await;
+    }
+
+    let task_manager = match init_task_manager().await {
+        Ok(tm) => tm,
+        Err(e) => {
+            tracing::debug!("no project context available, falling back to global store: {e:#}");
+            return dashboard_from_global_store(None).await;
+        }
+    };
 
     let statuses = [
         Status::New,
@@ -106,4 +119,100 @@ pub async fn dashboard() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Dashboard using the global store — works from any directory, across all projects.
+async fn dashboard_from_global_store(project: Option<&str>) -> anyhow::Result<()> {
+    let store = match crate::cli::init_store().await {
+        Ok(s) => Arc::new(s),
+        Err(_) => {
+            println!("Tasks (0 total)\n\nActive Sessions\n\nRecent (last 24h)");
+            return Ok(());
+        }
+    };
+
+    // Load all active tasks and recent done tasks from the store.
+    let mut active = store.list_all_active_global().await.unwrap_or_default();
+    let mut done = store
+        .list_all_by_status_global(TaskStatus::Done)
+        .await
+        .unwrap_or_default();
+
+    // Apply optional project filter.
+    if let Some(p) = project {
+        active.retain(|t| matches_project_filter(&t.repo, p));
+        done.retain(|t| matches_project_filter(&t.repo, p));
+    }
+
+    // Build a map from external_id -> agent for quick session lookups.
+    let agent_by_ext_id: HashMap<String, String> = active
+        .iter()
+        .filter_map(|t| {
+            let ext_id = t.external_id.as_deref()?;
+            let agent = t.agent.as_deref()?;
+            Some((ext_id.to_string(), agent.to_string()))
+        })
+        .collect();
+
+    // Count by status.
+    let status_order = [
+        TaskStatus::New,
+        TaskStatus::Routed,
+        TaskStatus::InProgress,
+        TaskStatus::InReview,
+        TaskStatus::NeedsReview,
+        TaskStatus::Blocked,
+        TaskStatus::Done,
+    ];
+
+    let done_count = done.len();
+    let total = active.len() + done_count;
+    println!("Tasks ({} total)", total);
+
+    for ts in &status_order {
+        let count = if *ts == TaskStatus::Done {
+            done_count
+        } else {
+            active.iter().filter(|t| t.status == *ts).count()
+        };
+        if count > 0 {
+            println!("  {:<12} {:>3}", ts.as_str().replace('_', ""), count);
+        }
+    }
+
+    println!("\nActive Sessions");
+    let tmux = TmuxManager::new();
+    let sessions = tmux.list_sessions().await.unwrap_or_default();
+    for s in sessions.iter() {
+        let agent = agent_by_ext_id
+            .get(&s.task_id)
+            .map(String::as_str)
+            .unwrap_or_default();
+        println!("  {:<25} {:<8} #{}", s.name, agent, s.task_id);
+    }
+
+    println!("\nRecent (last 24h)");
+    let cutoff: DateTime<Utc> = Utc::now() - Duration::hours(24);
+    for r in done.iter().take(10) {
+        if let Ok(dt) = DateTime::parse_from_rfc3339(&r.updated_at) {
+            let dt_utc = dt.with_timezone(&Utc);
+            if dt_utc >= cutoff {
+                let agent = r.agent.as_deref().unwrap_or_default();
+                let elapsed = Utc::now() - dt_utc;
+                let mins = elapsed.num_minutes();
+                let id_str = r.external_id.clone().unwrap_or_else(|| r.id.to_string());
+                println!(
+                    "  ✅ #{:<4} {:<30} {:<8} done {:>4}m ago",
+                    id_str, r.title, agent, mins
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn matches_project_filter(repo: &str, project: &str) -> bool {
+    let repo_name = repo.rsplit('/').next().unwrap_or(repo);
+    repo == project || repo_name == project || repo.ends_with(&format!("/{project}"))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,7 +295,14 @@ enum Commands {
         details: bool,
     },
     /// Combined dashboard: tasks, sessions, recent activity
-    Dashboard,
+    Dashboard {
+        /// Show tasks across all projects (default when outside a project directory)
+        #[arg(long, short = 'g')]
+        global: bool,
+        /// Filter to a specific project (e.g. owner/repo or just repo name)
+        #[arg(long)]
+        project: Option<String>,
+    },
     /// GitHub Projects V2 board management
     Board {
         #[command(subcommand)]
@@ -831,8 +838,8 @@ async fn main() -> anyhow::Result<()> {
             cli::metrics(details).await?;
         }
         // Combined dashboard view: tasks, sessions, recent activity
-        Commands::Dashboard => {
-            cli::dashboard::dashboard().await?;
+        Commands::Dashboard { global, project } => {
+            cli::dashboard::dashboard(global, project).await?;
         }
         Commands::Board { action } => match action {
             BoardAction::List => {


### PR DESCRIPTION
## Summary

orch dashboard now works globally — defaults to global store view when outside a project directory, and supports --global/-g and --project flags

### What was done

- Added --global/-g and --project <repo> flags to Dashboard CLI command in src/main.rs
- Refactored dashboard() to accept global and project params
- Added dashboard_from_global_store() that uses list_all_active_global() + list_all_by_status_global() — consistent with the existing `orch task list` fallback pattern
- Auto-fallback to global view when init_task_manager() fails (no .orch.yml found walking up)
- All 2400 tests pass, cargo fmt and clippy clean


Closes #1449

---
*Task #1449 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*