### PR TITLE
bug: validate_model opencode error shows filtered (empty) model list instead of all available models

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -157,16 +157,21 @@ pub async fn validate_model(spec: &ModelSpec) -> Result<()> {
     if spec.agent == "opencode" {
         if let Ok(models) = list_opencode_models().await {
             if !models.iter().any(|m| m == &spec.model) {
+                let suggestions: Vec<_> = models
+                    .iter()
+                    .filter(|m| m.contains(&spec.model) || spec.model.contains(m.as_str()))
+                    .take(10)
+                    .cloned()
+                    .collect();
+                let shown = if suggestions.is_empty() {
+                    models.iter().take(20).cloned().collect()
+                } else {
+                    suggestions
+                };
                 anyhow::bail!(
                     "model '{}' not found in opencode. Available models:\n{}",
                     spec.model,
-                    models
-                        .iter()
-                        .filter(|m| m.contains(&spec.model) || spec.model.contains(m.as_str()))
-                        .take(10)
-                        .cloned()
-                        .collect::<Vec<_>>()
-                        .join("\n")
+                    shown.join("\n")
                 );
             }
         }


### PR DESCRIPTION
## Summary

Fixed the opencode model validation error to show all available models when the fuzzy filter returns empty

### What was done

- Added fallback logic to show first 20 models when fuzzy suggestions are empty instead of showing blank error message


Closes #1777

---
*Task #1777 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*