### PR TITLE
bug: token budget enforcement still ineffective — 10+ tasks exceed 100K limit in 24h despite #1605/#1607 fixes

### DIFF
--- a/src/engine/runner/agents/codex.rs
+++ b/src/engine/runner/agents/codex.rs
@@ -42,6 +42,57 @@ use crate::parser;
 pub struct CodexRunner;
 
 impl CodexRunner {
+    /// Extract usage info from Codex NDJSON events if present.
+    ///
+    /// Codex's `exec --json` NDJSON format doesn't consistently include `usage`
+    /// fields. If found, returns them directly. Otherwise, returns None so the
+    /// caller can fall back to byte-count estimation.
+    fn extract_usage(&self, events: &[serde_json::Value]) -> (Option<u64>, Option<u64>) {
+        let mut input_tokens: Option<u64> = None;
+        let mut output_tokens: Option<u64> = None;
+
+        for event in events {
+            // Check top-level `usage` field
+            if let Some(usage) = event.get("usage") {
+                if let Some(inp) = usage.get("input_tokens").and_then(|v| v.as_u64()) {
+                    *input_tokens.get_or_insert(0) += inp;
+                }
+                if let Some(out) = usage.get("output_tokens").and_then(|v| v.as_u64()) {
+                    *output_tokens.get_or_insert(0) += out;
+                }
+            }
+            // Check nested `item.usage` (some Codex versions)
+            if let Some(item) = event.get("item") {
+                if let Some(usage) = item.get("usage") {
+                    if let Some(inp) = usage.get("input_tokens").and_then(|v| v.as_u64()) {
+                        *input_tokens.get_or_insert(0) += inp;
+                    }
+                    if let Some(out) = usage.get("output_tokens").and_then(|v| v.as_u64()) {
+                        *output_tokens.get_or_insert(0) += out;
+                    }
+                }
+            }
+        }
+
+        (input_tokens, output_tokens)
+    }
+
+    /// Estimate token count from raw output byte length.
+    ///
+    /// When agents don't report token usage (Codex never does currently),
+    /// we estimate using ~4 bytes per token (a common approximation for
+    /// English text). This is conservative — real tokenizers typically
+    /// produce fewer tokens, so this slightly overestimates usage.
+    fn estimate_tokens_from_bytes(raw: &str) -> (u64, u64) {
+        let bytes = raw.len() as u64;
+        // Rough estimate: 4 bytes per token, split 60% input / 40% output
+        // (typical for agent runs where input context is larger than response)
+        let total_estimated = bytes / 4;
+        let input_estimated = total_estimated * 60 / 100;
+        let output_estimated = total_estimated - input_estimated;
+        (input_estimated.max(1), output_estimated.max(1))
+    }
+
     /// Extract the agent's response text from NDJSON events.
     ///
     /// Looks for `item.completed` events with `item.type == "agent_message"`.
@@ -295,10 +346,12 @@ impl AgentRunner for CodexRunner {
         if events.is_empty() {
             // Maybe it's direct JSON, not NDJSON
             if let Ok(resp) = parser::parse(trimmed) {
+                // Use byte-count estimation for direct JSON (no NDJSON events)
+                let (est_input, est_output) = Self::estimate_tokens_from_bytes(trimmed);
                 return Ok(ParsedResponse {
                     response: resp,
-                    input_tokens: None,
-                    output_tokens: None,
+                    input_tokens: Some(est_input),
+                    output_tokens: Some(est_output),
                     duration_ms: None,
                 });
             }
@@ -324,10 +377,21 @@ impl AgentRunner for CodexRunner {
             raw: agent_text.clone(),
         })?;
 
+        // Try to extract real usage from events; fall back to byte-count estimate
+        let (input_tokens, output_tokens) = self.extract_usage(&events);
+        let (input_tokens, output_tokens) = match (input_tokens, output_tokens) {
+            (Some(i), Some(o)) if i > 0 || o > 0 => (Some(i), Some(o)),
+            _ => {
+                // Codex doesn't report usage — estimate from raw output size
+                let (est_input, est_output) = Self::estimate_tokens_from_bytes(trimmed);
+                (Some(est_input), Some(est_output))
+            }
+        };
+
         Ok(ParsedResponse {
             response,
-            input_tokens: None,
-            output_tokens: None,
+            input_tokens,
+            output_tokens,
             duration_ms: None,
         })
     }
@@ -413,8 +477,20 @@ pub fn find_codex_result(ndjson: &str) -> Option<super::AgentResult> {
     Some(super::AgentResult {
         is_error,
         result_text,
-        input_tokens: None,
-        output_tokens: None,
+        input_tokens: {
+            let (inp, _) = runner.extract_usage(&events);
+            inp.or_else(|| {
+                let (est, _) = CodexRunner::estimate_tokens_from_bytes(ndjson);
+                Some(est)
+            })
+        },
+        output_tokens: {
+            let (_, out) = runner.extract_usage(&events);
+            out.or_else(|| {
+                let (_, est) = CodexRunner::estimate_tokens_from_bytes(ndjson);
+                Some(est)
+            })
+        },
         cost_usd: None,
         duration_ms: None,
     })

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -561,6 +561,7 @@ impl TaskRunner {
                     init.new_attempts,
                     &self.repo,
                     &self.store,
+                    session_output.raw_stdout.len(),
                 )
                 .await?;
                 if budget_exceeded {
@@ -588,6 +589,41 @@ impl TaskRunner {
                 (status, budget_exceeded, push_failed)
             }
             Err(ref agent_err) => {
+                // Store estimated token usage for failed runs so budget tracking
+                // accounts for tokens burned before the error. Without this,
+                // agents that burn 200K tokens and then crash have zero tokens
+                // recorded, bypassing the budget system entirely.
+                if !session_output.raw_stdout.is_empty() {
+                    let stdout_bytes = session_output.raw_stdout.len() as u64;
+                    // Estimate ~4 bytes per token (conservative for English text)
+                    let estimated_total = stdout_bytes / 4;
+                    let est_input = (estimated_total * 60 / 100).max(1) as i64;
+                    let est_output = (estimated_total - estimated_total * 60 / 100).max(1) as i64;
+                    let model = init.model_name.as_deref().unwrap_or("haiku");
+                    if let Some(ref st) = self.store {
+                        if let Ok(Some(store_id)) = st.resolve_task_id(&self.repo, task_id).await {
+                            if let Err(e) = st
+                                .store_tokens(store_id, est_input, est_output, model)
+                                .await
+                            {
+                                tracing::warn!(
+                                    task_id,
+                                    ?e,
+                                    "failed to store estimated tokens for failed run"
+                                );
+                            } else {
+                                tracing::info!(
+                                    task_id,
+                                    est_input,
+                                    est_output,
+                                    stdout_bytes,
+                                    "stored estimated tokens for failed run"
+                                );
+                            }
+                        }
+                    }
+                }
+
                 match fallback::handle_error(
                     task_id,
                     agent_err,

--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -103,6 +103,7 @@ pub async fn handle_success(
     new_attempts: u32,
     repo: &str,
     store: &Option<Arc<TaskStore>>,
+    raw_output_bytes: usize,
 ) -> anyhow::Result<(String, bool, bool)> {
     let resp = parsed.response;
     tracing::info!(
@@ -565,16 +566,39 @@ pub async fn handle_success(
     )
     .await;
 
-    // Store token usage — prefer agent-parsed tokens, fall back to response
+    // Store token usage — prefer agent-parsed tokens, fall back to response,
+    // then fall back to byte-count estimation as a last resort.
+    // This ensures budget enforcement always has non-zero token data,
+    // even for agents that don't report usage (e.g. Codex, some OpenCode builds).
     let input_tokens = parsed.input_tokens.or(resp.input_tokens);
     let output_tokens = parsed.output_tokens.or(resp.output_tokens);
-    if let (Some(input), Some(output)) = (input_tokens, output_tokens) {
+    let (input_tokens, output_tokens) = match (input_tokens, output_tokens) {
+        (Some(i), Some(o)) if i > 0 || o > 0 => (i, o),
+        _ => {
+            // No tokens reported by agent — estimate from raw output byte length.
+            // Uses ~4 bytes per token (standard approximation for English text),
+            // split 60/40 input/output (typical for agent runs where input context
+            // is larger than response). Floor at 1 to ensure budget always tracks.
+            let total_estimated = (raw_output_bytes as u64) / 4;
+            let input_estimated = total_estimated * 60 / 100;
+            let output_estimated = total_estimated.saturating_sub(input_estimated);
+            tracing::info!(
+                task_id,
+                raw_output_bytes,
+                input_estimated,
+                output_estimated,
+                "no token usage reported by agent, using byte-count estimation"
+            );
+            (input_estimated.max(1), output_estimated.max(1))
+        }
+    };
+    {
         let model = model_name.unwrap_or("haiku");
         if let Some(ref st) = store {
             // Resolve store_id once and reuse
             if let Ok(Some(store_id)) = st.resolve_task_id(repo, task_id).await {
                 if let Err(e) = st
-                    .store_tokens(store_id, input as i64, output as i64, model)
+                    .store_tokens(store_id, input_tokens as i64, output_tokens as i64, model)
                     .await
                 {
                     tracing::warn!(task_id, ?e, "failed to store token usage");
@@ -608,10 +632,10 @@ pub async fn handle_success(
 
     if total_tokens > max_tokens {
         tracing::warn!(task_id, total_tokens, max_tokens, "exceeded token budget");
-        // Only override to needs_review if there's a PR to review;
-        // otherwise keep the already-computed final_status (e.g. "done" for
-        // read-only tasks with no code changes).
-        let budget_status = if has_pr { "needs_review" } else { final_status };
+        // Always override status when budget is exceeded. Tasks should never
+        // silently succeed beyond their token limit — this was the root cause
+        // of tasks being marked "done" despite burning 2-25x their budget.
+        let budget_status = "needs_review";
         let budget_msg = format!(
             "token budget exceeded: {}/{} tokens (${:.4})",
             total_tokens, max_tokens, cost.total_cost_usd

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -998,6 +998,10 @@ impl TaskStore {
     // ---------------------------------------------------------------
 
     /// Store token usage and cost for a task.
+    ///
+    /// Accumulates tokens across multiple calls (e.g. retries) rather than
+    /// overwriting. This ensures the budget check sees the true cumulative
+    /// token usage across all attempts, not just the latest run.
     pub async fn store_tokens(
         &self,
         id: i64,
@@ -1014,8 +1018,12 @@ impl TaskStore {
 
         sqlx::query(
             "UPDATE tasks SET
-            input_tokens = ?, output_tokens = ?, model = ?,
-            input_cost_usd = ?, output_cost_usd = ?, total_cost_usd = ?,
+            input_tokens = COALESCE(input_tokens, 0) + ?,
+            output_tokens = COALESCE(output_tokens, 0) + ?,
+            model = ?,
+            input_cost_usd = COALESCE(input_cost_usd, 0) + ?,
+            output_cost_usd = COALESCE(output_cost_usd, 0) + ?,
+            total_cost_usd = COALESCE(total_cost_usd, 0) + ?,
             updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
          WHERE id = ?",
         )

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -2743,11 +2743,13 @@ async fn store_tokens_accumulates_across_calls() {
     let cost1 = task.total_cost_usd;
     assert!(cost1 > 0.0);
 
-    // Second call replaces (not accumulates)
+    // Second call accumulates (not replaces) — critical for budget enforcement
+    // across retries. Without accumulation, only the last run's tokens are
+    // recorded, silently discarding all previous usage.
     store.store_tokens(id, 2000, 1000, "sonnet").await.unwrap();
     let task = store.get(id).await.unwrap();
-    assert_eq!(task.input_tokens, 2000);
-    assert_eq!(task.output_tokens, 1000);
+    assert_eq!(task.input_tokens, 3000); // 1000 + 2000
+    assert_eq!(task.output_tokens, 1500); // 500 + 1000
     assert!(task.total_cost_usd > cost1);
 }
 
@@ -3171,7 +3173,7 @@ async fn set_fields_multiple_fields_at_once() {
 }
 
 #[tokio::test]
-async fn store_tokens_overwrites_previous_values() {
+async fn store_tokens_accumulates_with_different_models() {
     let store = TaskStore::open_memory().await.unwrap();
     let id = store
         .create(&NewTask {
@@ -3189,17 +3191,17 @@ async fn store_tokens_overwrites_previous_values() {
         .await
         .unwrap();
 
-    // First token store
+    // First token store with haiku
     store.store_tokens(id, 1000, 500, "haiku").await.unwrap();
     let task = store.get(id).await.unwrap();
     assert_eq!(task.input_tokens, 1000);
     assert_eq!(task.output_tokens, 500);
 
-    // Second store overwrites (not accumulates)
+    // Second store accumulates; model field updates to latest
     store.store_tokens(id, 2000, 1000, "sonnet").await.unwrap();
     let task = store.get(id).await.unwrap();
-    assert_eq!(task.input_tokens, 2000);
-    assert_eq!(task.output_tokens, 1000);
+    assert_eq!(task.input_tokens, 3000); // 1000 + 2000
+    assert_eq!(task.output_tokens, 1500); // 500 + 1000
     assert_eq!(task.model, Some("sonnet".to_string()));
 }
 


### PR DESCRIPTION
## Summary

Let me start by understanding the current state of the branch and what the previous attempt accomplished.There are uncommitted changes from the previous attempt. Let me also check if there's a PR with review comments.No PR exists yet. The previous attempt added changes to 3 files but didn't commit. Let me now thoroughly understand the full picture — read the key files to understand the token budget enforcement flow.Now let me look at the task_init.rs pre-run budget check and the store's token-

Closes #1678

---
*Task #1678 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-opus-4.6`*