### PR TITLE
Reduce log noise: suppress expected tmux kill-session warnings

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -139,7 +139,11 @@ impl TmuxManager {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            tracing::warn!(session, %stderr, "kill-session failed (may already be dead)");
+            if stderr.contains("can't find session") || stderr.contains("no server running") {
+                tracing::debug!(session, %stderr, "kill-session: session already gone");
+            } else {
+                tracing::warn!(session, %stderr, "kill-session failed unexpectedly");
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Suppressed expected tmux kill-session warnings by classifying stderr output in kill_session()

### What was done

- Modified src/tmux.rs:kill_session() to parse stderr and distinguish expected vs unexpected failures
- Sessions already gone ('can't find session', 'no server running') now log at debug! level
- Real errors continue to log at warn! level with 'failed unexpectedly' message
- All 2515 tests pass, clippy clean, formatting clean
- Committed with conventional commit message


Closes #1701

---
*Task #1701 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*