### PR TITLE
bug: orch chat can't find session

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -683,7 +683,7 @@ pub async fn send_message(
     let (session_uuid, is_new) = get_or_create_session_uuid(store, session_id).await?;
 
     // Invoke agent one-shot with --session-id (new) or --resume (existing) for conversation continuity
-    let result = invoke_agent_with_session(
+    let result = match invoke_agent_with_session(
         &agent,
         &model,
         &ctx.system,
@@ -691,7 +691,38 @@ pub async fn send_message(
         Some(&session_uuid),
         !is_new,
     )
-    .await?;
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            // If the session UUID has expired server-side, reset it and retry
+            // with a fresh session. This handles the "No conversation found with
+            // session ID: <uuid>" error that Claude returns when a session expires.
+            // The AgentError is converted to a string by anyhow::bail! in direct.rs,
+            // so we match on the Display representation of StaleSession.
+            let is_stale = e.to_string().contains("stale session");
+            if is_stale {
+                tracing::info!(
+                    session_id,
+                    "chat session UUID expired; resetting and retrying with fresh session"
+                );
+                reset_session_uuid(store, session_id).await?;
+                // Fresh invocation — no resume, generates a new UUID
+                let (fresh_uuid, _) = get_or_create_session_uuid(store, session_id).await?;
+                invoke_agent_with_session(
+                    &agent,
+                    &model,
+                    &ctx.system,
+                    &full_message,
+                    Some(&fresh_uuid),
+                    false, // not resuming — new session
+                )
+                .await?
+            } else {
+                return Err(e);
+            }
+        }
+    };
 
     // Parse response for summary and memory tags
     let parsed = parse_response(&result.text);

--- a/src/engine/runner/agents/claude.rs
+++ b/src/engine/runner/agents/claude.rs
@@ -101,6 +101,11 @@ impl ClaudeRunner {
 
         if is_error {
             // Classify the error from the result text.
+            // Check stale session first — it requires a targeted recovery action
+            // (reset UUID + retry) that is distinct from generic agent failures.
+            if let Some(e) = super::patterns::detect_stale_session(result_text) {
+                return Err(e);
+            }
             // Check auth before rate_limit — billing errors (credit balance)
             // are auth issues, not transient rate limits.
             let combined = format!("{result_text} {}", raw);

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -171,6 +171,11 @@ pub enum AgentError {
     PermissionDenied { message: String },
     /// Agent is waiting for interactive input (e.g., 1Password, SSH).
     WaitingForInput { message: String },
+    /// The agent's session ID is no longer valid (session expired or was cleared).
+    ///
+    /// Returned when Claude reports "No conversation found with session ID: <uuid>".
+    /// The caller should reset the stored UUID and retry with a fresh `--session-id`.
+    StaleSession { session_id: String },
     /// Agent returned unparseable output.
     InvalidResponse { raw: String },
     /// Agent self-reported a failure in its response.
@@ -194,6 +199,9 @@ impl std::fmt::Display for AgentError {
             Self::MissingTool { tool } => write!(f, "missing tool: {tool}"),
             Self::PermissionDenied { message } => write!(f, "permission denied: {message}"),
             Self::WaitingForInput { message } => write!(f, "waiting for input: {message}"),
+            Self::StaleSession { session_id } => {
+                write!(f, "stale session (session expired): {session_id}")
+            }
             Self::InvalidResponse { raw } => {
                 let end = truncate_at_char_boundary(raw, 200);
                 write!(f, "invalid response: {}", &raw[..end])
@@ -221,6 +229,7 @@ pub fn error_class_name(err: &AgentError) -> &'static str {
         AgentError::MissingTool { .. } => "MissingTool",
         AgentError::PermissionDenied { .. } => "PermissionDenied",
         AgentError::WaitingForInput { .. } => "WaitingForInput",
+        AgentError::StaleSession { .. } => "StaleSession",
         AgentError::InvalidResponse { .. } => "InvalidResponse",
         AgentError::AgentFailed { .. } => "AgentFailed",
         AgentError::NetworkError { .. } => "NetworkError",
@@ -882,6 +891,28 @@ pub(crate) mod patterns {
         None
     }
 
+    /// Check for a stale/expired Claude session ID.
+    ///
+    /// Claude returns `"No conversation found with session ID: <uuid>"` when
+    /// the session UUID stored in orch's KV has expired server-side. The caller
+    /// should reset the stored UUID and retry with a fresh `--session-id`.
+    pub fn detect_stale_session(text: &str) -> Option<AgentError> {
+        // Case-insensitive match; extract the UUID if present.
+        let lower = text.to_lowercase();
+        if let Some(pos) = lower.find("no conversation found with session id") {
+            // Try to extract the UUID that follows the colon.
+            let after = &text[pos..];
+            let session_id = after
+                .split_once(':')
+                .map(|(_, rest)| rest.trim())
+                // Take only the UUID portion (up to whitespace or end)
+                .map(|s| s.split_whitespace().next().unwrap_or("").to_string())
+                .unwrap_or_default();
+            return Some(AgentError::StaleSession { session_id });
+        }
+        None
+    }
+
     /// Exit code returned by `timeout(1)` when the child is killed.
     const TIMEOUT_EXIT_CODE: i32 = 124;
 
@@ -1097,6 +1128,35 @@ mod tests {
         assert!(patterns::detect_waiting_for_input("Enter passphrase for key").is_some());
         assert!(patterns::detect_waiting_for_input("1Password CLI required").is_some());
         assert!(patterns::detect_waiting_for_input("done").is_none());
+    }
+
+    #[test]
+    fn pattern_detect_stale_session() {
+        // Exact error message from Claude
+        let err = patterns::detect_stale_session(
+            "No conversation found with session ID: 2be572c4-57bb-4f86-bc03-b593c329177c",
+        );
+        assert!(err.is_some(), "should detect stale session");
+        if let Some(AgentError::StaleSession { session_id }) = err {
+            assert_eq!(session_id, "2be572c4-57bb-4f86-bc03-b593c329177c");
+        }
+
+        // Case-insensitive
+        let err = patterns::detect_stale_session("no conversation found with session id: abc-123");
+        assert!(err.is_some(), "should detect lowercase variant");
+
+        // Non-matching text
+        assert!(patterns::detect_stale_session("all good").is_none());
+        assert!(patterns::detect_stale_session("conversation started").is_none());
+    }
+
+    #[test]
+    fn stale_session_display() {
+        let e = AgentError::StaleSession {
+            session_id: "abc-123".to_string(),
+        };
+        assert!(e.to_string().contains("stale session"));
+        assert!(e.to_string().contains("abc-123"));
     }
 
     #[test]

--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -214,6 +214,15 @@ pub async fn handle_error(
                 status: "routed".to_string(),
             });
         }
+        agents::AgentError::StaleSession { session_id } => {
+            // Stale session errors only occur in the orch chat control session, not
+            // in task runners (tasks don't use --session-id / --resume). Treat as a
+            // generic agent failure so the task is retried from scratch.
+            (
+                response::RetryableError::Failed,
+                format!("{agent_name} stale session: {session_id}"),
+            )
+        }
         agents::AgentError::Unknown { exit_code, message } => {
             // Exit 0 with empty output is a silent failure (common with GitHub
             // Copilot models in opencode).  Record a model-specific cooldown so


### PR DESCRIPTION
## Summary

Let me analyze this bug. The error message indicates that `orch chat` is trying to reuse a Claude session ID that no longer exists.Now I have a clear picture of the bug. Let me implement the fix:Now I have a clear picture. Let me look at the `direct.rs` file to understand the error flow and then implement the fix:Now I have all the context I need. The fix requires two changes:

1. **Add a `detect_stale_session` pattern** in `src/engine/runner/agents/mod.rs` 
2. **Add stale session retry logic** 

Closes #1635

---
*Task #1635 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*