### PR TITLE
bug: orphan worktree at ~/.orch/worktrees/bean/internal-31298-morning-briefing-daily-focus-plan

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -11,6 +11,81 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+/// Resolve the main git repository root for an orphaned worktree.
+///
+/// For orphaned worktrees, we cannot use `resolve_repo_root` because the worktree
+/// may belong to a different project than the current repo context. Instead, we
+/// derive the repo root from the worktree's `.git` file/directory.
+///
+/// A worktree's `.git` file contains a `gitdir:` pointer to the main repo's
+/// git directory (e.g., `/path/to/repo/.git/worktrees/<name>`). We extract this
+/// path and derive the repo root from it.
+async fn resolve_repo_root_for_orphaned_worktree(wt: &Path) -> anyhow::Result<String> {
+    // First, try to read the .git file in the worktree (it's a file for worktrees,
+    // not a directory)
+    let git_file = wt.join(".git");
+    if git_file.exists() {
+        if let Ok(content) = std::fs::read_to_string(&git_file) {
+            // Parse the gitdir: line
+            for line in content.lines() {
+                if let Some(gitdir) = line.strip_prefix("gitdir: ") {
+                    // gitdir points to something like /path/to/repo/.git/worktrees/<name>
+                    // The repo root is two levels up from here
+                    let gitdir_path = std::path::PathBuf::from(gitdir);
+                    if let Some(repo_root) = gitdir_path.parent().and_then(|p| p.parent()) {
+                        return Ok(repo_root.display().to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback: try to find the repo by looking at registered projects
+    // Extract the project name from the worktree path
+    // Worktree path format: ~/.orch/worktrees/<project>/<branch-name>
+    let worktrees_dir = crate::home::worktrees_dir()?;
+    if let Ok(relative) = wt.strip_prefix(&worktrees_dir) {
+        if let Some(project_name) = relative.components().next() {
+            let project_name = project_name.as_os_str().to_string_lossy();
+
+            // Look for a registered project with this name
+            if let Ok(paths) = config::get_project_paths() {
+                for path_str in &paths {
+                    let path = std::path::Path::new(path_str);
+                    if let Some(name) = path.file_name() {
+                        if name.to_string_lossy() == project_name {
+                            return Ok(path_str.clone());
+                        }
+                    }
+                }
+            }
+
+            // Try bare clone at ~/.orch/projects/<owner>/<project>.git
+            let parts: Vec<&str> = project_name.split('/').collect();
+            let bare = if parts.len() == 2 {
+                crate::home::projects_dir()
+                    .map(|d| d.join(parts[0]).join(format!("{}.git", parts[1])))
+                    .unwrap_or_default()
+            } else {
+                crate::home::projects_dir()
+                    .map(|d| {
+                        d.join("gabrielkoerich")
+                            .join(format!("{}.git", project_name))
+                    })
+                    .unwrap_or_default()
+            };
+            if bare.exists() {
+                return Ok(bare.display().to_string());
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "cannot resolve repo root for orphaned worktree at {} - tried .git file parsing and project lookup",
+        wt.display()
+    )
+}
+
 /// What kind of automatic repair can be applied to a finding.
 enum FixAction {
     /// Commit dirty worktree, push, create PR, reopen issue, set needs_review.
@@ -1405,9 +1480,14 @@ async fn apply_fixes(
                     continue;
                 }
 
-                match resolve_repo_root(repo).await {
+                // For orphaned worktrees, derive the repo root from the worktree path
+                // by examining the .git file/directory, since the worktree may belong to
+                // a different project than the current repo context.
+                let wt = Path::new(path);
+                let repo_root = resolve_repo_root_for_orphaned_worktree(wt).await;
+
+                match repo_root {
                     Ok(root) => {
-                        let wt = Path::new(path);
                         let removed = remove_worktree_and_branch(
                             &f.task_id,
                             wt,

--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -465,10 +465,14 @@ pub(crate) async fn cleanup_task_worktree_with_opts(
             );
         } else {
             tracing::info!(task_id, worktree = %wt.display(), "removing worktree");
-            // We need the repo root to run git commands that remove the
-            // worktree and delete branches. Resolve it lazily here so
-            // that tasks with nothing to clean don't fail early.
-            let repo_root = resolve_repo_root(repo).await?;
+            // Derive repo root from the worktree itself (for cross-project support).
+            // If the worktree belongs to a different project than the current repo
+            // context (e.g., internal task with worktree in another project), we can
+            // still find the repo root by examining the worktree's .git file.
+            let repo_root = match resolve_repo_root_from_worktree(&wt) {
+                Ok(root) => root,
+                Err(_) => resolve_repo_root(repo).await?,
+            };
             let removed = remove_worktree_and_branch(
                 task_id,
                 &wt,
@@ -733,6 +737,47 @@ fn worktree_age_hours(worktree: &std::path::Path) -> Option<u64> {
     let modified = metadata.modified().ok()?;
     let age = std::time::SystemTime::now().duration_since(modified).ok()?;
     Some(age.as_secs() / 3600)
+}
+
+/// Resolve the main git repository root from a worktree's .git file.
+///
+/// For cross-project worktree cleanup, we cannot rely on `resolve_repo_root` because
+/// the worktree may belong to a different project than the current repo context.
+/// Instead, we extract the repo root from the worktree's `.git` file which contains
+/// a `gitdir:` pointer to the main repo's git directory.
+fn resolve_repo_root_from_worktree(wt: &std::path::Path) -> anyhow::Result<String> {
+    // For worktrees, .git is a file (not a directory) containing gitdir path
+    let git_file = wt.join(".git");
+    if !git_file.exists() {
+        anyhow::bail!(".git file not found in worktree at {}", wt.display());
+    }
+
+    let content = std::fs::read_to_string(&git_file)
+        .map_err(|e| anyhow::anyhow!("failed to read .git file: {e}"))?;
+
+    // Parse gitdir line: "gitdir: /path/to/repo/.git/worktrees/<name>"
+    for line in content.lines() {
+        if let Some(gitdir) = line.strip_prefix("gitdir:") {
+            let gitdir = gitdir.trim();
+            // The main repo is the parent of the .git directory
+            // gitdir points to: <repo>/.git/worktrees/<name>
+            // We need to go up 3 levels: worktrees/<name> -> .git -> repo
+            let gitdir_path = std::path::Path::new(gitdir);
+            if let Some(repo_root) = gitdir_path
+                .parent() // worktrees/<name>
+                .and_then(|p| p.parent()) // .git
+                .and_then(|p| p.parent())
+            // repo root
+            {
+                return Ok(repo_root.display().to_string());
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "cannot resolve repo root from worktree .git file at {}",
+        wt.display()
+    )
 }
 
 /// Resolve the main git repository root path for a project.


### PR DESCRIPTION
## Summary

## Summary

I've fixed the cross-project worktree cleanup issue. Here's what was done:

### Root Cause
When an internal task (like `internal:31298`) has a worktree in a different project (like `bean`), the cleanup logic was failing because:

1. `cleanup_done_worktrees` is called per-project with a `repo` parameter (e.g., `gabrielkoerich/orch`)
2. It collects done tasks from ALL projects, including internal tasks
3. But when calling `cleanup_task_worktree_with_opts(task_id, repo, ...)`, it used t

Closes #1506

---
*Task #1506 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*