### PR TITLE
bug: cleanup.rs silently discards mark_cleaned errors — infinite retry loops with no logging

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -422,7 +422,9 @@ pub(crate) async fn cleanup_task_worktree_with_opts(
                 "stored worktree path no longer exists on disk — marking cleaned"
             );
             if let Ok(Some(store_id)) = store.resolve_task_id(repo, task_id).await {
-                let _ = store.mark_cleaned(store_id).await;
+                if let Err(e) = store.mark_cleaned(store_id).await {
+                    tracing::warn!(task_id, err = %e, "failed to mark worktree cleaned in store — will retry");
+                }
             }
         }
         return Ok(false);
@@ -517,7 +519,9 @@ pub(crate) async fn cleanup_task_worktree_with_opts(
         // If resolve_task_id returns None the task is not (or no longer) in
         // the store; that is fine — we already did the on-disk work.
         if let Ok(Some(store_id)) = store.resolve_task_id(repo, task_id).await {
-            let _ = store.mark_cleaned(store_id).await;
+            if let Err(e) = store.mark_cleaned(store_id).await {
+                tracing::warn!(task_id, err = %e, "failed to mark worktree cleaned in store — will retry");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixed silent mark_cleaned() errors in cleanup.rs by adding proper error logging at both locations

### What was done

- Fixed line 425: replaced let _ = store.mark_cleaned(...) with error logging
- Fixed line 520: replaced let _ = store.mark_cleaned(...) with error logging
- All 2336 tests pass
- cargo fmt and clippy checks pass
- Changes committed with proper message


Closes #1472

---
*Task #1472 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*