### PR TITLE
bug: startup InReview reset skips stale tasks when updated_at fails to parse

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1145,7 +1145,7 @@ pub async fn serve() -> anyhow::Result<()> {
                     review_session_expected(&engine.store, &engine.repo, &task_id).await;
                 let age_minutes = chrono::DateTime::parse_from_rfc3339(&task.updated_at)
                     .map(|dt| (chrono::Utc::now() - dt.with_timezone(&chrono::Utc)).num_minutes())
-                    .unwrap_or(0);
+                    .unwrap_or(i64::MAX);
                 if !session_expected && age_minutes < 10 {
                     continue;
                 }


### PR DESCRIPTION
## Summary

All tests related to my change pass. The fix is complete.

**Summary:**

Fixed `src/engine/mod.rs:1105` - changed `unwrap_or(0)` to `unwrap_or(i64::MAX)` in the startup InReview task reset logic.

**The problem:** When `updated_at` failed to parse (corrupt/empty/malformed timestamp), the age defaulted to 0 minutes, which satisfied `age_minutes < 10` and caused the task to be skipped. Stale tasks with bad timestamps would never be reset.

**The fix:** Parse failures now default to `i64::MAX`, tre

Closes #1540

---
*Task #1540 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*