### PR TITLE
feat: add task routing observability — track route decisions and retry chains

### DIFF
--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -67,6 +67,18 @@ impl Status {
             Self::NeedsReview => "status:needs_review",
         }
     }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::New => "new",
+            Self::Routed => "routed",
+            Self::InProgress => "in_progress",
+            Self::Done => "done",
+            Self::Blocked => "blocked",
+            Self::InReview => "in_review",
+            Self::NeedsReview => "needs_review",
+        }
+    }
 }
 
 /// The core trait for external task backends.

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -1611,6 +1611,112 @@ pub async fn activity_log(id: &str, limit: Option<usize>, json: bool) -> anyhow:
     Ok(())
 }
 
+/// Show task routing history with attempt timeline.
+pub async fn history(id: &str) -> anyhow::Result<()> {
+    let store = crate::cli::init_store().await?;
+    let repo = config::get_current_repo().unwrap_or_default();
+    let Some(task_id) = store.resolve_task_id(&repo, id).await? else {
+        anyhow::bail!("task not found: {id}");
+    };
+
+    let task = store.get(task_id).await?;
+    let events = store.get_activity(task_id, None).await?;
+
+    // Header
+    println!("Routing History for Task {}", id);
+    println!("{}", "=".repeat(60));
+    println!("Title: {}", task.title);
+    println!("Status: {:?}", task.status);
+    println!();
+
+    // Find routing events (routed, rerouted)
+    let routing_events: Vec<_> = events
+        .iter()
+        .filter(|e| e.event_type == "routed" || e.event_type == "rerouted")
+        .collect();
+
+    if routing_events.is_empty() {
+        println!("No routing history found. Task has not been routed yet.");
+        return Ok(());
+    }
+
+    // Display routing timeline
+    println!("Attempt Timeline:");
+    println!("{}", "-".repeat(60));
+
+    for (i, event) in routing_events.iter().enumerate() {
+        let attempt_num = i + 1;
+        let agent = event.agent.as_deref().unwrap_or("-");
+        let model = event.model.as_deref().unwrap_or("-");
+        let timestamp = &event.timestamp;
+
+        if event.event_type == "routed" {
+            println!("\nAttempt #{}", attempt_num);
+            println!("  Time:     {}", timestamp);
+            println!("  Agent:    {}", agent);
+            println!("  Model:    {}", model);
+
+            // Extract routing details
+            if let Some(reason) = event.details.get("reason").and_then(|r| r.as_str()) {
+                println!("  Reason:   {}", reason);
+            }
+            if let Some(complexity) = event.details.get("complexity").and_then(|c| c.as_str()) {
+                println!("  Complexity: {}", complexity);
+            }
+        } else if event.event_type == "rerouted" {
+            println!("  → Rerouted at {}", timestamp);
+
+            // Check for failure reason
+            if let Some(failure) = event.details.get("failure_reason").and_then(|f| f.as_str()) {
+                println!("    Failure: {}", failure);
+            } else if let Some(failure) = event.details.get("silence_duration_secs") {
+                println!("    Failure: Agent silent for {}s", failure);
+            }
+
+            // Show from/to agent if available
+            if let Some(from) = event.details.get("from_agent").and_then(|a| a.as_str()) {
+                if let Some(to) = event.details.get("to_agent").and_then(|a| a.as_str()) {
+                    println!("    Change:   {} → {}", from, to);
+                }
+            }
+
+            // Show if agents were exhausted
+            if event.details.get("agents_exhausted").is_some() {
+                println!("    Note:     All agents exhausted");
+            }
+            if event.details.get("no_fallback_available").is_some() {
+                println!("    Note:     No fallback available");
+            }
+        }
+    }
+
+    // Summary
+    println!("\n{}", "-".repeat(60));
+    println!("Summary:");
+    println!("  Total routing attempts: {}", routing_events.len());
+
+    // Get cost summary from task
+    let total_tokens = task.input_tokens + task.output_tokens;
+    if total_tokens > 0 {
+        println!("  Input tokens:  {}", task.input_tokens);
+        println!("  Output tokens: {}", task.output_tokens);
+        println!(
+            "  Total cost:    ${:.6}",
+            task.input_cost_usd + task.output_cost_usd
+        );
+    }
+
+    // Show current assigned agent/model if available
+    if let Some(ref agent) = task.agent {
+        println!("  Current agent: {}", agent);
+    }
+    if let Some(ref model) = task.model {
+        println!("  Current model: {}", model);
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -22,7 +22,9 @@ pub use config::{parse_pool_entry, RouterConfig};
 pub use weights::AgentWeights;
 
 use crate::backends::ExternalTask;
+use crate::store::store_log_activity;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use llm::LlmRouter;
 
@@ -496,15 +498,18 @@ impl Router {
                             complexity = %complexity,
                             "routed via label"
                         );
-                        return Ok(RouteResult {
+                        let result = RouteResult {
                             agent: agent.clone(),
-                            model,
+                            model: model.clone(),
                             complexity: complexity.clone(),
                             reason: format!("label agent:{agent}"),
                             profile,
                             selected_skills: self.config.default_skills.clone(),
                             warning: None,
-                        });
+                        };
+                        self.log_route_activity(store, repo, &task.id.0, &result, None)
+                            .await;
+                        return Ok(result);
                     } else {
                         // No concrete model found for the labeled agent — do
                         // not honor the label override. Fall through to the
@@ -533,25 +538,31 @@ impl Router {
 
             // 2. Weighted round-robin — capacity-based selection
             if self.config.weighted_round_robin {
-                return strategies::route_via_weighted_round_robin(
+                let result = strategies::route_via_weighted_round_robin(
                     &candidates,
                     &self.weights,
                     &self.config,
                     task,
                     &mut self.last_agent,
-                );
+                )?;
+                self.log_route_activity(store, repo, &task.id.0, &result, None)
+                    .await;
+                return Ok(result);
             }
 
             // 3. Round-robin mode — use stateful round-robin
             if self.config.mode == "round_robin" {
                 tracing::debug!(task_id = %task.id.0, "routing via round-robin mode");
-                return strategies::route_via_round_robin_stateful(
+                let result = strategies::route_via_round_robin_stateful(
                     &candidates,
                     &self.config,
                     task,
                     &mut self.rr_index,
                     &mut self.last_agent,
-                );
+                )?;
+                self.log_route_activity(store, repo, &task.id.0, &result, None)
+                    .await;
+                return Ok(result);
             }
 
             // 3. LLM-based routing with retry tracking
@@ -569,13 +580,16 @@ impl Router {
                     self.wait_for_cooldown(Some(&complexity)).await?;
                     continue;
                 }
-                return strategies::route_via_round_robin_stateful(
+                let result = strategies::route_via_round_robin_stateful(
                     &candidates,
                     &self.config,
                     task,
                     &mut self.rr_index,
                     &mut self.last_agent,
-                );
+                )?;
+                self.log_route_activity(store, repo, &task.id.0, &result, None)
+                    .await;
+                return Ok(result);
             }
 
             // Log routing start (before await)
@@ -620,18 +634,21 @@ impl Router {
                             fallback_agent
                         );
 
-                        return Ok(RouteResult {
-                            agent: fallback_agent,
+                        let result = RouteResult {
+                            agent: fallback_agent.clone(),
                             model: fallback_model,
                             complexity: result.complexity.clone(),
-                            reason,
-                            profile: result.profile,
-                            selected_skills: result.selected_skills,
+                            reason: reason.clone(),
+                            profile: result.profile.clone(),
+                            selected_skills: result.selected_skills.clone(),
                             warning: Some(
                                 "LLM-selected agent/model was cooled; rerouted to available agent"
                                     .to_string(),
                             ),
-                        });
+                        };
+                        self.log_route_activity(store, repo, &task.id.0, &result, None)
+                            .await;
+                        return Ok(result);
                     }
 
                     // Reset attempts on success
@@ -642,6 +659,8 @@ impl Router {
                         complexity = %result.complexity,
                         "routed via LLM"
                     );
+                    self.log_route_activity(store, repo, &task.id.0, &result, None)
+                        .await;
                     return Ok(result);
                 }
                 Err(e) => {
@@ -680,13 +699,16 @@ impl Router {
                             self.wait_for_cooldown(Some(&complexity)).await?;
                             continue;
                         }
-                        return strategies::route_via_round_robin_stateful(
+                        let result = strategies::route_via_round_robin_stateful(
                             &candidates,
                             &self.config,
                             task,
                             &mut self.rr_index,
                             &mut self.last_agent,
-                        );
+                        )?;
+                        self.log_route_activity(store, repo, &task.id.0, &result, None)
+                            .await;
+                        return Ok(result);
                     }
 
                     let candidates = self.available_agents_for_complexity(&complexity);
@@ -694,12 +716,15 @@ impl Router {
                         self.wait_for_cooldown(Some(&complexity)).await?;
                         continue;
                     }
-                    return strategies::route_via_fallback(
+                    let result = strategies::route_via_fallback(
                         &candidates,
                         &self.config,
                         task,
                         Some(&self.weights),
-                    );
+                    )?;
+                    self.log_route_activity(store, repo, &task.id.0, &result, None)
+                        .await;
+                    return Ok(result);
                 }
             }
         }
@@ -738,6 +763,41 @@ impl Router {
                 tracing::warn!(task_id, error = %e, "failed to store route_attempts");
             }
         }
+    }
+
+    /// Log a route event to task activity timeline.
+    async fn log_route_activity(
+        &self,
+        store: &std::sync::Arc<crate::store::TaskStore>,
+        repo: &str,
+        task_id: &str,
+        result: &RouteResult,
+        from_agent: Option<&str>,
+    ) {
+        let details = serde_json::json!({
+            "reason": result.reason,
+            "complexity": result.complexity,
+            "skills": result.selected_skills,
+            "role": result.profile.role,
+            "warning": result.warning,
+        });
+        let event_type = if from_agent.is_some() {
+            "rerouted"
+        } else {
+            "routed"
+        };
+        store_log_activity(
+            &Some(Arc::clone(store)),
+            repo,
+            task_id,
+            event_type,
+            None,
+            Some("routed"),
+            Some(&result.agent),
+            result.model.as_deref(),
+            Some(&details),
+        )
+        .await;
     }
 
     /// Route using LLM classification with pool round-robin.

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -295,6 +295,27 @@ pub async fn handle_failover(
         if matches!(error_type, RetryableError::Timeout) {
             record_agent_failure_with_message(agent_name, error_message).await;
         }
+
+        // Log reroute activity for exhausted agents
+        let details = serde_json::json!({
+            "failure_reason": error_type.type_str(),
+            "error_message": error_message,
+            "chain": chain,
+            "agents_exhausted": true,
+        });
+        crate::store::store_log_activity(
+            store,
+            repo,
+            task_id,
+            "rerouted",
+            Some("in_progress"),
+            Some("needs_review"),
+            None::<&str>,
+            None::<&str>,
+            Some(&details),
+        )
+        .await;
+
         return "needs_review".to_string();
     }
 
@@ -337,6 +358,27 @@ pub async fn handle_failover(
         // from scratch via model_for_complexity() + model_map in config.
         wait_for_fallback_backoff(task_id, store, repo).await;
 
+        // Log reroute activity for successful failover
+        let details = serde_json::json!({
+            "failure_reason": error_type.type_str(),
+            "error_message": error_message,
+            "from_agent": agent_name,
+            "to_agent": next,
+            "chain": chain,
+        });
+        crate::store::store_log_activity(
+            store,
+            repo,
+            task_id,
+            "rerouted",
+            Some("in_progress"),
+            Some("routed"),
+            Some(&next),
+            None::<&str>,
+            Some(&details),
+        )
+        .await;
+
         return "routed".to_string();
     }
 
@@ -357,6 +399,27 @@ pub async fn handle_failover(
         &[("last_error", serde_json::json!(msg))],
     )
     .await;
+
+    // Log reroute activity for no fallback available
+    let details = serde_json::json!({
+        "failure_reason": error_type.type_str(),
+        "error_message": error_message,
+        "chain": chain,
+        "no_fallback_available": true,
+    });
+    crate::store::store_log_activity(
+        store,
+        repo,
+        task_id,
+        "rerouted",
+        Some("in_progress"),
+        Some("needs_review"),
+        None::<&str>,
+        None::<&str>,
+        Some(&details),
+    )
+    .await;
+
     "needs_review".to_string()
 }
 

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -345,6 +345,26 @@ pub(crate) async fn tick_detect_silent_agents(
             continue;
         }
 
+        // Log reroute activity
+        let details = serde_json::json!({
+            "failure_reason": "agent_silence",
+            "silence_duration_secs": config.silence_grace_period,
+            "cooldown_applied": !agent_name.is_empty() && !model_name.is_empty(),
+            "fallback_available": next_agent.is_some(),
+        });
+        crate::store::store_log_activity(
+            &Some(Arc::clone(store)),
+            repo,
+            &task_id,
+            "rerouted",
+            Some("in_progress"),
+            Some(next_status.as_str()),
+            next_agent.as_deref(),
+            None,
+            Some(&details),
+        )
+        .await;
+
         // 5. Post a comment explaining what happened
         let action = if let Some(ref fallback) = next_agent {
             format!("failing over to {fallback}")
@@ -451,6 +471,26 @@ pub(crate) async fn tick_recover_stuck_tasks(
             tracing::warn!(task_id = task.id.0, ?e, "failed to reset stuck task status");
             continue;
         }
+
+        // Log reroute activity for stuck task recovery
+        let details = serde_json::json!({
+            "failure_reason": if timing.has_session { "stuck_with_session" } else { "stuck_no_session" },
+            "age_minutes": timing.age.num_minutes(),
+            "had_session": timing.has_session,
+        });
+        crate::store::store_log_activity(
+            &Some(Arc::clone(store)),
+            repo,
+            &task.id.0,
+            "rerouted",
+            Some("in_progress"),
+            Some("new"),
+            None::<&str>,
+            None::<&str>,
+            Some(&details),
+        )
+        .await;
+
         let reason = if timing.has_session {
             format!(
                 "timed out after {}m with active session (cleared agent for re-routing)",
@@ -604,6 +644,25 @@ pub(crate) async fn tick_recover_stuck_tasks(
         } else {
             set_review_session_expected(store, repo, &task.id.0, false).await;
         }
+
+        // Log activity for stuck in_review recovery
+        let details = serde_json::json!({
+            "failure_reason": "stuck_in_review",
+            "age_minutes": timing.age.num_minutes(),
+            "had_session": timing.has_session,
+        });
+        crate::store::store_log_activity(
+            &Some(Arc::clone(store)),
+            repo,
+            &task.id.0,
+            "rerouted",
+            Some("in_review"),
+            Some("needs_review"),
+            None::<&str>,
+            None::<&str>,
+            Some(&details),
+        )
+        .await;
         if let Err(e) = backend
             .post_comment(
                 &task.id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -534,6 +534,11 @@ enum TaskAction {
         #[arg(long)]
         json: bool,
     },
+    /// Show task routing history with attempt timeline
+    History {
+        /// Task ID (e.g. "internal:8" or issue number)
+        id: String,
+    },
     /// Show task run history and audit details
     Runs {
         /// Task ID (e.g. "internal:8" or issue number)
@@ -790,6 +795,9 @@ async fn main() -> anyhow::Result<()> {
             }
             TaskAction::Log { id, limit, json } => {
                 cli::task::activity_log(&id, limit, json).await?;
+            }
+            TaskAction::History { id } => {
+                cli::task::history(&id).await?;
             }
             TaskAction::Runs { id, verbose } => {
                 cli::task::runs(&id, verbose).await?;


### PR DESCRIPTION
## Summary

All quality gates pass. Here's a summary of the implementation:

## Summary

I've implemented task routing observability as requested:

### 1. Router Activity Logging (`src/engine/router/mod.rs`)
- Added `log_route_activity()` helper that logs route decisions
- Logs both "routed" (initial) and "rerouted" (subsequent) events
- Captures: agent, model, reason, complexity, skills, role, warnings

### 2. Reroute Event Logging (`src/engine/tick.rs` and `src/engine/runner/response.rs`)
- **tick.rs**: L

Closes #1575

---
*Task #1575 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*