### PR TITLE
bug: tasks can exceed max_review_cycles without being blocked when review agent fails silently

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -925,6 +925,16 @@ pub(crate) async fn handle_review_changes(
                 );
                 // Fall through to escalation below.
             } else {
+                // Reset review_cycles so the fresh review against new code starts
+                // from a clean count. Without this reset, the next review would
+                // immediately see review_cycles >= max_cycles and escalate again.
+                store_set(
+                    &Some(Arc::clone(store)),
+                    repo,
+                    &task.id.0,
+                    &[("review_cycles", serde_json::json!(0))],
+                )
+                .await;
                 return Ok(());
             }
         }

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -465,8 +465,6 @@ impl TaskStore {
         let model: Option<String> = previous.try_get("model").unwrap_or(None);
         let sql = if status == TaskStatus::Blocked {
             "UPDATE tasks SET status = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?"
-        } else if status == TaskStatus::NeedsReview {
-            "UPDATE tasks SET status = ?, block_reason = NULL, review_cycles = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?"
         } else {
             "UPDATE tasks SET status = ?, block_reason = NULL, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?"
         };


### PR DESCRIPTION
## Summary

Done. The fix for #1566 is committed (`29745c8`).

**What changed:**
- `src/store/tasks.rs`: Removed the blanket `review_cycles = 0` reset on every `NeedsReview` transition in `TaskStore::update_status`. This was the root cause of the bug.
- `src/engine/auto_merge.rs`: Added an explicit `review_cycles` reset only in the `branch_newer_than_last_review` stale-review bypass path, where new commits legitimately justify a fresh counter.

All 581 relevant tests pass. The one unrelated failure in `gith

Closes #1566

---
*Task #1566 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*