### PR TITLE
feat: orch session export — human-readable conversation dumps for debugging

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@ pub mod events;
 pub mod job;
 pub mod ndjson;
 pub mod service;
+pub mod session;
 pub mod stats;
 pub mod task;
 pub mod tree;

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -1,0 +1,260 @@
+use crate::cli::init_store;
+use crate::cli::ndjson;
+use crate::home;
+use crate::store::{TaskStatus, TaskStore};
+use anyhow::Context;
+use serde::Serialize;
+use std::sync::Arc;
+
+pub async fn export(
+    task_id: &str,
+    attempt: Option<u32>,
+    format: ExportFormat,
+) -> anyhow::Result<()> {
+    let store = Arc::new(init_store().await?);
+
+    let (internal_id, repo) = parse_task_id(task_id, &store).await?;
+    let task = store.get(internal_id).await.context("task not found")?;
+
+    let attempt = match attempt {
+        Some(n) => n,
+        None => {
+            let runs = store.get_runs(internal_id).await?;
+            if runs.is_empty() {
+                anyhow::bail!("no attempts found for task");
+            }
+            let max_attempt = runs.iter().map(|r| r.attempt).max().unwrap_or(1);
+            max_attempt as u32
+        }
+    };
+
+    let attempt_dir = home::task_attempt_dir(&repo, task_id, attempt)?;
+    let output_path = attempt_dir.join("output.json");
+
+    if !output_path.exists() {
+        anyhow::bail!("attempt {} not found (no output file)", attempt);
+    }
+
+    let content = std::fs::read_to_string(&output_path)?;
+
+    match format {
+        ExportFormat::Markdown => export_markdown(&task, attempt, &content, &store, &repo).await,
+        ExportFormat::Json => export_json(&task, attempt, &content),
+        ExportFormat::Raw => {
+            println!("{}", content);
+            Ok(())
+        }
+    }
+}
+
+async fn export_markdown(
+    task: &crate::store::Task,
+    attempt: u32,
+    content: &str,
+    store: &Arc<TaskStore>,
+    _repo: &str,
+) -> anyhow::Result<()> {
+    let runs = store.get_runs(task.id).await?;
+    let attempt_run = runs.iter().find(|r| r.attempt == attempt as i32);
+
+    let agent = task.agent.as_deref().unwrap_or("unknown");
+    let model = task.model.as_deref().unwrap_or("-");
+
+    let duration = attempt_run.map(|r| r.duration_secs).unwrap_or(0.0);
+    let duration_str = format_duration(duration);
+
+    let input_tokens = task.input_tokens;
+    let output_tokens = task.output_tokens;
+
+    let cost = task.total_cost_usd;
+
+    println!(
+        "# Session: {} (Attempt {})",
+        task_id_display(&task.id, &task.external_id),
+        attempt
+    );
+    println!();
+    println!("**Agent**: {} ({})", agent, model);
+    println!("**Duration**: {}", duration_str);
+    println!(
+        "**Tokens**: {} in / {} out",
+        format_num(input_tokens),
+        format_num(output_tokens)
+    );
+    if cost > 0.0 {
+        println!("**Cost**: ${:.4}", cost);
+    }
+    println!("---");
+
+    if content.trim().is_empty() {
+        println!("(no output captured)");
+        return Ok(());
+    }
+
+    println!();
+    println!("## Output");
+    println!();
+
+    let lines: Vec<&str> = content.lines().collect();
+
+    for line in &lines {
+        if let Some(formatted) = ndjson::format_line(line) {
+            for fline in formatted.lines() {
+                println!("{fline}");
+            }
+        }
+    }
+
+    let summary = &task.summary;
+    if !summary.is_empty() {
+        println!();
+        println!("---");
+        println!();
+        println!("## Result");
+        println!();
+
+        let status = if task.status == TaskStatus::Done {
+            "success"
+        } else if task.status == TaskStatus::Blocked {
+            "blocked"
+        } else {
+            "incomplete"
+        };
+
+        println!("**Status**: {}", status);
+        println!("**Summary**: {}", summary);
+    }
+
+    let error = &task.last_error;
+    if !error.is_empty() {
+        println!();
+        println!("**Error**: {}", error);
+    }
+
+    Ok(())
+}
+
+fn export_json(task: &crate::store::Task, attempt: u32, content: &str) -> anyhow::Result<()> {
+    let output_lines: Vec<serde_json::Value> = content
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            serde_json::from_str(trimmed).ok()
+        })
+        .collect();
+
+    #[derive(Serialize)]
+    struct SessionExport {
+        task_id: i64,
+        external_id: Option<String>,
+        attempt: u32,
+        agent: Option<String>,
+        model: Option<String>,
+        input_tokens: i64,
+        output_tokens: i64,
+        total_cost_usd: f64,
+        summary: String,
+        last_error: String,
+        status: String,
+        output: Vec<serde_json::Value>,
+    }
+
+    let export = SessionExport {
+        task_id: task.id,
+        external_id: task.external_id.clone(),
+        attempt,
+        agent: task.agent.clone(),
+        model: task.model.clone(),
+        input_tokens: task.input_tokens,
+        output_tokens: task.output_tokens,
+        total_cost_usd: task.total_cost_usd,
+        summary: task.summary.clone(),
+        last_error: task.last_error.clone(),
+        status: task.status.as_str().to_string(),
+        output: output_lines,
+    };
+
+    println!("{}", serde_json::to_string_pretty(&export)?);
+
+    Ok(())
+}
+
+async fn parse_task_id(task_id: &str, store: &Arc<TaskStore>) -> anyhow::Result<(i64, String)> {
+    if task_id.starts_with("internal:") {
+        let id_part = task_id
+            .strip_prefix("internal:")
+            .unwrap()
+            .parse::<i64>()
+            .context("invalid internal task ID")?;
+        let repo = store
+            .get(id_part)
+            .await
+            .context("internal task not found")?
+            .repo;
+        Ok((id_part, repo))
+    } else {
+        let id: i64 = task_id.parse().context("invalid task ID")?;
+        let repo = crate::config::get_current_repo()
+            .context("no project configured — run `orch init` first")?;
+        Ok((id, repo))
+    }
+}
+
+fn task_id_display(internal_id: &i64, external_id: &Option<String>) -> String {
+    match external_id {
+        Some(ext) => format!("{}:{}", ext, internal_id),
+        None => format!("internal:{}", internal_id),
+    }
+}
+
+fn format_num(n: i64) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
+fn format_duration(secs: f64) -> String {
+    if secs < 60.0 {
+        format!("{:.0}s", secs)
+    } else if secs < 3600.0 {
+        let mins = secs / 60.0;
+        if mins < 10.0 {
+            format!("{:.1}m", mins)
+        } else {
+            format!("{:.0}m", mins)
+        }
+    } else {
+        let hours = secs / 3600.0;
+        format!("{:.1}h", hours)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub enum ExportFormat {
+    #[default]
+    Markdown,
+    Json,
+    Raw,
+}
+
+impl std::str::FromStr for ExportFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "markdown" | "md" => Ok(Self::Markdown),
+            "json" | "js" => Ok(Self::Json),
+            "raw" | "ndjson" => Ok(Self::Raw),
+            _ => Err(format!("unknown format: {}", s)),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -368,6 +368,11 @@ enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Export task session output in human-readable format
+    Session {
+        #[command(subcommand)]
+        action: SessionAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -388,6 +393,21 @@ enum CooldownAction {
 enum WebhookAction {
     /// Show webhook server health status
     Status,
+}
+
+#[derive(Subcommand)]
+enum SessionAction {
+    /// Export session output for a task in human-readable format
+    Export {
+        /// Task ID (e.g. "internal:8" or issue number)
+        task_id: String,
+        /// Attempt number (defaults to latest)
+        #[arg(long, short = 'a')]
+        attempt: Option<u32>,
+        /// Output format: markdown (default), json, raw
+        #[arg(long, short = 'f', default_value = "markdown")]
+        format: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -910,6 +930,19 @@ async fn main() -> anyhow::Result<()> {
         Commands::Doctor { full, fix, dry_run } => {
             cli::doctor::run(full, fix, dry_run).await?;
         }
+        Commands::Session { action } => match action {
+            SessionAction::Export {
+                task_id,
+                attempt,
+                format,
+            } => {
+                use crate::cli::session::ExportFormat;
+                let fmt = format
+                    .parse::<ExportFormat>()
+                    .unwrap_or(ExportFormat::Markdown);
+                cli::session::export(&task_id, attempt, fmt).await?;
+            }
+        },
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Implemented orch session export command for human-readable conversation dumps

### What was done

- Created src/cli/session.rs - new CLI module implementing session export
- Added Session command with Export subcommand to main.rs
- Exported session module in cli/mod.rs
- Supports three output formats: markdown (default), json, raw (NDJSON)
- Parses task ID to support both internal (internal:N) and external (GitHub issue) task IDs
- Uses existing ndjson::format_line() for multi-agent format detection (Claude, Codex, OpenCode, Kimi)
- Defaults to latest attempt when --attempt not specified
- Handles missing tasks with clear error messages


Closes #1531

---
*Task #1531 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/nemotron-3-super-free`*