### PR TITLE
Security: Channel startup logs may leak tokens

### DIFF
--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -21,6 +21,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use reqwest::Client;
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use std::time::Duration;
 
 pub struct SlackChannel {
@@ -172,8 +173,16 @@ impl Channel for SlackChannel {
             .expect("BUG: channel_id is Some; None case returned early above");
         let last_ts = self.last_ts.clone();
 
+        let token_fingerprint = {
+            let mut hasher = Sha256::new();
+            hasher.update(bot_token.as_bytes());
+            let hash = hasher.finalize();
+            let hex: String = hash[..8].iter().map(|b| format!("{:02x}", b)).collect();
+            format!("sha256:{hex}")
+        };
+
         tracing::info!(
-            token_prefix = %bot_token.chars().take(12).collect::<String>(),
+            token_fingerprint = %token_fingerprint,
             channel_id = %channel_id,
             "slack channel started"
         );

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use reqwest::Client;
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use std::time::Duration;
 
 const TELEGRAM_LONG_POLL_TIMEOUT_SECS: u64 = 30;
@@ -254,7 +255,15 @@ impl Channel for TelegramChannel {
         let chat_id = self.chat_id.clone();
         let offset = self.offset.clone();
 
-        tracing::info!(token_prefix = %token.chars().take(8).collect::<String>(), "telegram channel started");
+        let token_fingerprint = {
+            let mut hasher = Sha256::new();
+            hasher.update(token.as_bytes());
+            let hash = hasher.finalize();
+            let hex: String = hash[..8].iter().map(|b| format!("{:02x}", b)).collect();
+            format!("sha256:{hex}")
+        };
+
+        tracing::info!(token_fingerprint = %token_fingerprint, "telegram channel started");
 
         // Create a single TelegramChannel instance to reuse for all API calls
         let channel = TelegramChannel {


### PR DESCRIPTION
## Summary

Now I'll apply the fix to both files:Now let's verify the changes compile and pass tests:All 2503 tests passed. Let me verify the final changes:Task complete. The security fix has been committed:

- **Slack**: Replaced `token_prefix` (first 12 chars of token) with `sha256:{16-hex-chars}` fingerprint
- **Telegram**: Replaced `token_prefix` (first 8 chars of token) with `sha256:{16-hex-chars}` fingerprint

Both changes use irreversible SHA256 hashes, allowing log-based debugging without exposing c

Closes #1690

---
*Task #1690 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*