### PR TITLE
bug: Telegram still timeout

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -10,7 +10,8 @@ use serde::Deserialize;
 use std::time::Duration;
 
 const TELEGRAM_LONG_POLL_TIMEOUT_SECS: u64 = 30;
-const TELEGRAM_HTTP_TIMEOUT_SECS: u64 = TELEGRAM_LONG_POLL_TIMEOUT_SECS + 5;
+const TELEGRAM_HTTP_TIMEOUT_SECS: u64 = TELEGRAM_LONG_POLL_TIMEOUT_SECS + 15;
+const TELEGRAM_MAX_RETRIES: u32 = 3;
 const _: () = assert!(TELEGRAM_HTTP_TIMEOUT_SECS > TELEGRAM_LONG_POLL_TIMEOUT_SECS);
 
 pub struct TelegramChannel {
@@ -92,20 +93,43 @@ impl TelegramChannel {
             "allowed_updates": ["message", "callback_query"]
         });
 
-        let response = self.client.post(&url).json(&params).send().await?;
+        let mut last_err = None;
+        for attempt in 0..TELEGRAM_MAX_RETRIES {
+            let response = match self.client.post(&url).json(&params).send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    last_err = Some(e);
+                    if attempt + 1 < TELEGRAM_MAX_RETRIES {
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                        continue;
+                    }
+                    anyhow::bail!(
+                        "telegram getUpdates failed after {} attempts: {:?}",
+                        TELEGRAM_MAX_RETRIES,
+                        last_err.unwrap()
+                    );
+                }
+            };
 
-        if !response.status().is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("telegram API error: {}", body);
+            if !response.status().is_success() {
+                let body = response.text().await.unwrap_or_default();
+                anyhow::bail!("telegram API error: {}", body);
+            }
+
+            let updates: GetUpdatesResponse = response.json().await?;
+
+            if !updates.ok {
+                anyhow::bail!("telegram API returned ok=false");
+            }
+
+            return Ok(updates.result);
         }
 
-        let updates: GetUpdatesResponse = response.json().await?;
-
-        if !updates.ok {
-            anyhow::bail!("telegram API returned ok=false");
-        }
-
-        Ok(updates.result)
+        anyhow::bail!(
+            "telegram getUpdates failed after {} attempts: {:?}",
+            TELEGRAM_MAX_RETRIES,
+            last_err.unwrap()
+        );
     }
 
     async fn send_message(


### PR DESCRIPTION
## Summary

Fixed Telegram timeout issue by increasing HTTP client timeout margin and adding retry logic to getUpdates requests

### What was done

- Increased HTTP client timeout margin from 5s to 15s above the 30s long-poll timeout (now 45s total) to accommodate network latency and TLS handshake delays
- Added retry logic with up to 3 attempts and 2s backoff between retries for getUpdates requests before reporting errors
- Code compiles successfully (cargo check --lib passed)
- Changes committed with conventional commit message


Closes #1639

---
*Task #1639 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*