### PR TITLE
Reaction when a GitHub issue is acknowledged

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -446,4 +446,8 @@ impl ExternalBackend for GitHubBackend {
             })
             .collect())
     }
+
+    async fn acknowledge_issue(&self, id: &ExternalId) -> anyhow::Result<()> {
+        self.gh.add_reaction(&self.repo, &id.0, "eyes").await
+    }
 }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -321,6 +321,14 @@ pub trait ExternalBackend: Send + Sync {
     async fn list_issue_comments(&self, _id: &ExternalId) -> anyhow::Result<Vec<Mention>> {
         Ok(vec![])
     }
+
+    /// Acknowledge a newly detected issue (e.g., add a reaction emoji).
+    ///
+    /// Called when an issue is first ingested into the store.
+    /// Default is a no-op; GitHub backend adds an eyes emoji reaction.
+    async fn acknowledge_issue(&self, _id: &ExternalId) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1132,12 +1132,30 @@ pub(crate) async fn ingest_external_tasks(
     }
 
     // 3. Upsert into the store, collecting store IDs for batch status check.
+    //    Also acknowledge newly detected issues (eyes reaction).
     let mut id_status_pairs: Vec<(i64, crate::backends::Status)> = Vec::new();
     for (task, status) in &all_tasks {
+        // Check if this task already exists in the store before upserting.
+        let is_new = store
+            .get_by_external_id(repo, &task.id.0)
+            .await
+            .map(|t| t.is_none())
+            .unwrap_or(true);
+
         match store.ensure_external_task(repo, task).await {
             Ok(store_id) => {
                 if let Some(s) = status {
                     id_status_pairs.push((store_id, *s));
+                }
+                // Acknowledge newly detected issues with an eyes reaction.
+                if is_new {
+                    if let Err(e) = backend.acknowledge_issue(&task.id).await {
+                        tracing::debug!(
+                            task_id = task.id.0,
+                            err = %e,
+                            "ingest: acknowledgment failed"
+                        );
+                    }
                 }
             }
             Err(e) => {

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -1109,6 +1109,21 @@ impl GhHttp {
         Ok(())
     }
 
+    /// Add a reaction to an issue.
+    ///
+    /// Supported content values: "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
+    pub async fn add_reaction(
+        &self,
+        repo: &str,
+        number: &str,
+        content: &str,
+    ) -> anyhow::Result<()> {
+        let url = format!("{GITHUB_API}/repos/{repo}/issues/{number}/reactions");
+        let payload = serde_json::json!({ "content": content });
+        self.post_json_raw(&url, &payload).await?;
+        Ok(())
+    }
+
     /// List comments on an issue.
     pub async fn list_comments(
         &self,


### PR DESCRIPTION
## Summary

Now I have a clear picture. Let me look at the specific code I need to modify:Now let me look at how `ensure_external_task` works to understand when a task is truly "new":Let me look at the `ensure_external_task` implementation to understand if it tells us whether the task was newly created:Now let me understand the approach. The best place to add the reaction is in `ingest_external_tasks` in `sync.rs`. When a new issue is detected (task doesn't exist yet in the store), we should react with 👀

Closes #1550

---
*Task #1550 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*