### PR TITLE
bug: UTF-8 panics in router LLM response and transport chunk splitting

### DIFF
--- a/src/channels/transport.rs
+++ b/src/channels/transport.rs
@@ -202,8 +202,12 @@ fn split_chunks(content: &str, max_bytes: usize) -> Vec<String> {
 
     while start < total {
         let mut end = (start + max_bytes).min(total);
-        while end < total && !content.is_char_boundary(end) {
-            end += 1;
+        while end > start && !content.is_char_boundary(end) {
+            end -= 1;
+        }
+        if end == start {
+            // Single char exceeds limit — advance one byte to avoid infinite loop
+            end = (start + 1).min(total);
         }
         chunks.push(content[start..end].to_string());
         start = end;

--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -319,7 +319,10 @@ impl LlmRouter {
             router_agent,
             router_model = router_model.unwrap_or("default"),
             response_len = response.len(),
-            response_preview = %if response.len() > 500 { &response[..500] } else { &response },
+            response_preview = %{
+                let end = response.floor_char_boundary(500);
+                &response[..end]
+            },
             "LLM router raw response"
         );
 
@@ -565,8 +568,8 @@ impl LlmRouter {
                     crate::engine::runner::response::record_model_failure(agent, model_str).await;
                     anyhow::bail!("router LLM rate limited: {agent}:{model_str}");
                 }
-                let stdout_preview = &stdout[..stdout.len().min(500)];
-                let stderr_preview = &stderr[..stderr.len().min(500)];
+                let stdout_preview = &stdout[..stdout.floor_char_boundary(500)];
+                let stderr_preview = &stderr[..stderr.floor_char_boundary(500)];
                 tracing::warn!(stderr = %stderr_preview, stdout = %stdout_preview, "router LLM command failed");
                 anyhow::bail!("router LLM failed: {stderr}");
             }


### PR DESCRIPTION
## Summary

Fixed three UTF-8 byte-boundary panics by using floor_char_boundary() for safe truncation and walking backward in chunk splitting

### What was done

- Fixed llm.rs:322 — replaced `&response[..500]` with `&response[..response.floor_char_boundary(500)]` to avoid panicking when byte 500 lands inside a multi-byte character
- Fixed llm.rs:568-569 — replaced `&stdout[..stdout.len().min(500)]` and `&stderr[..stderr.len().min(500)]` with floor_char_boundary() equivalents
- Fixed transport.rs:203-207 — changed chunk splitter to walk backward to char boundary (matching stream.rs:52 pattern) instead of forward, preventing oversized chunks that exceed platform limits like Discord's 2000-byte cap
- Confirmed pre-existing unrelated test failure (github::projects::tests::from_config_returns_none_when_not_configured) exists on main before any changes
- All other tests pass, fmt and clippy clean


Closes #1537

---
*Task #1537 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*