### PR TITLE
bug: bind() holds bindings write-lock across two .await points — deadlock risk under concurrent rebinds

### DIFF
--- a/src/channels/transport.rs
+++ b/src/channels/transport.rs
@@ -72,24 +72,27 @@ impl Transport {
     /// Bind a channel thread to a task's tmux session.
     pub async fn bind(&self, task_id: &str, tmux_session: &str, channel: &str, thread_id: &str) {
         let key = format!("{channel}:{thread_id}");
-        let mut bindings = self.bindings.write().await;
-        let binding = bindings.entry(task_id.to_string()).or_insert_with(|| {
-            let (tx, _) = broadcast::channel(256);
-            SessionBinding {
-                tmux_session: tmux_session.to_string(),
-                connected_threads: Vec::new(),
-                output_tx: tx,
-            }
-        });
-        // Always update tmux_session — task retries get a new session
-        binding.tmux_session = tmux_session.to_string();
-        // When rebinding a task (retry/new tmux session), clear any cached
-        // last_output for the previous session so stale text is not replayed
-        // into the new attempt. Use the helper to centralize behavior.
+        // Clear stale output before updating bindings to avoid holding
+        // write lock across await points (deadlock risk).
         self.clear_output(task_id).await;
-        if !binding.connected_threads.contains(&key) {
-            binding.connected_threads.push(key.clone());
-        }
+        // Update bindings synchronously (no await while lock held)
+        {
+            let mut bindings = self.bindings.write().await;
+            let binding = bindings.entry(task_id.to_string()).or_insert_with(|| {
+                let (tx, _) = broadcast::channel(256);
+                SessionBinding {
+                    tmux_session: tmux_session.to_string(),
+                    connected_threads: Vec::new(),
+                    output_tx: tx,
+                }
+            });
+            // Always update tmux_session — task retries get a new session
+            binding.tmux_session = tmux_session.to_string();
+            if !binding.connected_threads.contains(&key) {
+                binding.connected_threads.push(key.clone());
+            }
+        } // bindings lock released here
+          // Update thread_to_task after releasing bindings lock
         self.thread_to_task
             .write()
             .await


### PR DESCRIPTION
## Summary

{"type":"step_start","timestamp":1775103391418,"sessionID":"ses_2b397d874ffeKzADs2TxcqGEzF","part":{"id":"prt_d4c6836b9001LjV62ji0KrMnq8","messageID":"msg_d4c6827cb00154zvISNqbtOQ3h","sessionID":"ses_2b397d874ffeKzADs2TxcqGEzF","snapshot":"9952464872e0837c90e44147c71b97e6029ba39c","type":"step-start"}}
{"type":"tool_use","timestamp":1775103392181,"sessionID":"ses_2b397d874ffeKzADs2TxcqGEzF","part":{"id":"prt_d4c6839b00021jK6fDMXPtanws","messageID":"msg_d4c6827cb00154zvISNqbtOQ3h","sessionID":"se

Closes #1518

---
*Task #1518 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2-omni-free`*