### PR TITLE
bug: repo subscriptions drop topic/thread context for channel notifications

### DIFF
--- a/migrations/016_topic_aware_subscriptions.sql
+++ b/migrations/016_topic_aware_subscriptions.sql
@@ -1,0 +1,2 @@
+-- Add topic_id column to channel_subscriptions for topic-aware notification delivery
+ALTER TABLE channel_subscriptions ADD COLUMN topic_id TEXT DEFAULT '';

--- a/src/engine/channel_handler.rs
+++ b/src/engine/channel_handler.rs
@@ -455,6 +455,7 @@ pub(super) async fn handle_channel_message(
                     &cmd_str,
                     &channel,
                     &thread_id,
+                    msg_topic_id.as_deref(),
                     engine_refs,
                     channel_router,
                 )
@@ -814,6 +815,7 @@ pub(super) async fn handle_subscribe_command(
     cmd_str: &str,
     channel: &str,
     thread_id: &str,
+    topic_id: Option<&str>,
     engine_refs: &[EngineRef],
     channel_router: &Arc<ChannelRouter>,
 ) -> String {
@@ -846,7 +848,10 @@ pub(super) async fn handle_subscribe_command(
 
     // Find a store to use for subscription
     if let Some((_, _, _, Some(store))) = engine_refs.first() {
-        match store.subscribe_channel(channel, thread_id, project).await {
+        match store
+            .subscribe_channel(channel, thread_id, project, topic_id)
+            .await
+        {
             Ok(()) => format!("Subscribed to notifications from `{project}`."),
             Err(e) => format!("Failed to subscribe: {e}"),
         }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -897,7 +897,7 @@ pub async fn serve() -> anyhow::Result<()> {
                             if let Some(store) = &notif_store {
                                 match store.list_subscribers_for_repo(repo).await {
                                     Ok(subscribers) => {
-                                        for (ch_name, thread_id) in subscribers {
+                                        for (ch_name, thread_id, topic_id) in subscribers {
                                             let channel =
                                                 channels.iter().find(|c| c.name() == ch_name);
                                             let Some(channel) = channel else {
@@ -909,12 +909,17 @@ pub async fn serve() -> anyhow::Result<()> {
                                             } else {
                                                 serde_json::json!({})
                                             };
+                                            let resolved_topic = if topic_id.is_empty() {
+                                                None
+                                            } else {
+                                                Some(topic_id.clone())
+                                            };
                                             let msg = OutgoingMessage {
                                                 thread_id: thread_id.clone(),
                                                 body,
                                                 reply_to: None,
                                                 metadata,
-                                                topic_id: None,
+                                                topic_id: resolved_topic,
                                             };
                                             if let Err(e) = channel.send(&msg).await {
                                                 tracing::warn!(

--- a/src/store/jobs.rs
+++ b/src/store/jobs.rs
@@ -89,15 +89,18 @@ impl TaskStore {
         channel: &str,
         thread_id: &str,
         repo: &str,
+        topic_id: Option<&str>,
     ) -> anyhow::Result<()> {
+        let topic = topic_id.unwrap_or("");
         sqlx::query(
-        "INSERT OR IGNORE INTO channel_subscriptions (channel, thread_id, repo) VALUES (?, ?, ?)",
+        "INSERT OR IGNORE INTO channel_subscriptions (channel, thread_id, repo, topic_id) VALUES (?, ?, ?, ?)",
     )
-    .bind(channel)
-    .bind(thread_id)
-    .bind(repo)
-    .execute(&self.pool)
-    .await?;
+        .bind(channel)
+        .bind(thread_id)
+        .bind(repo)
+        .bind(topic)
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 
@@ -137,17 +140,18 @@ impl TaskStore {
         Ok(rows.into_iter().map(|r| r.0).collect())
     }
 
-    /// List all channel/thread pairs subscribed to a repo's notifications.
+    /// List all subscriptions (channel, thread_id, topic_id) for a repo.
     #[allow(dead_code)]
     pub async fn list_subscribers_for_repo(
         &self,
         repo: &str,
-    ) -> anyhow::Result<Vec<(String, String)>> {
-        let rows: Vec<(String, String)> =
-            sqlx::query_as("SELECT channel, thread_id FROM channel_subscriptions WHERE repo = ?")
-                .bind(repo)
-                .fetch_all(&self.pool)
-                .await?;
+    ) -> anyhow::Result<Vec<(String, String, String)>> {
+        let rows: Vec<(String, String, String)> = sqlx::query_as(
+            "SELECT channel, thread_id, topic_id FROM channel_subscriptions WHERE repo = ?",
+        )
+        .bind(repo)
+        .fetch_all(&self.pool)
+        .await?;
         Ok(rows)
     }
 }

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -4343,11 +4343,11 @@ async fn increment_returns_new_value_via_named_column() {
 async fn subscribe_and_list_channel_subscriptions() {
     let store = TaskStore::open_memory().await.unwrap();
     store
-        .subscribe_channel("telegram", "42", "owner/orch")
+        .subscribe_channel("telegram", "42", "owner/orch", None)
         .await
         .unwrap();
     store
-        .subscribe_channel("telegram", "42", "owner/bean")
+        .subscribe_channel("telegram", "42", "owner/bean", None)
         .await
         .unwrap();
     let subs = store
@@ -4363,7 +4363,7 @@ async fn subscribe_and_list_channel_subscriptions() {
 async fn unsubscribe_channel() {
     let store = TaskStore::open_memory().await.unwrap();
     store
-        .subscribe_channel("telegram", "42", "owner/orch")
+        .subscribe_channel("telegram", "42", "owner/orch", None)
         .await
         .unwrap();
     store
@@ -4381,11 +4381,11 @@ async fn unsubscribe_channel() {
 async fn subscribe_idempotent() {
     let store = TaskStore::open_memory().await.unwrap();
     store
-        .subscribe_channel("telegram", "42", "owner/orch")
+        .subscribe_channel("telegram", "42", "owner/orch", None)
         .await
         .unwrap();
     store
-        .subscribe_channel("telegram", "42", "owner/orch")
+        .subscribe_channel("telegram", "42", "owner/orch", None)
         .await
         .unwrap(); // duplicate
     let subs = store
@@ -4399,15 +4399,15 @@ async fn subscribe_idempotent() {
 async fn list_subscribers_for_repo() {
     let store = TaskStore::open_memory().await.unwrap();
     store
-        .subscribe_channel("telegram", "42", "owner/orch")
+        .subscribe_channel("telegram", "42", "owner/orch", None)
         .await
         .unwrap();
     store
-        .subscribe_channel("discord", "99", "owner/orch")
+        .subscribe_channel("discord", "99", "owner/orch", None)
         .await
         .unwrap();
     store
-        .subscribe_channel("telegram", "42", "owner/bean")
+        .subscribe_channel("telegram", "42", "owner/bean", None)
         .await
         .unwrap();
     let subs = store.list_subscribers_for_repo("owner/orch").await.unwrap();
@@ -4508,17 +4508,17 @@ async fn subscription_round_trip_with_multiple_channels() {
 
     // Subscribe telegram and discord to orch
     store
-        .subscribe_channel("telegram", "42", "owner/orch")
+        .subscribe_channel("telegram", "42", "owner/orch", None)
         .await
         .unwrap();
     store
-        .subscribe_channel("discord", "1111", "owner/orch")
+        .subscribe_channel("discord", "1111", "owner/orch", None)
         .await
         .unwrap();
 
     // Subscribe telegram to bean too
     store
-        .subscribe_channel("telegram", "42", "owner/bean")
+        .subscribe_channel("telegram", "42", "owner/bean", None)
         .await
         .unwrap();
 
@@ -4551,7 +4551,47 @@ async fn subscription_round_trip_with_multiple_channels() {
     // orch should now only have discord subscriber
     let orch_subs = store.list_subscribers_for_repo("owner/orch").await.unwrap();
     assert_eq!(orch_subs.len(), 1);
-    assert_eq!(orch_subs[0], ("discord".to_string(), "1111".to_string()));
+    assert_eq!(
+        orch_subs[0],
+        ("discord".to_string(), "1111".to_string(), "".to_string())
+    );
+}
+
+#[tokio::test]
+async fn subscribe_with_topic_id_preserved() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    // Subscribe to orch with a topic_id (e.g., Telegram forum topic)
+    store
+        .subscribe_channel("telegram", "42", "owner/orch", Some("topic-123"))
+        .await
+        .unwrap();
+
+    // Subscribe to bean without a topic (root thread)
+    store
+        .subscribe_channel("telegram", "42", "owner/bean", None)
+        .await
+        .unwrap();
+
+    // List subscribers for orch - should include topic_id
+    let orch_subs = store.list_subscribers_for_repo("owner/orch").await.unwrap();
+    assert_eq!(orch_subs.len(), 1);
+    assert_eq!(
+        orch_subs[0],
+        (
+            "telegram".to_string(),
+            "42".to_string(),
+            "topic-123".to_string()
+        )
+    );
+
+    // List subscribers for bean - should have empty topic_id
+    let bean_subs = store.list_subscribers_for_repo("owner/bean").await.unwrap();
+    assert_eq!(bean_subs.len(), 1);
+    assert_eq!(
+        bean_subs[0],
+        ("telegram".to_string(), "42".to_string(), "".to_string())
+    );
 }
 
 // ── get_cost_summary_24h_by_repo ────────────────────────────────


### PR DESCRIPTION
## Summary

Fixed channel subscriptions to preserve topic context for notification delivery

### What was done

- Created migration 016_topic_aware_subscriptions.sql adding topic_id column to channel_subscriptions
- Extended subscribe_channel() in src/store/jobs.rs to accept optional topic_id parameter
- Updated list_subscribers_for_repo() to return (channel, thread_id, topic_id) tuple
- Updated handle_subscribe_command() in src/engine/channel_handler.rs to capture topic_id from incoming message context
- Updated fanout in src/engine/mod.rs to preserve topic_id when sending subscribed notifications (instead of hardcoding None)
- Added test subscribe_with_topic_id_preserved to verify topic context is stored and retrieved correctly


Closes #1721

---
*Task #1721 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*