### PR TITLE
bug: Config parsing silently ignores invalid values

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -146,30 +146,40 @@ impl EngineConfig {
         if let Ok(val) = crate::config::get("engine.tick_interval") {
             if let Ok(secs) = val.parse::<u64>() {
                 config.tick_interval = std::time::Duration::from_secs(secs);
+            } else {
+                tracing::warn!(key = "engine.tick_interval", value = %val, default_secs = config.tick_interval.as_secs(), "invalid value for engine.tick_interval, using default");
             }
         }
 
         if let Ok(val) = crate::config::get("engine.sync_interval") {
             if let Ok(secs) = val.parse::<u64>() {
                 config.sync_interval = std::time::Duration::from_secs(secs);
+            } else {
+                tracing::warn!(key = "engine.sync_interval", value = %val, default_secs = config.sync_interval.as_secs(), "invalid value for engine.sync_interval, using default");
             }
         }
 
         if let Ok(val) = crate::config::get("engine.max_parallel") {
             if let Ok(n) = val.parse::<usize>() {
                 config.max_parallel = n;
+            } else {
+                tracing::warn!(key = "engine.max_parallel", value = %val, default = config.max_parallel, "invalid value for engine.max_parallel, using default");
             }
         }
 
         if let Ok(val) = crate::config::get("engine.stuck_timeout") {
             if let Ok(secs) = val.parse::<u64>() {
                 config.stuck_timeout = secs;
+            } else {
+                tracing::warn!(key = "engine.stuck_timeout", value = %val, default_secs = config.stuck_timeout, "invalid value for engine.stuck_timeout, using default");
             }
         }
 
         if let Ok(val) = crate::config::get("engine.no_session_stuck_timeout") {
             if let Ok(secs) = val.parse::<u64>() {
                 config.no_session_stuck_timeout = secs;
+            } else {
+                tracing::warn!(key = "engine.no_session_stuck_timeout", value = %val, default_secs = config.no_session_stuck_timeout, "invalid value for engine.no_session_stuck_timeout, using default");
             }
         }
 
@@ -181,6 +191,8 @@ impl EngineConfig {
                 } else {
                     config.webhook_health_check_interval = None;
                 }
+            } else {
+                tracing::warn!(key = "engine.webhook_health_check_interval", value = %val, default = ?config.webhook_health_check_interval, "invalid value for engine.webhook_health_check_interval, using default");
             }
         }
 
@@ -199,18 +211,24 @@ impl EngineConfig {
         if let Ok(val) = crate::config::get("engine.graceful_shutdown_timeout") {
             if let Ok(secs) = val.parse::<u64>() {
                 config.graceful_shutdown_timeout = std::time::Duration::from_secs(secs);
+            } else {
+                tracing::warn!(key = "engine.graceful_shutdown_timeout", value = %val, default_secs = config.graceful_shutdown_timeout.as_secs(), "invalid value for engine.graceful_shutdown_timeout, using default");
             }
         }
 
         if let Ok(val) = crate::config::get("engine.silence_grace_period") {
             if let Ok(secs) = val.parse::<u64>() {
                 config.silence_grace_period = secs;
+            } else {
+                tracing::warn!(key = "engine.silence_grace_period", value = %val, default = config.silence_grace_period, "invalid value for engine.silence_grace_period, using default");
             }
         }
 
         if let Ok(val) = crate::config::get("engine.silence_cooldown") {
             if let Ok(secs) = val.parse::<u64>() {
                 config.silence_cooldown = secs;
+            } else {
+                tracing::warn!(key = "engine.silence_cooldown", value = %val, default = config.silence_cooldown, "invalid value for engine.silence_cooldown, using default");
             }
         }
 


### PR DESCRIPTION
## Summary

Log warnings when invalid engine configuration values are provided instead of silently ignoring them.

### What was done

- Updated EngineConfig::from_config in src/engine/mod.rs to emit tracing::warn! when parsing of engine config values fails
- Added warnings for: engine.tick_interval, engine.sync_interval, engine.max_parallel, engine.stuck_timeout, engine.no_session_stuck_timeout, engine.webhook_health_check_interval, engine.graceful_shutdown_timeout, engine.silence_grace_period, engine.silence_cooldown
- Committed change on branch gh-issue-1715-bug-config-parsing-silently-ignores-inva with message: "fix(engine): warn on invalid engine config values instead of silently ignoring (#1715)"


### Remaining

- If desired, extend similar warnings to other config parsing sites across the codebase (many crate::config::get usages exist) — I limited scope to EngineConfig::from_config per the issue
- Run full test suite and clippy locally (cargo fmt, cargo clippy, cargo nextest) before pushing / opening PR


Closes #1715

---
*Task #1715 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*