### PR TITLE
panic risk: unwrap() on Mutex lock in router free-model cache

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -272,7 +272,7 @@ impl Router {
         let now = chrono::Utc::now().timestamp();
         // If cached and not expired (1 hour), return cached copy.
         {
-            let guard = cache.lock().unwrap();
+            let guard = cache.lock().unwrap_or_else(|e| e.into_inner());
             let (ts, models) = &*guard;
             if *ts != 0 && now.saturating_sub(*ts) < 3600 {
                 return models.clone();
@@ -311,7 +311,7 @@ impl Router {
 
         // Update cache with current timestamp (even if empty) so we don't hammer I/O.
         {
-            let mut guard = cache.lock().unwrap();
+            let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
             *guard = (now, discovered.clone());
         }
 


### PR DESCRIPTION
## Summary

I can see the issue. The code uses `.unwrap()` on `Mutex::lock()` at lines 275 and 314, which will panic if the mutex becomes poisoned. Let me check if there are existing patterns in the codebase for handling this.I can see the established pattern in the codebase: production code uses `.unwrap_or_else(|e| e.into_inner())` to handle poisoned mutexes gracefully (e.g., `src/engine/cooldown.rs:118`, `src/engine/sync.rs:275`, `src/engine/tick.rs:962`). The `.unwrap()` calls are only in test code.

No

Closes #1602

---
*Task #1602 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*