### PR TITLE
bug: opencode free_models_refresh_in_progress flag permanently stuck if background thread panics

### DIFF
--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -232,6 +232,9 @@ impl RouterConfig {
         // refresh runs at a time to avoid duplicate subprocess spawns.
         if !REFRESH_IN_PROGRESS.swap(true, Ordering::AcqRel) {
             std::thread::spawn(|| {
+                let _guard = scopeguard::guard((), |_| {
+                    REFRESH_IN_PROGRESS.store(false, Ordering::Release);
+                });
                 let now_bg = chrono::Utc::now().timestamp();
                 let discovered = Self::run_opencode_models_discovery();
                 // Access the module-level static directly — no Arc needed.
@@ -239,7 +242,6 @@ impl RouterConfig {
                 if let Ok(mut guard) = cache.lock() {
                     *guard = (now_bg, discovered);
                 }
-                REFRESH_IN_PROGRESS.store(false, Ordering::Release);
             });
         }
 

--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -403,11 +403,13 @@ impl OpenCodeRunner {
             let cache_arc = Arc::clone(&self.free_models_cache);
             let flag_arc = Arc::clone(&self.free_models_refresh_in_progress);
             std::thread::spawn(move || {
+                let _guard = scopeguard::guard((), |_| {
+                    flag_arc.store(false, std::sync::atomic::Ordering::Release);
+                });
                 let models = discover_free_models();
                 if let Ok(mut cache) = cache_arc.lock() {
                     *cache = Some((models, std::time::Instant::now()));
                 }
-                flag_arc.store(false, std::sync::atomic::Ordering::Release);
             });
         }
 


### PR DESCRIPTION
## Summary

Fixed panic safety for free model cache refresh flags using scopeguard guards

### What was done

- Added scopeguard guard to src/engine/runner/agents/opencode.rs:399-413 to reset free_models_refresh_in_progress flag on panic
- Added scopeguard guard to src/engine/router/config.rs:233-246 to reset REFRESH_IN_PROGRESS flag on panic


Closes #1761

---
*Task #1761 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*