### PR TITLE
bug: GitHub issues gets duplicate model labels

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -681,7 +681,17 @@ pub(crate) async fn tick_route_tasks(
                         );
                     }
                 } else {
-                    // Add agent, complexity, and model labels (additive — does not remove existing labels)
+                    // Remove old agent/complexity/model labels to avoid duplicates on re-route
+                    for label in &task.labels {
+                        if label.starts_with("agent:")
+                            || label.starts_with("complexity:")
+                            || label.starts_with("model:")
+                        {
+                            backend.remove_label(&task.id, label).await.ok();
+                        }
+                    }
+
+                    // Add agent, complexity, and model labels
                     let mut labels = vec![
                         format!("agent:{}", result.agent),
                         format!("complexity:{}", result.complexity),


### PR DESCRIPTION
## Summary

The fix is complete. Here's a summary:

## Problem
GitHub issues were getting duplicate `model:` labels (e.g., `model:sonnet` appearing multiple times on the same issue).

## Root Cause
In `src/engine/tick.rs:684-691`, when a task was routed to an agent, labels were added via `backend.set_labels()` which uses GitHub's **additive** label API (`POST /repos/{owner}/{repo}/issues/{number}/labels`). 

When tasks were re-routed (e.g., after silence detection failover or stuck task recovery), the new l

Closes #1502

---
*Task #1502 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*