### PR TITLE
Code quality review

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -475,16 +475,16 @@ impl GhHttp {
                             snippet
                         ));
 
-                        if attempt + 1 < attempts {
-                            // Exponential backoff (2^attempt * base), capped
-                            // Cap exponent at 62 to prevent overflow when attempt >= 64
-                            let exp = 1u64.checked_shl(attempt.min(62)).unwrap_or(u64::MAX);
-                            let mut backoff = base_secs.saturating_mul(exp);
-                            if backoff > max_secs {
-                                backoff = max_secs;
-                            }
-                            // Add small linear jitter to avoid synchronized retries
-                            let jitter_ms = attempt as u64 * 100;
+                         if attempt + 1 < attempts {
+                             // Exponential backoff (2^attempt * base), capped
+                             // Cap exponent at 63 to prevent undefined behavior when attempt >= 64
+                             let exp = 1u64.checked_shl(attempt.min(63)).unwrap_or(u64::MAX);
+                             let mut backoff = base_secs.saturating_mul(exp);
+                             if backoff > max_secs {
+                                 backoff = max_secs;
+                             }
+                             // Add small linear jitter to avoid synchronized retries
+                             let jitter_ms = attempt as u64 * 100;
                             let sleep_dur = Duration::from_secs(backoff)
                                 + Duration::from_millis(jitter_ms.min(1000));
                             tokio::time::sleep(sleep_dur).await;
@@ -507,15 +507,15 @@ impl GhHttp {
                     // Network/transport error — treat as transient like 5xx
                     tracing::warn!(err = %e, attempt, "HTTP send failed, will retry if attempts remain");
                     last_err = Some(anyhow::anyhow!("HTTP send failed: {}", e));
-                    if attempt + 1 < attempts {
-                        // Cap exponent at 62 to prevent overflow when attempt >= 64
-                        let exp = 1u64.checked_shl(attempt.min(62)).unwrap_or(u64::MAX);
-                        let backoff = base_secs.saturating_mul(exp);
-                        let sleep_dur = Duration::from_secs(backoff)
-                            + Duration::from_millis((attempt as u64 * 100).min(1000));
-                        tokio::time::sleep(sleep_dur).await;
-                        continue;
-                    }
+                      if attempt + 1 < attempts {
+                          // Cap exponent at 63 to prevent undefined behavior when attempt >= 64
+                          let exp = 1u64.checked_shl(attempt.min(63)).unwrap_or(u64::MAX);
+                          let backoff = base_secs.saturating_mul(exp);
+                          let sleep_dur = Duration::from_secs(backoff)
+                              + Duration::from_millis((attempt as u64 * 100).min(1000));
+                          tokio::time::sleep(sleep_dur).await;
+                          continue;
+                      }
                     // Exhausted attempts — set circuit-breaker and break so last_err is read
                     tracing::warn!(
                         "HTTP send failed after {} attempts — setting circuit-breaker",


### PR DESCRIPTION
## Summary

Fixed incorrect bit shift cap in send_with_retries function causing suboptimal exponential backoff

### What was done

- Fixed bit shift cap from 62 to 63 for u64 values in exponential backoff calculation
- Updated comments to clarify the fix prevents undefined behavior
- Applied fix to both locations in send_with_retries function in src/github/http.rs


---
*Task internal-34220 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/nemotron-3-super-free`*