### PR TITLE
bug: store create/upsert returns id=0 silently on corrupt INSERT RETURNING — downstream operations silently no-op

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -341,7 +341,8 @@ impl TaskStore {
     .fetch_one(&self.pool)
     .await?;
 
-        Ok(row.try_get("id").unwrap_or(0))
+        row.try_get("id")
+            .map_err(|e| anyhow::anyhow!("INSERT RETURNING id returned NULL or invalid: {e}"))
     }
 
     /// Create an internal task, returning its auto-generated ID.
@@ -434,7 +435,8 @@ impl TaskStore {
         .fetch_one(&self.pool)
         .await?;
 
-        Ok(row.try_get("id").unwrap_or(0))
+        row.try_get("id")
+            .map_err(|e| anyhow::anyhow!("INSERT RETURNING id returned NULL or invalid: {e}"))
     }
 
     // ---------------------------------------------------------------
@@ -1315,7 +1317,9 @@ impl TaskStore {
         .fetch_one(&self.pool)
         .await?;
 
-        let run_id = row.try_get("id").unwrap_or(0);
+        let run_id: i64 = row
+            .try_get("id")
+            .map_err(|e| anyhow::anyhow!("INSERT RETURNING id returned NULL or invalid: {e}"))?;
         let event_type = match run.run_type {
             "review" => "review_start",
             _ => "dispatch",
@@ -1535,7 +1539,9 @@ impl TaskStore {
         let delegations_str: String = row.try_get("delegations").unwrap_or_default();
 
         Ok(Task {
-            id: row.try_get("id").unwrap_or(0),
+            id: row
+                .try_get("id")
+                .map_err(|e| anyhow::anyhow!("task row missing id: {e}"))?,
             external_id: row.try_get("external_id").unwrap_or(None),
             repo: row.try_get("repo").unwrap_or_default(),
             origin: row.try_get("origin").unwrap_or_default(),


### PR DESCRIPTION
## Summary

Replaced all four unwrap_or(0) calls on INSERT RETURNING id with proper error propagation so a missing primary key surfaces immediately rather than silently corrupting downstream operations

### What was done

- Fixed create() at line 344 to propagate error instead of returning id=0
- Fixed upsert_external() at line 437 to propagate error instead of returning id=0
- Fixed start_run() at line 1318 to propagate error instead of returning id=0
- Fixed row_to_task() at line 1538 to return Err instead of id=0


Closes #1520

---
*Task #1520 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*