### PR TITLE
bug: tmux session leaked on wait_for_completion error — orphaned sessions accumulate

### DIFF
--- a/src/engine/runner/session.rs
+++ b/src/engine/runner/session.rs
@@ -75,6 +75,7 @@ pub async fn run_agent_session(
         }
         Ok(Err(e)) => {
             tracing::error!(task_id, ?e, "error waiting for session");
+            let _ = tmux.kill_session(&session).await;
         }
         Err(_) => {
             tracing::error!(


### PR DESCRIPTION
## Summary

Fixed. Added `let _ = tmux.kill_session(&session).await;` to the `Ok(Err(e))` branch in `src/engine/runner/session.rs:77`.

Checks:
- `cargo fmt` — passed
- `cargo clippy --all-targets -- -D warnings` — passed
- `cargo nextest run` — one unrelated pre-existing failure in `github::projects::tests::from_config_returns_none_when_not_configured` (environment config issue), 912 tests passed

Committed as `46c2724`.

Closes #1539

---
*Task #1539 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*