### PR TITLE
bug: store_reset_failure_counters silently discards DB errors — stale failure counts after review dispatch

### DIFF
--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -138,7 +138,9 @@ pub async fn store_reset_failure_counters(
 ) {
     if let Some(ref store) = store {
         if let Ok(Some(store_id)) = store.resolve_task_id(repo, task_id).await {
-            let _ = store.reset_failure_counters(store_id).await;
+            if let Err(e) = store.reset_failure_counters(store_id).await {
+                tracing::warn!(task_id, err = %e, "failed to reset failure counters after review dispatch");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Added error logging to store_reset_failure_counters to prevent silent DB failures

### What was done

- Fixed store_reset_failure_counters() to log errors instead of silently discarding them
- All 2336 tests pass
- Code formatted and linted successfully
- Committed fix


Closes #1474

---
*Task #1474 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*