### PR TITLE
fix: incorrect bit shift cap in send_with_retries causing suboptimal backoff

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -477,8 +477,9 @@ impl GhHttp {
 
                         if attempt + 1 < attempts {
                             // Exponential backoff (2^attempt * base), capped
-                            // Cap exponent at 62 to prevent overflow when attempt >= 64
-                            let exp = 1u64.checked_shl(attempt.min(62)).unwrap_or(u64::MAX);
+                            // Cap exponent at 63 to prevent shifting by >=64 which is undefined
+                            // for u64; valid shift amounts are 0..=63.
+                            let exp = 1u64.checked_shl(attempt.min(63)).unwrap_or(u64::MAX);
                             let mut backoff = base_secs.saturating_mul(exp);
                             if backoff > max_secs {
                                 backoff = max_secs;
@@ -508,8 +509,9 @@ impl GhHttp {
                     tracing::warn!(err = %e, attempt, "HTTP send failed, will retry if attempts remain");
                     last_err = Some(anyhow::anyhow!("HTTP send failed: {}", e));
                     if attempt + 1 < attempts {
-                        // Cap exponent at 62 to prevent overflow when attempt >= 64
-                        let exp = 1u64.checked_shl(attempt.min(62)).unwrap_or(u64::MAX);
+                        // Cap exponent at 63 to prevent shifting by >=64 which is undefined
+                        // for u64; valid shift amounts are 0..=63.
+                        let exp = 1u64.checked_shl(attempt.min(63)).unwrap_or(u64::MAX);
                         let backoff = base_secs.saturating_mul(exp);
                         let sleep_dur = Duration::from_secs(backoff)
                             + Duration::from_millis((attempt as u64 * 100).min(1000));


### PR DESCRIPTION
## Summary

Fix cap on bit shift in exponential backoff to use 63 (valid for u64) instead of 62.

### What was done

- Inspected src/github/http.rs and located the exponential backoff logic in send_with_retries
- Replaced incorrect shift cap of 62 with 63 in both places where checked_shl was used
- Ran formatting and clippy checks locally to ensure no regressions introduced


### Remaining

- No further code changes required for this issue. Consider increasing tests that exercise high attempt counts if desired.


Closes #1642

---
*Task #1642 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*