### PR TITLE
bug: Slack/Telegram/Discord HTTP clients lack request timeouts

### DIFF
--- a/src/channels/discord_ws.rs
+++ b/src/channels/discord_ws.rs
@@ -58,7 +58,10 @@ impl DiscordGateway {
     pub fn new(token: String, channel_id: Option<String>, shard_id: u64, shard_count: u64) -> Self {
         Self {
             token,
-            client: Client::new(),
+            client: Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .expect("valid TLS config"),
             channel_id,
             shard_id,
             shard_count,

--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -21,6 +21,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use reqwest::Client;
 use serde::Deserialize;
+use std::time::Duration;
 
 pub struct SlackChannel {
     pub bot_token: String,
@@ -65,7 +66,10 @@ impl SlackChannel {
     pub fn new(bot_token: String, channel_id: Option<String>) -> Self {
         Self {
             bot_token,
-            client: Client::new(),
+            client: Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .expect("valid TLS config"),
             channel_id,
             last_ts: std::sync::Arc::new(std::sync::Mutex::new(None)),
         }

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use reqwest::Client;
 use serde::Deserialize;
+use std::time::Duration;
 
 pub struct TelegramChannel {
     pub token: String,
@@ -63,7 +64,10 @@ impl TelegramChannel {
     pub fn new(token: String, chat_id: Option<String>) -> Self {
         Self {
             token,
-            client: Client::new(),
+            client: Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .expect("valid TLS config"),
             chat_id,
             offset: std::sync::Arc::new(std::sync::Mutex::new(0)),
         }


### PR DESCRIPTION
## Summary

Done. Added 30-second request timeouts to the HTTP clients in all three channel implementations:

- `src/channels/slack.rs:68`
- `src/channels/telegram.rs:66`
- `src/channels/discord_ws.rs:61`

Each now uses `Client::builder().timeout(Duration::from_secs(30)).build().expect("valid TLS config")` instead of `Client::new()`.

Quality gates:
- `cargo fmt` — passed
- `cargo clippy --all-targets -- -D warnings` — passed
- `cargo nextest run` for the modified channel modules — all 32 tests passed

Closes #1588

---
*Task #1588 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*