### PR TITLE
fix: incorrect bit shift cap in send_with_retries causing suboptimal backoff

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -477,8 +477,8 @@ impl GhHttp {
 
                         if attempt + 1 < attempts {
                             // Exponential backoff (2^attempt * base), capped
-                            // Cap exponent at 62 to prevent overflow when attempt >= 64
-                            let exp = 1u64.checked_shl(attempt.min(62)).unwrap_or(u64::MAX);
+                            // Cap exponent at 63 to prevent overflow when attempt >= 64
+                            let exp = 1u64.checked_shl(attempt.min(63)).unwrap_or(u64::MAX);
                             let mut backoff = base_secs.saturating_mul(exp);
                             if backoff > max_secs {
                                 backoff = max_secs;
@@ -508,8 +508,8 @@ impl GhHttp {
                     tracing::warn!(err = %e, attempt, "HTTP send failed, will retry if attempts remain");
                     last_err = Some(anyhow::anyhow!("HTTP send failed: {}", e));
                     if attempt + 1 < attempts {
-                        // Cap exponent at 62 to prevent overflow when attempt >= 64
-                        let exp = 1u64.checked_shl(attempt.min(62)).unwrap_or(u64::MAX);
+                        // Cap exponent at 63 to prevent overflow when attempt >= 64
+                        let exp = 1u64.checked_shl(attempt.min(63)).unwrap_or(u64::MAX);
                         let backoff = base_secs.saturating_mul(exp);
                         let sleep_dur = Duration::from_secs(backoff)
                             + Duration::from_millis((attempt as u64 * 100).min(1000));


### PR DESCRIPTION
## Summary

Fixed the incorrect bit shift cap in `src/github/http.rs`. Changed both occurrences from `attempt.min(62)` to `attempt.min(63)` (lines 481 and 512), allowing the exponential backoff to use the full valid range for u64 shifts (0-63).

Closes #1645

---
*Task #1645 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*