### PR TITLE
bug: discord gateway processes malformed MESSAGE_CREATE events with empty IDs

### DIFF
--- a/src/channels/discord_ws.rs
+++ b/src/channels/discord_ws.rs
@@ -539,14 +539,24 @@ async fn handle_dispatch(
             tracing::info!("discord gateway: session resumed");
         }
         Some("MESSAGE_CREATE") => {
-            let msg_channel_id = data["channel_id"].as_str().unwrap_or("");
+            // Validate channel_id is present and non-empty — it's required for routing/replies.
+            let Some(msg_channel_id) = data["channel_id"].as_str().filter(|s| !s.is_empty()) else {
+                tracing::warn!("discord MESSAGE_CREATE missing channel_id, skipping");
+                return Ok(());
+            };
 
             // Skip messages from bots (avoid reacting to ourselves)
             if data["author"]["bot"].as_bool().unwrap_or(false) {
                 return Ok(());
             }
 
-            let id = data["id"].as_str().unwrap_or("").to_string();
+            // Validate message id is present and non-empty. If malformed, skip the event.
+            let Some(id_str) = data["id"].as_str().filter(|s| !s.is_empty()) else {
+                tracing::warn!("discord MESSAGE_CREATE missing message id, skipping");
+                return Ok(());
+            };
+
+            let id = id_str.to_string();
             let author = data["author"]["username"]
                 .as_str()
                 .unwrap_or("unknown")


### PR DESCRIPTION
## Summary

Validate Discord MESSAGE_CREATE events and skip malformed events missing message id or channel_id.

### What was done

- Inspected src/channels/discord_ws.rs to find MESSAGE_CREATE handling
- Added validation to ensure channel_id is present and non-empty; skip and warn if missing
- Added validation to ensure message id is present and non-empty; skip and warn if missing
- Ran unit tests and updated code compiled successfully; committed the change


### Remaining

- Monitor logs for warnings indicating skipped malformed Discord events in production
- If desired, mirror the same defensive checks in other Discord-related code paths that parse externally-provided IDs


Closes #1582

---
*Task #1582 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*