### PR TITLE
bug: batch PR merge check fails every tick — cleanup phase silently skipped

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -805,7 +805,23 @@ impl GhHttp {
             Self::maybe_record_graphql_rate_limit_from_body(status, &text);
             anyhow::bail!("GitHub GraphQL failed ({status}): {text}");
         }
-        Ok(serde_json::from_str(&text)?)
+        let json: serde_json::Value = serde_json::from_str(&text)?;
+        // GraphQL always returns 200 even for errors; check the errors field explicitly.
+        if let Some(errors) = json.get("errors").and_then(|e| e.as_array()) {
+            if !errors.is_empty() {
+                let messages: Vec<&str> = errors
+                    .iter()
+                    .filter_map(|e| e.get("message").and_then(|m| m.as_str()))
+                    .collect();
+                if json.get("data").is_none() || json["data"].is_null() {
+                    // No data at all — surface the errors as a proper error.
+                    anyhow::bail!("GitHub GraphQL errors: {}", messages.join("; "));
+                }
+                // Partial data alongside errors — log and continue.
+                tracing::warn!(errors = ?messages, "GitHub GraphQL returned partial errors");
+            }
+        }
+        Ok(json)
     }
 
     // ── Public API (mirrors GhCli) ───────────────────────────────
@@ -1147,9 +1163,10 @@ impl GhHttp {
             format!(r#"{{ repository(owner: "{owner}", name: "{name}") {{ {aliases} }} }}"#);
 
         let resp = self.graphql(&query).await?;
-        let repo_data = resp
-            .pointer("/data/repository")
-            .ok_or_else(|| anyhow::anyhow!("missing /data/repository in GraphQL response"))?;
+        let repo_data = resp.pointer("/data/repository").ok_or_else(|| {
+            let preview: String = resp.to_string().chars().take(500).collect();
+            anyhow::anyhow!("missing /data/repository in GraphQL response: {}", preview)
+        })?;
 
         let mut result = std::collections::HashMap::new();
         for (i, branch) in branches.iter().enumerate() {


### PR DESCRIPTION
## Summary

Fixed GraphQL error surfacing so batch PR merge check failures expose the root cause instead of repeating a generic warning every tick

### What was done

- In `graphql_request` (http.rs:799-823): added post-parse check for GraphQL-level `errors` array — when `data` is null/absent returns a proper error with the error messages; when partial data exists alongside errors logs a warning and continues
- In `batch_is_pr_merged_by_branch` (http.rs:1168-1175): included first 500 chars of actual response body in the error message so the real cause is visible in logs
- All 2384 tests pass, clippy clean


Closes #1466

---
*Task #1466 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*