### PR TITLE
docs: control session prompt and docs still describe removed tmux commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -560,14 +560,14 @@ An interactive conversational control plane. Talk to orch in natural language �
 
 ### How It Works
 
-Uses **persistent agent sessions in tmux** for speed (~2s per message vs 15-20s cold start):
+Uses one-shot agent invocations with SQLite-backed continuity:
 
 ```
-1. First message → spawn agent in orch-chat-{session_id} tmux session
-2. Subsequent messages → send-keys + pane capture diffing (~2s)
-3. Response extracted via line-count diff (before/after comparison)
-4. Session idle timeout (10 min) auto-kills inactive sessions
-5. Agent/model switch restarts session with new config
+1. Each named session stores conversation history, summaries, memories, and a session UUID in SQLite
+2. Every message assembles fresh context from that stored state
+3. The agent runs one-shot via `bash -c` with a timeout, not inside tmux
+4. Claude-compatible agents receive the stored session UUID for conversation continuity
+5. Changing `/model` or `/agent` resets the stored session UUID so the next message starts fresh with the new selection
 
 Storage: context assembled from SQLite (live state + memories)
 ```
@@ -590,6 +590,8 @@ orch chat history --search "bean"   # search past conversations
 /model sonnet                       # infer agent (claude)
 /model minimax:sonnet               # explicit agent:model
 /model opencode:minimax-m2.5-free   # opencode with specific model
+/agent codex                        # switch agent and its default model
+/agent                              # show current agent:model
 /model                              # show current agent:model
 ```
 
@@ -632,7 +634,7 @@ All in `~/.orch/orch.db`:
 
 ```yaml
 # No config needed — works with defaults (claude:sonnet)
-# Model/agent stored in KV, changed via /model command
+# Model/agent stored in KV, changed via /model or /agent commands
 ```
 
 ## Landing the Plane (Session Completion)

--- a/README.md
+++ b/README.md
@@ -235,11 +235,13 @@ orch chat history                   # Show recent messages
 orch chat history --search "bean"   # Search past conversations
 ```
 
-In the REPL, use `/model` to switch models:
+In the REPL, use `/model` and `/agent` to manage the sticky agent:model selection:
 ```
 orch> /model sonnet                 # Infer agent (claude)
 orch> /model minimax:sonnet         # Explicit agent:model
 orch> /model opencode:minimax-m2.5-free  # OpenCode with specific model
+orch> /agent codex                  # Switch agent and its default model
+orch> /agent                        # Show current agent:model
 orch> /model                        # Show current agent:model
 ```
 

--- a/prompts/control_system.md
+++ b/prompts/control_system.md
@@ -1,6 +1,6 @@
 You are the orch control session — an interactive ops assistant for orch.
 
-You can run commands to manage tasks, check status, and take actions. Use bash for all commands.
+You can run CLI commands to manage tasks, check status, and take actions. Use bash for CLI commands. Handle `/model` and `/agent` as built-in control commands, and do not suggest tmux-specific session management commands.
 
 ## Available Commands
 
@@ -20,8 +20,6 @@ You can run commands to manage tasks, check status, and take actions. Use bash f
 - `orch service restart` — restart the service
 - `/model [agent:]<model>` — switch the sticky model (or show current agent:model)
 - `/agent <claude|codex|opencode>` — switch the sticky agent and its default model (or show current)
-- `/session` — show current persistent session info (agent, model, idle time, active status)
-- `/kill` — kill the persistent tmux session (next message starts fresh)
 - `gh pr list` — list open pull requests
 - `gh run list` — list CI workflow runs
 - `gh issue list` — list open issues

--- a/src/control.rs
+++ b/src/control.rs
@@ -979,6 +979,22 @@ mod tests {
         assert_eq!(parse_control_command("/session"), None);
     }
 
+    #[test]
+    fn control_prompt_slash_commands_match_supported_surface() {
+        let documented = Regex::new(r"`/([a-z]+)(?:[^`]*)`")
+            .unwrap()
+            .captures_iter(SYSTEM_TEMPLATE)
+            .map(|caps| caps[1].to_string())
+            .collect::<std::collections::BTreeSet<_>>();
+
+        let expected = ["agent", "model"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<std::collections::BTreeSet<_>>();
+
+        assert_eq!(documented, expected);
+    }
+
     #[tokio::test]
     async fn set_agent_spec_persists_default_model() {
         let store = TaskStore::open_memory().await.unwrap();


### PR DESCRIPTION
## Summary

Aligned the control-session prompt and operator docs with the shipped one-shot control architecture and supported slash commands, and added a regression test to keep the prompt surface in sync.

### What was done

- Removed unsupported `/session` and `/kill` commands from `prompts/control_system.md` and clarified that only `/model` and `/agent` are built-in control commands.
- Updated `AGENTS.md` and `README.md` to describe the current SQLite-backed, one-shot `orch chat` architecture instead of the removed tmux-backed persistent chat flow.
- Added `control_prompt_slash_commands_match_supported_surface` in `src/control.rs` to assert the control prompt only documents supported slash commands.
- Ran `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` successfully.
- Committed the changes as `627c859` (`docs: align control session prompt with supported commands`).


Closes #1720

---
*Task #1720 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4`*