### PR TITLE
fix: allow skip token budget limit

### DIFF
--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -597,10 +597,17 @@ pub async fn handle_success(
     .await;
 
     // Check token budget with warning thresholds
-    let max_tokens: u64 = config::get("max_tokens_per_task")
+    // Use the same config key as pre-run checks. If set to 0, disable budget
+    // enforcement so tasks may continue without token budget gating.
+    let max_tokens: u64 = config::get("workflow.max_tokens_per_task")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(100_000);
+
+    if max_tokens == 0 {
+        // Budget checks disabled — nothing to do here.
+        return Ok((final_status.to_string(), false, push_failed));
+    }
 
     // Query total tokens and cost estimate together (single DB read)
     let (total_tokens, cost) = store::get_token_summary(store, repo, task_id).await;

--- a/src/engine/runner/task_init.rs
+++ b/src/engine/runner/task_init.rs
@@ -108,6 +108,11 @@ pub async fn check_token_budget(
         .and_then(|s| s.parse().ok())
         .unwrap_or(100_000);
 
+    // If set to 0, token budget checks are disabled.
+    if max_tokens == 0 {
+        return BudgetCheckOutcome::Proceed;
+    }
+
     let (total_tokens, cost) = store::get_token_summary(store, repo, task_id).await;
 
     if total_tokens > max_tokens {


### PR DESCRIPTION
## Summary

Allow disabling token budget checks when workflow.max_tokens_per_task is set to 0 and unify config key usage.

### What was done

- Updated pre-run token budget check to skip enforcement when workflow.max_tokens_per_task == 0 (src/engine/runner/task_init.rs)
- Updated post-run response handling to use the same config key and skip budget checks when workflow.max_tokens_per_task == 0 (src/engine/runner/response_handler.rs)
- Ran formatting check and built the project to verify changes compile


### Remaining

- Consider adding unit tests that explicitly assert budget-check skipping behaviour when the config key is 0 (not required for this small change but recommended)
- If you use other config-loading conventions, verify runtime config includes workflow.max_tokens_per_task in user configs or examples


Closes #1693

---
*Task #1693 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*