### PR TITLE
fix: ReviewDecision::Blocked recorded as "success" in run audit trail

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1361,7 +1361,7 @@ pub(crate) async fn review_and_merge(
             ReviewDecision::Approve => "success",
             ReviewDecision::RequestChanges { .. } => "success",
             ReviewDecision::Failed(_) => "failed",
-            ReviewDecision::Blocked(_) => "success",
+            ReviewDecision::Blocked(_) => "failed",
             ReviewDecision::Skipped => "success",
         };
         let error = match &decision {


### PR DESCRIPTION
## Summary

Fixed. Changed `ReviewDecision::Blocked(_)` from `"success"` to `"failed"` at `src/engine/review.rs:1364`.

Closes #1629

---
*Task #1629 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*