### PR TITLE
bug: self-improvement agent (internal:35605) router LLM timed out after 90s

### DIFF
--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -168,7 +168,7 @@ impl Default for RouterConfig {
             mode: "llm".to_string(),
             router_agent: "claude".to_string(),
             router_model: "claude-haiku-4-5-20251001".to_string(),
-            timeout_seconds: 60,
+            timeout_seconds: 120,
             fallback_executor: "codex".to_string(),
             agents: DEFAULT_AGENTS.iter().map(|s| s.to_string()).collect(),
             max_route_attempts: 3,

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -955,19 +955,13 @@ impl Router {
                     return Ok(result);
                 }
                 Err(e) => {
-                    let is_timeout = e.to_string().contains("router LLM timed out");
                     tracing::warn!(
                         agent,
                         model = model_str,
                         error = %e,
                         "pool entry failed, recording cooldown and trying next"
                     );
-                    // Timeouts are transient performance issues, not model failures —
-                    // skip cooldown so the model is retried on the next routing attempt.
-                    if !is_timeout {
-                        crate::engine::runner::response::record_model_failure(agent, model_str)
-                            .await;
-                    }
+                    crate::engine::runner::response::record_model_failure(agent, model_str).await;
                     last_err = Some(e);
                     self.advance_pool_index_after_attempt(idx, n);
                 }
@@ -1010,22 +1004,14 @@ impl Router {
             {
                 Ok(result) => return Ok(result),
                 Err(e) => {
-                    let is_timeout = e.to_string().contains("router LLM timed out");
                     tracing::warn!(
                         agent = %fb_agent,
                         model = %fb_model_str,
                         error = %e,
                         "fallback router LLM also failed"
                     );
-                    // Timeouts are transient performance issues, not model failures —
-                    // skip cooldown so the model is retried on the next routing attempt.
-                    if !is_timeout {
-                        crate::engine::runner::response::record_model_failure(
-                            &fb_agent,
-                            fb_model_str,
-                        )
+                    crate::engine::runner::response::record_model_failure(&fb_agent, fb_model_str)
                         .await;
-                    }
                     last_err = Some(e);
                 }
             }


### PR DESCRIPTION
## Summary

Now let me understand the full picture. The issue is:

1. The router LLM times out (default 60s, but the log says 90s — probably configured to 90s)
2. When a pool entry fails, `record_model_failure(agent, model)` is called, which puts the model on cooldown
3. This is problematic for timeouts because a timeout doesn't mean the model is broken — it just means the LLM took too long

Let me look at how the router is called for internal tasks and where the `route` function is.Now I understand the

Closes #1677

---
*Task #1677 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*