### PR TITLE
Are GitHub issues being synced/updated on Github Projects?

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -86,6 +86,35 @@ impl ExternalBackend for GitHubBackend {
             .await
     }
 
+    /// Sync a task to the GitHub Project board (if configured).
+    ///
+    /// Called when a task is first ingested to ensure it appears on the
+    /// project board immediately, not just when status changes later.
+    async fn sync_to_project(&self, id: &ExternalId, status: Status) -> anyhow::Result<()> {
+        // Only sync if project integration is configured
+        let project = match ProjectSync::from_config() {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+
+        // Fetch the issue to get its node_id
+        let issue = self.gh.get_issue(&self.repo, &id.0).await?;
+
+        // Get the node_id (required for project board operations)
+        let node_id = issue
+            .node_id
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("issue missing node_id"))?;
+
+        // Add to project board and set initial status
+        project
+            .sync_item_status(node_id, &status)
+            .await
+            .map_err(|e| anyhow::anyhow!("project board sync failed: {e}"))?;
+
+        Ok(())
+    }
+
     /// Override default update_status to add project board sync after label update.
     async fn update_status(&self, id: &ExternalId, status: Status) -> anyhow::Result<()> {
         // Run the standard label-based status update (default trait impl logic)

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -249,6 +249,15 @@ pub trait ExternalBackend: Send + Sync {
         Ok(())
     }
 
+    /// Sync a task to the project board (if configured).
+    ///
+    /// Called when a task is first ingested to ensure it appears on the
+    /// project board immediately, not just when status changes later.
+    /// Default is a no-op; GitHub backend implements project board sync.
+    async fn sync_to_project(&self, _id: &ExternalId, _status: Status) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     /// Check if an open issue with the given title already exists.
     ///
     /// Used for deduplication before creating issues. The `label` parameter

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1146,6 +1146,20 @@ pub(crate) async fn ingest_external_tasks(
         }
     }
 
+    // Sync newly ingested tasks to project board (if backend supports it).
+    // This ensures new issues appear on the project board immediately,
+    // not just when their status changes later.
+    for (task, status) in &all_tasks {
+        let task_status = status.unwrap_or(Status::New);
+        if let Err(e) = backend.sync_to_project(&task.id, task_status).await {
+            tracing::debug!(
+                task_id = task.id.0,
+                err = %e,
+                "ingest: project board sync failed"
+            );
+        }
+    }
+
     // Batch-fetch all upserted tasks in a single query, then sync status for NEW tasks.
     // Only sync status from backend → store for NEW tasks (first ingest).
     // Once a task exists in the store, its status is authoritative —


### PR DESCRIPTION
## Summary

All checks pass. Let me provide a summary of the fix.

## Summary

### The Problem
GitHub issues were not appearing on the GitHub Projects board. The investigation revealed:

1. **Project board WAS correctly configured** in `~/.orch/config.yml`:
   - Board ID: `PVT_kwHOAB49Hs4BOfcs` ("Autonomous Orchestrator" project #5)
   - Status field and column mappings were set up correctly

2. **Root cause**: New issues discovered from GitHub were only added to the project board when their status changed 

Closes #1526

---
*Task #1526 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*