### PR TITLE
bug: summary truncation in minimax.rs uses byte index — panic on mid-UTF8-char boundary

### DIFF
--- a/src/engine/runner/agents/minimax.rs
+++ b/src/engine/runner/agents/minimax.rs
@@ -13,7 +13,7 @@
 //! while delegating command building and routing to `ClaudeRunner`.
 
 use super::claude::ClaudeRunner;
-use super::{AgentError, AgentRunner, ParsedResponse, PermissionRules};
+use super::{truncate_at_char_boundary, AgentError, AgentRunner, ParsedResponse, PermissionRules};
 
 /// Count Edit and Write tool_use events in NDJSON stream output.
 fn count_edit_tools(raw: &str) -> usize {
@@ -180,10 +180,9 @@ impl AgentRunner for MiniMaxClaudeRunner {
 
         let response = crate::parser::AgentResponse {
             status,
-            summary: if summary.len() > 500 {
-                summary[..500].to_string()
-            } else {
-                summary
+            summary: {
+                let end = truncate_at_char_boundary(&summary, 500);
+                summary[..end].to_string()
             },
             accomplished: vec![],
             remaining: vec![],

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -427,7 +427,7 @@ pub(crate) fn shell_single_quote(value: &str) -> String {
 
 /// Find the largest byte index <= `max_bytes` that lies on a UTF-8 char
 /// boundary.  Used for safe string truncation in error messages.
-fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> usize {
+pub fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> usize {
     if max_bytes >= s.len() {
         return s.len();
     }


### PR DESCRIPTION
## Summary

## ✅ UTF-8 Truncation Bug Fixed

I've successfully fixed the UTF-8 truncation panic in minimax.rs. Here's what was done:

### Changes Made

**1. `src/engine/runner/agents/mod.rs`**
- Made `truncate_at_char_boundary()` public so it can be imported by minimax.rs

**2. `src/engine/runner/agents/minimax.rs`**
- Imported `truncate_at_char_boundary` from the parent module
- Replaced the unsafe byte-indexing truncation (`summary[..500]`) with a safe UTF-8-aware call:
  ```rust
  summary: {
      let 

Closes #1757

---
*Task #1757 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*