### PR TITLE
bug: update_task_status_with_duration omits set_block_reason(None) when unblocking tasks

### DIFF
--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -390,6 +390,9 @@ impl TaskManager {
                 .ok_or_else(|| anyhow::anyhow!("store required for internal task status update"))?;
             let store_id = snapshot_store_id
                 .ok_or_else(|| anyhow::anyhow!("internal task {} not found in store", id.0))?;
+            if task_status != TaskStatus::Blocked {
+                store.set_block_reason(store_id, None).await?;
+            }
             store.update_status(store_id, task_status).await?;
             self.publish_event(id, status, &pre_snapshot, duration_seconds);
             return Ok(());
@@ -397,6 +400,9 @@ impl TaskManager {
 
         if let Some(ref store) = self.store {
             if let Some(store_id) = snapshot_store_id {
+                if task_status != TaskStatus::Blocked {
+                    store.set_block_reason(store_id, None).await?;
+                }
                 store.update_status(store_id, task_status).await?;
             }
         }


### PR DESCRIPTION
## Summary

## Summary

✅ Fixed bug #1778: `update_task_status_with_duration` now correctly clears `block_reason` when transitioning tasks away from `Blocked` status.

### Changes Made

Added the missing `set_block_reason(None)` guard to both branches of `update_task_status_with_duration`:

1. **Internal task branch** (line 393-395): Added guard before `store.update_status()`
2. **External task branch** (line 403-405): Added guard before `store.update_status()`

This mirrors the correct implementation in 

Closes #1778

---
*Task #1778 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*