### PR TITLE
bug: review reroutes treat agent stream errors as transient GitHub errors

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -49,6 +49,10 @@ fn review_started_comment(review_agent: &str, review_model: &str) -> String {
     )
 }
 
+fn should_skip_no_code_reroute_increment(last_error: &str) -> bool {
+    crate::engine::runner::git_ops::is_transient_github_api_error(last_error)
+}
+
 use crate::backends::{ExternalBackend, ExternalTask, Status};
 use crate::cmd::CommandErrorContext;
 use crate::config;
@@ -615,7 +619,7 @@ async fn ensure_pr_exists(
                 // If the last_error indicates a transient GitHub 5xx/transport error,
                 // do NOT increment the persistent reroute counter which would
                 // eventually block the task. Instead, retry later.
-                if crate::engine::runner::git_ops::is_transient_github_error(&last_error) {
+                if should_skip_no_code_reroute_increment(&last_error) {
                     tracing::warn!(
                         task_id = task.id.0,
                         last_error = %last_error,
@@ -1795,6 +1799,13 @@ mod tests {
             review_started_comment("kimi", "opus"),
             "🔍 Automated review started (agent: kimi, model: opus)"
         );
+    }
+
+    #[test]
+    fn no_code_reroute_skip_check_rejects_agent_stream_disconnects() {
+        let last_error =
+            "codex failed: Reconnecting... (stream disconnected before completion: Broken pipe)";
+        assert!(!should_skip_no_code_reroute_increment(last_error));
     }
 
     #[tokio::test]

--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -252,7 +252,7 @@ pub(crate) async fn review_open_prs(
                 // Avoid incrementing persistent reroute counters when the last
                 // store error indicates a transient GitHub 5xx/transport failure.
                 let last_error = task_info.stored.last_error.clone();
-                if crate::engine::runner::git_ops::is_transient_github_error(&last_error) {
+                if crate::engine::runner::git_ops::is_transient_github_api_error(&last_error) {
                     tracing::warn!(task_id, "transient GitHub error recorded in last_error; skipping persistent no_pr_reroutes increment and retrying later");
                     continue;
                 }

--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -723,6 +723,30 @@ pub(crate) fn is_transient_github_error(err_str: &str) -> bool {
     false
 }
 
+/// Returns true when an error looks like a transient *GitHub API/CLI* failure.
+///
+/// This is stricter than [`is_transient_github_error`]: in addition to matching
+/// a transient transport pattern, it requires GitHub-specific context in the
+/// message. This prevents generic agent/runtime transport failures (for
+/// example "broken pipe" from a model stream disconnect) from being treated as
+/// GitHub retry signals in review reroute logic.
+pub(crate) fn is_transient_github_api_error(err_str: &str) -> bool {
+    if !is_transient_github_error(err_str) {
+        return false;
+    }
+
+    if extract_github_http_status(err_str).is_some() {
+        return true;
+    }
+
+    let lower = err_str.to_lowercase();
+    lower.contains("github")
+        || lower.contains("api.github.com")
+        || lower.contains("gh api")
+        || lower.contains("gh pr")
+        || lower.contains("gh error")
+}
+
 /// Extract the HTTP status code from a GhHttp error string.
 ///
 /// GhHttp formats errors as: `"GitHub API POST https://... failed (NNN): body"`
@@ -1063,6 +1087,19 @@ mod tests {
         assert!(!is_transient_github_error("invalid argument"));
         assert!(!is_transient_github_error("authentication failed"));
         assert!(!is_transient_github_error("bad credentials"));
+    }
+
+    #[test]
+    fn is_transient_github_api_error_requires_github_context() {
+        assert!(is_transient_github_api_error(
+            "GitHub API POST https://api.github.com/repos/foo/bar/pulls failed (502): Bad Gateway"
+        ));
+        assert!(is_transient_github_api_error(
+            "gh error: transport error: connection reset by peer"
+        ));
+        assert!(!is_transient_github_api_error(
+            "codex failed: Reconnecting... (stream disconnected before completion: Broken pipe)"
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Scoped review reroute transient-error detection to GitHub-context errors so Codex stream disconnects no longer bypass `no_code_reroutes` increments, and added regression tests.

### What was done

- Added `is_transient_github_api_error()` in `src/engine/runner/git_ops.rs` to require both transient signals and GitHub context.
- Updated no-PR reroute skip logic in `src/engine/review.rs` to use the GitHub-scoped matcher via `should_skip_no_code_reroute_increment()`.
- Updated `src/engine/review_poll.rs` to use the same GitHub-scoped matcher for persistent reroute counter behavior consistency.
- Added regression tests proving `codex failed ... Broken pipe` is not treated as a transient GitHub API error and thus should not skip reroute counting.
- Ran required quality gates successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo nextest run`.


Closes #1672

---
*Task #1672 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*