### PR TITLE
bug: ingest_external_tasks makes N+1 SQL queries per sync tick instead of 1 batch query

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1187,13 +1187,24 @@ pub(crate) async fn ingest_external_tasks(
     // 3. Upsert into the store, collecting store IDs for batch status check.
     //    Also acknowledge newly detected issues (eyes reaction).
     let mut id_status_pairs: Vec<(i64, crate::backends::Status)> = Vec::new();
+    // Pre-load existing external IDs for this repo to avoid N+1 queries
+    // (each get_by_external_id call is an individual SQL query). If the
+    // lookup fails, fall back to an empty set so we conservatively treat
+    // tasks as new (they will be upserted below).
+    let existing_ext_ids: std::collections::HashSet<String> = match store
+        .existing_external_ids(repo)
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(repo = repo, err = %e, "ingest: failed to load existing external ids — proceeding");
+            std::collections::HashSet::new()
+        }
+    };
     for (task, status) in &all_tasks {
         // Check if this task already exists in the store before upserting.
-        let is_new = store
-            .get_by_external_id(repo, &task.id.0)
-            .await
-            .map(|t| t.is_none())
-            .unwrap_or(true);
+        // Use the pre-loaded HashSet to avoid issuing N individual queries.
+        let is_new = !existing_ext_ids.contains(&task.id.0);
 
         if is_new {
             let duplicate_target = existing_by_title

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -647,6 +647,26 @@ impl TaskStore {
         .is_some()
     }
 
+    /// Return a set of external IDs for all external tasks in a repo.
+    ///
+    /// Used to eliminate N+1 queries when ingesting lists of external tasks.
+    pub async fn existing_external_ids(
+        &self,
+        repo: &str,
+    ) -> anyhow::Result<std::collections::HashSet<String>> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT external_id FROM tasks WHERE repo = ? AND origin != 'internal' AND external_id IS NOT NULL",
+        )
+        .bind(repo)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .filter_map(|(id,)| if id.is_empty() { None } else { Some(id) })
+            .collect())
+    }
+
     /// List tasks for `orch doctor`: active tasks + done tasks updated since `cutoff_str`.
     /// Much cheaper than `list_all` on repos with many historical done tasks.
     pub async fn list_for_doctor(&self, repo: &str, cutoff_str: &str) -> anyhow::Result<Vec<Task>> {


### PR DESCRIPTION
## Summary

Eliminated N+1 SQL queries in ingest_external_tasks by adding a batch lookup for existing external IDs and using it during ingest.

### What was done

- Added TaskStore::existing_external_ids(repo) to perform a single query returning a HashSet of external IDs for a repo.
- Changed ingest_external_tasks() in src/engine/sync.rs to pre-load existing external IDs once and use HashSet membership checks instead of calling get_by_external_id per task.
- Formatted code and ran clippy/local checks to ensure build hygiene.


### Remaining

- Consider adding unit tests that assert the N+1 behavior is eliminated (e.g., count queries during ingest) — not required for this change but useful for regression protection.


Closes #1742

---
*Task #1742 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*