### PR TITLE
bug: SQLite OOB panics — enforce explicit column lists via lint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,22 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      - name: Check for SELECT * in store files
+        run: |
+          # Fail CI if any store file contains SELECT * (excluding comments)
+          # This prevents SQLite OOB panics when schema changes
+          # Filter out: // comments, /// doc comments, //! module docs (format: file.rs:line:// content)
+          MATCHES=$(grep -n 'SELECT \*' src/store/*.rs | grep -vE ':[0-9]+:\s*(//|///|//!|#|\*)' | grep -v 'COLUMN_COLS' || true)
+          if [ -n "$MATCHES" ]; then
+            echo "ERROR: Found SELECT * in src/store/ files. Use explicit column lists instead."
+            echo "Matches:"
+            echo "$MATCHES"
+            echo ""
+            echo "See TASK_COLS, CONTROL_MESSAGE_COLS, JOB_STATE_COLS for examples."
+            exit 1
+          fi
+          echo "✓ No SELECT * found in store files"
+
       - name: Run tests with coverage
         run: cargo llvm-cov nextest --lcov --output-path lcov.info
 

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -1,6 +1,14 @@
 use super::*;
 use serde::{Deserialize, Serialize};
 
+/// Explicit column list for `SELECT` queries on the `job_state` table.
+///
+/// Using `SELECT *` with `sqlx-sqlite`'s prepared statement cache can cause OOB
+/// panics when the schema changes (new migration columns) because the cached
+/// column metadata may not match the current table structure. Explicit columns
+/// prevent this mismatch.
+const JOB_STATE_COLS: &str = "repo, job_id, last_run, last_task_status, active_task_id";
+
 /// Runtime state for a scheduled job, stored in SQLite (not in .orch.yml).
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct JobState {
@@ -17,14 +25,15 @@ impl TaskStore {
         repo: &str,
         job_id: &str,
     ) -> anyhow::Result<Option<JobState>> {
-        let row: Option<JobState> = sqlx::query_as(
-            "SELECT repo, job_id, last_run, last_task_status, active_task_id
-         FROM job_state WHERE repo = ? AND job_id = ?",
-        )
-        .bind(repo)
-        .bind(job_id)
-        .fetch_optional(&self.pool)
-        .await?;
+        let sql = format!(
+            "SELECT {} FROM job_state WHERE repo = ? AND job_id = ?",
+            JOB_STATE_COLS
+        );
+        let row: Option<JobState> = sqlx::query_as(&sql)
+            .bind(repo)
+            .bind(job_id)
+            .fetch_optional(&self.pool)
+            .await?;
         Ok(row)
     }
 
@@ -50,13 +59,11 @@ impl TaskStore {
 
     /// List all job states for a repo.
     pub async fn list_job_states(&self, repo: &str) -> anyhow::Result<Vec<JobState>> {
-        let rows: Vec<JobState> = sqlx::query_as(
-            "SELECT repo, job_id, last_run, last_task_status, active_task_id
-         FROM job_state WHERE repo = ?",
-        )
-        .bind(repo)
-        .fetch_all(&self.pool)
-        .await?;
+        let sql = format!("SELECT {} FROM job_state WHERE repo = ?", JOB_STATE_COLS);
+        let rows: Vec<JobState> = sqlx::query_as(&sql)
+            .bind(repo)
+            .fetch_all(&self.pool)
+            .await?;
         Ok(rows)
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -7,6 +7,21 @@
 //! Uses sqlx for async SQLite access with file-based migrations.
 //!
 //! All task state, metrics, KV, and rate limits flow through this module.
+//!
+//! # Safety Warning: Never Use `SELECT *`
+//!
+//! Using `SELECT *` with `sqlx-sqlite`'s prepared statement cache can cause **OOB
+//! (out-of-bounds) panics** when the schema changes (e.g., new migration adds a column).
+//!
+//! The issue occurs because:
+//! 1. SQLite caches prepared statements with column metadata at prepare time
+//! 2. When a migration adds a new column, `sqlite3_column_count()` returns the updated count
+//! 3. The cached statement's column metadata vector was built with the old count
+//! 4. Accessing column index N when only N columns exist (0..N-1) causes a panic
+//!
+//! **Solution:** Always use explicit column lists via constants like `TASK_COLS`,
+//! `CONTROL_MESSAGE_COLS`, `JOB_STATE_COLS`, etc. See `tasks.rs` and `control.rs`
+//! for examples. CI will fail if `SELECT *` is detected in store files.
 
 use anyhow::Context;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions};


### PR DESCRIPTION
## Summary

All changes are complete. Here's a summary:

## Changes Made

### 1. `src/store/jobs.rs` — Added `JOB_STATE_COLS` constant
- Added explicit column list constant for the `job_state` table
- Updated `get_job_state()` and `list_job_states()` to use the constant
- Added documentation explaining why `SELECT *` is dangerous

### 2. `.github/workflows/release.yml` — Added CI lint check
- New step "Check for SELECT * in store files" runs after clippy
- Fails CI if any actual `SELECT *` queries are f

Closes #1573

---
*Task #1573 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*