### PR TITLE
Panics and expect/unwrap usage in core engine modules (tasks/sync/dispatch_guard)

### DIFF
--- a/src/cli/job.rs
+++ b/src/cli/job.rs
@@ -209,7 +209,7 @@ pub async fn run(job_id: &str, project: Option<&str>) -> anyhow::Result<()> {
 
         match matches.len() {
             0 => anyhow::bail!("job '{}' not found in any project", job_id),
-            1 => resolved = Some(matches.into_iter().next().unwrap()),
+            1 => resolved = matches.pop(),
             _ => {
                 let repos: Vec<&str> = matches.iter().map(|(r, _)| r.as_str()).collect();
                 anyhow::bail!(
@@ -223,7 +223,10 @@ pub async fn run(job_id: &str, project: Option<&str>) -> anyhow::Result<()> {
         }
     }
 
-    let (repo, job) = resolved.unwrap();
+    let (repo, job) = match resolved {
+        Some(r) => r,
+        None => anyhow::bail!("job '{}' not found", job_id),
+    };
 
     if !job.enabled {
         println!("Warning: job '{}' is disabled, running anyway", job_id);

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -1067,7 +1067,10 @@ pub async fn reopen(id: &str) -> anyhow::Result<()> {
         anyhow::bail!("could not open task store");
     };
 
-    let s = store.as_ref().unwrap();
+    let s = match store.as_ref() {
+        Some(s) => s,
+        None => anyhow::bail!("task store unexpectedly None"),
+    };
 
     // 1. Reset failure counters
     let ext_id_str = task

--- a/src/control.rs
+++ b/src/control.rs
@@ -23,7 +23,7 @@
 //! - opencode supports `opencode models` for listing available models
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use anyhow::{Context, Result};
 use regex::Regex;
@@ -443,26 +443,29 @@ pub struct ParsedResponse {
     pub memories: Vec<MemoryEntry>,
 }
 
+static MEMORY_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?s)<memory\s+key="([^"]+)">(.+?)</memory>"#).expect("valid memory regex")
+});
+
+static SUMMARY_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?s)<summary>(.+?)</summary>"#).expect("valid summary regex"));
+
 /// Parse an agent response, extracting optional `<summary>` and `<memory>` tags.
 pub fn parse_response(raw: &str) -> ParsedResponse {
-    let memory_re =
-        Regex::new(r#"(?s)<memory\s+key="([^"]+)">(.+?)</memory>"#).expect("valid memory regex");
-
     let mut clean = raw.to_string();
-    let memories = memory_re
+    let memories = MEMORY_RE
         .captures_iter(raw)
         .map(|caps| MemoryEntry {
             key: caps[1].trim().to_string(),
             value: caps[2].trim().to_string(),
         })
         .collect::<Vec<_>>();
-    clean = memory_re.replace_all(&clean, "").to_string();
+    clean = MEMORY_RE.replace_all(&clean, "").to_string();
 
-    let summary_re = Regex::new(r#"(?s)<summary>(.+?)</summary>"#).expect("valid summary regex");
-    let summary = summary_re
+    let summary = SUMMARY_RE
         .captures(raw)
         .map(|caps| caps[1].trim().to_string());
-    clean = summary_re.replace_all(&clean, "").to_string();
+    clean = SUMMARY_RE.replace_all(&clean, "").to_string();
 
     ParsedResponse {
         clean_text: clean.trim().to_string(),

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -71,7 +71,8 @@ pub fn expand_alias(s: &str) -> String {
         }
         "@daily" => {
             if param.contains(':') {
-                let (h, m) = param.split_once(':').unwrap();
+                // split_once is guaranteed because contains(':') returned true
+                let (h, m) = param.split_once(':').unwrap_or(("", ""));
                 let hour: u8 = h.parse().unwrap_or(0);
                 let min: u8 = m.parse().unwrap_or(0);
                 format!("{min} {hour} * * *")
@@ -90,7 +91,8 @@ pub fn expand_alias(s: &str) -> String {
         }
         "@yearly" => {
             if param.contains('-') {
-                let (m, d) = param.split_once('-').unwrap();
+                // split_once is guaranteed because contains('-') returned true
+                let (m, d) = param.split_once('-').unwrap_or(("", ""));
                 let month: u8 = m.parse().unwrap_or(1);
                 let dom: u8 = d.parse().unwrap_or(1);
                 format!("0 0 {dom} {month} *")

--- a/src/engine/commands.rs
+++ b/src/engine/commands.rs
@@ -75,7 +75,7 @@ pub fn parse_command(body: &str) -> Option<OwnerCommand> {
     for line in body.lines() {
         let trimmed = line.trim();
         if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
-            let ch = trimmed.chars().next().unwrap();
+            let ch = trimmed.chars().next().unwrap_or('\0');
             match fence_char {
                 None => fence_char = Some(ch),
                 Some(c) if c == ch => fence_char = None,

--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -364,9 +364,12 @@ pub(crate) async fn review_open_prs(
         let task = &task_info.task;
         let stored_task = &task_info.stored;
         let task_id = &task.id.0;
-        let pr_number = task_info
-            .pr_number
-            .expect("tasks_with_pr always have pr_number");
+        let Some(pr_number) = task_info.pr_number else {
+            // tasks_with_pr is constructed to only include items with pr_number,
+            // but guard defensively against future refactors.
+            tracing::warn!(task_id, "task in tasks_with_pr has no pr_number — skipping");
+            continue;
+        };
 
         // Persist PR number (idempotent if already stored).
         store_set(

--- a/src/engine/router/weights.rs
+++ b/src/engine/router/weights.rs
@@ -221,8 +221,14 @@ impl AgentWeights {
             }
         }
 
-        // Rounding edge case — return last agent
-        Some(agents.last().unwrap().clone())
+        // Rounding edge case — return last agent (agents is guaranteed non-empty by caller)
+        debug_assert!(!agents.is_empty(), "agents must not be empty");
+        Some(
+            agents
+                .last()
+                .cloned()
+                .unwrap_or_else(|| String::from("unknown")),
+        )
     }
 
     /// Get the current weight for an agent.

--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -577,7 +577,9 @@ pub async fn create_pr_if_needed(
     let url = match created_url {
         Some(u) => u,
         None => {
-            let e = last_error.unwrap();
+            let e = last_error.unwrap_or_else(|| {
+                anyhow::anyhow!("PR creation failed after retries (no error captured)")
+            });
             let err_str = format!("{e}");
             // For transient 5xx errors, GitHub may have created the PR despite returning
             // an error (e.g. 502 after the write succeeded). Re-check for an existing PR

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -721,7 +721,11 @@ fn extract_review_response_object(text: &str) -> Option<ReviewResponse> {
                 '}' => {
                     depth -= 1;
                     if depth == 0 {
-                        let start_idx = start.unwrap();
+                        debug_assert!(
+                            start.is_some(),
+                            "start must be Some when depth returns to 0"
+                        );
+                        let start_idx = start.unwrap_or(0);
                         let candidate = &text[start_idx..=idx];
                         if let Ok(resp) = serde_json::from_str::<ReviewResponse>(candidate) {
                             return Some(resp);

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -577,7 +577,10 @@ async fn post_review_failure_comment(
     blocking: bool,
 ) {
     let pr_number = match opt_store_get_task(&Some(store.clone()), repo, task_id).await {
-        Some(t) if t.pr_number.is_some() => t.pr_number.unwrap(),
+        Some(t) => match t.pr_number {
+            Some(n) => n,
+            None => return, // No PR to comment on
+        },
         _ => return, // No PR to comment on
     };
 

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -716,7 +716,12 @@ impl GhHttp {
                     req = req.query(q);
                 }
 
-                let make_req = || req.try_clone().expect("request clone failed");
+                // try_clone returns None only for streaming bodies; REST API
+                // requests use JSON bodies which are always clonable.
+                let make_req = || {
+                    req.try_clone()
+                        .expect("request body must be clonable (JSON body expected)")
+                };
                 let resp = self.send_with_retries(make_req, false).await?;
                 let status = resp.status();
                 let next_from_headers = parse_link_next(resp.headers());
@@ -796,8 +801,13 @@ impl GhHttp {
             req = req.header(*k, *v);
         }
 
-        // Use send_with_retries wrapper for GraphQL (is_graphql = true)
-        let make_req = || req.try_clone().expect("graphql request clone failed");
+        // Use send_with_retries wrapper for GraphQL (is_graphql = true).
+        // try_clone returns None only for streaming bodies; GraphQL requests
+        // use JSON bodies which are always clonable.
+        let make_req = || {
+            req.try_clone()
+                .expect("graphql request body must be clonable (JSON body expected)")
+        };
         let resp = self.send_with_retries(make_req, true).await?;
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();
@@ -1918,7 +1928,10 @@ impl GhHttp {
             .body(query)
             .header(header::AUTHORIZATION, &auth)
             .header(header::ACCEPT, "application/vnd.github+json");
-        let make_req = || req.try_clone().expect("graphql request clone failed");
+        let make_req = || {
+            req.try_clone()
+                .expect("graphql request body must be clonable (JSON body expected)")
+        };
         let resp = self.send_with_retries(make_req, true).await?;
         let body: serde_json::Value = resp.json().await?;
         let pr_id = body
@@ -1937,7 +1950,10 @@ impl GhHttp {
             .body(mutation)
             .header(header::AUTHORIZATION, &auth)
             .header(header::ACCEPT, "application/vnd.github+json");
-        let make_req = || req.try_clone().expect("graphql request clone failed");
+        let make_req = || {
+            req.try_clone()
+                .expect("graphql request body must be clonable (JSON body expected)")
+        };
         let resp = self.send_with_retries(make_req, true).await?;
         let status = resp.status();
         if !status.is_success() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,7 +10,8 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::io::Read;
 
-static TRAILING_COMMA_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r",(\s*[}\]])").unwrap());
+static TRAILING_COMMA_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r",(\s*[}\]])").expect("trailing comma regex is valid"));
 
 /// Normalized agent response.
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

The exploration found most `.expect()`/`.unwrap()` usage is in test code or well-guarded invariants. But the task specifically mentions `cron.rs` line ~310 with `Schedule::from_str(&full_expr).expect("should parse")` — let me check that directly.The `cron.rs:310` `.expect()` is actually in test code (line 310 is inside `#[cfg(test)]`), and the production `check()` function at line 119-120 already properly uses `.with_context()` + `?`. Let me check the other files mentioned in the task.Let me s

Closes #1496

---
*Task #1496 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*