### PR TITLE
orch chat session bug

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -663,17 +663,35 @@ pub async fn send_message(
     let full_message = format!("{}\n\n---\n\n{}", ctx.state, message);
 
     // Get or create a session UUID for conversation continuity
-    let session_uuid = get_or_create_session_uuid(store, session_id).await?;
+    // We will retry once if the agent reports the session UUID is already in use
+    // (some agent CLIs reject reusing the same session ID across processes).
+    let mut session_uuid = get_or_create_session_uuid(store, session_id).await?;
+    let mut attempt = 0u8;
+    let result = loop {
+        attempt += 1;
+        let res = invoke_agent_with_session(
+            &agent,
+            &model,
+            &ctx.system,
+            &full_message,
+            Some(&session_uuid),
+        )
+        .await;
 
-    // Invoke agent one-shot with --session-id for conversation continuity
-    let result = invoke_agent_with_session(
-        &agent,
-        &model,
-        &ctx.system,
-        &full_message,
-        Some(&session_uuid),
-    )
-    .await?;
+        match res {
+            Ok(r) => break r,
+            Err(e) if attempt == 1 && e.to_string().to_lowercase().contains("already in use") => {
+                // Agent rejected the session UUID as already in use. Generate a new
+                // session UUID so the next invocation starts a fresh conversation.
+                tracing::warn!(session = %session_uuid, "agent rejected session id as already in use; regenerating session id and retrying");
+                reset_session_uuid(store, session_id).await?;
+                session_uuid = get_or_create_session_uuid(store, session_id).await?;
+                // retry once
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    };
 
     // Parse response for summary and memory tags
     let parsed = parse_response(&result.text);


### PR DESCRIPTION
## Summary

Added a one-retry recovery when an agent CLI rejects the control session UUID as already in use.

### What was done

- Located control session logic in src/control.rs that builds and reuses session UUIDs
- Implemented a targeted retry: if the agent returns an error containing "already in use" on the first attempt, regenerate the session UUID and retry once
- Kept retry behavior minimal (single retry) to avoid surprising behavior while improving robustness for CLIs that reject reused session IDs
- Ran library tests and formatting; all tests mostly passed (1148 passed, 2 failures unrelated to control session change)


### Remaining

- Investigate the two failing cooldown tests seen during the test run (they appear unrelated to this change).
- Optionally add unit/integration tests specifically exercising the 'already in use' retry path by mocking runner errors to ensure the behavior remains stable.


Closes #1512

---
*Task #1512 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*