### PR TITLE
bug: review_poll no-code reroute counter not reset on reason change — premature task blocking

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -572,9 +572,13 @@ async fn ensure_pr_exists(
                 }
 
                 // Atomically increment the persistent reroute counter and decide.
-                let reroutes =
-                    store_increment(&Some(Arc::clone(store)), repo, &task.id.0, "no_pr_reroutes")
-                        .await;
+                let reroutes = store_increment(
+                    &Some(Arc::clone(store)),
+                    repo,
+                    &task.id.0,
+                    "no_code_reroutes",
+                )
+                .await;
 
                 if reroutes as u32 >= max_reroutes {
                     tracing::error!(

--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -259,7 +259,7 @@ pub(crate) async fn review_open_prs(
                 }
 
                 let reroutes =
-                    store_increment(&Some(Arc::clone(store)), repo, task_id, "no_pr_reroutes")
+                    store_increment(&Some(Arc::clone(store)), repo, task_id, "no_code_reroutes")
                         .await;
 
                 if reroutes as u32 >= max_reroutes {

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -356,6 +356,7 @@ async fn auto_unblock_blocked_tasks(
             fields.push(("attempts", serde_json::json!(0)));
             fields.push(("route_attempts", serde_json::json!(0)));
         }
+        fields.push(("no_code_reroutes", serde_json::json!(0)));
         if has_review_failure {
             fields.push(("review_agent_failures", serde_json::json!(0)));
             fields.push(("review_invocations", serde_json::json!(0)));


### PR DESCRIPTION
## Summary

Fixed two related bugs: (1) sync.rs auto-unblock now resets no_code_reroutes so the circuit breaker gets a fresh budget after each unblock cycle; (2) review.rs and review_poll.rs were incrementing the non-existent "no_pr_reroutes" field (not in the INCREMENTABLE allowlist, silently returned 0) — corrected to "no_code_reroutes"

### What was done

- Added no_code_reroutes reset to auto-unblock field list in sync.rs
- Fixed wrong field name no_pr_reroutes → no_code_reroutes in review.rs
- Fixed wrong field name no_pr_reroutes → no_code_reroutes in review_poll.rs
- All 2336 tests pass
- Committed


Closes #1475

---
*Task #1475 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*