### PR TITLE
tech-debt: std::sync::Mutex used in async contexts in slack/telegram channels

### DIFF
--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -27,7 +27,7 @@ pub struct SlackChannel {
     pub client: Client,
     pub channel_id: Option<String>,
     /// Cursor tracking the latest message timestamp seen (Slack uses `ts` as cursor).
-    pub last_ts: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    pub last_ts: std::sync::Arc<tokio::sync::Mutex<Option<String>>>,
 }
 
 #[derive(Deserialize)]
@@ -67,7 +67,7 @@ impl SlackChannel {
             bot_token,
             client: Client::new(),
             channel_id,
-            last_ts: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            last_ts: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 
@@ -85,7 +85,7 @@ impl SlackChannel {
         ];
 
         {
-            let last = self.last_ts.lock().unwrap_or_else(|e| e.into_inner());
+            let last = self.last_ts.lock().await;
             if let Some(ref ts) = *last {
                 // `oldest` is exclusive — add a tiny epsilon to avoid re-fetching the last msg
                 params.push(("oldest", ts.clone()));
@@ -217,7 +217,7 @@ impl Channel for SlackChannel {
 
                     // Update last_ts to the maximum ts seen
                     {
-                        let mut last = last_ts.lock().unwrap_or_else(|e| e.into_inner());
+                        let mut last = last_ts.lock().await;
                         if last.as_ref().is_none_or(|prev: &String| msg.ts > *prev) {
                             *last = Some(msg.ts.clone());
                         }

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -12,7 +12,7 @@ pub struct TelegramChannel {
     pub token: String,
     pub client: Client,
     pub chat_id: Option<String>,
-    pub offset: std::sync::Arc<std::sync::Mutex<i64>>,
+    pub offset: std::sync::Arc<tokio::sync::Mutex<i64>>,
 }
 
 #[derive(Deserialize)]
@@ -65,7 +65,7 @@ impl TelegramChannel {
             token,
             client: Client::new(),
             chat_id,
-            offset: std::sync::Arc::new(std::sync::Mutex::new(0)),
+            offset: std::sync::Arc::new(tokio::sync::Mutex::new(0)),
         }
     }
 
@@ -209,7 +209,7 @@ impl Channel for TelegramChannel {
         tokio::spawn(async move {
             loop {
                 let current_offset = {
-                    let off = offset.lock().unwrap_or_else(|e| e.into_inner());
+                    let off = offset.lock().await;
                     *off
                 };
 
@@ -227,7 +227,7 @@ impl Channel for TelegramChannel {
                 for update in updates {
                     // Update offset
                     {
-                        let mut off = offset.lock().unwrap_or_else(|e| e.into_inner());
+                        let mut off = offset.lock().await;
                         if update.update_id + 1 > *off {
                             *off = update.update_id + 1;
                         }


### PR DESCRIPTION
## Summary

Replaced std::sync::Mutex with tokio::sync::Mutex in Slack and Telegram channel code and updated lock usage to async .lock().await to prevent accidental blocking of the async executor.

### What was done

- Replaced SlackChannel.last_ts type from std::sync::Arc<std::sync::Mutex<Option<String>>> to std::sync::Arc<tokio::sync::Mutex<Option<String>>>
- Initialized SlackChannel.last_ts with tokio::sync::Mutex::new(None)
- Updated Slack lock usage in get_messages and polling loop to use .lock().await
- Replaced TelegramChannel.offset type from std::sync::Arc<std::sync::Mutex<i64>> to std::sync::Arc<tokio::sync::Mutex<i64>>
- Initialized TelegramChannel.offset with tokio::sync::Mutex::new(0)
- Updated Telegram lock usage in polling loop to use .lock().await
- Committed the changes with a concise commit message


### Remaining

- Review other usages of std::sync::Mutex across the codebase to ensure synchronous mutexes are only used where appropriate (some usages are intentionally sync; do not change without review). I noticed multiple other std::sync::Mutex occurrences (e.g., router, engine) — they may be fine as-is but should be audited separately.
- Run full test suite and CI locally (cargo fmt, cargo clippy, cargo nextest) to ensure no regressions (I did not run tests in this session).


Closes #1585

---
*Task #1585 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*