### PR TITLE
bug: discord INTERACTION_CREATE processes events with empty channel_id/custom_id

### DIFF
--- a/src/channels/discord_ws.rs
+++ b/src/channels/discord_ws.rs
@@ -599,8 +599,17 @@ async fn handle_dispatch(
                 };
                 let interaction_id = interaction_id.to_string();
                 let interaction_token = interaction_token.to_string();
-                let custom_id = data["data"]["custom_id"].as_str().unwrap_or("").to_string();
-                let inter_channel_id = data["channel_id"].as_str().unwrap_or("").to_string();
+                let Some(inter_channel_id) = data["channel_id"].as_str().filter(|s| !s.is_empty())
+                else {
+                    tracing::warn!("ignoring INTERACTION_CREATE with missing channel_id");
+                    return Ok(());
+                };
+                let inter_channel_id = inter_channel_id.to_string();
+                let custom_id = data["data"]["custom_id"]
+                    .as_str()
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or("button_click")
+                    .to_string();
                 let author = data["member"]["user"]["username"]
                     .as_str()
                     .or_else(|| data["user"]["username"].as_str())


### PR DESCRIPTION
## Summary

Fixed INTERACTION_CREATE to validate channel_id and custom_id instead of silently accepting empty strings.

### What was done

- Added early-return validation for channel_id (returns Ok with warning if missing/empty)
- Changed custom_id to fall back to 'button_click' when missing/empty, matching the validation pattern used for interaction_id
- All quality gates pass: cargo fmt ✓, cargo clippy -D warnings ✓


Closes #1584

---
*Task #1584 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2-pro-free`*