### PR TITLE
bug: channel transport and capture collide across repos because they key sessions only by task_id

### DIFF
--- a/src/channels/capture.rs
+++ b/src/channels/capture.rs
@@ -10,7 +10,7 @@
 //! when they complete.
 
 use crate::channels::tmux;
-use crate::channels::transport::Transport;
+use crate::channels::transport::{session_key, Transport};
 use crate::channels::OutputChunk;
 use chrono::{DateTime, Utc};
 use sha2::{Digest, Sha256};
@@ -52,7 +52,7 @@ pub struct OutputBuffer {
 
 /// Service that captures tmux pane output and broadcasts to transport.
 pub struct CaptureService {
-    /// Session buffers keyed by task_id
+    /// Session buffers keyed by session_key(repo, task_id)
     buffers: Arc<RwLock<HashMap<String, OutputBuffer>>>,
     /// Transport layer for broadcasting output
     transport: Arc<Transport>,
@@ -73,6 +73,7 @@ impl CaptureService {
     /// Register a session to be tracked.
     pub async fn register_session(&self, repo: &str, task_id: &str, session: &str) {
         let now = Utc::now();
+        let skey = session_key(repo, task_id);
         let buffer = OutputBuffer {
             repo: repo.to_string(),
             session: session.to_string(),
@@ -85,16 +86,14 @@ impl CaptureService {
             registered_at: now,
             has_output: false,
         };
-        self.buffers
-            .write()
-            .await
-            .insert(task_id.to_string(), buffer);
+        self.buffers.write().await.insert(skey, buffer);
         tracing::debug!(repo, task_id, session, "session registered for capture");
     }
 
     /// Unregister a session (stop tracking).
-    pub async fn unregister_session(&self, task_id: &str) {
-        if let Some(buffer) = self.buffers.write().await.remove(task_id) {
+    pub async fn unregister_session(&self, repo: &str, task_id: &str) {
+        let skey = session_key(repo, task_id);
+        if let Some(buffer) = self.buffers.write().await.remove(&skey) {
             tracing::debug!(
                 repo = buffer.repo,
                 task_id = buffer.task_id,
@@ -175,14 +174,14 @@ impl CaptureService {
     /// Run one tick of the capture loop.
     async fn tick(&self) {
         let buffers = self.buffers.read().await;
-        let task_ids: Vec<String> = buffers.keys().cloned().collect();
+        let session_keys: Vec<String> = buffers.keys().cloned().collect();
         drop(buffers);
 
-        for task_id in task_ids {
+        for skey in session_keys {
             // Get buffer (reborrow for each iteration)
             let buffer = {
                 let buffers = self.buffers.read().await;
-                buffers.get(&task_id).cloned()
+                buffers.get(&skey).cloned()
             };
 
             if let Some(buffer) = buffer {
@@ -196,7 +195,7 @@ impl CaptureService {
                         // and session creation).
                         if buffer.seen_alive && tmux::is_session_dead(&buffer.session).await {
                             tracing::info!(
-                                task_id,
+                                task_id = buffer.task_id,
                                 session = buffer.session,
                                 "session ended, sending final chunk"
                             );
@@ -204,11 +203,13 @@ impl CaptureService {
                                 content: String::new(),
                                 is_final: true,
                             };
-                            self.transport.push_output(&task_id, chunk).await;
-                            self.unregister_session(&task_id).await;
+                            self.transport
+                                .push_output(&buffer.repo, &buffer.task_id, chunk)
+                                .await;
+                            self.unregister_session(&buffer.repo, &buffer.task_id).await;
                         } else {
                             tracing::trace!(
-                                task_id,
+                                task_id = buffer.task_id,
                                 session = buffer.session,
                                 ?e,
                                 "capture failed (transient)"
@@ -220,7 +221,7 @@ impl CaptureService {
 
                 let new_content = {
                     let mut buffers = self.buffers.write().await;
-                    if let Some(buf) = buffers.get_mut(&task_id) {
+                    if let Some(buf) = buffers.get_mut(&skey) {
                         buf.seen_alive = true;
                         buf.diff_and_update(&current_content)
                     } else {
@@ -233,7 +234,9 @@ impl CaptureService {
                         content: new_content,
                         is_final: false,
                     };
-                    self.transport.push_output(&task_id, chunk).await;
+                    self.transport
+                        .push_output(&buffer.repo, &buffer.task_id, chunk)
+                        .await;
                 }
             }
         }
@@ -413,8 +416,9 @@ mod tests {
         svc.register_session(repo, "silent-task", "orch-test-silent")
             .await;
         {
+            let skey = session_key(repo, "silent-task");
             let mut buffers = svc.buffers.write().await;
-            let buf = buffers.get_mut("silent-task").unwrap();
+            let buf = buffers.get_mut(&skey).unwrap();
             buf.registered_at = Utc::now() - chrono::Duration::seconds(200);
         }
 
@@ -422,8 +426,9 @@ mod tests {
         svc.register_session(repo, "active-task", "orch-test-active")
             .await;
         {
+            let skey = session_key(repo, "active-task");
             let mut buffers = svc.buffers.write().await;
-            let buf = buffers.get_mut("active-task").unwrap();
+            let buf = buffers.get_mut(&skey).unwrap();
             buf.registered_at = Utc::now() - chrono::Duration::seconds(200);
             buf.has_output = true;
         }
@@ -448,10 +453,12 @@ mod tests {
         svc.register_session("owner/repo-b", "task-b", "orch-b")
             .await;
         {
+            let skey_a = session_key("owner/repo-a", "task-a");
+            let skey_b = session_key("owner/repo-b", "task-b");
             let mut buffers = svc.buffers.write().await;
-            let buf_a = buffers.get_mut("task-a").unwrap();
+            let buf_a = buffers.get_mut(&skey_a).unwrap();
             buf_a.registered_at = Utc::now() - chrono::Duration::seconds(200);
-            let buf_b = buffers.get_mut("task-b").unwrap();
+            let buf_b = buffers.get_mut(&skey_b).unwrap();
             buf_b.registered_at = Utc::now() - chrono::Duration::seconds(200);
         }
 
@@ -467,6 +474,31 @@ mod tests {
             .await;
         assert_eq!(silent_b.len(), 1);
         assert_eq!(silent_b[0].0, "task-b");
+    }
+
+    /// Same external task ID in two repos must not collide in capture buffers.
+    #[tokio::test]
+    async fn same_task_id_different_repos_capture_buffers_isolated() {
+        let transport = Arc::new(Transport::new());
+        let svc = CaptureService::new(transport);
+
+        svc.register_session("owner/repo-a", "42", "orch-a-42")
+            .await;
+        svc.register_session("owner/repo-b", "42", "orch-b-42")
+            .await;
+
+        let skey_a = session_key("owner/repo-a", "42");
+        let skey_b = session_key("owner/repo-b", "42");
+
+        let buffers = svc.buffers.read().await;
+        let buf_a = buffers.get(&skey_a).unwrap();
+        let buf_b = buffers.get(&skey_b).unwrap();
+
+        assert_eq!(buf_a.session, "orch-a-42");
+        assert_eq!(buf_b.session, "orch-b-42");
+        assert_ne!(buf_a.session, buf_b.session);
+        assert_eq!(buf_a.repo, "owner/repo-a");
+        assert_eq!(buf_b.repo, "owner/repo-b");
     }
 
     #[test]

--- a/src/channels/stream.rs
+++ b/src/channels/stream.rs
@@ -104,11 +104,12 @@ async fn send_to_thread(
 /// This function should be spawned as a background task when a channel
 /// thread is bound to an agent session.
 pub async fn fanout_output(
+    repo: String,
     task_id: String,
     transport: Arc<Transport>,
     channels: Arc<ChannelRegistry>,
 ) {
-    let mut rx = match transport.subscribe(&task_id).await {
+    let mut rx = match transport.subscribe(&repo, &task_id).await {
         Some(r) => r,
         None => {
             tracing::debug!(task_id, "fanout: no binding for task, cannot subscribe");
@@ -131,7 +132,7 @@ pub async fn fanout_output(
 
                 if !chunk.content.is_empty() {
                     // Look up current binding to find connected threads
-                    if let Some(binding) = transport.get_binding(&task_id).await {
+                    if let Some(binding) = transport.get_binding(&repo, &task_id).await {
                         let now = Instant::now();
 
                         for thread_key in &binding.connected_threads {
@@ -172,7 +173,7 @@ pub async fn fanout_output(
 
                 if is_final {
                     // Flush all remaining buffers immediately regardless of rate limits
-                    if let Some(_binding) = transport.get_binding(&task_id).await {
+                    if let Some(_binding) = transport.get_binding(&repo, &task_id).await {
                         // Drain buffers map and send everything
                         for (thread_key, buffered) in buffers.drain() {
                             if buffered.is_empty() {
@@ -241,7 +242,7 @@ pub async fn fanout_output(
                 tokio::time::sleep(sleep_dur).await;
 
                 // After waiting, attempt to flush any buffers whose rate limit expired
-                if let Some(_binding) = transport.get_binding(&task_id).await {
+                if let Some(_binding) = transport.get_binding(&repo, &task_id).await {
                     let now = Instant::now();
                     // Collect keys to flush to avoid borrowing issues
                     let keys: Vec<String> = buffers.keys().cloned().collect();
@@ -369,17 +370,26 @@ mod tests {
 
         // Bind a task to the channel:thread so fanout knows where to send
         let task_id = "fanout-test-task";
+        let repo = "owner/test-repo";
         transport
-            .bind(task_id, "orch-fanout-test", "telegram", "thread-1", None)
+            .bind(
+                repo,
+                task_id,
+                "orch-fanout-test",
+                "telegram",
+                "thread-1",
+                None,
+            )
             .await;
 
         // Spawn the fanout_output task
         let transport_clone = transport.clone();
         let registry_clone = registry.clone();
         let task_id_str = task_id.to_string();
-        tokio::spawn(
-            async move { fanout_output(task_id_str, transport_clone, registry_clone).await },
-        );
+        let repo_str = repo.to_string();
+        tokio::spawn(async move {
+            fanout_output(repo_str, task_id_str, transport_clone, registry_clone).await
+        });
 
         // Give fanout time to subscribe to the broadcast
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -387,6 +397,7 @@ mod tests {
         // Push some output into the transport; the fanout should forward it
         transport
             .push_output(
+                repo,
                 task_id,
                 crate::channels::OutputChunk {
                     content: "hello from agent".to_string(),
@@ -398,6 +409,7 @@ mod tests {
         // Push a final chunk to force flush
         transport
             .push_output(
+                repo,
                 task_id,
                 crate::channels::OutputChunk {
                     content: "".to_string(),
@@ -446,9 +458,11 @@ mod tests {
         let registry = std::sync::Arc::new(registry);
 
         let task_id = "topic-forward-task";
+        let repo = "owner/test-repo";
         // Bind with a specific topic_id
         transport
             .bind(
+                repo,
                 task_id,
                 "orch-topic-test",
                 "telegram",
@@ -460,14 +474,16 @@ mod tests {
         let transport_clone = transport.clone();
         let registry_clone = registry.clone();
         let task_id_str = task_id.to_string();
-        tokio::spawn(
-            async move { fanout_output(task_id_str, transport_clone, registry_clone).await },
-        );
+        let repo_str = repo.to_string();
+        tokio::spawn(async move {
+            fanout_output(repo_str, task_id_str, transport_clone, registry_clone).await
+        });
 
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         transport
             .push_output(
+                repo,
                 task_id,
                 crate::channels::OutputChunk {
                     content: "topic reply".to_string(),

--- a/src/channels/transport.rs
+++ b/src/channels/transport.rs
@@ -34,6 +34,36 @@ use tokio::sync::{broadcast, RwLock};
 
 const MAX_OUTPUT_CHUNK_BYTES: usize = 64 * 1024;
 
+/// Build a globally unique session key from `(repo, task_id)`.
+///
+/// External task IDs (e.g. `"42"` for GitHub issue #42) are only unique
+/// within a repo. Internal tasks (`"internal:<id>"`) are globally unique.
+/// This function prefixes external task IDs with the repo slug to avoid
+/// collisions across repos while keeping internal task keys unchanged.
+pub fn session_key(repo: &str, task_id: &str) -> String {
+    if task_id.starts_with("internal:") {
+        task_id.to_string()
+    } else {
+        format!("{repo}:{task_id}")
+    }
+}
+
+/// Parse a session key created by [`session_key`] back into `(repo, task_id)`.
+///
+/// Returns `None` if the key is malformed.
+pub fn parse_session_key(key: &str) -> Option<(&str, &str)> {
+    if key.starts_with("internal:") {
+        // Internal tasks don't have a repo component in the key.
+        // Callers that need repo must track it separately.
+        None
+    } else {
+        // Format is "repo:task_id" — repo itself may contain "/" but not ":"
+        // The first ":" separates repo from task_id.
+        let (repo, task_id) = key.split_once(':')?;
+        Some((repo, task_id))
+    }
+}
+
 /// A live connection between a channel thread and a tmux session.
 #[derive(Debug, Clone)]
 pub struct SessionBinding {
@@ -84,13 +114,13 @@ pub fn parse_conversation_key(key: &str) -> Option<(&str, &str, Option<&str>)> {
 
 /// The transport layer manages all session bindings and routes messages.
 pub struct Transport {
-    /// Active session bindings, keyed by task_id
+    /// Active session bindings, keyed by session_key(repo, task_id)
     bindings: Arc<RwLock<HashMap<String, SessionBinding>>>,
-    /// Reverse lookup: conversation_key → task_id
+    /// Reverse lookup: conversation_key → session_key(repo, task_id)
     thread_to_task: Arc<RwLock<HashMap<String, String>>>,
     /// Broadcast sender for task completion notifications
     notification_tx: broadcast::Sender<TaskNotification>,
-    /// Last seen output per task (for PTY-backed sessions)
+    /// Last seen output per session (for PTY-backed sessions)
     last_output: Arc<RwLock<HashMap<String, String>>>,
 }
 
@@ -107,11 +137,15 @@ impl Transport {
 
     /// Bind a channel thread to a task's tmux session.
     ///
+    /// `repo` is required to build a globally unique session key, preventing
+    /// collisions when multiple repos share the same external task ID.
+    ///
     /// `topic_id` should be set for topic-aware channels (Telegram forum topics,
     /// Discord threads) so that bindings for different topics inside the same
     /// parent chat / channel do not collide.
     pub async fn bind(
         &self,
+        repo: &str,
         task_id: &str,
         tmux_session: &str,
         channel: &str,
@@ -119,13 +153,14 @@ impl Transport {
         topic_id: Option<&str>,
     ) {
         let key = conversation_key(channel, thread_id, topic_id);
+        let skey = session_key(repo, task_id);
         // Clear stale output before updating bindings to avoid holding
         // write lock across await points (deadlock risk).
-        self.clear_output(task_id).await;
+        self.clear_output(&skey).await;
         // Update bindings synchronously (no await while lock held)
         {
             let mut bindings = self.bindings.write().await;
-            let binding = bindings.entry(task_id.to_string()).or_insert_with(|| {
+            let binding = bindings.entry(skey.clone()).or_insert_with(|| {
                 let (tx, _) = broadcast::channel(256);
                 SessionBinding {
                     tmux_session: tmux_session.to_string(),
@@ -140,23 +175,26 @@ impl Transport {
             }
         } // bindings lock released here
           // Update thread_to_task after releasing bindings lock
-        self.thread_to_task
-            .write()
-            .await
-            .insert(key, task_id.to_string());
+        self.thread_to_task.write().await.insert(key, skey);
     }
 
     /// Get the broadcast receiver for a task's output stream.
-    pub async fn subscribe(&self, task_id: &str) -> Option<broadcast::Receiver<OutputChunk>> {
+    pub async fn subscribe(
+        &self,
+        repo: &str,
+        task_id: &str,
+    ) -> Option<broadcast::Receiver<OutputChunk>> {
+        let skey = session_key(repo, task_id);
         let bindings = self.bindings.read().await;
-        bindings.get(task_id).map(|b| b.output_tx.subscribe())
+        bindings.get(&skey).map(|b| b.output_tx.subscribe())
     }
 
     /// Push an output chunk to all subscribers of a task.
-    pub async fn push_output(&self, task_id: &str, chunk: OutputChunk) {
+    pub async fn push_output(&self, repo: &str, task_id: &str, chunk: OutputChunk) {
+        let skey = session_key(repo, task_id);
         if chunk.content.is_empty() {
             let bindings = self.bindings.read().await;
-            if let Some(binding) = bindings.get(task_id) {
+            if let Some(binding) = bindings.get(&skey) {
                 let _ = binding.output_tx.send(chunk.clone());
             }
             return;
@@ -171,12 +209,12 @@ impl Transport {
                 is_final: chunk.is_final && idx == last_index,
             };
             let bindings = self.bindings.read().await;
-            if let Some(binding) = bindings.get(task_id) {
+            if let Some(binding) = bindings.get(&skey) {
                 let _ = binding.output_tx.send(part_chunk.clone());
             }
             if !part_chunk.content.is_empty() {
                 let mut last = self.last_output.write().await;
-                let entry = last.entry(task_id.to_string()).or_insert_with(String::new);
+                let entry = last.entry(skey.clone()).or_insert_with(String::new);
                 entry.push_str(&part_chunk.content);
             }
         }
@@ -187,25 +225,26 @@ impl Transport {
     /// When a task is rebound to a new tmux session (retry) the previous
     /// run's output must not be replayed. Call this when registering or
     /// rebinding sessions so stale output is discarded.
-    pub async fn clear_output(&self, task_id: &str) {
+    pub async fn clear_output(&self, session_key: &str) {
         let mut last = self.last_output.write().await;
-        last.remove(task_id);
+        last.remove(session_key);
     }
 
     /// Get the session binding for a specific task, if any.
-    pub async fn get_binding(&self, task_id: &str) -> Option<SessionBinding> {
-        self.bindings.read().await.get(task_id).cloned()
+    pub async fn get_binding(&self, repo: &str, task_id: &str) -> Option<SessionBinding> {
+        let skey = session_key(repo, task_id);
+        self.bindings.read().await.get(&skey).cloned()
     }
 
     /// Route an incoming message to the appropriate handler.
-    /// Returns the task_id if this message maps to an existing session.
+    /// Returns the session_key if this message maps to an existing session.
     pub async fn route(&self, msg: &IncomingMessage) -> MessageRoute {
         let key = conversation_key(&msg.channel, &msg.thread_id, msg.topic_id.as_deref());
 
         // Check if this thread is bound to a task
-        if let Some(task_id) = self.thread_to_task.read().await.get(&key) {
+        if let Some(session_key) = self.thread_to_task.read().await.get(&key) {
             return MessageRoute::TaskSession {
-                task_id: task_id.clone(),
+                session_key: session_key.clone(),
             };
         }
 
@@ -266,8 +305,9 @@ fn split_chunks(content: &str, max_bytes: usize) -> Vec<String> {
 /// How an incoming message should be handled.
 #[derive(Debug)]
 pub enum MessageRoute {
-    /// Message belongs to an existing task session — forward to tmux
-    TaskSession { task_id: String },
+    /// Message belongs to an existing task session — forward to tmux.
+    /// `session_key` is the globally unique key (repo:task_id or internal:id).
+    TaskSession { session_key: String },
     /// Message is a command (e.g. "/status", "orch task list")
     Command { raw: String },
     /// Message is in the configured control session channel — route to control agent
@@ -345,7 +385,14 @@ mod tests {
     async fn bind_and_route_to_session() {
         let transport = Transport::new();
         transport
-            .bind("42", "orch-myproject-42", "telegram", "12345", None)
+            .bind(
+                "owner/repo",
+                "42",
+                "orch-myproject-42",
+                "telegram",
+                "12345",
+                None,
+            )
             .await;
 
         let msg = IncomingMessage {
@@ -360,7 +407,9 @@ mod tests {
         };
 
         match transport.route(&msg).await {
-            MessageRoute::TaskSession { task_id } => assert_eq!(task_id, "42"),
+            MessageRoute::TaskSession { session_key } => {
+                assert_eq!(session_key, "owner/repo:42");
+            }
             _ => panic!("expected TaskSession"),
         }
     }
@@ -384,6 +433,111 @@ mod tests {
             MessageRoute::Command { raw } => assert_eq!(raw, "/status"),
             _ => panic!("expected Command"),
         }
+    }
+
+    // ── session_key ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn session_key_external_is_prefixed_with_repo() {
+        assert_eq!(session_key("owner/repo", "42"), "owner/repo:42");
+    }
+
+    #[test]
+    fn session_key_internal_is_unchanged() {
+        assert_eq!(session_key("owner/repo", "internal:99"), "internal:99");
+    }
+
+    #[test]
+    fn session_key_same_id_different_repos_are_unique() {
+        let k1 = session_key("owner/repo-a", "42");
+        let k2 = session_key("owner/repo-b", "42");
+        assert_ne!(k1, k2);
+        assert_eq!(k1, "owner/repo-a:42");
+        assert_eq!(k2, "owner/repo-b:42");
+    }
+
+    // ── cross-repo collision regression ──────────────────────────────────────
+
+    /// Two repos with the same external task ID must not collide in bindings.
+    #[tokio::test]
+    async fn same_external_id_different_repos_do_not_collide() {
+        let transport = Transport::new();
+
+        // Repo A binds task "42"
+        transport
+            .bind(
+                "owner/repo-a",
+                "42",
+                "orch-repo-a-42",
+                "telegram",
+                "111",
+                None,
+            )
+            .await;
+        // Repo B binds task "42" (same external ID, different repo)
+        transport
+            .bind(
+                "owner/repo-b",
+                "42",
+                "orch-repo-b-42",
+                "telegram",
+                "222",
+                None,
+            )
+            .await;
+
+        // Each binding has its own session
+        let binding_a = transport.get_binding("owner/repo-a", "42").await.unwrap();
+        let binding_b = transport.get_binding("owner/repo-b", "42").await.unwrap();
+        assert_eq!(binding_a.tmux_session, "orch-repo-a-42");
+        assert_eq!(binding_b.tmux_session, "orch-repo-b-42");
+        assert_ne!(binding_a.tmux_session, binding_b.tmux_session);
+    }
+
+    /// Same external task ID in two repos: pushing output to one must not
+    /// reach the other's subscribers.
+    #[tokio::test]
+    async fn push_output_isolated_across_repos_with_same_task_id() {
+        let transport = Transport::new();
+
+        // Subscribe to repo-a's task 42
+        transport
+            .bind("owner/repo-a", "42", "orch-a-42", "cli", "stream-a", None)
+            .await;
+        let mut rx_a = transport.subscribe("owner/repo-a", "42").await.unwrap();
+
+        // Subscribe to repo-b's task 42
+        transport
+            .bind("owner/repo-b", "42", "orch-b-42", "cli", "stream-b", None)
+            .await;
+        let mut rx_b = transport.subscribe("owner/repo-b", "42").await.unwrap();
+
+        // Push output to repo-a's task 42
+        transport
+            .push_output(
+                "owner/repo-a",
+                "42",
+                OutputChunk {
+                    content: "hello from repo-a".to_string(),
+                    is_final: false,
+                },
+            )
+            .await;
+
+        // repo-a receives it
+        let chunk_a = tokio::time::timeout(std::time::Duration::from_millis(100), rx_a.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(chunk_a.content, "hello from repo-a");
+
+        // repo-b should NOT receive anything (timeout)
+        let result_b =
+            tokio::time::timeout(std::time::Duration::from_millis(100), rx_b.recv()).await;
+        assert!(
+            result_b.is_err(),
+            "repo-b should not receive repo-a's output"
+        );
     }
 
     // ── conversation_key ──────────────────────────────────────────────────────
@@ -459,11 +613,25 @@ mod tests {
 
         // Task 10 is in topic 100 of chat 999
         transport
-            .bind("10", "orch-proj-10", "telegram", "999", Some("100"))
+            .bind(
+                "owner/repo",
+                "10",
+                "orch-proj-10",
+                "telegram",
+                "999",
+                Some("100"),
+            )
             .await;
         // Task 20 is in topic 200 of the same chat 999
         transport
-            .bind("20", "orch-proj-20", "telegram", "999", Some("200"))
+            .bind(
+                "owner/repo",
+                "20",
+                "orch-proj-20",
+                "telegram",
+                "999",
+                Some("200"),
+            )
             .await;
 
         let msg_topic_100 = IncomingMessage {
@@ -489,12 +657,16 @@ mod tests {
         };
 
         match transport.route(&msg_topic_100).await {
-            MessageRoute::TaskSession { task_id } => assert_eq!(task_id, "10"),
+            MessageRoute::TaskSession { session_key } => {
+                assert_eq!(session_key, "owner/repo:10");
+            }
             other => panic!("expected TaskSession for task 10, got {other:?}"),
         }
 
         match transport.route(&msg_topic_200).await {
-            MessageRoute::TaskSession { task_id } => assert_eq!(task_id, "20"),
+            MessageRoute::TaskSession { session_key } => {
+                assert_eq!(session_key, "owner/repo:20");
+            }
             other => panic!("expected TaskSession for task 20, got {other:?}"),
         }
     }
@@ -507,7 +679,14 @@ mod tests {
 
         // Task 5 bound to topic 10 of chat 42
         transport
-            .bind("5", "orch-proj-5", "telegram", "42", Some("10"))
+            .bind(
+                "owner/repo",
+                "5",
+                "orch-proj-5",
+                "telegram",
+                "42",
+                Some("10"),
+            )
             .await;
 
         // Message arrives in topic 99 of the same chat — should NOT route to task 5
@@ -524,8 +703,8 @@ mod tests {
 
         match transport.route(&msg).await {
             MessageRoute::NewTask => {} // correct — not routed to task 5
-            MessageRoute::TaskSession { task_id } => {
-                panic!("should not have routed to task {task_id}")
+            MessageRoute::TaskSession { session_key } => {
+                panic!("should not have routed to session {session_key}")
             }
             other => panic!("unexpected route result: {other:?}"),
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -388,7 +388,7 @@ pub async fn stream_task(task_id: &str, raw: bool) -> anyhow::Result<()> {
     let repo = crate::config::get_current_repo().unwrap_or_default();
     let session_name = tmux.session_name(&repo, task_id);
     transport
-        .bind(task_id, &session_name, "cli", "stream", None)
+        .bind(&repo, task_id, &session_name, "cli", "stream", None)
         .await;
 
     // Start a CaptureService to poll the tmux session and push chunks to transport.
@@ -402,7 +402,7 @@ pub async fn stream_task(task_id: &str, raw: bool) -> anyhow::Result<()> {
         async move { capture.run().await }
     });
 
-    let mut rx = match transport.subscribe(task_id).await {
+    let mut rx = match transport.subscribe(&repo, task_id).await {
         Some(rx) => rx,
         None => {
             capture_handle.abort();
@@ -443,7 +443,7 @@ pub async fn stream_task(task_id: &str, raw: bool) -> anyhow::Result<()> {
     }
 
     // Clean up: unregister and stop capture
-    capture.unregister_session(task_id).await;
+    capture.unregister_session(&repo, task_id).await;
     capture_handle.abort();
 
     Ok(())
@@ -491,7 +491,7 @@ pub async fn stream_all(raw: bool) -> anyhow::Result<()> {
                     }
                     // Use session name as the task key (unique, descriptive)
                     transport
-                        .bind(&session, &session, "cli", "stream-all", None)
+                        .bind("cli", &session, &session, "cli", "stream-all", None)
                         .await;
                     capture.register_session("cli", &session, &session).await;
                     known.insert(session.clone());

--- a/src/engine/channel_handler.rs
+++ b/src/engine/channel_handler.rs
@@ -154,8 +154,13 @@ pub(super) async fn send_channel_reply(
 }
 
 /// Forward a text message to an agent's tmux session via send-keys.
-pub(super) async fn forward_to_tmux(transport: &Arc<Transport>, task_id: &str, text: &str) {
-    if let Some(binding) = transport.get_binding(task_id).await {
+pub(super) async fn forward_to_tmux(
+    transport: &Arc<Transport>,
+    repo: &str,
+    task_id: &str,
+    text: &str,
+) {
+    if let Some(binding) = transport.get_binding(repo, task_id).await {
         if let Err(e) = crate::channels::tmux::send_keys(&binding.tmux_session, text).await {
             tracing::warn!(
                 task_id,
@@ -280,7 +285,7 @@ async fn create_and_announce_task(
             };
             let session_name = tmux.session_name(repo, &task_id);
             transport
-                .bind(&task_id, &session_name, channel, thread_id, topic_id)
+                .bind(repo, &task_id, &session_name, channel, thread_id, topic_id)
                 .await;
             capture
                 .register_session(repo, &task_id, &session_name)
@@ -288,8 +293,9 @@ async fn create_and_announce_task(
             let transport_clone = transport.clone();
             let channels_clone = channels.clone();
             let task_id_clone = task_id.clone();
+            let repo_clone = repo.to_string();
             tokio::spawn(async move {
-                fanout_output(task_id_clone, transport_clone, channels_clone).await;
+                fanout_output(repo_clone, task_id_clone, transport_clone, channels_clone).await;
             });
             // Always show project label (caller sets forced_repo when project isn't obvious)
             let project_label = format!(" in [{repo}]");
@@ -345,10 +351,21 @@ pub(super) async fn handle_channel_message(
     let route = normalize_channel_route(&msg, transport.route(&msg).await, is_control);
 
     match route {
-        MessageRoute::TaskSession { task_id } => {
+        MessageRoute::TaskSession { session_key } => {
             let body = msg.body.trim().to_string();
             let channel = msg.channel.clone();
             let thread_id = msg.thread_id.clone();
+
+            // Derive repo and task_id from the session key.
+            // For external tasks the key is "repo:task_id"; for internal tasks
+            // it is "internal:<id>" and we fall back to resolved_repo.
+            let (repo, task_id): (&str, &str) =
+                if let Some((r, t)) = crate::channels::transport::parse_session_key(&session_key) {
+                    (r, t)
+                } else {
+                    // Internal task or unparseable key — use resolved_repo
+                    (resolved_repo.unwrap_or(""), &session_key)
+                };
 
             if body.starts_with('/') {
                 // Parse slash command and execute it on the bound task
@@ -360,11 +377,9 @@ pub(super) async fn handle_channel_message(
                     let repos: Vec<&str> =
                         engine_refs.iter().map(|(r, _, _, _)| r.as_str()).collect();
                     let idx = transport
-                        .get_binding(&task_id)
+                        .get_binding(repo, task_id)
                         .await
-                        .map(|b| {
-                            engine_ref_idx_for_session(&repos, tmux, &task_id, &b.tmux_session)
-                        })
+                        .map(|b| engine_ref_idx_for_session(&repos, tmux, task_id, &b.tmux_session))
                         .unwrap_or(0);
                     if let Some((repo, backend, task_manager, store)) = engine_refs.get(idx) {
                         let gh = match GhHttp::new() {
@@ -382,7 +397,7 @@ pub(super) async fn handle_channel_message(
                                 return;
                             }
                         };
-                        let ext_id = ExternalId(task_id.clone());
+                        let ext_id = ExternalId(task_id.to_string());
                         let result =
                             execute_command(backend, &gh, repo, &ext_id, &cmd, store, task_manager)
                                 .await;
@@ -401,11 +416,11 @@ pub(super) async fn handle_channel_message(
                     }
                 } else {
                     // Unknown command — forward to agent as-is
-                    forward_to_tmux(transport, &task_id, &body).await;
+                    forward_to_tmux(transport, repo, task_id, &body).await;
                 }
             } else {
                 // Regular message — forward to the agent's tmux session
-                forward_to_tmux(transport, &task_id, &body).await;
+                forward_to_tmux(transport, repo, task_id, &body).await;
             }
         }
 
@@ -476,6 +491,7 @@ pub(super) async fn handle_channel_message(
                     &thread_id,
                     msg_topic_id.as_deref(),
                     transport,
+                    engine_refs,
                 )
                 .await;
                 send_channel_reply(
@@ -875,6 +891,7 @@ pub(super) async fn handle_stream_command(
     thread_id: &str,
     topic_id: Option<&str>,
     transport: &Arc<Transport>,
+    engine_refs: &[EngineRef],
 ) -> String {
     let parts: Vec<&str> = cmd_str.splitn(2, ' ').collect();
     if parts.len() < 2 || parts[1].trim().is_empty() {
@@ -883,11 +900,28 @@ pub(super) async fn handle_stream_command(
     let task_id = parts[1].trim();
 
     // Check if the task has an active binding (i.e. is running)
-    if let Some(binding) = transport.get_binding(task_id).await {
+    // Try all known repos to find the binding
+    let repos: Vec<&str> = engine_refs.iter().map(|(r, _, _, _)| r.as_str()).collect();
+    let mut found = None;
+    for repo in &repos {
+        if let Some(binding) = transport.get_binding(repo, task_id).await {
+            found = Some((repo.to_string(), binding));
+            break;
+        }
+    }
+
+    if let Some((repo, binding)) = found {
         // Bind this channel/thread as an additional output target
         // The session name is retrieved from the existing binding
         transport
-            .bind(task_id, &binding.tmux_session, channel, thread_id, topic_id)
+            .bind(
+                &repo,
+                task_id,
+                &binding.tmux_session,
+                channel,
+                thread_id,
+                topic_id,
+            )
             .await;
         format!("Streaming output from task `{task_id}` to this channel.")
     } else {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1658,7 +1658,14 @@ mod tests {
             .register_session("owner/repo", &task_id, &session_name)
             .await;
         transport
-            .bind(&task_id, &session_name, "telegram", "12345", None)
+            .bind(
+                "owner/repo",
+                &task_id,
+                &session_name,
+                "telegram",
+                "12345",
+                None,
+            )
             .await;
 
         // Spawn capture.run() which exits when session is unregistered
@@ -1667,7 +1674,7 @@ mod tests {
 
         // Subscribe to transport output for this task
         let mut rx = transport
-            .subscribe(&task_id)
+            .subscribe("owner/repo", &task_id)
             .await
             .expect("no subscription");
 
@@ -1699,7 +1706,7 @@ mod tests {
         }
 
         // Clean up: unregister and kill tmux session
-        capture.unregister_session(&task_id).await;
+        capture.unregister_session("owner/repo", &task_id).await;
         let _ = tokio::process::Command::new("tmux")
             .args(["kill-session", "-t", &session_name])
             .output()

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -98,7 +98,7 @@ pub(crate) async fn tick_check_session_completions(
             );
             // Unregister from capture service using the task id the capture service
             // was registered under (task id without project prefix).
-            capture.unregister_session(&session.task_id).await;
+            capture.unregister_session(repo, &session.task_id).await;
             // Kill the actual tmux session name we discovered (do not reconstruct)
             if let Err(e) = tmux.kill_session(&session.name).await {
                 tracing::debug!(
@@ -218,7 +218,7 @@ pub(crate) async fn tick_detect_silent_agents(
         }
 
         // 2. Unregister from capture
-        capture.unregister_session(&task_id).await;
+        capture.unregister_session(repo, &task_id).await;
 
         let mut extended_note = String::new();
 
@@ -1197,7 +1197,7 @@ pub(crate) async fn tick_dispatch_tasks(
             }
 
             // Unregister session from capture
-            capture.unregister_session(&task_id_for_cleanup).await;
+            capture.unregister_session(&repo_owned, &task_id_for_cleanup).await;
 
             // Release the semaphore permit
             drop(permit);

--- a/tests/capture_diff.rs
+++ b/tests/capture_diff.rs
@@ -19,6 +19,14 @@ mod channels {
     pub mod transport {
         use crate::channels::OutputChunk;
 
+        pub fn session_key(repo: &str, task_id: &str) -> String {
+            if task_id.starts_with("internal:") {
+                task_id.to_string()
+            } else {
+                format!("{repo}:{task_id}")
+            }
+        }
+
         #[derive(Debug)]
         pub struct Transport;
 
@@ -31,7 +39,7 @@ mod channels {
                 None
             }
 
-            pub async fn push_output(&self, _task_id: &str, _chunk: OutputChunk) {}
+            pub async fn push_output(&self, _repo: &str, _task_id: &str, _chunk: OutputChunk) {}
         }
     }
 }


### PR DESCRIPTION
## Summary

I need to check if there are any missing repo parameters in the transport/capture method calls. Looking at the output, I see that most calls include the repo parameter, but let me double-check the specific locations mentioned in the issue:

1. `src/channels/transport.rs:85-103,113-147,155-197` - This looks like the Transport struct and methods
2. `src/channels/capture.rs:53-57,73-105,175-239` - This looks like the CaptureService struct and methods
3. Registration call sites: `src/engine/tick.rs:

Closes #1665

---
*Task #1665 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/nemotron-3-super-free`*