### PR TITLE
bug: review agent blocks tasks on transient GitHub 503 — ensure_pr_exists() doesn't check is_transient_github_error()

### DIFF
--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -298,6 +298,13 @@ pub fn spawn(
                                         "review agent hit rate limit — deferring retry until cooldown expires"
                                     );
                                     ReviewOutcome::RateLimited
+                                } else if crate::engine::runner::git_ops::is_transient_github_error(&reason) {
+                                    tracing::warn!(
+                                        task_id = tid,
+                                        reason,
+                                        "review agent hit transient GitHub error — deferring retry without counting as failure"
+                                    );
+                                    ReviewOutcome::Reset
                                 } else {
                                     let failures = crate::store::store_increment(
                                         &Some(store_c.clone()),
@@ -342,6 +349,13 @@ pub fn spawn(
                                         "review_and_merge hit rate limit — deferring retry until cooldown expires"
                                     );
                                     ReviewOutcome::RateLimited
+                                } else if crate::engine::runner::git_ops::is_transient_github_error(&reason) {
+                                    tracing::warn!(
+                                        task_id = tid,
+                                        reason,
+                                        "review_and_merge hit transient GitHub error — deferring retry without counting as failure"
+                                    );
+                                    ReviewOutcome::Reset
                                 } else {
                                     let failures = crate::store::store_increment(
                                         &Some(store_c.clone()),


### PR DESCRIPTION
## Summary

Fixed review subscriber to exempt transient GitHub 5xx errors from failure counter, preventing tasks from being permanently blocked during brief GitHub outages

### What was done

- Added `is_transient_github_error()` check to `Ok(ReviewDecision::Failed)` path in review.rs:290-333
- Added `is_transient_github_error()` check to `Err(e)` path in review.rs:335-377
- Both transient error paths now return `ReviewOutcome::Reset` without incrementing `review_agent_failures`
- All 2336 tests pass


Closes #1484

---
*Task #1484 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*