### PR TITLE
Fix: cache opencode free models

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -24,7 +24,7 @@ pub use weights::AgentWeights;
 use crate::backends::ExternalTask;
 use crate::store::store_log_activity;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use llm::LlmRouter;
 
@@ -229,34 +229,59 @@ impl Router {
     /// (called once from `Router::new()` and `Router::reload()`). The result is
     /// stored in `router_pool` and not re-queried until the next reload.
     fn discover_free_opencode_models() -> Vec<String> {
-        if !crate::cmd_cache::command_exists("opencode") {
-            tracing::debug!("opencode not in PATH — skipping free model discovery");
-            return vec![];
+        // Cache discovered free opencode models for 1 hour to avoid repeatedly
+        // running the blocking `opencode models` command during router init
+        // or reloads. The cache stores (timestamp_seconds, models).
+        static FREE_MODELS_CACHE: OnceLock<Mutex<(i64, Vec<String>)>> = OnceLock::new();
+        let cache = FREE_MODELS_CACHE.get_or_init(|| Mutex::new((0, Vec::new())));
+
+        let now = chrono::Utc::now().timestamp();
+        // If cached and not expired (1 hour), return cached copy.
+        {
+            let guard = cache.lock().unwrap();
+            let (ts, models) = &*guard;
+            if *ts != 0 && now.saturating_sub(*ts) < 3600 {
+                return models.clone();
+            }
         }
 
-        match std::process::Command::new("opencode")
-            .args(["models"])
-            .output()
+        // Not cached or expired — perform discovery and refresh the cache.
+        let discovered = if !crate::cmd_cache::command_exists("opencode") {
+            tracing::debug!("opencode not in PATH — skipping free model discovery");
+            Vec::new()
+        } else {
+            match std::process::Command::new("opencode")
+                .args(["models"])
+                .output()
+            {
+                Ok(output) if output.status.success() => {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    stdout
+                        .lines()
+                        .filter(|l| l.contains("free"))
+                        .map(|l| l.trim().to_string())
+                        .filter(|l| !l.is_empty())
+                        .map(|l| RouterConfig::normalize_model_identifier(&l))
+                        .collect()
+                }
+                Ok(output) => {
+                    tracing::debug!(status = ?output.status, "opencode models command failed");
+                    Vec::new()
+                }
+                Err(e) => {
+                    tracing::debug!(error = %e, "failed to run opencode models");
+                    Vec::new()
+                }
+            }
+        };
+
+        // Update cache with current timestamp (even if empty) so we don't hammer I/O.
         {
-            Ok(output) if output.status.success() => {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                stdout
-                    .lines()
-                    .filter(|l| l.contains("free"))
-                    .map(|l| l.trim().to_string())
-                    .filter(|l| !l.is_empty())
-                    .map(|l| RouterConfig::normalize_model_identifier(&l))
-                    .collect()
-            }
-            Ok(output) => {
-                tracing::debug!(status = ?output.status, "opencode models command failed");
-                vec![]
-            }
-            Err(e) => {
-                tracing::debug!(error = %e, "failed to run opencode models");
-                vec![]
-            }
+            let mut guard = cache.lock().unwrap();
+            *guard = (now, discovered.clone());
         }
+
+        discovered
     }
 
     /// Run the pre-emptive health check, refreshing the degraded-agent set.


### PR DESCRIPTION
## Summary

Add a 1-hour in-process cache for discovered OpenCode free models to avoid repeated blocking I/O during router initialization/reload. Committed the change and ran formatting + tests locally.

### What was done

- Added a 1-hour cache around Router::discover_free_opencode_models() to avoid repeatedly invoking the blocking `opencode models` command.
- Implemented cache using a static OnceLock<Mutex<(timestamp, Vec<String>)>> and refreshed it on expiry (3600s).
- Ensured cache is updated even when discovery returns an empty list (avoids hammering I/O on repeated failures).
- Ran rustfmt and committed the change (single commit).
- Ran the test suite locally to validate (most tests passed).


### Remaining

- Please run CI (full pipeline) — my local test run reported a few unrelated failing tests intermittently (see 'blockers' and 'reason' for details).
- If CI shows failures related to this change, I will iterate — otherwise this is ready for review and merge.


Closes #1597

---
*Task #1597 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*