### PR TITLE
bug: closed PR without merge triggers false review agent failures and blocks task

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -164,26 +164,61 @@ pub(crate) async fn auto_merge_pr(
             // Treat a closed/merged PR as idempotent success rather than a
             // retryable failure so the review-agent failure counter is not
             // incremented when the work is already done.
-            let already_merged = gh.is_pr_merged(repo, branch).await.unwrap_or(false);
-            if already_merged {
-                tracing::info!(
-                    task_id = task.id.0,
-                    branch,
-                    "PR already merged — marking task done (idempotent)"
-                );
-                task_manager
-                    .update_task_status(&task.id, Status::Done)
-                    .await?;
-                if let Err(e) = cleanup_task_worktree(&task.id.0, repo, store).await {
+            match gh.get_closed_pr_state(repo, branch).await {
+                Ok(Some((true, _))) => {
+                    // PR was merged
+                    tracing::info!(
+                        task_id = task.id.0,
+                        branch,
+                        "PR already merged — marking task done (idempotent)"
+                    );
+                    task_manager
+                        .update_task_status(&task.id, Status::Done)
+                        .await?;
+                    if let Err(e) = cleanup_task_worktree(&task.id.0, repo, store).await {
+                        tracing::warn!(
+                            task_id = task.id.0,
+                            err = %e,
+                            "post-merge cleanup failed"
+                        );
+                    }
+                    return Ok(());
+                }
+                Ok(Some((false, state))) => {
+                    // PR exists but is closed without merge
+                    tracing::info!(
+                        task_id = task.id.0,
+                        branch,
+                        pr_state = %state,
+                        "PR was closed without merge — marking task done"
+                    );
+                    task_manager
+                        .update_task_status(&task.id, Status::Done)
+                        .await?;
+                    if let Err(e) = cleanup_task_worktree(&task.id.0, repo, store).await {
+                        tracing::warn!(
+                            task_id = task.id.0,
+                            err = %e,
+                            "post-close cleanup failed"
+                        );
+                    }
+                    return Ok(());
+                }
+                Ok(None) => {
+                    // No closed PR found either — this is a genuine error
+                    anyhow::bail!("no open PR found for branch {}", branch);
+                }
+                Err(e) => {
+                    // Error checking closed PR state — fail gracefully
                     tracing::warn!(
                         task_id = task.id.0,
+                        branch,
                         err = %e,
-                        "post-merge cleanup failed"
+                        "failed to check closed PR state"
                     );
+                    anyhow::bail!("no open PR found for branch {}", branch);
                 }
-                return Ok(());
             }
-            anyhow::bail!("no open PR found for branch {}", branch);
         }
     };
 

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -1157,6 +1157,45 @@ impl GhHttp {
         Ok(merged_at.map(|v| !v.is_null()).unwrap_or(false))
     }
 
+    /// Get the state of a closed PR for the given branch.
+    ///
+    /// Returns `Some((merged, state))` if a closed PR exists for the branch,
+    /// where `merged` indicates if it was merged and `state` is the PR state ("closed" or "merged").
+    /// Returns `None` if no closed PR exists for the branch.
+    pub async fn get_closed_pr_state(
+        &self,
+        repo: &str,
+        branch: &str,
+    ) -> anyhow::Result<Option<(bool, String)>> {
+        let owner = repo
+            .split('/')
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("invalid repo format: {}", repo))?;
+        let head = format!("{}:{}", owner, branch);
+
+        let url = format!("{GITHUB_API}/repos/{repo}/pulls");
+        let prs: Vec<serde_json::Value> = self
+            .get_with_query(
+                &url,
+                &[("head", &head), ("state", "closed"), ("per_page", "1")],
+            )
+            .await?;
+
+        if prs.is_empty() {
+            return Ok(None);
+        }
+
+        let merged_at = prs[0].get("merged_at");
+        let merged = merged_at.map(|v| !v.is_null()).unwrap_or(false);
+        let state = prs[0]
+            .get("state")
+            .and_then(|v| v.as_str())
+            .unwrap_or("closed")
+            .to_string();
+
+        Ok(Some((merged, state)))
+    }
+
     /// Batch-check whether the PR for each branch was merged via a single GraphQL query.
     ///
     /// Returns a map of branch → merged. Branches with no matching PR are omitted


### PR DESCRIPTION
## Summary

The fix is complete. Here's a summary of the changes:

## Summary

**Issue**: When a PR is manually closed without merging, the review agent fails because `get_pr_number()` returns `None` and `is_pr_merged()` returns `false`. This causes an error that increments `review_agent_failures`, eventually blocking the task even though no further work is possible.

**Fix**:

1. **Added `get_closed_pr_state` in `src/github/http.rs`** (lines 1160-1198):
   - Returns `Some((merged, state))` if a closed PR e

Closes #1559

---
*Task #1559 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*