### PR TITLE
bug: webhook signature verification panics on mismatched-length signatures via ct_eq

### DIFF
--- a/src/channels/github.rs
+++ b/src/channels/github.rs
@@ -380,6 +380,9 @@ fn verify_signature(secret: &str, payload: &[u8], signature: &str) -> bool {
     let result = mac.finalize().into_bytes();
 
     let expected = format!("sha256={:x}", result);
+    if expected.len() != signature.len() {
+        return false;
+    }
     // Use constant-time comparison to prevent timing side-channel attacks
     bool::from(expected.as_bytes().ct_eq(signature.as_bytes()))
 }


### PR DESCRIPTION
## Summary

Fixed webhook signature verification panic by checking signature length before ct_eq comparison

### What was done

- Added length check to `verify_signature` in `src/channels/github.rs` to prevent panics when checking mismatched-length signatures using `ct_eq`.


Closes #1760

---
*Task #1760 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gemini-3.1-pro-preview`*