### PR TITLE
bug: Silent fallback to /tmp/.orch when orch_home() fails in TaskRunner::new

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -228,8 +228,10 @@ pub struct TaskRunner {
 
 impl TaskRunner {
     pub fn new(repo: String) -> Self {
-        let orch_home =
-            crate::home::orch_home().unwrap_or_else(|_| PathBuf::from("/tmp").join(".orch"));
+        let orch_home = crate::home::orch_home().unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "orch_home() failed — falling back to /tmp/.orch");
+            PathBuf::from("/tmp").join(".orch")
+        });
 
         Self {
             repo,


### PR DESCRIPTION
## Summary

Done. The fix is at `src/engine/runner/mod.rs:231-234`. When `orch_home()` fails, it now logs a warning with the error message before falling back to `/tmp/.orch`:

```rust
let orch_home = crate::home::orch_home().unwrap_or_else(|e| {
    tracing::warn!(error = %e, "orch_home() failed — falling back to /tmp/.orch");
    PathBuf::from("/tmp").join(".orch")
});
```

This uses the existing `tracing::warn!` pattern already used throughout the module, and includes the actual error (typically "canno

Closes #1714

---
*Task #1714 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*