### PR TITLE
fix: "no changes" and "the commit" cause false-positive done-detection in synthesize_response_from_text

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -281,7 +281,6 @@ pub fn synthesize_response_from_text(text: &str) -> Option<AgentResponse> {
     // Strong explicit completion phrases. These are high-confidence indicators
     // that the agent performed an action (filed issues, created commits, etc.).
     let explicit_done = [
-        "no changes",
         "nothing to",
         "nothing to do",
         "nothing to execute",
@@ -290,6 +289,7 @@ pub fn synthesize_response_from_text(text: &str) -> Option<AgentResponse> {
         "no trades",
         "no trade",
         "no action needed",
+        "no changes to commit",
         "completed",
         // Action/issue completion phrases
         "filed",
@@ -307,7 +307,6 @@ pub fn synthesize_response_from_text(text: &str) -> Option<AgentResponse> {
         "comment posted",
         "changes committed",
         "commit created",
-        "the commit",
         // Agent completion phrases (regression: #1362/#1363)
         "the fix is complete",
         "fix is working",
@@ -1270,7 +1269,7 @@ mod tests {
     #[test]
     fn synthesize_response_marks_done_for_commit_created() {
         let response = synthesize_response_from_text(
-            "The commit is created locally. The push is being blocked by permissions.",
+            "Commit created locally. The push is being blocked by permissions.",
         )
         .unwrap();
         assert_eq!(response.status, "done");


### PR DESCRIPTION
## Summary

Let me look at the tests for this function and understand the full context:Let me look at the relevant tests:Now I have the full picture. Let me make the three changes:

1. Remove `"the commit"` from `explicit_done`
2. Replace `"no changes"` with `"no changes to commit"`
3. The `looks_negative` veto is already applied on line 376: `let looks_done = !looks_negative && (explicit_done || done_confident);` — this already covers `explicit_done`, so no change needed there.Now let me check the test a

Closes #1630

---
*Task #1630 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*