### PR TITLE
bug: auto_merge PR URL parsing lacks validation — may cause incorrect merge attempts

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -165,44 +165,114 @@ pub(crate) async fn auto_merge_pr(
             // retryable failure so the review-agent failure counter is not
             // incremented when the work is already done.
             match gh.get_closed_pr_state(repo, branch).await {
-                Ok(Some((true, _))) => {
-                    // PR was merged
-                    tracing::info!(
-                        task_id = task.id.0,
-                        branch,
-                        "PR already merged — marking task done (idempotent)"
-                    );
-                    task_manager
-                        .update_task_status(&task.id, Status::Done)
-                        .await?;
-                    if let Err(e) = cleanup_task_worktree(&task.id.0, repo, store).await {
-                        tracing::warn!(
-                            task_id = task.id.0,
-                            err = %e,
-                            "post-merge cleanup failed"
-                        );
+                Ok(Some((closed_pr_number, true, _))) => {
+                    // Validate the PR's head ref matches our branch before treating as merged
+                    match gh.get_pr(repo, closed_pr_number).await {
+                        Ok(pr) if pr.head.ref_ == branch => {
+                            tracing::info!(
+                                task_id = task.id.0,
+                                branch,
+                                pr_number = closed_pr_number,
+                                "PR already merged — marking task done (idempotent)"
+                            );
+                            task_manager
+                                .update_task_status(&task.id, Status::Done)
+                                .await?;
+                            if let Err(e) = cleanup_task_worktree(&task.id.0, repo, store).await {
+                                tracing::warn!(
+                                    task_id = task.id.0,
+                                    err = %e,
+                                    "post-merge cleanup failed"
+                                );
+                            }
+                            return Ok(());
+                        }
+                        Ok(_) => {
+                            tracing::warn!(
+                                task_id = task.id.0,
+                                branch,
+                                pr_number = closed_pr_number,
+                                "closed PR head ref does not match branch — may be wrong PR"
+                            );
+                            anyhow::bail!("no matching merged PR found for branch {}", branch);
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                task_id = task.id.0,
+                                branch,
+                                pr_number = closed_pr_number,
+                                err = %e,
+                                "failed to verify PR details, assuming merged"
+                            );
+                            // Fall through to marking done since get_closed_pr_state said it was merged
+                            task_manager
+                                .update_task_status(&task.id, Status::Done)
+                                .await?;
+                            if let Err(e) = cleanup_task_worktree(&task.id.0, repo, store).await {
+                                tracing::warn!(
+                                    task_id = task.id.0,
+                                    err = %e,
+                                    "post-merge cleanup failed"
+                                );
+                            }
+                            return Ok(());
+                        }
                     }
-                    return Ok(());
                 }
-                Ok(Some((false, state))) => {
-                    // PR exists but is closed without merge
-                    tracing::info!(
-                        task_id = task.id.0,
-                        branch,
-                        pr_state = %state,
-                        "PR was closed without merge — marking task done"
-                    );
-                    task_manager
-                        .update_task_status(&task.id, Status::Done)
-                        .await?;
-                    if let Err(e) = cleanup_task_worktree(&task.id.0, repo, store).await {
-                        tracing::warn!(
-                            task_id = task.id.0,
-                            err = %e,
-                            "post-close cleanup failed"
-                        );
+                Ok(Some((closed_pr_number, false, state))) => {
+                    // Validate the PR's head ref matches our branch before treating as closed
+                    match gh.get_pr(repo, closed_pr_number).await {
+                        Ok(pr) if pr.head.ref_ == branch => {
+                            tracing::info!(
+                                task_id = task.id.0,
+                                branch,
+                                pr_number = closed_pr_number,
+                                pr_state = %state,
+                                "PR was closed without merge — marking task done"
+                            );
+                            task_manager
+                                .update_task_status(&task.id, Status::Done)
+                                .await?;
+                            if let Err(e) = cleanup_task_worktree(&task.id.0, repo, store).await {
+                                tracing::warn!(
+                                    task_id = task.id.0,
+                                    err = %e,
+                                    "post-close cleanup failed"
+                                );
+                            }
+                            return Ok(());
+                        }
+                        Ok(_) => {
+                            tracing::warn!(
+                                task_id = task.id.0,
+                                branch,
+                                pr_number = closed_pr_number,
+                                "closed PR head ref does not match branch — may be wrong PR"
+                            );
+                            anyhow::bail!("no matching closed PR found for branch {}", branch);
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                task_id = task.id.0,
+                                branch,
+                                pr_number = closed_pr_number,
+                                err = %e,
+                                "failed to verify PR details, assuming closed"
+                            );
+                            // Fall through to marking done since get_closed_pr_state said it was closed
+                            task_manager
+                                .update_task_status(&task.id, Status::Done)
+                                .await?;
+                            if let Err(e) = cleanup_task_worktree(&task.id.0, repo, store).await {
+                                tracing::warn!(
+                                    task_id = task.id.0,
+                                    err = %e,
+                                    "post-close cleanup failed"
+                                );
+                            }
+                            return Ok(());
+                        }
                     }
-                    return Ok(());
                 }
                 Ok(None) => {
                     // No closed PR found either — this is a genuine error

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -14,6 +14,34 @@ pub(crate) const MAX_REVIEW_AGENT_FAILURES: u64 = 3;
 /// Maximum consecutive PR-creation failures before blocking the task.
 const MAX_PR_CREATE_FAILURES: u64 = 3;
 
+/// Parse a PR number from a GitHub PR URL.
+///
+/// Validates that the URL matches the expected GitHub PR URL format
+/// (`https://github.com/<owner>/<repo>/pull/<number>`) before extracting the
+/// number. Returns `None` for any URL that doesn't conform to this structure,
+/// including URLs with wrong domains, missing `/pull/` segments, or
+/// non-numeric trailing components.
+///
+/// The extracted segment is stripped of any query string (`?`) or hash
+/// fragment (`#`) before parsing so that URLs like
+/// `https://github.com/owner/repo/pull/42?tab=files` are handled correctly.
+pub(crate) fn parse_pr_number_from_url(url: &str) -> Option<u64> {
+    let url = url.trim();
+    if !url.starts_with("https://github.com/") {
+        return None;
+    }
+    if !url.contains("/pull/") {
+        return None;
+    }
+    url.trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .and_then(|seg| seg.split(['?', '#']).next())
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+}
+
 fn review_started_comment(review_agent: &str, review_model: &str) -> String {
     format!(
         "🔍 Automated review started (agent: {}, model: {})",
@@ -231,18 +259,13 @@ async fn ensure_pr_exists(
                     .await
                 {
                     Ok(url) => {
-                        let pr_num = url
-                            .rsplit('/')
-                            .next()
-                            .filter(|s| !s.is_empty())
-                            .and_then(|s| s.parse::<i64>().ok())
-                            .filter(|&n| n > 0);
+                        let pr_num = parse_pr_number_from_url(&url);
                         if let Some(pr_num) = pr_num {
                             store_set(
                                 &Some(Arc::clone(store)),
                                 repo,
                                 &task.id.0,
-                                &[("pr_number", serde_json::json!(pr_num))],
+                                &[("pr_number", serde_json::json!(pr_num as i64))],
                             )
                             .await;
                         }
@@ -253,7 +276,7 @@ async fn ensure_pr_exists(
                             "created missing PR via GhHttp — continuing review"
                         );
                         if let Some(pr_num) = pr_num {
-                            Ok(EnsurePrResult::Ready(pr_num as u64))
+                            Ok(EnsurePrResult::Ready(pr_num))
                         } else {
                             Ok(EnsurePrResult::EarlyReturn(ReviewDecision::Failed(
                                 "created missing PR, but could not parse PR number".to_string(),
@@ -307,19 +330,13 @@ async fn ensure_pr_exists(
                         match pr_result {
                             Ok(o) if o.status.success() => {
                                 let stdout = String::from_utf8_lossy(&o.stdout);
-                                let pr_num = stdout
-                                    .trim()
-                                    .rsplit('/')
-                                    .next()
-                                    .filter(|s| !s.is_empty())
-                                    .and_then(|s| s.parse::<i64>().ok())
-                                    .filter(|&n| n > 0);
+                                let pr_num = parse_pr_number_from_url(stdout.trim());
                                 if let Some(pr_num) = pr_num {
                                     store_set(
                                         &Some(Arc::clone(store)),
                                         repo,
                                         &task.id.0,
-                                        &[("pr_number", serde_json::json!(pr_num))],
+                                        &[("pr_number", serde_json::json!(pr_num as i64))],
                                     )
                                     .await;
                                 }
@@ -329,7 +346,7 @@ async fn ensure_pr_exists(
                                     "created missing PR via CLI — continuing review"
                                 );
                                 if let Some(pr_num) = pr_num {
-                                    Ok(EnsurePrResult::Ready(pr_num as u64))
+                                    Ok(EnsurePrResult::Ready(pr_num))
                                 } else {
                                     Ok(EnsurePrResult::EarlyReturn(ReviewDecision::Failed(
                                         "created missing PR via CLI, but could not parse PR number"
@@ -343,11 +360,7 @@ async fn ensure_pr_exists(
                                     if let Some(pr_url) =
                                         stderr.lines().find(|l| l.trim().starts_with("https://"))
                                     {
-                                        let pr_url = pr_url.trim();
-                                        let pr_num = pr_url
-                                            .rsplit('/')
-                                            .next()
-                                            .and_then(|n| n.parse::<u64>().ok());
+                                        let pr_num = parse_pr_number_from_url(pr_url.trim());
                                         if let Some(pr_num) = pr_num {
                                             store_set(
                                                 &Some(Arc::clone(store)),
@@ -1496,6 +1509,103 @@ mod tests {
     use crate::github::types::{GitHubReview, GitHubReviewComment, GitHubUser, PullRequestReview};
     use crate::store::TaskStore;
     use tempfile::TempDir;
+
+    // ── parse_pr_number_from_url ────────────────────────────────────────────
+
+    #[test]
+    fn parse_pr_number_standard_url() {
+        assert_eq!(
+            parse_pr_number_from_url("https://github.com/owner/repo/pull/42"),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn parse_pr_number_trailing_slash() {
+        assert_eq!(
+            parse_pr_number_from_url("https://github.com/owner/repo/pull/42/"),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn parse_pr_number_with_query_string() {
+        assert_eq!(
+            parse_pr_number_from_url("https://github.com/owner/repo/pull/42?tab=files"),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn parse_pr_number_with_hash_fragment() {
+        assert_eq!(
+            parse_pr_number_from_url("https://github.com/owner/repo/pull/42#issuecomment-123"),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn parse_pr_number_with_query_and_hash() {
+        assert_eq!(
+            parse_pr_number_from_url("https://github.com/owner/repo/pull/42?quick_pull=1#top"),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn parse_pr_number_with_leading_whitespace() {
+        assert_eq!(
+            parse_pr_number_from_url("  https://github.com/owner/repo/pull/42\n"),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn parse_pr_number_wrong_domain() {
+        assert_eq!(
+            parse_pr_number_from_url("https://gitlab.com/owner/repo/merge_requests/42"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_pr_number_missing_pull_segment() {
+        // Issue URL — not a PR URL
+        assert_eq!(
+            parse_pr_number_from_url("https://github.com/owner/repo/issues/42"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_pr_number_zero_is_rejected() {
+        assert_eq!(
+            parse_pr_number_from_url("https://github.com/owner/repo/pull/0"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_pr_number_non_numeric_segment() {
+        assert_eq!(
+            parse_pr_number_from_url("https://github.com/owner/repo/pull/abc"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_pr_number_empty_string() {
+        assert_eq!(parse_pr_number_from_url(""), None);
+    }
+
+    #[test]
+    fn parse_pr_number_http_not_https() {
+        // HTTP URLs are not accepted — only HTTPS
+        assert_eq!(
+            parse_pr_number_from_url("http://github.com/owner/repo/pull/42"),
+            None
+        );
+    }
 
     fn git(dir: &std::path::Path, args: &[&str]) {
         let status = std::process::Command::new("git")

--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -272,13 +272,12 @@ pub async fn handle_success(
                     // Save pr_number to the store so the review gate can find it
                     // immediately without racing GitHub's list-API cache (~300 ms lag).
                     // This is set for both newly-created and pre-existing PRs.
-                    if let Some(pr_num) = url.rsplit('/').next().and_then(|n| n.parse::<i64>().ok())
-                    {
+                    if let Some(pr_num) = crate::engine::review::parse_pr_number_from_url(url) {
                         store::store_set(
                             store,
                             repo,
                             task_id,
-                            &[("pr_number", serde_json::json!(pr_num))],
+                            &[("pr_number", serde_json::json!(pr_num as i64))],
                         )
                         .await;
                     }

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -1162,11 +1162,18 @@ impl GhHttp {
     /// Returns `Some((merged, state))` if a closed PR exists for the branch,
     /// where `merged` indicates if it was merged and `state` is the PR state ("closed" or "merged").
     /// Returns `None` if no closed PR exists for the branch.
+    /// Get the state of a closed PR for a given branch.
+    ///
+    /// Returns `Some((pr_number, merged, state))` if a closed PR is found that
+    /// matches the expected branch. Returns `None` if no matching closed PR is found.
+    ///
+    /// Validates that the returned PR's head ref matches the expected branch to
+    /// prevent incorrect merge decisions when multiple PRs exist for the same branch.
     pub async fn get_closed_pr_state(
         &self,
         repo: &str,
         branch: &str,
-    ) -> anyhow::Result<Option<(bool, String)>> {
+    ) -> anyhow::Result<Option<(u64, bool, String)>> {
         let owner = repo
             .split('/')
             .next()
@@ -1177,7 +1184,7 @@ impl GhHttp {
         let prs: Vec<serde_json::Value> = self
             .get_with_query(
                 &url,
-                &[("head", &head), ("state", "closed"), ("per_page", "1")],
+                &[("head", &head), ("state", "closed"), ("per_page", "5")],
             )
             .await?;
 
@@ -1185,15 +1192,43 @@ impl GhHttp {
             return Ok(None);
         }
 
-        let merged_at = prs[0].get("merged_at");
-        let merged = merged_at.map(|v| !v.is_null()).unwrap_or(false);
-        let state = prs[0]
-            .get("state")
-            .and_then(|v| v.as_str())
-            .unwrap_or("closed")
-            .to_string();
+        // Find the first PR where head ref actually matches our branch
+        // This validates that we're working with the correct PR
+        for pr in prs {
+            let pr_branch = pr
+                .get("head")
+                .and_then(|h| h.get("ref"))
+                .and_then(|r| r.as_str())
+                .unwrap_or("");
 
-        Ok(Some((merged, state)))
+            if pr_branch != branch {
+                tracing::debug!(
+                    repo,
+                    branch,
+                    pr_branch,
+                    "skipping PR with mismatched head ref"
+                );
+                continue;
+            }
+
+            let pr_number = pr
+                .get("number")
+                .and_then(|n| n.as_u64())
+                .ok_or_else(|| anyhow::anyhow!("PR missing number field"))?;
+
+            let merged_at = pr.get("merged_at");
+            let merged = merged_at.map(|v| !v.is_null()).unwrap_or(false);
+            let state = pr
+                .get("state")
+                .and_then(|v| v.as_str())
+                .unwrap_or("closed")
+                .to_string();
+
+            return Ok(Some((pr_number, merged, state)));
+        }
+
+        // No PR with matching head ref found
+        Ok(None)
     }
 
     /// Batch-check whether the PR for each branch was merged via a single GraphQL query.


### PR DESCRIPTION
## Summary

The fix is complete. Here's a summary of the changes:

## Summary

**Issue:** The `auto_merge_pr()` function in `src/engine/auto_merge.rs:158-221` parsed PR numbers from branch names using `get_pr_number()`, but when falling back to `get_closed_pr_state()`, it extracted state information without validating the PR actually belonged to the expected branch. This could lead to incorrect merge decisions if multiple PRs existed for the same branch name.

**Changes made:**

### 1. `src/github/http.rs` 

Closes #1565

---
*Task #1565 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*