### PR TITLE
bug: stale tmux session survives graceful shutdown and blocks task dispatch

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1518,17 +1518,39 @@ pub async fn serve() -> anyhow::Result<()> {
 
                 // Kill all orch-managed tmux sessions so stale sessions don't
                 // block dispatch after restart (session_exists check).
+                let mut killed_sessions = Vec::new();
                 if let Ok(sessions) = tmux.list_sessions().await {
-                    let mut killed = 0u32;
                     for session in &sessions {
                         if session.name.starts_with("orch-") {
-                            tmux.kill_session(&session.name).await.ok();
-                            killed += 1;
+                            if let Err(e) = tmux.kill_session(&session.name).await {
+                                tracing::warn!(session = %session.name, error = %e, "failed to kill tmux session");
+                            } else {
+                                killed_sessions.push(session.name.clone());
+                            }
                         }
                     }
-                    if killed > 0 {
-                        tracing::info!(killed, "killed orch tmux sessions on shutdown");
+                    if !killed_sessions.is_empty() {
+                        tracing::info!(killed = killed_sessions.len(), "killing orch tmux sessions on shutdown");
                     }
+                }
+
+                // Wait for sessions to actually die before exiting.
+                // Prevents race where process exits before tmux finishes cleanup.
+                if !killed_sessions.is_empty() {
+                    let still_alive = tmux
+                        .wait_for_sessions_dead(
+                            &killed_sessions,
+                            std::time::Duration::from_millis(100),
+                            std::time::Duration::from_secs(5),
+                        )
+                        .await;
+                    if still_alive > 0 {
+                        tracing::warn!(
+                            still_alive,
+                            "some tmux sessions did not terminate cleanly - they will be cleaned up on startup"
+                        );
+                    }
+                    tracing::info!(killed = killed_sessions.len() - still_alive, "confirmed tmux sessions terminated");
                 }
 
                 break;

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -21,8 +21,54 @@ use crate::repo_context::REPO_CONTEXT;
 use crate::store;
 use crate::store::TaskStore;
 use crate::tmux::TmuxManager;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::LazyLock;
+use std::time::SystemTime;
 use tokio::sync::{mpsc, Semaphore};
+
+/// Unix timestamp when the engine process started.
+/// Used to identify tmux sessions from previous runs.
+static ENGINE_START_TIME: LazyLock<u64> = LazyLock::new(|| {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+});
+
+/// Flag to ensure startup cleanup only runs once.
+static STARTUP_CLEANUP_DONE: AtomicBool = AtomicBool::new(false);
+
+/// Cleanup stale tmux sessions from previous engine runs.
+/// Called once at startup to kill sessions created before this process started.
+async fn startup_cleanup(tmux: &TmuxManager) {
+    // Use compare_exchange to ensure this only runs once across all threads
+    if STARTUP_CLEANUP_DONE
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
+
+    let start_time = *ENGINE_START_TIME;
+    tracing::info!(
+        start_time,
+        "running startup cleanup for stale tmux sessions"
+    );
+
+    match tmux.kill_stale_sessions(start_time).await {
+        Ok(killed) => {
+            if killed > 0 {
+                tracing::info!(killed, "startup cleanup killed stale sessions");
+            } else {
+                tracing::debug!("no stale tmux sessions found on startup");
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to run startup cleanup");
+        }
+    }
+}
 
 use super::EngineConfig;
 use crate::store::{review_session_expected, set_review_session_expected};
@@ -869,6 +915,11 @@ pub(crate) async fn tick_dispatch_tasks(
         // Check if already running (has active session)
         let session_name = tmux.session_name(repo, &task.id.0);
         if tmux.session_exists(&session_name).await {
+            tracing::warn!(
+                task_id = task.id.0,
+                session_name,
+                "task has existing tmux session, skipping dispatch"
+            );
             continue; // dispatch_guard drops here, removing the key
         }
 
@@ -1168,6 +1219,10 @@ pub(crate) async fn tick(
     store: &Arc<TaskStore>,
 ) -> anyhow::Result<()> {
     let _tick_span = tracing::info_span!("engine.tick").entered();
+
+    // Run startup cleanup once to kill stale sessions from previous runs.
+    startup_cleanup(tmux).await;
+
     tick_check_session_completions(tmux, repo, capture).await?;
     tick_detect_silent_agents(tmux, repo, capture, backend, task_manager, config, store).await?;
     tick_recover_stuck_tasks(backend, tmux, repo, task_manager, config, store).await?;

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -16,6 +16,7 @@ use tokio::process::Command;
 pub struct Session {
     pub name: String,
     pub task_id: String,
+    pub created_at: Option<u64>, // Unix timestamp from tmux #{session_created}
 }
 
 /// Manage tmux sessions for agent tasks.
@@ -224,10 +225,11 @@ impl TmuxManager {
         map
     }
 
-    /// List all orch-prefixed sessions with metadata.
+    /// List all orch-prefixed sessions with metadata including creation time.
     pub async fn list_sessions(&self) -> anyhow::Result<Vec<Session>> {
+        // Get both name and creation timestamp in one call
         let output = Command::new("tmux")
-            .args(["list-sessions", "-F", "#{session_name}"])
+            .args(["list-sessions", "-F", "#{session_name} #{session_created}"])
             .output_with_context()
             .await?;
 
@@ -237,13 +239,95 @@ impl TmuxManager {
 
         let mut sessions = Vec::new();
         for line in String::from_utf8_lossy(&output.stdout).lines() {
-            let name = line.trim().to_string();
+            let parts: Vec<&str> = line.trim().splitn(2, ' ').collect();
+            if parts.is_empty() {
+                continue;
+            }
+            let name = parts[0].to_string();
+            let created_at = parts.get(1).and_then(|s| s.parse::<u64>().ok());
+
             if let Some(task_id) = self.task_id_from_session_name(&name) {
-                sessions.push(Session { name, task_id });
+                sessions.push(Session {
+                    name,
+                    task_id,
+                    created_at,
+                });
             }
         }
 
         Ok(sessions)
+    }
+
+    /// Kill all orch-prefixed sessions created before a given timestamp.
+    /// Returns the number of sessions killed.
+    pub async fn kill_stale_sessions(&self, before_timestamp: u64) -> anyhow::Result<usize> {
+        let sessions = self.list_sessions().await?;
+        let mut killed = 0;
+
+        for session in sessions {
+            let should_kill = match session.created_at {
+                Some(created) => created < before_timestamp,
+                // If we can't determine creation time, be conservative and don't kill
+                None => false,
+            };
+
+            if should_kill {
+                tracing::info!(
+                    session = %session.name,
+                    created_at = session.created_at,
+                    "killing stale tmux session from previous run"
+                );
+                if let Err(e) = self.kill_session(&session.name).await {
+                    tracing::warn!(session = %session.name, error = %e, "failed to kill stale session");
+                } else {
+                    killed += 1;
+                }
+            }
+        }
+
+        if killed > 0 {
+            tracing::info!(killed, "killed stale tmux sessions on startup");
+        }
+
+        Ok(killed)
+    }
+
+    /// Wait for multiple sessions to be fully dead (no longer exist).
+    /// Polls every `poll_interval` up to `timeout`.
+    /// Returns the number of sessions that were still alive after timeout.
+    pub async fn wait_for_sessions_dead(
+        &self,
+        sessions: &[String],
+        poll_interval: std::time::Duration,
+        timeout: std::time::Duration,
+    ) -> usize {
+        let start = std::time::Instant::now();
+        let mut remaining: std::collections::HashSet<String> = sessions.iter().cloned().collect();
+
+        while !remaining.is_empty() && start.elapsed() < timeout {
+            let mut to_remove = Vec::new();
+            for session in &remaining {
+                if !self.session_exists(session).await {
+                    to_remove.push(session.clone());
+                }
+            }
+            for session in to_remove {
+                remaining.remove(&session);
+            }
+            if !remaining.is_empty() {
+                tokio::time::sleep(poll_interval).await;
+            }
+        }
+
+        let still_alive = remaining.len();
+        if still_alive > 0 {
+            tracing::warn!(
+                still_alive,
+                sessions = ?remaining.iter().collect::<Vec<_>>(),
+                "tmux sessions did not terminate within timeout"
+            );
+        }
+        still_alive
     }
 
     /// Wait for a session to finish (pane process exits).


### PR DESCRIPTION
## Summary

All tests pass (except one unrelated pre-existing failure). Here's a summary of the fix:

## Summary

Fixed issue #1560 where stale tmux sessions could survive graceful shutdown and block task dispatch.

### Changes Made

**1. `src/tmux.rs`**
- Added `created_at: Option<u64>` field to `Session` struct to track session creation time
- Added `wait_for_sessions_dead()` method that polls until sessions are confirmed dead or timeout
- Added `kill_stale_sessions()` method to kill sessions created befo

Closes #1560

---
*Task #1560 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*