### PR TITLE
bug: 2u64.pow(attempt) overflows in send_with_retries backoff when retry_attempts > 63

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -477,7 +477,9 @@ impl GhHttp {
 
                         if attempt + 1 < attempts {
                             // Exponential backoff (2^attempt * base), capped
-                            let mut backoff = base_secs.saturating_mul(2u64.pow(attempt));
+                            // Cap exponent at 62 to prevent overflow when attempt >= 64
+                            let exp = 1u64.checked_shl(attempt.min(62)).unwrap_or(u64::MAX);
+                            let mut backoff = base_secs.saturating_mul(exp);
                             if backoff > max_secs {
                                 backoff = max_secs;
                             }
@@ -506,7 +508,9 @@ impl GhHttp {
                     tracing::warn!(err = %e, attempt, "HTTP send failed, will retry if attempts remain");
                     last_err = Some(anyhow::anyhow!("HTTP send failed: {}", e));
                     if attempt + 1 < attempts {
-                        let backoff = base_secs.saturating_mul(2u64.pow(attempt));
+                        // Cap exponent at 62 to prevent overflow when attempt >= 64
+                        let exp = 1u64.checked_shl(attempt.min(62)).unwrap_or(u64::MAX);
+                        let backoff = base_secs.saturating_mul(exp);
                         let sleep_dur = Duration::from_secs(backoff)
                             + Duration::from_millis((attempt as u64 * 100).min(1000));
                         tokio::time::sleep(sleep_dur).await;


### PR DESCRIPTION
## Summary

Fixed overflow in exponential backoff when retry_attempts > 63

### What was done

- replaced 2u64.pow(attempt) with safe checked_shl capped at 62
- all 2400 tests pass
- committed fix


Closes #1459

---
*Task #1459 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*