### PR TITLE
fix: clear both agent and model on reroute to prevent mismatched dispatches

### DIFF
--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -314,13 +314,13 @@ pub async fn handle_failover(
             record_agent_failure_with_message(agent_name, error_message).await;
         }
 
-        let msg = format!("{error_message}, rerouted to {next}");
+        let msg = format!("{error_message}, clearing agent/model for re-route");
         store::store_set(
             store,
             repo,
             task_id,
             &[
-                ("agent", serde_json::json!(next)),
+                ("agent", serde_json::json!("")),
                 ("model", serde_json::json!("")),
                 ("last_error", serde_json::json!(msg)),
             ],
@@ -328,8 +328,8 @@ pub async fn handle_failover(
         .await;
 
         // Apply exponential backoff with jitter before retry.
-        // Return "routed" (not "new") since agent/model are already stored;
-        // this skips the LLM re-routing cycle and preserves progress.
+        // Return "routed" so the router re-selects a compatible agent+model
+        // from scratch via model_for_complexity() + model_map in config.
         wait_for_fallback_backoff(task_id, store, repo).await;
 
         return "routed".to_string();

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -253,19 +253,19 @@ pub(crate) async fn tick_detect_silent_agents(
             }
         }
 
-        if let Some(ref fallback) = next_agent {
+        if next_agent.is_some() {
             store::store_set(
                 &Some(Arc::clone(store)),
                 repo,
                 &task_id,
                 &[
-                    ("agent", serde_json::json!(fallback)),
+                    ("agent", serde_json::json!("")),
                     ("model", serde_json::json!("")),
                     (
                         "last_error",
                         serde_json::json!(format!(
-                            "silence detected after {}s, rerouted from {} to {}",
-                            config.silence_grace_period, agent_name, fallback
+                            "silence detected after {}s, clearing agent/model for re-route",
+                            config.silence_grace_period
                         )),
                     ),
                 ],


### PR DESCRIPTION
## Summary

Cleared both agent and model fields on reroute in response.rs and tick.rs

### What was done

- Fixed response.rs: agent field now set to empty string instead of next agent on failover
- Fixed tick.rs: agent field now set to empty string instead of fallback agent on silence detection
- Updated comments to reflect new re-routing from scratch behavior
- All 2336 tests pass, clippy clean, fmt clean


Closes #1490

---
*Task #1490 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*