### PR TITLE
bug: rebase_on_default uses refs/stash instead of refs/stash@0 -- race with concurrent worktrees

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -230,7 +230,7 @@ pub async fn rebase_on_default(dir: &Path, default_branch: &str) {
                 // apply it back by its exact ref, regardless of any stashes
                 // that other worktrees may push between now and then.
                 let ref_out = Command::new("git")
-                    .args(["rev-parse", "refs/stash"])
+                    .args(["rev-parse", "refs/stash@{0}"])
                     .current_dir(dir)
                     .output_with_context()
                     .await;


### PR DESCRIPTION
## Summary

Perfect! I've successfully fixed the race condition bug in issue #1762. Here's a summary:

## What was fixed

**File:** `src/engine/runner/git_ops.rs:233`

**Problem:** The `rebase_on_default()` function used `refs/stash` when capturing the stash reference, which creates a race condition when multiple worktrees run concurrently. If another worktree pushes a stash between our `git stash` and `rev-parse`, we'd capture the wrong stash OID and lose uncommitted changes.

**Solution:** Changed `"refs/

Closes #1762

---
*Task #1762 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*