### PR TITLE
bug: stale tmux session detection prevents dispatch (existing session check too permissive)

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -973,13 +973,65 @@ pub(crate) async fn tick_dispatch_tasks(
 
         // Check if already running (has active session)
         let session_name = tmux.session_name(repo, &task.id.0);
-        if tmux.session_exists(&session_name).await {
-            tracing::warn!(
-                task_id = task.id.0,
-                session_name,
-                "task has existing tmux session, skipping dispatch"
-            );
-            continue; // dispatch_guard drops here, removing the key
+        let health = tmux.check_session_health(&session_name).await;
+
+        if health.exists {
+            if health.is_healthy() {
+                // Session is alive and well - skip dispatch
+                tracing::warn!(
+                    task_id = task.id.0,
+                    session_name,
+                    "task has active tmux session, skipping dispatch"
+                );
+                continue; // dispatch_guard drops here, removing the key
+            } else {
+                // Session exists but appears dead/orphaned - reclaim it
+                let now = SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                let age_secs = health.age_secs(now);
+                let idle_secs = health.idle_secs(now);
+
+                tracing::warn!(
+                    task_id = task.id.0,
+                    session_name,
+                    pane_alive = health.pane_alive,
+                    age_secs = age_secs,
+                    idle_secs = idle_secs,
+                    "task has orphaned tmux session (dead pane), killing and reclaiming"
+                );
+
+                // Kill the orphaned session and allow dispatch to proceed
+                if let Err(e) = tmux.kill_session(&session_name).await {
+                    tracing::warn!(
+                        task_id = task.id.0,
+                        session_name,
+                        error = %e,
+                        "failed to kill orphaned tmux session, skipping dispatch"
+                    );
+                    continue; // dispatch_guard drops here
+                }
+
+                // Give tmux a moment to clean up
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+                // Verify the session is actually gone
+                if tmux.session_exists(&session_name).await {
+                    tracing::warn!(
+                        task_id = task.id.0,
+                        session_name,
+                        "orphaned session still exists after kill, skipping dispatch"
+                    );
+                    continue; // dispatch_guard drops here
+                }
+
+                tracing::info!(
+                    task_id = task.id.0,
+                    session_name,
+                    "successfully reclaimed orphaned session, proceeding with dispatch"
+                );
+            }
         }
 
         // Try to acquire a slot

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -26,6 +26,39 @@ pub struct TmuxManager {
     prefix: String,
 }
 
+/// Info about session health for dispatch decisions.
+#[derive(Debug, Clone)]
+pub struct SessionHealth {
+    pub exists: bool,
+    pub pane_alive: bool,
+    pub created_at: Option<u64>,
+    pub last_activity: Option<u64>,
+}
+
+impl SessionHealth {
+    /// Returns true if the session is healthy and should prevent dispatch.
+    pub fn is_healthy(&self) -> bool {
+        self.exists && self.pane_alive
+    }
+
+    /// Returns true if the session appears dead/orphaned and can be reclaimed.
+    #[allow(dead_code)]
+    pub fn is_orphaned(&self) -> bool {
+        self.exists && !self.pane_alive
+    }
+
+    /// Returns the session age in seconds, if creation time is available.
+    pub fn age_secs(&self, now: u64) -> Option<u64> {
+        self.created_at.map(|created| now.saturating_sub(created))
+    }
+
+    /// Returns the idle time in seconds since last activity, if available.
+    pub fn idle_secs(&self, now: u64) -> Option<u64> {
+        self.last_activity
+            .map(|activity| now.saturating_sub(activity))
+    }
+}
+
 impl TmuxManager {
     pub fn new() -> Self {
         Self {
@@ -171,6 +204,64 @@ impl TmuxManager {
                 flag.trim() == "0" // 0 = alive, 1 = dead
             }
             _ => false,
+        }
+    }
+
+    /// Check comprehensive session health for dispatch decisions.
+    ///
+    /// This checks:
+    /// - Session existence (via has-session)
+    /// - Pane liveness (pane_dead flag)
+    /// - Session creation time
+    /// - Last activity time
+    ///
+    /// Returns a SessionHealth struct with all info needed for dispatch decisions.
+    pub async fn check_session_health(&self, session: &str) -> SessionHealth {
+        // First check if session exists at all
+        let exists = self.session_exists(session).await;
+        if !exists {
+            return SessionHealth {
+                exists: false,
+                pane_alive: false,
+                created_at: None,
+                last_activity: None,
+            };
+        }
+
+        // Get pane status, creation time, and activity in one call
+        let output = Command::new("tmux")
+            .args([
+                "list-panes",
+                "-t",
+                session,
+                "-F",
+                "#{pane_dead} #{session_created} #{session_activity}",
+            ])
+            .output_with_context()
+            .await;
+
+        match output {
+            Ok(o) if o.status.success() => {
+                let stdout = String::from_utf8_lossy(&o.stdout);
+                let parts: Vec<&str> = stdout.split_whitespace().collect();
+
+                let pane_alive = parts.first().map(|&s| s == "0").unwrap_or(false);
+                let created_at = parts.get(1).and_then(|s| s.parse::<u64>().ok());
+                let last_activity = parts.get(2).and_then(|s| s.parse::<u64>().ok());
+
+                SessionHealth {
+                    exists: true,
+                    pane_alive,
+                    created_at,
+                    last_activity,
+                }
+            }
+            _ => SessionHealth {
+                exists: true,
+                pane_alive: false,
+                created_at: None,
+                last_activity: None,
+            },
         }
     }
 


### PR DESCRIPTION
## Summary

I've fixed the stale tmux session detection bug. Here's a summary of the changes:

## Changes Made

### 1. `src/tmux.rs` — Added `SessionHealth` struct and `check_session_health` method

- Added `SessionHealth` struct to hold comprehensive session health info:
  - `exists`: whether the session exists
  - `pane_alive`: whether the pane has an active process
  - `created_at`: session creation timestamp
  - `last_activity`: last activity timestamp

- Added helper methods:
  - `is_healthy()`: retu

Closes #1608

---
*Task #1608 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*