### PR TITLE
bug: batch GraphQL queries double-encode JSON — cleanup phase completely broken

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -1139,9 +1139,8 @@ impl GhHttp {
             .collect::<Vec<_>>()
             .join(" ");
 
-        let query = format!(
-            r#"{{ "query": "{{ repository(owner: \"{owner}\", name: \"{name}\") {{ {aliases} }} }}" }}"#
-        );
+        let query =
+            format!(r#"{{ repository(owner: "{owner}", name: "{name}") {{ {aliases} }} }}"#);
 
         let resp = self.graphql(&query).await?;
         let repo_data = resp
@@ -1320,9 +1319,8 @@ impl GhHttp {
                 .collect::<Vec<_>>()
                 .join("\n  ");
 
-            let query = format!(
-                r#"{{ "query": "{{ repository(owner: \"{owner}\", name: \"{name}\") {{ {aliases} }} }}" }}"#
-            );
+            let query =
+                format!(r#"{{ repository(owner: "{owner}", name: "{name}") {{ {aliases} }} }}"#);
 
             let resp = self.graphql(&query).await?;
             let repo_data = resp
@@ -1370,9 +1368,8 @@ impl GhHttp {
             .collect::<Vec<_>>()
             .join(" ");
 
-        let query = format!(
-            r#"{{ "query": "{{ repository(owner: \"{owner}\", name: \"{name}\") {{ {aliases} }} }}" }}"#
-        );
+        let query =
+            format!(r#"{{ repository(owner: "{owner}", name: "{name}") {{ {aliases} }} }}"#);
 
         let resp = self.graphql(&query).await?;
         let repo_data = resp


### PR DESCRIPTION
## Summary

Fixed double-encoding in three batch GraphQL functions that were breaking the cleanup phase

### What was done

- Removed extra JSON wrapping from batch_is_pr_merged_by_branch
- Removed extra JSON wrapping from batch_get_pr_states
- Removed extra JSON wrapping from batch_get_issue_states
- All 2400 unit tests pass
- Code formatting and linting pass
- Commit created with proper attribution


Closes #1451

---
*Task #1451 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*