### PR TITLE
bug: reroute assigns incompatible models to agents — claude dispatched with github-copilot/gpt-5-mini

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -951,7 +951,14 @@ pub async fn get_route_result(
     };
 
     let reason = task.route_reason.clone();
-    let model = task.model.clone().filter(|m| !m.is_empty());
+    let model = task.model.clone().filter(|m| !m.is_empty()).or_else(|| {
+        // Reroute path: agent was set but model was left empty ("").
+        // Resolve a compatible model from the agent + complexity tier
+        // to prevent dispatching incompatible agent-model combinations
+        // (e.g., claude with github-copilot/gpt-5-mini).
+        let cfg = crate::engine::router::RouterConfig::default();
+        cfg.model_for_complexity(&agent, &complexity, task_id)
+    });
 
     Ok(RouteResult {
         agent,

--- a/src/engine/runner/task_init.rs
+++ b/src/engine/runner/task_init.rs
@@ -146,7 +146,35 @@ pub async fn prepare_task(
 
     let model_name = model
         .map(String::from)
-        .or_else(|| route_result.as_ref().and_then(|r| r.model.clone()));
+        .or_else(|| route_result.as_ref().and_then(|r| r.model.clone()))
+        .or_else(|| {
+            // Reroute path: agent was set but model was left empty.
+            // Resolve a compatible model from the agent + complexity tier.
+            route_result.as_ref().and_then(|r| {
+                let cfg = crate::engine::router::RouterConfig::default();
+                cfg.model_for_complexity(&agent_name, &r.complexity, task_id)
+            })
+        });
+
+    // Safety log: detect agent-model namespace mismatches at dispatch time.
+    if let Some(ref m) = model_name {
+        if agent_name == "claude" && (m.starts_with("github-copilot/") || m.starts_with("openai/"))
+        {
+            tracing::error!(
+                agent = agent_name,
+                model = m,
+                task_id,
+                "agent-model mismatch: claude dispatched with non-anthropic model"
+            );
+        } else if agent_name == "codex" && m.starts_with("anthropic/") {
+            tracing::error!(
+                agent = agent_name,
+                model = m,
+                task_id,
+                "agent-model mismatch: codex dispatched with anthropic model"
+            );
+        }
+    }
 
     let complexity = route_result.as_ref().map(|r| r.complexity.clone());
 


### PR DESCRIPTION
## Summary

Fixed reroute agent-model mismatch bug where tasks rerouted to a different agent were dispatched with an empty model, causing incompatible agent-model combinations (e.g., claude with github-copilot/gpt-5-mini).

### What was done

- Identified root cause: reroute sets model='' but dispatch never resolves it for the new agent
- Fixed get_route_result() in src/engine/router/mod.rs to resolve model from agent+complexity when empty
- Added defense-in-depth fix in prepare_task() in src/engine/runner/task_init.rs for the same scenario
- Added safety logging to detect agent-model namespace mismatches at dispatch time
- All 2336 tests pass, clippy clean, formatting clean


Closes #1486

---
*Task #1486 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*