### PR TITLE
bug: review agent exhausts cycles on CI formatting failures instead of self-healing

### DIFF
--- a/prompts/review_system.md
+++ b/prompts/review_system.md
@@ -29,7 +29,7 @@ GitHub CI is the authoritative test environment. Check its status first (`gh pr 
 - **GitHub CI fails** → check if the failure is related to files in this PR. If not, it's pre-existing — note it and proceed. If it is, set `request_changes`.
 - **CI not run yet or unavailable** → run local checks as fallback. Look at `.github/workflows/` to find the exact CI commands and run them in the worktree.
 
-If you can fix a minor issue yourself (run formatter, fix a lint warning), do it, commit, re-run checks, then approve.
+If you can fix a minor issue yourself (run formatter, fix a lint warning), do it, commit, re-run checks, then approve. **Do NOT consume a review cycle for auto-fixable issues** — apply the fix and approve directly.
 
 ## Output Format
 

--- a/prompts/review_task.md
+++ b/prompts/review_task.md
@@ -26,8 +26,12 @@ timeout 300 gh pr checks {{PR_NUMBER}} --watch --fail-fast --required || true
 
 - **Required checks pass AND branch is up to date** (Step 1 rebase was a no-op or already applied) → proceed to Step 3 (skip local test runs)
 - **Required checks pass BUT branch was rebased** (Step 1 changed commits) → CI results are stale. Note in your review that CI needs to re-run post-rebase and proceed with code review. Orch will push the rebased branch (before posting the review decision) and CI will re-run before merging.
-- **Required checks fail** → check if the failure is related to files in this PR. If not, it's pre-existing — note it and proceed. If it is, set decision = `request_changes`
+- **Required checks fail** → check if the failure is related to files in this PR. If not, it's pre-existing — note it and proceed. If it is, **first check if it is trivially fixable** (e.g., `cargo fmt`, `cargo clippy --fix`, `npm run lint -- --fix`). If fixable: apply the fix in the worktree, commit, re-run the check locally to confirm it passes, then **approve** — do NOT request changes for auto-fixable issues. If not trivially fixable, set decision = `request_changes`
 - **Required checks not run yet or pending** → run local checks as fallback: read `.github/workflows/` to identify what CI runs and execute those commands. Do NOT hardcode language-specific commands
+
+**Self-fix rule**: If CI fails on formatting, linting, or other auto-fixable issues, apply the fix yourself, commit, and approve. Do NOT consume a review cycle for trivially fixable issues. Example: `cargo fmt --check` fails → run `cargo fmt`, `git add -A`, `git commit -m "style: run cargo fmt"`, re-run the check, then approve.
+
+**Worktree state**: Before running CI checks or applying fixes, run `git status` to verify the worktree is clean and not in a rebase state. If the worktree is mid-rebase (`git rebase --continue` needed), resolve that first. If conflicts are too complex to resolve safely, set decision = `request_changes`.
 
 **Do NOT request changes for local-only test failures when required checks are green.**
 


### PR DESCRIPTION
## Summary

The fix has been committed. Here's what was changed:

**`prompts/review_task.md`** - Added explicit self-fix rule with concrete example:
- When required checks fail, agents must first check if it's trivially fixable (e.g., `cargo fmt`, `cargo clippy --fix`, `npm run lint -- --fix`)
- If fixable: apply the fix, commit, re-run the check locally, then **approve** — do NOT request changes
- Added worktree state guidance: run `git status` before applying fixes to ensure clean state

**`prompts/revi

Closes #1728

---
*Task #1728 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*