### PR TITLE
bug: channel task bindings ignore topic/thread identity and misroute multi-topic messages

### DIFF
--- a/src/channels/stream.rs
+++ b/src/channels/stream.rs
@@ -9,7 +9,7 @@
 //! - Discord:  2 KB per message, 500 ms between sends
 //! - Slack:    4 KB per message, 200 ms between sends
 
-use crate::channels::transport::Transport;
+use crate::channels::transport::{parse_conversation_key, Transport};
 use crate::channels::{ChannelRegistry, OutgoingMessage};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -63,10 +63,15 @@ fn split_for_platform(content: &str, channel_name: &str) -> Vec<String> {
 }
 
 /// Send a message to a specific channel thread, finding the channel by name.
+///
+/// `topic_id` is forwarded to the channel so that topic-aware channels
+/// (Telegram forum topics, Discord threads) deliver the message to the
+/// correct sub-conversation rather than the parent chat/channel.
 async fn send_to_thread(
     channels: &Arc<ChannelRegistry>,
     channel_name: &str,
     thread_id: &str,
+    topic_id: Option<&str>,
     body: String,
 ) {
     for ch in channels.iter() {
@@ -76,7 +81,7 @@ async fn send_to_thread(
                 body,
                 reply_to: None,
                 metadata: serde_json::json!({}),
-                topic_id: None,
+                topic_id: topic_id.map(String::from),
             };
             if let Err(e) = ch.send(&msg).await {
                 tracing::warn!(channel = channel_name, thread_id, ?e, "stream: send failed");
@@ -130,10 +135,11 @@ pub async fn fanout_output(
                         let now = Instant::now();
 
                         for thread_key in &binding.connected_threads {
-                            let (ch_name, thread_id) = match thread_key.split_once(':') {
-                                Some(p) => p,
-                                None => continue,
-                            };
+                            let (ch_name, thread_id, topic_id) =
+                                match parse_conversation_key(thread_key) {
+                                    Some(p) => p,
+                                    None => continue,
+                                };
 
                             // Append new content to this thread's buffer
                             buffers
@@ -152,7 +158,10 @@ pub async fn fanout_output(
                                 if let Some(buffered) = buffers.remove(thread_key) {
                                     let parts = split_for_platform(&buffered, ch_name);
                                     for part in parts {
-                                        send_to_thread(&channels, ch_name, thread_id, part).await;
+                                        send_to_thread(
+                                            &channels, ch_name, thread_id, topic_id, part,
+                                        )
+                                        .await;
                                     }
                                     last_send.insert(ch_name.to_string(), now);
                                 }
@@ -169,13 +178,14 @@ pub async fn fanout_output(
                             if buffered.is_empty() {
                                 continue;
                             }
-                            let (ch_name, thread_id) = match thread_key.split_once(':') {
-                                Some(p) => p,
-                                None => continue,
-                            };
+                            let (ch_name, thread_id, topic_id) =
+                                match parse_conversation_key(&thread_key) {
+                                    Some(p) => p,
+                                    None => continue,
+                                };
                             let parts = split_for_platform(&buffered, ch_name);
                             for part in parts {
-                                send_to_thread(&channels, ch_name, thread_id, part).await;
+                                send_to_thread(&channels, ch_name, thread_id, topic_id, part).await;
                             }
                         }
                     }
@@ -203,7 +213,7 @@ pub async fn fanout_output(
             let now = Instant::now();
             let mut earliest = None::<Instant>;
             for thread_key in buffers.keys() {
-                if let Some((ch_name, _)) = thread_key.split_once(':') {
+                if let Some((ch_name, _, _)) = parse_conversation_key(thread_key) {
                     let rate = platform_rate(ch_name);
                     if let Some(last) = last_send.get(ch_name) {
                         let when = *last + rate;
@@ -237,10 +247,11 @@ pub async fn fanout_output(
                     let keys: Vec<String> = buffers.keys().cloned().collect();
                     for thread_key in keys {
                         if let Some(buffered) = buffers.remove(&thread_key) {
-                            let (ch_name, thread_id) = match thread_key.split_once(':') {
-                                Some(p) => p,
-                                None => continue,
-                            };
+                            let (ch_name, thread_id, topic_id) =
+                                match parse_conversation_key(&thread_key) {
+                                    Some(p) => p,
+                                    None => continue,
+                                };
                             let rate = platform_rate(ch_name);
                             let can_send = last_send
                                 .get(ch_name)
@@ -249,7 +260,8 @@ pub async fn fanout_output(
                             if can_send {
                                 let parts = split_for_platform(&buffered, ch_name);
                                 for part in parts {
-                                    send_to_thread(&channels, ch_name, thread_id, part).await;
+                                    send_to_thread(&channels, ch_name, thread_id, topic_id, part)
+                                        .await;
                                 }
                                 last_send.insert(ch_name.to_string(), now);
                             } else {
@@ -358,7 +370,7 @@ mod tests {
         // Bind a task to the channel:thread so fanout knows where to send
         let task_id = "fanout-test-task";
         transport
-            .bind(task_id, "orch-fanout-test", "telegram", "thread-1")
+            .bind(task_id, "orch-fanout-test", "telegram", "thread-1", None)
             .await;
 
         // Spawn the fanout_output task
@@ -413,6 +425,80 @@ mod tests {
         assert!(
             got,
             "fanout did not send expected outgoing message to test channel"
+        );
+    }
+
+    /// When a task is bound with a `topic_id`, the outgoing `OutgoingMessage`
+    /// forwarded by fanout must carry the same `topic_id` so that the channel
+    /// delivers the reply to the correct forum topic / thread.
+    #[tokio::test]
+    async fn fanout_forwards_topic_id() {
+        let transport = std::sync::Arc::new(Transport::new());
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::channels::OutgoingMessage>(16);
+        let test_ch = TestChannel {
+            name: "telegram".to_string(),
+            tx,
+        };
+
+        let mut registry = crate::channels::ChannelRegistry::new();
+        registry.register(Box::new(test_ch));
+        let registry = std::sync::Arc::new(registry);
+
+        let task_id = "topic-forward-task";
+        // Bind with a specific topic_id
+        transport
+            .bind(
+                task_id,
+                "orch-topic-test",
+                "telegram",
+                "chat-111",
+                Some("topic-42"),
+            )
+            .await;
+
+        let transport_clone = transport.clone();
+        let registry_clone = registry.clone();
+        let task_id_str = task_id.to_string();
+        tokio::spawn(
+            async move { fanout_output(task_id_str, transport_clone, registry_clone).await },
+        );
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        transport
+            .push_output(
+                task_id,
+                crate::channels::OutputChunk {
+                    content: "topic reply".to_string(),
+                    is_final: true,
+                },
+            )
+            .await;
+
+        let mut got_topic = false;
+        for _ in 0..10 {
+            if let Ok(Some(msg)) =
+                tokio::time::timeout(std::time::Duration::from_millis(200), async {
+                    rx.recv().await
+                })
+                .await
+            {
+                if msg.body.contains("topic reply") {
+                    assert_eq!(
+                        msg.topic_id.as_deref(),
+                        Some("topic-42"),
+                        "outgoing message must carry the bound topic_id"
+                    );
+                    got_topic = true;
+                    break;
+                }
+            }
+        }
+
+        assert!(
+            got_topic,
+            "fanout did not forward topic_id in outgoing message"
         );
     }
 }

--- a/src/channels/transport.rs
+++ b/src/channels/transport.rs
@@ -40,17 +40,53 @@ pub struct SessionBinding {
     /// tmux session name (e.g. "orch-myproject-42")
     pub tmux_session: String,
     /// Channel threads connected to this session.
-    /// Key: "channel:thread_id" (e.g. "telegram:12345", "github:42")
+    ///
+    /// Each entry is a canonical conversation key produced by
+    /// [`conversation_key`].  The format is either:
+    ///   - `"channel:thread_id"` (no topic), or
+    ///   - `"channel:thread_id|topic_id"` (with topic/thread)
+    ///
+    /// Use [`parse_conversation_key`] to decompose a key back into its parts.
     pub connected_threads: Vec<String>,
     /// Broadcast sender for output streaming
     pub output_tx: broadcast::Sender<OutputChunk>,
+}
+
+/// Build a canonical conversation key that is unique per topic/thread when
+/// `topic_id` is present, and falls back to `channel:thread_id` otherwise.
+///
+/// Telegram and Discord encode the forum-topic / thread identity in `topic_id`
+/// while `thread_id` carries the parent chat / channel id.  Two different topics
+/// inside the same parent would share the same `"channel:thread_id"` key —
+/// causing bindings to collide.  Including `topic_id` in the key avoids that.
+///
+/// `|` is used as the topic separator because it cannot appear in Telegram or
+/// Discord snowflake IDs (they are numeric / alphanumeric).
+pub fn conversation_key(channel: &str, thread_id: &str, topic_id: Option<&str>) -> String {
+    match topic_id {
+        Some(tid) if !tid.is_empty() => format!("{channel}:{thread_id}|{tid}"),
+        _ => format!("{channel}:{thread_id}"),
+    }
+}
+
+/// Decompose a conversation key created by [`conversation_key`] back into
+/// `(channel, thread_id, topic_id)`.
+///
+/// Returns `None` if the key is malformed (no `':'` separator).
+pub fn parse_conversation_key(key: &str) -> Option<(&str, &str, Option<&str>)> {
+    let (channel, rest) = key.split_once(':')?;
+    let (thread_id, topic_id) = match rest.split_once('|') {
+        Some((tid, topic)) => (tid, Some(topic)),
+        None => (rest, None),
+    };
+    Some((channel, thread_id, topic_id))
 }
 
 /// The transport layer manages all session bindings and routes messages.
 pub struct Transport {
     /// Active session bindings, keyed by task_id
     bindings: Arc<RwLock<HashMap<String, SessionBinding>>>,
-    /// Reverse lookup: "channel:thread_id" → task_id
+    /// Reverse lookup: conversation_key → task_id
     thread_to_task: Arc<RwLock<HashMap<String, String>>>,
     /// Broadcast sender for task completion notifications
     notification_tx: broadcast::Sender<TaskNotification>,
@@ -70,8 +106,19 @@ impl Transport {
     }
 
     /// Bind a channel thread to a task's tmux session.
-    pub async fn bind(&self, task_id: &str, tmux_session: &str, channel: &str, thread_id: &str) {
-        let key = format!("{channel}:{thread_id}");
+    ///
+    /// `topic_id` should be set for topic-aware channels (Telegram forum topics,
+    /// Discord threads) so that bindings for different topics inside the same
+    /// parent chat / channel do not collide.
+    pub async fn bind(
+        &self,
+        task_id: &str,
+        tmux_session: &str,
+        channel: &str,
+        thread_id: &str,
+        topic_id: Option<&str>,
+    ) {
+        let key = conversation_key(channel, thread_id, topic_id);
         // Clear stale output before updating bindings to avoid holding
         // write lock across await points (deadlock risk).
         self.clear_output(task_id).await;
@@ -153,7 +200,7 @@ impl Transport {
     /// Route an incoming message to the appropriate handler.
     /// Returns the task_id if this message maps to an existing session.
     pub async fn route(&self, msg: &IncomingMessage) -> MessageRoute {
-        let key = format!("{}:{}", msg.channel, msg.thread_id);
+        let key = conversation_key(&msg.channel, &msg.thread_id, msg.topic_id.as_deref());
 
         // Check if this thread is bound to a task
         if let Some(task_id) = self.thread_to_task.read().await.get(&key) {
@@ -298,7 +345,7 @@ mod tests {
     async fn bind_and_route_to_session() {
         let transport = Transport::new();
         transport
-            .bind("42", "orch-myproject-42", "telegram", "12345")
+            .bind("42", "orch-myproject-42", "telegram", "12345", None)
             .await;
 
         let msg = IncomingMessage {
@@ -336,6 +383,151 @@ mod tests {
         match transport.route(&msg).await {
             MessageRoute::Command { raw } => assert_eq!(raw, "/status"),
             _ => panic!("expected Command"),
+        }
+    }
+
+    // ── conversation_key ──────────────────────────────────────────────────────
+
+    #[test]
+    fn conversation_key_without_topic() {
+        let key = conversation_key("telegram", "12345", None);
+        assert_eq!(key, "telegram:12345");
+    }
+
+    #[test]
+    fn conversation_key_with_topic() {
+        let key = conversation_key("telegram", "12345", Some("678"));
+        assert_eq!(key, "telegram:12345|678");
+    }
+
+    #[test]
+    fn conversation_key_empty_topic_treated_as_none() {
+        // An empty topic_id should produce the same key as None.
+        let key_empty = conversation_key("discord", "abc", Some(""));
+        let key_none = conversation_key("discord", "abc", None);
+        assert_eq!(key_empty, key_none);
+    }
+
+    // ── parse_conversation_key ────────────────────────────────────────────────
+
+    #[test]
+    fn parse_key_without_topic() {
+        let (channel, thread_id, topic_id) =
+            parse_conversation_key("telegram:12345").expect("valid key");
+        assert_eq!(channel, "telegram");
+        assert_eq!(thread_id, "12345");
+        assert!(topic_id.is_none());
+    }
+
+    #[test]
+    fn parse_key_with_topic() {
+        let (channel, thread_id, topic_id) =
+            parse_conversation_key("telegram:12345|678").expect("valid key");
+        assert_eq!(channel, "telegram");
+        assert_eq!(thread_id, "12345");
+        assert_eq!(topic_id, Some("678"));
+    }
+
+    #[test]
+    fn parse_key_malformed_returns_none() {
+        assert!(parse_conversation_key("no-colon-here").is_none());
+    }
+
+    #[test]
+    fn conversation_key_round_trips() {
+        // Build a key and parse it back; values must match what went in.
+        for (ch, tid, topic) in [
+            ("telegram", "111", Some("222")),
+            ("discord", "abc", None),
+            ("slack", "x", Some("y")),
+        ] {
+            let key = conversation_key(ch, tid, topic);
+            let (ch2, tid2, topic2) = parse_conversation_key(&key).expect("round-trip valid");
+            assert_eq!(ch2, ch);
+            assert_eq!(tid2, tid);
+            assert_eq!(topic2, topic);
+        }
+    }
+
+    // ── topic collision prevention ────────────────────────────────────────────
+
+    /// Two different Telegram forum topics inside the same chat must bind to
+    /// different keys and not collide.
+    #[tokio::test]
+    async fn different_topics_do_not_collide() {
+        let transport = Transport::new();
+
+        // Task 10 is in topic 100 of chat 999
+        transport
+            .bind("10", "orch-proj-10", "telegram", "999", Some("100"))
+            .await;
+        // Task 20 is in topic 200 of the same chat 999
+        transport
+            .bind("20", "orch-proj-20", "telegram", "999", Some("200"))
+            .await;
+
+        let msg_topic_100 = IncomingMessage {
+            channel: "telegram".to_string(),
+            id: "m1".to_string(),
+            thread_id: "999".to_string(),
+            author: "user".to_string(),
+            body: "reply for task 10".to_string(),
+            timestamp: chrono::Utc::now(),
+            metadata: serde_json::json!({}),
+            topic_id: Some("100".to_string()),
+        };
+
+        let msg_topic_200 = IncomingMessage {
+            channel: "telegram".to_string(),
+            id: "m2".to_string(),
+            thread_id: "999".to_string(),
+            author: "user".to_string(),
+            body: "reply for task 20".to_string(),
+            timestamp: chrono::Utc::now(),
+            metadata: serde_json::json!({}),
+            topic_id: Some("200".to_string()),
+        };
+
+        match transport.route(&msg_topic_100).await {
+            MessageRoute::TaskSession { task_id } => assert_eq!(task_id, "10"),
+            other => panic!("expected TaskSession for task 10, got {other:?}"),
+        }
+
+        match transport.route(&msg_topic_200).await {
+            MessageRoute::TaskSession { task_id } => assert_eq!(task_id, "20"),
+            other => panic!("expected TaskSession for task 20, got {other:?}"),
+        }
+    }
+
+    /// A message arriving in a *different* topic must not be routed to a task
+    /// that was bound to another topic in the same chat.
+    #[tokio::test]
+    async fn wrong_topic_does_not_route_to_bound_task() {
+        let transport = Transport::new();
+
+        // Task 5 bound to topic 10 of chat 42
+        transport
+            .bind("5", "orch-proj-5", "telegram", "42", Some("10"))
+            .await;
+
+        // Message arrives in topic 99 of the same chat — should NOT route to task 5
+        let msg = IncomingMessage {
+            channel: "telegram".to_string(),
+            id: "m1".to_string(),
+            thread_id: "42".to_string(),
+            author: "user".to_string(),
+            body: "hello from a different topic".to_string(),
+            timestamp: chrono::Utc::now(),
+            metadata: serde_json::json!({}),
+            topic_id: Some("99".to_string()),
+        };
+
+        match transport.route(&msg).await {
+            MessageRoute::NewTask => {} // correct — not routed to task 5
+            MessageRoute::TaskSession { task_id } => {
+                panic!("should not have routed to task {task_id}")
+            }
+            other => panic!("unexpected route result: {other:?}"),
         }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -388,7 +388,7 @@ pub async fn stream_task(task_id: &str, raw: bool) -> anyhow::Result<()> {
     let repo = crate::config::get_current_repo().unwrap_or_default();
     let session_name = tmux.session_name(&repo, task_id);
     transport
-        .bind(task_id, &session_name, "cli", "stream")
+        .bind(task_id, &session_name, "cli", "stream", None)
         .await;
 
     // Start a CaptureService to poll the tmux session and push chunks to transport.
@@ -491,7 +491,7 @@ pub async fn stream_all(raw: bool) -> anyhow::Result<()> {
                     }
                     // Use session name as the task key (unique, descriptive)
                     transport
-                        .bind(&session, &session, "cli", "stream-all")
+                        .bind(&session, &session, "cli", "stream-all", None)
                         .await;
                     capture.register_session("cli", &session, &session).await;
                     known.insert(session.clone());

--- a/src/engine/channel_handler.rs
+++ b/src/engine/channel_handler.rs
@@ -253,7 +253,7 @@ async fn create_and_announce_task(
             };
             let session_name = tmux.session_name(repo, &task_id);
             transport
-                .bind(&task_id, &session_name, channel, thread_id)
+                .bind(&task_id, &session_name, channel, thread_id, topic_id)
                 .await;
             capture
                 .register_session(repo, &task_id, &session_name)
@@ -447,7 +447,14 @@ pub(super) async fn handle_channel_message(
                 )
                 .await;
             } else if cmd_str.starts_with("/stream") {
-                let reply = handle_stream_command(&cmd_str, &channel, &thread_id, transport).await;
+                let reply = handle_stream_command(
+                    &cmd_str,
+                    &channel,
+                    &thread_id,
+                    msg_topic_id.as_deref(),
+                    transport,
+                )
+                .await;
                 send_channel_reply(
                     channels,
                     &channel,
@@ -842,6 +849,7 @@ pub(super) async fn handle_stream_command(
     cmd_str: &str,
     channel: &str,
     thread_id: &str,
+    topic_id: Option<&str>,
     transport: &Arc<Transport>,
 ) -> String {
     let parts: Vec<&str> = cmd_str.splitn(2, ' ').collect();
@@ -855,7 +863,7 @@ pub(super) async fn handle_stream_command(
         // Bind this channel/thread as an additional output target
         // The session name is retrieved from the existing binding
         transport
-            .bind(task_id, &binding.tmux_session, channel, thread_id)
+            .bind(task_id, &binding.tmux_session, channel, thread_id, topic_id)
             .await;
         format!("Streaming output from task `{task_id}` to this channel.")
     } else {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1649,7 +1649,7 @@ mod tests {
             .register_session("owner/repo", &task_id, &session_name)
             .await;
         transport
-            .bind(&task_id, &session_name, "telegram", "12345")
+            .bind(&task_id, &session_name, "telegram", "12345", None)
             .await;
 
         // Spawn capture.run() which exits when session is unregistered


### PR DESCRIPTION
## Summary

Let me start by exploring the relevant code to understand the current implementation before making changes.Now let me read the actual file contents to see the specific line numbers and code:Now let me read the discord_ws.rs and telegram.rs files to understand the topic_id handling:Now I have a clear picture of the bug. Let me look at how `bind()` is called in the channel handler to understand the full context:Now I have a complete picture. Let me plan the fix:No prior commits. Now I understand t

Closes #1594

---
*Task #1594 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*