### PR TITLE
fix: incorrect bit shift cap in send_with_retries causing suboptimal backoff

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -477,8 +477,8 @@ impl GhHttp {
 
                         if attempt + 1 < attempts {
                             // Exponential backoff (2^attempt * base), capped
-                            // Cap exponent at 62 to prevent overflow when attempt >= 64
-                            let exp = 1u64.checked_shl(attempt.min(62)).unwrap_or(u64::MAX);
+                            // Cap exponent at 63 to prevent overflow when attempt >= 64
+                            let exp = 1u64.checked_shl(attempt.min(63)).unwrap_or(u64::MAX);
                             let mut backoff = base_secs.saturating_mul(exp);
                             if backoff > max_secs {
                                 backoff = max_secs;
@@ -508,8 +508,8 @@ impl GhHttp {
                     tracing::warn!(err = %e, attempt, "HTTP send failed, will retry if attempts remain");
                     last_err = Some(anyhow::anyhow!("HTTP send failed: {}", e));
                     if attempt + 1 < attempts {
-                        // Cap exponent at 62 to prevent overflow when attempt >= 64
-                        let exp = 1u64.checked_shl(attempt.min(62)).unwrap_or(u64::MAX);
+                        // Cap exponent at 63 to prevent overflow when attempt >= 64
+                        let exp = 1u64.checked_shl(attempt.min(63)).unwrap_or(u64::MAX);
                         let backoff = base_secs.saturating_mul(exp);
                         let sleep_dur = Duration::from_secs(backoff)
                             + Duration::from_millis((attempt as u64 * 100).min(1000));


### PR DESCRIPTION
## Summary

Fixed the bit shift cap in `src/github/http.rs:481` and `:512`, changing `attempt.min(62)` to `attempt.min(63)` (and updating the associated comments). For `u64`, valid shift amounts are 0–63, so capping at 63 is correct and prevents the suboptimal backoff behavior described in #1646.

All quality gates pass:
- `cargo fmt` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo nextest run` — 2460 passed, 18 skipped

Closes #1646

---
*Task #1646 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*