### PR TITLE
bug: router blocks task routing for hours when all agents/models are cooled

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -371,6 +371,12 @@ impl Router {
     }
 
     async fn wait_for_cooldown(&self, complexity: Option<&str>) -> anyhow::Result<()> {
+        // If any cooldowns are present, return an error immediately so the
+        // caller (the tick loop) can skip this task and retry on the next tick.
+        // Sleeping inside the router blocks the entire tick loop for the
+        // cooldown duration which starves other tasks. The engine tick already
+        // retries every `tick_interval` (default 10s), so allow the tick loop
+        // to drive retries instead of sleeping here.
         let now = chrono::Utc::now().timestamp();
         let earliest = self.earliest_cooldown_until(complexity).ok_or_else(|| {
             anyhow::anyhow!("no cooldowns found while waiting for routing availability")
@@ -378,12 +384,15 @@ impl Router {
 
         let remaining = earliest.saturating_sub(now);
         if remaining > 0 {
+            let scope_str = complexity.unwrap_or("all agents").to_string();
             tracing::warn!(
                 remaining_secs = remaining,
-                scope = complexity.unwrap_or("all agents"),
-                "all agents/models cooled — waiting for cooldown to expire"
+                scope = %scope_str,
+                "all agents/models cooled — routing is unavailable until cooldown expires; failing fast to let tick retry"
             );
-            tokio::time::sleep(std::time::Duration::from_secs(remaining as u64)).await;
+            // Return a domain error indicating all candidates are cooled so the
+            // caller can handle it (tick will skip this task and retry later).
+            return Err(AllCooledError { scope: scope_str }.into());
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

Make router fail fast when all agents/models are cooled instead of sleeping inside routing loop to avoid blocking the engine tick.

### What was done

- Inspected router implementation and tick caller to confirm blocking behavior
- Replaced long sleep in Router::wait_for_cooldown with a fast-fail that returns an AllCooledError when cooldowns remain
- Added explanatory comment to wait_for_cooldown describing reasoning (tick loop retry handles scheduling)
- Verified all existing call sites propagate the error and already handle retry/continue logic (no further call-site edits required)


### Remaining

- Run full test suite and CI checks locally (cargo fmt, clippy, nextest) before merging to ensure no regressions
- Optionally add a unit/integration test to assert route() no longer sleeps when models are cooled and that tick continues to process other tasks


Closes #1579

---
*Task #1579 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*