### PR TITLE
bug: review prompt still tells sandboxed agents to run git fetch

### DIFF
--- a/prompts/review_task.md
+++ b/prompts/review_task.md
@@ -5,8 +5,9 @@ You are reviewing a PR created by an AI agent. Complete all steps in order (Step
 ### Step 1: Rebase onto default branch (optional)
 
 Keep the branch up to date — other PRs may have merged since this was created:
-1. Fetch remote refs and rebase onto the default branch:
-   - `git fetch origin && git rebase origin/{{DEFAULT_BRANCH}}`
+1. Rebase onto the default branch:
+   - `git rebase origin/{{DEFAULT_BRANCH}}`
+   - Orch has already run `git fetch origin` before launching you — do NOT run `git fetch` or `git pull` yourself (they will fail in sandboxed environments because they need to write outside the worktree directory). Remote refs are already available locally.
 2. If there are conflicts:
    - Resolve each conflict by understanding both sides of the change
    - `git add <resolved files>` then `git rebase --continue`


### PR DESCRIPTION
## Summary

The bug is clear. `prompts/review_task.md:8-9` tells review agents to run `git fetch origin && git rebase origin/{{DEFAULT_BRANCH}}`, but this conflicts with the worktree rules that forbid `git fetch` in sandboxed environments. The task agent prompt (`agent_system.md:50-54`) was already fixed to remove `git fetch`, but the review prompt still has the old instruction.

Let me fix `prompts/review_task.md` to match the settled workflow:Let me verify the change and then commit:Fixed. Updated `prompt

Closes #1666

---
*Task #1666 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*