### PR TITLE
bug: session continuation flag silently dropped when shell command format doesn't match expected pattern

### DIFF
--- a/src/engine/runner/direct.rs
+++ b/src/engine/runner/direct.rs
@@ -3,7 +3,7 @@
 //! Used by the control session and the router LLM to run agents
 //! in a fire-and-forget mode without a persistent tmux session.
 
-use crate::engine::runner::agents::{get_runner, AgentError, PermissionRules};
+use crate::engine::runner::agents::{get_runner, shell_single_quote, AgentError, PermissionRules};
 use anyhow::Result;
 use std::time::Duration;
 
@@ -119,7 +119,15 @@ pub async fn run_direct_with_session(
             let flag = if s.resume { "--resume" } else { "--session-id" };
             // Insert flag before the stdin redirect (< "msg_file")
             if let Some(pos) = shell_cmd.rfind("< \"") {
-                shell_cmd.insert_str(pos, &format!("{flag} {} \\\n  ", s.session_id));
+                let quoted = shell_single_quote(s.session_id);
+                shell_cmd.insert_str(pos, &format!("{flag} {quoted} \\\n  "));
+            } else {
+                tracing::warn!(
+                    agent,
+                    flag,
+                    session_id = s.session_id,
+                    "could not insert session flag: '< \"' pattern not found in shell command"
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary

All 2515 tests pass. The fix is complete:

1. **Added `else` branch with `tracing::warn!`** — when `< "` pattern isn't found, logs agent, flag, and session_id so operators can diagnose silently-dropped session flags.
2. **Quoted `session_id` with `shell_single_quote()`** — eliminates the latent shell injection risk, consistent with how `--model` flags are quoted elsewhere in the codebase.

Closes #1706

---
*Task #1706 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*