### PR TITLE
bug: push failures skip PR creation (response_handler doesn't surface or persist push errors)

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -85,7 +85,11 @@ fn serialize_parsed_response(
 fn classify_run_outcome(
     status: &str,
     parse_result: &Result<agents::ParsedResponse, agents::AgentError>,
+    push_failed: bool,
 ) -> &'static str {
+    if push_failed {
+        return "push_failed";
+    }
     match parse_result {
         Err(agents::AgentError::Timeout { .. }) => "timeout",
         Err(agents::AgentError::RateLimit { .. }) => "rate_limit",
@@ -173,6 +177,7 @@ struct RunAuditInput<'a> {
     started_at: &'a chrono::DateTime<Utc>,
     error_override: Option<String>,
     elapsed_secs: Option<u64>,
+    push_failed: bool,
 }
 
 fn parse_success_output(
@@ -287,7 +292,8 @@ impl TaskRunner {
             stdout: input.raw_stdout.to_string(),
             stderr: input.raw_stderr.to_string(),
             parsed_response: serialize_parsed_response(input.parse_result, input.raw_stdout),
-            outcome: classify_run_outcome(input.status, input.parse_result).to_string(),
+            outcome: classify_run_outcome(input.status, input.parse_result, input.push_failed)
+                .to_string(),
             error,
             input_tokens,
             output_tokens,
@@ -424,6 +430,7 @@ impl TaskRunner {
                         started_at,
                         error_override: Some(format!("silence detection set task to {status_str}")),
                         elapsed_secs: session_output.elapsed_secs,
+                        push_failed: false,
                     })
                     .await;
                 return Ok(Some(RunExecution {
@@ -505,9 +512,9 @@ impl TaskRunner {
         );
 
         // Handle outcome: success or error recovery
-        let final_status = match parse_result {
+        let (final_status, _budget_exceeded, push_failed) = match parse_result {
             Ok(ref parsed) => {
-                let (status, budget_exceeded) = response_handler::handle_success(
+                let (status, budget_exceeded, push_failed) = response_handler::handle_success(
                     task_id,
                     parsed.clone(),
                     &init.wt,
@@ -532,6 +539,7 @@ impl TaskRunner {
                             started_at,
                             error_override: None,
                             elapsed_secs: session_output.elapsed_secs,
+                            push_failed,
                         })
                         .await;
                     return Ok(Some(RunExecution {
@@ -540,7 +548,7 @@ impl TaskRunner {
                         audit,
                     }));
                 }
-                status
+                (status, budget_exceeded, push_failed)
             }
             Err(ref agent_err) => {
                 match fallback::handle_error(
@@ -569,6 +577,7 @@ impl TaskRunner {
                                 started_at,
                                 error_override: Some(agent_err.to_string()),
                                 elapsed_secs: session_output.elapsed_secs,
+                                push_failed: false,
                             })
                             .await;
                         return Ok(Some(RunExecution {
@@ -577,7 +586,7 @@ impl TaskRunner {
                             audit,
                         }));
                     }
-                    fallback::ErrorHandleResult::Continue { status } => status,
+                    fallback::ErrorHandleResult::Continue { status } => (status, false, false),
                 }
             }
         };
@@ -588,7 +597,7 @@ impl TaskRunner {
         // For no-op done tasks (agent finished with no code changes and no PR),
         // clean up the worktree and branch immediately — tmux session is already
         // dead so the tmux guard won't block removal.
-        if final_status == "done" {
+        if final_status.as_str() == "done" {
             if let Some(ref st) = self.store {
                 if let Err(e) =
                     crate::engine::cleanup::cleanup_task_worktree(task_id, &self.repo, st).await
@@ -609,11 +618,12 @@ impl TaskRunner {
                 started_at,
                 error_override: None,
                 elapsed_secs: session_output.elapsed_secs,
+                push_failed,
             })
             .await;
 
         Ok(Some(RunExecution {
-            status: final_status,
+            status: final_status.to_string(),
             exit_code: Some(session_output.exit_code),
             audit,
         }))

--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -89,8 +89,9 @@ pub fn write_result_json(
 
 /// Handle a successful agent response: commit, push, PR, delegations, tokens, budget.
 ///
-/// Returns `Ok((status, budget_exceeded))` where `status` is the final task status
-/// string and `budget_exceeded` is `true` if `run()` should return early.
+/// Returns `Ok((status, budget_exceeded, push_failed))` where `status` is the final task status
+/// string, `budget_exceeded` is `true` if `run()` should return early, and `push_failed`
+/// is `true` when a push was attempted but failed (for audit trail classification).
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_success(
     task_id: &str,
@@ -102,7 +103,7 @@ pub async fn handle_success(
     new_attempts: u32,
     repo: &str,
     store: &Option<Arc<TaskStore>>,
-) -> anyhow::Result<(String, bool)> {
+) -> anyhow::Result<(String, bool, bool)> {
     let resp = parsed.response;
     tracing::info!(
         task_id,
@@ -362,19 +363,18 @@ pub async fn handle_success(
     // If agent said "done", no PR, but has delegations — blocked on children.
     let has_delegations = !resp.delegations.is_empty();
 
-    // Track push failures — block after 3 consecutive failures
-    // Check if push was attempted but failed: agent said done, tried to push, but has_pushed is still false
-    // and last_error contains a push failure. Only count when there were commits to push.
+    // Track push failures — block after 3 consecutive failures.
+    // Check if push was attempted but failed: tried to push (has_commits),
+    // but has_pushed is still false and last_error contains a push failure.
+    // Applies regardless of agent-reported status — push failures must be
+    // surfaced so task_runs records them correctly and the task is rerouted.
     // Read last_error once (reuse the value read earlier if available)
     let stored_last_error = store::opt_store_get_task(store, repo, task_id)
         .await
         .map(|t| t.last_error)
         .unwrap_or_default();
 
-    let push_failed = resp.status == "done"
-        && !has_pushed
-        && has_commits
-        && stored_last_error.contains("push failed");
+    let push_failed = !has_pushed && has_commits && stored_last_error.contains("push failed");
 
     // Determine whether this external task can be marked done without a PR.
     // External tasks with code-related labels must have a merged PR before
@@ -583,7 +583,7 @@ pub async fn handle_success(
             ],
         )
         .await;
-        return Ok((budget_status.to_string(), true)); // signal early return to caller
+        return Ok((budget_status.to_string(), true, push_failed)); // signal early return to caller
     } else if total_tokens > warning_threshold {
         let pct = (total_tokens as f64 / max_tokens as f64 * 100.0) as u32;
         tracing::warn!(
@@ -608,7 +608,7 @@ pub async fn handle_success(
 
     // Note: done → in_review transition is handled by the engine
     // after triggering the review agent (engine/mod.rs)
-    Ok((final_status.to_string(), false))
+    Ok((final_status.to_string(), false, push_failed))
 }
 
 /// Labels that indicate a task is non-code and can be marked done without a PR.


### PR DESCRIPTION
## Summary

Now I understand the issue. Let me trace the bug:

1. When push fails, `last_error` is set and PR creation is skipped (line 246-247)
2. The `push_failed` check at line 374-377 only triggers when `resp.status == "done"`
3. If the agent said "in_progress" or "needs_review", push failure is silently swallowed — status remains a "success" status, and `task_runs` records `outcome: "success"`

The fix has two parts:
1. **`response_handler.rs`**: Remove the `resp.status == "done"` requirement from th

Closes #1609

---
*Task #1609 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*