### PR TITLE
bug: batch_is_pr_merged_by_branch GraphQL query has invalid escaping — cleanup fails every tick

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -1155,7 +1155,7 @@ impl GhHttp {
             .map(|(i, branch)| {
                 let escaped = branch.replace('\\', "\\\\").replace('"', "\\\"");
                 format!(
-                    r#"b{i}: pullRequests(headRefName: \"{escaped}\", states: [MERGED], last: 1) {{ nodes {{ merged }} }}"#
+                    r#"b{i}: pullRequests(headRefName: "{escaped}", states: [MERGED], last: 1) {{ nodes {{ merged }} }}"#
                 )
             })
             .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary

Now I understand the full picture. The `graphql()` method wraps the query in `serde_json::json!({ "query": query })` at line 785, which handles JSON escaping automatically. So the raw string on line 1158 should use plain `"` not `\"`.

Let me also check the `escaped` variable — it does `branch.replace('"', "\\\"")` which in a regular string produces `\"`. Since the query goes through serde JSON serialization, we actually don't need to pre-escape quotes at all — serde will do it. But let me k

Closes #1480

---
*Task #1480 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*