### PR TITLE
bug: elegram API error: 400 Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 25

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -14,6 +14,16 @@ const TELEGRAM_HTTP_TIMEOUT_SECS: u64 = TELEGRAM_LONG_POLL_TIMEOUT_SECS + 15;
 const TELEGRAM_MAX_RETRIES: u32 = 3;
 const _: () = assert!(TELEGRAM_HTTP_TIMEOUT_SECS > TELEGRAM_LONG_POLL_TIMEOUT_SECS);
 
+/// Escape text for Telegram HTML parse_mode.
+///
+/// Telegram's HTML parser is strict: bare `<`, `>`, or `&` cause
+/// "can't parse entities" errors. This function escapes those characters.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
 pub struct TelegramChannel {
     pub token: String,
     pub client: Client,
@@ -138,11 +148,22 @@ impl TelegramChannel {
         text: &str,
         topic_id: Option<i64>,
     ) -> anyhow::Result<()> {
+        let escaped = html_escape(text);
+        self.send_formatted_message(chat_id, &escaped, topic_id)
+            .await
+    }
+
+    async fn send_formatted_message(
+        &self,
+        chat_id: i64,
+        text: &str,
+        topic_id: Option<i64>,
+    ) -> anyhow::Result<()> {
         let url = self.api_url("sendMessage");
 
-        // Use HTML parse mode to avoid Markdown parsing edge-cases from
-        // user-provided summaries/titles. Notifications are formatted as
-        // HTML by TaskNotification::format_telegram(), so send as HTML here.
+        // Use HTML parse mode. Callers must ensure text is properly escaped
+        // (send_message escapes automatically; send_formatted_message expects
+        // pre-escaped/pre-formatted input from TaskNotification::format_telegram).
         let mut params = serde_json::json!({
             "chat_id": chat_id,
             "text": text,
@@ -394,7 +415,20 @@ impl Channel for TelegramChannel {
             }
         }
 
-        self.send_message(chat_id, &msg.body, topic_id).await
+        // Check if body is already pre-formatted HTML (e.g. TaskNotification::format_telegram)
+        // or raw text that needs escaping (e.g. streamed agent output).
+        let preformatted = msg
+            .metadata
+            .get("preformatted_html")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        if preformatted {
+            self.send_formatted_message(chat_id, &msg.body, topic_id)
+                .await
+        } else {
+            self.send_message(chat_id, &msg.body, topic_id).await
+        }
     }
 
     async fn ack_interaction(&self, callback_query_id: &str) -> anyhow::Result<()> {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -800,11 +800,16 @@ pub async fn serve() -> anyhow::Result<()> {
                                         "slack" => notification.format_slack(),
                                         _ => continue,
                                     };
+                                    let metadata = if ch_name == "telegram" {
+                                        serde_json::json!({"preformatted_html": true})
+                                    } else {
+                                        serde_json::json!({})
+                                    };
                                     let msg = OutgoingMessage {
                                         thread_id: notification.task_id.clone(),
                                         body,
                                         reply_to: None,
-                                        metadata: serde_json::json!({}),
+                                        metadata,
                                         topic_id: Some(topic_id.to_string()),
                                     };
                                     if let Err(e) = channel.send(&msg).await {
@@ -831,11 +836,16 @@ pub async fn serve() -> anyhow::Result<()> {
                                                 continue;
                                             };
                                             let body = notification.format_with_project(&ch_name);
+                                            let metadata = if ch_name == "telegram" {
+                                                serde_json::json!({"preformatted_html": true})
+                                            } else {
+                                                serde_json::json!({})
+                                            };
                                             let msg = OutgoingMessage {
                                                 thread_id: thread_id.clone(),
                                                 body,
                                                 reply_to: None,
-                                                metadata: serde_json::json!({}),
+                                                metadata,
                                                 topic_id: None,
                                             };
                                             if let Err(e) = channel.send(&msg).await {
@@ -864,24 +874,29 @@ pub async fn serve() -> anyhow::Result<()> {
                         // 3. Fallback: broadcast to all channels when no routing happened.
                         if !routed {
                             for channel in channels.iter() {
-                                let (body, should_send) = match channel.name() {
-                                    "telegram" => (notification.format_telegram(), true),
-                                    "discord" => (notification.format_discord(), true),
-                                    "slack" => (notification.format_slack(), true),
+                                let (body, should_send, is_telegram) = match channel.name() {
+                                    "telegram" => (notification.format_telegram(), true, true),
+                                    "discord" => (notification.format_discord(), true, false),
+                                    "slack" => (notification.format_slack(), true, false),
                                     // GitHub is already handled by backend.post_comment()
                                     // tmux doesn't need task completion notifications
-                                    _ => (String::new(), false),
+                                    _ => (String::new(), false, false),
                                 };
 
                                 if !should_send {
                                     continue;
                                 }
 
+                                let metadata = if is_telegram {
+                                    serde_json::json!({"preformatted_html": true})
+                                } else {
+                                    serde_json::json!({})
+                                };
                                 let msg = OutgoingMessage {
                                     thread_id: notification.task_id.clone(),
                                     body,
                                     reply_to: None,
-                                    metadata: serde_json::json!({}),
+                                    metadata,
                                     topic_id: None,
                                 };
 


### PR DESCRIPTION
## Summary

The bug is clear: `send_message()` in `src/channels/telegram.rs` always uses `parse_mode: "HTML"`, but streamed agent output is raw and unescaped. Let me read the relevant code and fix it.Now I understand the bug. `send_message()` uses `parse_mode: "HTML"` but the streaming path sends raw, unescaped agent output. When the output contains `<`, `>`, or `&`, Telegram's HTML parser fails.

The fix: escape HTML entities in `send_message()` for raw text. For pre-formatted notifications (which already 

Closes #1688

---
*Task #1688 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*