### PR TITLE
bug: unbounded IN (...) placeholders can crash SQLite in batch reset/clean operations

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1212,10 +1212,17 @@ impl TaskStore {
         if ids.is_empty() {
             return Ok(());
         }
-        // Build WHERE id IN (?, ?, ...) placeholders
-        let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-        let sql = format!(
-            "UPDATE tasks SET
+        // SQLite has a hard limit on host parameters (commonly 999). Chunk the
+        // IN-list into smaller batches to avoid exceeding the limit.
+        const CHUNK_SIZE: usize = 500;
+
+        let mut tx = self.pool.begin().await?;
+
+        for chunk in ids.chunks(CHUNK_SIZE) {
+            // Build WHERE id IN (?, ?, ...) placeholders for this chunk
+            let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+            let sql = format!(
+                "UPDATE tasks SET
             attempts = 0,
             route_attempts = 0,
             review_agent_failures = 0,
@@ -1230,13 +1237,16 @@ impl TaskStore {
             ci_recovery_count = 0,
             no_code_reroutes = 0,
             updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
-         WHERE id IN ({placeholders})"
-        );
-        let mut query = sqlx::query(&sql);
-        for id in ids {
-            query = query.bind(*id);
+         WHERE id IN ({placeholders})",
+            );
+            let mut query = sqlx::query(&sql);
+            for id in chunk {
+                query = query.bind(*id);
+            }
+            query.execute(&mut *tx).await?;
         }
-        query.execute(&self.pool).await?;
+
+        tx.commit().await?;
         Ok(())
     }
 
@@ -1248,21 +1258,45 @@ impl TaskStore {
         if ids.is_empty() {
             return Ok(());
         }
-        let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-        let sql = format!(
-            "UPDATE tasks SET worktree_cleaned = 1, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id IN ({placeholders})"
-        );
-        let mut query = sqlx::query(&sql);
-        for id in ids {
-            query = query.bind(*id);
+
+        // Chunk updates to avoid exceeding SQLite's parameter limit.
+        const CHUNK_SIZE: usize = 500;
+
+        let mut tx = self.pool.begin().await?;
+
+        for chunk in ids.chunks(CHUNK_SIZE) {
+            let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+            let sql = format!(
+                "UPDATE tasks SET worktree_cleaned = 1, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id IN ({placeholders})",
+            );
+            let mut query = sqlx::query(&sql);
+            for id in chunk {
+                query = query.bind(*id);
+            }
+            query.execute(&mut *tx).await?;
         }
-        query.execute(&self.pool).await?;
+
         // Append activity for each task (must be done individually — activity is per-task JSON)
+        // Insert using the same transaction to avoid connection pool exhaustion
+        // / deadlocks in tests.
         let details = serde_json::json!({ "worktree_cleaned": true });
+        let details_json = serde_json::to_string(&details)?;
         for id in ids {
-            self.append_activity(*id, "branch_delete", None, None, None, None, Some(&details))
-                .await?;
+            sqlx::query(
+                "INSERT INTO task_activity (task_id, event_type, from_status, to_status, agent, model, details) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(*id)
+            .bind("branch_delete")
+            .bind(None::<&str>)
+            .bind(None::<&str>)
+            .bind(None::<&str>)
+            .bind(None::<&str>)
+            .bind(details_json.as_str())
+            .execute(&mut *tx)
+            .await?;
         }
+
+        tx.commit().await?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Fix batch SQL queries that built unbounded IN(...) parameter lists by chunking into safe sizes and executing each chunk in a transaction to avoid SQLite host-parameter limits.

### What was done

- Updated src/store/tasks.rs to chunk large id slices when building WHERE id IN (...) queries to avoid exceeding SQLite host-parameter limits.
- Applied the chunking pattern to batch_reset_failure_counters (now chunks of 500 IDs per UPDATE executed inside a transaction).
- Applied the chunking pattern to batch_mark_cleaned (now chunks of 500 IDs per UPDATE executed inside a transaction).
- Ensured batch_mark_cleaned appends task activity consistently inside the same transaction for atomicity.
- Ran the test suite locally to verify changes and fixed binding usage to avoid compilation/runtime issues.
- Committed the change on the feature branch.


### Remaining

- No further code changes required for this specific issue. Recommend a brief follow-up note in a changelog or PR description explaining the SQLite parameter-limit rationale for reviewers.


Closes #1580

---
*Task #1580 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*