### PR TITLE
enhancement: add configurable time windows to orch metrics/stats for 7-day self-review analysis

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -267,15 +267,27 @@ pub fn agents() {
 }
 
 /// Show task metrics summary.
-pub async fn metrics(details: bool) -> anyhow::Result<()> {
+///
+/// `since_hours` controls the time window (default 24; pass 168 for 7 days, etc.).
+pub async fn metrics(details: bool, since_hours: u32) -> anyhow::Result<()> {
     let store = init_store().await?;
 
-    let summary = store.get_metrics_summary_24h().await?;
+    let summary = store.get_metrics_summary(since_hours).await?;
+    let window_label = hours_to_label(since_hours);
 
     println!();
-    println!("╔══════════════════════════════════════════════════════════╗");
-    println!("║              Orch Metrics (Last 24 Hours)               ║");
-    println!("╚══════════════════════════════════════════════════════════╝");
+    let header = format!("Orch Metrics (Last {})", window_label);
+    let width = 58usize;
+    let pad = width.saturating_sub(header.len() + 2);
+    let left_pad = pad / 2;
+    let right_pad = pad - left_pad;
+    println!("╔{}╗", "═".repeat(width));
+    println!(
+        "║{}{header}{}║",
+        " ".repeat(left_pad),
+        " ".repeat(right_pad)
+    );
+    println!("╚{}╝", "═".repeat(width));
     println!();
 
     // Task counts
@@ -320,10 +332,10 @@ pub async fn metrics(details: bool) -> anyhow::Result<()> {
     println!();
 
     if details {
-        // Slow tasks (last 7 days)
-        let slow = store.get_slow_tasks_7d().await?;
+        // Slow tasks
+        let slow = store.get_slow_tasks(since_hours).await?;
         if !slow.is_empty() {
-            println!(" Slowest Tasks (Last 7 Days):");
+            println!(" Slowest Tasks (Last {}):", window_label);
             println!(
                 "   {:<20} {:<12} {:<10} DURATION",
                 "TASK ID", "AGENT", "COMPLEXITY"
@@ -341,10 +353,10 @@ pub async fn metrics(details: bool) -> anyhow::Result<()> {
             println!();
         }
 
-        // Error distribution (last 7 days)
-        let errors = store.get_error_distribution_7d().await?;
+        // Error distribution
+        let errors = store.get_error_distribution(since_hours).await?;
         if !errors.is_empty() {
-            println!(" Error Distribution (Last 7 Days):");
+            println!(" Error Distribution (Last {}):", window_label);
             println!("   {:<30} {:>6}", "ERROR TYPE", "COUNT");
             println!("   {}", "-".repeat(38));
             for e in &errors {
@@ -356,12 +368,51 @@ pub async fn metrics(details: bool) -> anyhow::Result<()> {
             }
             println!();
         } else {
-            println!(" Error Distribution (Last 7 Days): none");
+            println!(" Error Distribution (Last {}): none", window_label);
+            println!();
+        }
+
+        // Repeated review loops
+        let review_loops = store.get_high_review_cycle_tasks(since_hours).await?;
+        if !review_loops.is_empty() {
+            println!(" Tasks with Repeated Review Loops (Last {}):", window_label);
+            println!("   {:<10} {:<12} TITLE", "CYCLES", "AGENT");
+            println!("   {}", "-".repeat(60));
+            for t in &review_loops {
+                println!(
+                    "   {:<10} {:<12} {}",
+                    t.review_cycles,
+                    t.agent.as_deref().unwrap_or("-"),
+                    t.title,
+                );
+            }
             println!();
         }
     }
 
     Ok(())
+}
+
+/// Convert hours to a human-readable label (e.g. 24 → "24h", 168 → "7d").
+pub fn hours_to_label(hours: u32) -> String {
+    if hours.is_multiple_of(24) {
+        format!("{}d", hours / 24)
+    } else {
+        format!("{hours}h")
+    }
+}
+
+/// Parse a `--since` string like "24h", "7d", "30d" into hours.
+/// Returns `None` if the format is unrecognised.
+pub fn parse_since(s: &str) -> Option<u32> {
+    if let Some(d) = s.strip_suffix('d') {
+        d.parse::<u32>().ok().map(|n| n * 24)
+    } else if let Some(h) = s.strip_suffix('h') {
+        h.parse::<u32>().ok()
+    } else {
+        // bare number treated as hours
+        s.parse::<u32>().ok()
+    }
 }
 
 /// Print a content chunk in human-readable form, formatting each NDJSON line.
@@ -1024,6 +1075,21 @@ pub async fn init_store() -> anyhow::Result<crate::store::TaskStore> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hours_to_label_prefers_days_for_full_day_windows() {
+        assert_eq!(hours_to_label(24), "1d");
+        assert_eq!(hours_to_label(168), "7d");
+        assert_eq!(hours_to_label(30), "30h");
+    }
+
+    #[test]
+    fn parse_since_supports_days_hours_and_bare_numbers() {
+        assert_eq!(parse_since("7d"), Some(168));
+        assert_eq!(parse_since("24h"), Some(24));
+        assert_eq!(parse_since("36"), Some(36));
+        assert_eq!(parse_since("bad"), None);
+    }
 
     #[test]
     fn parse_slug_owner_repo() {

--- a/src/cli/stats.rs
+++ b/src/cli/stats.rs
@@ -1,28 +1,31 @@
 use crate::config;
 
 /// Show task metrics and statistics, per-project by default.
-pub async fn stats(all: bool) -> anyhow::Result<()> {
+///
+/// `since_hours` controls the time window (default 24; pass 168 for 7 days, etc.).
+pub async fn stats(all: bool, since_hours: u32) -> anyhow::Result<()> {
     let store = crate::cli::init_store().await?;
+    let window_label = crate::cli::hours_to_label(since_hours);
 
     if all {
-        let summary = store.get_metrics_summary_24h().await?;
+        let summary = store.get_metrics_summary(since_hours).await?;
         let cost = store.get_cost_summary().await.ok();
         println!();
-        print_summary_table("All Projects", &summary, cost.as_ref());
+        print_summary_table("All Projects", &window_label, &summary, cost.as_ref());
     } else {
         let repos = get_configured_repos();
         if repos.is_empty() {
             // Fallback to global stats if no projects configured
-            let summary = store.get_metrics_summary_24h().await?;
+            let summary = store.get_metrics_summary(since_hours).await?;
             let cost = store.get_cost_summary().await.ok();
             println!();
-            print_summary_table("All Projects", &summary, cost.as_ref());
+            print_summary_table("All Projects", &window_label, &summary, cost.as_ref());
         } else {
             println!();
             for repo in &repos {
-                let summary = store.get_metrics_summary_24h_by_repo(repo).await?;
-                let cost = store.get_cost_summary_24h_by_repo(repo).await.ok();
-                print_summary_table(repo, &summary, cost.as_ref());
+                let summary = store.get_metrics_summary_by_repo(repo, since_hours).await?;
+                let cost = store.get_cost_summary_by_repo(repo, since_hours).await.ok();
+                print_summary_table(repo, &window_label, &summary, cost.as_ref());
             }
         }
     }
@@ -32,6 +35,7 @@ pub async fn stats(all: bool) -> anyhow::Result<()> {
 
 fn print_summary_table(
     title: &str,
+    window_label: &str,
     summary: &crate::store::MetricsSummary,
     cost: Option<&crate::store::CostSummary>,
 ) {
@@ -45,8 +49,8 @@ fn print_summary_table(
     };
 
     println!(
-        "  Tasks (24h):  {} completed, {} failed",
-        summary.tasks_completed_24h, summary.tasks_failed_24h
+        "  Tasks ({}):  {} completed, {} failed",
+        window_label, summary.tasks_completed_24h, summary.tasks_failed_24h
     );
     println!("  Success rate: {:.1}%", success_rate);
 
@@ -75,11 +79,16 @@ fn print_summary_table(
         println!("  Agents:       {}", agents.join(" | "));
     }
 
-    // Cost: extract 24h period if available
+    // Cost: show total across all recorded periods
     if let Some(c) = cost {
-        if let Some(period_24h) = c.periods.iter().find(|p| p.label == "24h") {
-            if period_24h.total_cost_usd > 0.0 {
-                println!("  Cost (24h):   ${:.2}", period_24h.total_cost_usd);
+        let total_cost: f64 = c.periods.iter().map(|p| p.total_cost_usd).sum();
+        if total_cost > 0.0 {
+            if let Some(period) = c.periods.iter().find(|p| p.label == window_label) {
+                println!("  Cost ({}): ${:.2}", window_label, period.total_cost_usd);
+            } else if let Some(period_24h) = c.periods.iter().find(|p| p.label == "24h") {
+                if period_24h.total_cost_usd > 0.0 {
+                    println!("  Cost (24h):   ${:.2}", period_24h.total_cost_usd);
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,9 +293,12 @@ enum Commands {
     },
     /// Show task metrics summary
     Metrics {
-        /// Show slow tasks and error distribution (last 7 days)
+        /// Show slow tasks and error distribution
         #[arg(long)]
         details: bool,
+        /// Time window to report on (e.g. "24h", "7d", "30d"; default: "24h")
+        #[arg(long, default_value = "24h")]
+        since: String,
     },
     /// Combined dashboard: tasks, sessions, recent activity
     Dashboard {
@@ -340,6 +343,9 @@ enum Commands {
         /// Aggregate all projects into one table
         #[arg(long)]
         all: bool,
+        /// Time window to report on (e.g. "24h", "7d", "30d"; default: "24h")
+        #[arg(long, default_value = "24h")]
+        since: String,
     },
     /// Generate shell completions
     Completions {
@@ -900,8 +906,15 @@ async fn main() -> anyhow::Result<()> {
                 cli::service::status()?;
             }
         },
-        Commands::Metrics { details } => {
-            cli::metrics(details).await?;
+        Commands::Metrics { details, since } => {
+            let hours = cli::parse_since(&since).unwrap_or_else(|| {
+                eprintln!(
+                    "Warning: unrecognised --since value {:?}, defaulting to 24h",
+                    since
+                );
+                24
+            });
+            cli::metrics(details, hours).await?;
         }
         // Combined dashboard view: tasks, sessions, recent activity
         Commands::Dashboard { global, project } => {
@@ -959,8 +972,15 @@ async fn main() -> anyhow::Result<()> {
                 cli::cost::show_summary().await?;
             }
         }
-        Commands::Stats { all } => {
-            cli::stats::stats(all).await?;
+        Commands::Stats { all, since } => {
+            let hours = cli::parse_since(&since).unwrap_or_else(|| {
+                eprintln!(
+                    "Warning: unrecognised --since value {:?}, defaulting to 24h",
+                    since
+                );
+                24
+            });
+            cli::stats::stats(all, hours).await?;
         }
         Commands::Completions { shell } => {
             let mut cmd = Cli::command();

--- a/src/store/metrics.rs
+++ b/src/store/metrics.rs
@@ -189,7 +189,97 @@ impl TaskStore {
         Ok(row.try_get("id").unwrap_or(0))
     }
 
+    /// Get aggregated metrics for a configurable time window.
+    ///
+    /// `hours` controls how far back to look (e.g. 24 for 24 h, 168 for 7 days).
+    /// The interval string is built from a `u32` config value, not user input.
+    pub async fn get_metrics_summary(&self, hours: u32) -> anyhow::Result<MetricsSummary> {
+        let interval = format!("-{hours} hours");
+
+        let completed: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM task_metrics WHERE completed_at >= datetime('now', ?) AND outcome = 'success'",
+        )
+        .bind(&interval)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let failed: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM task_metrics WHERE completed_at >= datetime('now', ?) AND outcome != 'success'",
+        )
+        .bind(&interval)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let avg_simple: Option<(f64,)> = sqlx::query_as(
+            "SELECT AVG(duration_seconds) FROM task_metrics WHERE completed_at >= datetime('now', ?) AND complexity = 'simple'",
+        )
+        .bind(&interval)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let avg_medium: Option<(f64,)> = sqlx::query_as(
+            "SELECT AVG(duration_seconds) FROM task_metrics WHERE completed_at >= datetime('now', ?) AND complexity = 'medium'",
+        )
+        .bind(&interval)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let avg_complex: Option<(f64,)> = sqlx::query_as(
+            "SELECT AVG(duration_seconds) FROM task_metrics WHERE completed_at >= datetime('now', ?) AND complexity = 'complex'",
+        )
+        .bind(&interval)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let agent_rows = sqlx::query(
+            "SELECT agent, COUNT(*) as total,
+                SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END) as success_count
+         FROM task_metrics
+         WHERE completed_at >= datetime('now', ?)
+         GROUP BY agent",
+        )
+        .bind(&interval)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let agent_stats: Vec<AgentStat> = agent_rows
+            .iter()
+            .map(|row| {
+                let total: i64 = row.try_get("total").unwrap_or(0);
+                let success: i64 = row.try_get("success_count").unwrap_or(0);
+                AgentStat {
+                    agent: row.try_get("agent").unwrap_or_default(),
+                    total_runs: total,
+                    success_count: success,
+                    success_rate: if total > 0 {
+                        (success as f64 / total as f64) * 100.0
+                    } else {
+                        0.0
+                    },
+                }
+            })
+            .collect();
+
+        let rate_limit_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM rate_limits WHERE occurred_at >= datetime('now', ?)",
+        )
+        .bind(&interval)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(MetricsSummary {
+            tasks_completed_24h: completed.0,
+            tasks_failed_24h: failed.0,
+            avg_duration_simple: avg_simple.map(|r| r.0),
+            avg_duration_medium: avg_medium.map(|r| r.0),
+            avg_duration_complex: avg_complex.map(|r| r.0),
+            agent_stats,
+            rate_limits_24h: rate_limit_count.0,
+        })
+    }
+
     /// Get aggregated metrics for the last 24 hours.
+    #[allow(dead_code)]
     pub async fn get_metrics_summary_24h(&self) -> anyhow::Result<MetricsSummary> {
         let completed: (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM task_metrics WHERE completed_at >= datetime('now', '-24 hours') AND outcome = 'success'",
@@ -263,6 +353,124 @@ impl TaskStore {
             avg_duration_complex: avg_complex.map(|r| r.0),
             agent_stats,
             rate_limits_24h: rate_limit_count.0,
+        })
+    }
+
+    /// Get metrics summary for a configurable time window, filtered by repo.
+    ///
+    /// `hours` controls how far back to look. Uses `COALESCE(NULLIF(m.repo, ''), t.repo)`
+    /// join pattern so older metric rows without a repo column still match.
+    pub async fn get_metrics_summary_by_repo(
+        &self,
+        repo: &str,
+        hours: u32,
+    ) -> anyhow::Result<MetricsSummary> {
+        let interval = format!("-{hours} hours");
+
+        let completed: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM task_metrics m
+         LEFT JOIN tasks t ON m.task_id = CAST(t.id AS TEXT) OR m.task_id = t.external_id
+         WHERE m.completed_at >= datetime('now', ?)
+         AND m.outcome = 'success'
+         AND COALESCE(NULLIF(m.repo, ''), t.repo) = ?",
+        )
+        .bind(&interval)
+        .bind(repo)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let failed: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM task_metrics m
+         LEFT JOIN tasks t ON m.task_id = CAST(t.id AS TEXT) OR m.task_id = t.external_id
+         WHERE m.completed_at >= datetime('now', ?)
+         AND m.outcome != 'success'
+         AND COALESCE(NULLIF(m.repo, ''), t.repo) = ?",
+        )
+        .bind(&interval)
+        .bind(repo)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let avg_simple: Option<(f64,)> = sqlx::query_as(
+            "SELECT AVG(m.duration_seconds) FROM task_metrics m
+         LEFT JOIN tasks t ON m.task_id = CAST(t.id AS TEXT) OR m.task_id = t.external_id
+         WHERE m.completed_at >= datetime('now', ?) AND m.complexity = 'simple'
+         AND COALESCE(NULLIF(m.repo, ''), t.repo) = ?",
+        )
+        .bind(&interval)
+        .bind(repo)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let avg_medium: Option<(f64,)> = sqlx::query_as(
+            "SELECT AVG(m.duration_seconds) FROM task_metrics m
+         LEFT JOIN tasks t ON m.task_id = CAST(t.id AS TEXT) OR m.task_id = t.external_id
+         WHERE m.completed_at >= datetime('now', ?) AND m.complexity = 'medium'
+         AND COALESCE(NULLIF(m.repo, ''), t.repo) = ?",
+        )
+        .bind(&interval)
+        .bind(repo)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let avg_complex: Option<(f64,)> = sqlx::query_as(
+            "SELECT AVG(m.duration_seconds) FROM task_metrics m
+         LEFT JOIN tasks t ON m.task_id = CAST(t.id AS TEXT) OR m.task_id = t.external_id
+         WHERE m.completed_at >= datetime('now', ?) AND m.complexity = 'complex'
+         AND COALESCE(NULLIF(m.repo, ''), t.repo) = ?",
+        )
+        .bind(&interval)
+        .bind(repo)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let agent_rows = sqlx::query(
+            "SELECT m.agent, COUNT(*) as total,
+                SUM(CASE WHEN m.outcome = 'success' THEN 1 ELSE 0 END) as success_count
+         FROM task_metrics m
+         LEFT JOIN tasks t ON m.task_id = CAST(t.id AS TEXT) OR m.task_id = t.external_id
+         WHERE m.completed_at >= datetime('now', ?)
+         AND COALESCE(NULLIF(m.repo, ''), t.repo) = ?
+         GROUP BY m.agent",
+        )
+        .bind(&interval)
+        .bind(repo)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let agent_stats: Vec<AgentStat> = agent_rows
+            .iter()
+            .map(|row| {
+                let total: i64 = row.try_get("total").unwrap_or(0);
+                let success: i64 = row.try_get("success_count").unwrap_or(0);
+                AgentStat {
+                    agent: row.try_get("agent").unwrap_or_default(),
+                    total_runs: total,
+                    success_count: success,
+                    success_rate: if total > 0 {
+                        (success as f64 / total as f64) * 100.0
+                    } else {
+                        0.0
+                    },
+                }
+            })
+            .collect();
+
+        let rate_limits: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM rate_limits WHERE occurred_at >= datetime('now', ?)",
+        )
+        .bind(&interval)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(MetricsSummary {
+            tasks_completed_24h: completed.0,
+            tasks_failed_24h: failed.0,
+            avg_duration_simple: avg_simple.map(|r| r.0),
+            avg_duration_medium: avg_medium.map(|r| r.0),
+            avg_duration_complex: avg_complex.map(|r| r.0),
+            agent_stats,
+            rate_limits_24h: rate_limits.0,
         })
     }
 
@@ -374,12 +582,17 @@ impl TaskStore {
         })
     }
 
-    /// Get 24-hour cost summary filtered to a specific repository.
+    /// Get cost summary filtered to a specific repository for a configurable window.
     ///
     /// Uses the same `COALESCE(NULLIF(m.repo, ''), t.repo)` join pattern as
-    /// `get_metrics_summary_24h_by_repo` so older metrics rows that lack a `repo`
+    /// `get_metrics_summary_by_repo` so older metrics rows that lack a `repo`
     /// column value are still matched via the tasks table.
-    pub async fn get_cost_summary_24h_by_repo(&self, repo: &str) -> anyhow::Result<CostSummary> {
+    pub async fn get_cost_summary_by_repo(
+        &self,
+        repo: &str,
+        hours: u32,
+    ) -> anyhow::Result<CostSummary> {
+        let interval = format!("-{hours} hours");
         let row = sqlx::query(
             "SELECT COALESCE(SUM(m.input_tokens), 0) as input_tokens,
                 COALESCE(SUM(m.output_tokens), 0) as output_tokens,
@@ -389,16 +602,23 @@ impl TaskStore {
                 COUNT(*) as task_count
          FROM task_metrics m
          LEFT JOIN tasks t ON m.task_id = CAST(t.id AS TEXT) OR m.task_id = t.external_id
-         WHERE m.completed_at >= datetime('now', '-24 hours')
+         WHERE m.completed_at >= datetime('now', ?)
          AND COALESCE(NULLIF(m.repo, ''), t.repo) = ?",
         )
+        .bind(&interval)
         .bind(repo)
         .fetch_one(&self.pool)
         .await?;
 
         Ok(CostSummary {
             periods: vec![CostPeriod {
-                label: "24h".to_string(),
+                label: if hours == 24 {
+                    "24h".to_string()
+                } else if hours.is_multiple_of(24) {
+                    format!("{}d", hours / 24)
+                } else {
+                    format!("{hours}h")
+                },
                 input_tokens: row.try_get("input_tokens").unwrap_or(0),
                 output_tokens: row.try_get("output_tokens").unwrap_or(0),
                 input_cost_usd: row.try_get("input_cost_usd").unwrap_or(0.0),
@@ -407,6 +627,12 @@ impl TaskStore {
                 task_count: row.try_get("task_count").unwrap_or(0),
             }],
         })
+    }
+
+    /// Get 24-hour cost summary filtered to a specific repository.
+    #[allow(dead_code)]
+    pub async fn get_cost_summary_24h_by_repo(&self, repo: &str) -> anyhow::Result<CostSummary> {
+        self.get_cost_summary_by_repo(repo, 24).await
     }
 
     /// Record a rate limit event. Prunes records older than 30 days.
@@ -465,7 +691,33 @@ impl TaskStore {
         Ok(map)
     }
 
+    /// Get slow tasks (top 10 longest running) for a configurable time window.
+    pub async fn get_slow_tasks(&self, hours: u32) -> anyhow::Result<Vec<SlowTaskInfo>> {
+        let interval = format!("-{hours} hours");
+        let rows = sqlx::query(
+            "SELECT task_id, agent, complexity, duration_seconds
+         FROM task_metrics
+         WHERE completed_at >= datetime('now', ?) AND outcome = 'success'
+         ORDER BY duration_seconds DESC
+         LIMIT 10",
+        )
+        .bind(&interval)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .iter()
+            .map(|row| SlowTaskInfo {
+                task_id: row.try_get("task_id").unwrap_or_default(),
+                agent: row.try_get("agent").unwrap_or_default(),
+                complexity: row.try_get("complexity").unwrap_or(None),
+                duration_seconds: row.try_get("duration_seconds").unwrap_or(0.0),
+            })
+            .collect())
+    }
+
     /// Get slow tasks (top 10 longest running) from the last 7 days.
+    #[allow(dead_code)]
     pub async fn get_slow_tasks_7d(&self) -> anyhow::Result<Vec<SlowTaskInfo>> {
         let rows = sqlx::query(
             "SELECT task_id, agent, complexity, duration_seconds
@@ -488,17 +740,19 @@ impl TaskStore {
             .collect())
     }
 
-    /// Get error type distribution from the last 7 days.
-    pub async fn get_error_distribution_7d(&self) -> anyhow::Result<Vec<ErrorStat>> {
+    /// Get error type distribution for a configurable time window.
+    pub async fn get_error_distribution(&self, hours: u32) -> anyhow::Result<Vec<ErrorStat>> {
+        let interval = format!("-{hours} hours");
         let rows = sqlx::query(
             "SELECT error_type, COUNT(*) as count
          FROM task_metrics
-         WHERE completed_at >= datetime('now', '-7 days')
+         WHERE completed_at >= datetime('now', ?)
            AND outcome != 'success'
            AND error_type IS NOT NULL
          GROUP BY error_type
          ORDER BY count DESC",
         )
+        .bind(&interval)
         .fetch_all(&self.pool)
         .await?;
 
@@ -509,6 +763,12 @@ impl TaskStore {
                 count: row.try_get("count").unwrap_or(0),
             })
             .collect())
+    }
+
+    /// Get error type distribution from the last 7 days.
+    #[allow(dead_code)]
+    pub async fn get_error_distribution_7d(&self) -> anyhow::Result<Vec<ErrorStat>> {
+        self.get_error_distribution(24 * 7).await
     }
 
     /// Get cost summary over multiple time windows (24h, 7d, 30d).
@@ -643,6 +903,35 @@ impl TaskStore {
         let key = self_improvement_key();
         let count = self.kv_get(&key).await?;
         Ok(count.and_then(|c| c.parse().ok()).unwrap_or(0))
+    }
+
+    /// Get tasks with high review cycle counts (persistent review loops) for a configurable window.
+    pub async fn get_high_review_cycle_tasks(
+        &self,
+        hours: u32,
+    ) -> anyhow::Result<Vec<HighReviewCycleTask>> {
+        let interval = format!("-{hours} hours");
+        let rows = sqlx::query(
+            "SELECT external_id, agent, review_cycles, title
+         FROM tasks
+         WHERE review_cycles >= 2
+           AND updated_at >= datetime('now', ?)
+         ORDER BY review_cycles DESC
+         LIMIT 10",
+        )
+        .bind(&interval)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .iter()
+            .map(|row| HighReviewCycleTask {
+                external_id: row.try_get("external_id").unwrap_or(None),
+                agent: row.try_get("agent").unwrap_or(None),
+                review_cycles: row.try_get("review_cycles").unwrap_or(0),
+                title: row.try_get("title").unwrap_or_default(),
+            })
+            .collect())
     }
 
     /// Get tasks with high review cycle counts (persistent review loops) from the last 7 days.

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -3768,7 +3768,7 @@ async fn slow_tasks_empty() {
 #[tokio::test]
 async fn error_distribution_empty() {
     let store = TaskStore::open_memory().await.unwrap();
-    let errors = store.get_error_distribution_7d().await.unwrap();
+    let errors = store.get_error_distribution(24 * 7).await.unwrap();
     assert!(errors.is_empty());
 }
 
@@ -3880,7 +3880,7 @@ async fn error_distribution_groups_by_type() {
             .unwrap();
     }
 
-    let errors = store.get_error_distribution_7d().await.unwrap();
+    let errors = store.get_error_distribution(24 * 7).await.unwrap();
     assert_eq!(errors.len(), 2);
     // timeout should be first (count=2)
     assert_eq!(errors[0].error_type.as_deref(), Some("timeout"));
@@ -3919,7 +3919,7 @@ async fn slow_tasks_returns_sorted_by_duration() {
             .unwrap();
     }
 
-    let slow = store.get_slow_tasks_7d().await.unwrap();
+    let slow = store.get_slow_tasks(24 * 7).await.unwrap();
     assert_eq!(slow.len(), 3);
     // Should be sorted descending by duration
     assert_eq!(slow[0].task_id, "t2");
@@ -4594,10 +4594,10 @@ async fn subscribe_with_topic_id_preserved() {
     );
 }
 
-// ── get_cost_summary_24h_by_repo ────────────────────────────────
+// ── get_cost_summary_by_repo ───────────────────────────────────
 
 #[tokio::test]
-async fn cost_summary_24h_by_repo_isolates_per_repo() {
+async fn cost_summary_by_repo_isolates_per_repo() {
     use chrono::Utc;
     let store = TaskStore::open_memory().await.unwrap();
     let now = Utc::now();
@@ -4652,7 +4652,7 @@ async fn cost_summary_24h_by_repo_isolates_per_repo() {
 
     // owner/orch should only see its own cost
     let orch_cost = store
-        .get_cost_summary_24h_by_repo("owner/orch")
+        .get_cost_summary_by_repo("owner/orch", 24)
         .await
         .unwrap();
     assert_eq!(orch_cost.periods.len(), 1);
@@ -4662,7 +4662,7 @@ async fn cost_summary_24h_by_repo_isolates_per_repo() {
 
     // owner/bean should only see its own cost
     let bean_cost = store
-        .get_cost_summary_24h_by_repo("owner/bean")
+        .get_cost_summary_by_repo("owner/bean", 24)
         .await
         .unwrap();
     assert_eq!(bean_cost.periods[0].task_count, 1);
@@ -4670,7 +4670,7 @@ async fn cost_summary_24h_by_repo_isolates_per_repo() {
 
     // Unknown repo returns zeros
     let unknown = store
-        .get_cost_summary_24h_by_repo("unknown/repo")
+        .get_cost_summary_by_repo("unknown/repo", 24)
         .await
         .unwrap();
     assert_eq!(unknown.periods[0].task_count, 0);
@@ -4678,7 +4678,7 @@ async fn cost_summary_24h_by_repo_isolates_per_repo() {
 }
 
 #[tokio::test]
-async fn cost_summary_24h_by_repo_falls_back_to_tasks_join() {
+async fn cost_summary_by_repo_falls_back_to_tasks_join() {
     use chrono::Utc;
     let store = TaskStore::open_memory().await.unwrap();
     let now = Utc::now();
@@ -4714,11 +4714,81 @@ async fn cost_summary_24h_by_repo_falls_back_to_tasks_join() {
         .unwrap();
 
     let cost = store
-        .get_cost_summary_24h_by_repo("owner/orch")
+        .get_cost_summary_by_repo("owner/orch", 24)
         .await
         .unwrap();
     assert_eq!(cost.periods[0].task_count, 1);
     assert!((cost.periods[0].total_cost_usd - 0.0045).abs() < 1e-6);
+}
+
+#[tokio::test]
+async fn cost_summary_by_repo_uses_requested_window_label() {
+    use chrono::{Duration, Utc};
+    let store = TaskStore::open_memory().await.unwrap();
+    let now = Utc::now();
+    let eight_days_ago = now - Duration::days(8);
+
+    store
+        .insert_task_metric(&InsertTaskMetric {
+            repo: "owner/orch",
+            task_id: "recent",
+            agent: "claude",
+            model: Some("sonnet"),
+            complexity: None,
+            outcome: "success",
+            duration_seconds: 10.0,
+            started_at: &now,
+            completed_at: &now,
+            attempts: 1,
+            files_changed: 1,
+            error_type: None,
+            input_tokens: Some(100),
+            output_tokens: Some(50),
+            input_cost_usd: Some(0.001),
+            output_cost_usd: Some(0.002),
+            total_cost_usd: Some(0.003),
+        })
+        .await
+        .unwrap();
+
+    store
+        .insert_task_metric(&InsertTaskMetric {
+            repo: "owner/orch",
+            task_id: "older",
+            agent: "claude",
+            model: Some("sonnet"),
+            complexity: None,
+            outcome: "success",
+            duration_seconds: 12.0,
+            started_at: &eight_days_ago,
+            completed_at: &eight_days_ago,
+            attempts: 1,
+            files_changed: 1,
+            error_type: None,
+            input_tokens: Some(200),
+            output_tokens: Some(100),
+            input_cost_usd: Some(0.002),
+            output_cost_usd: Some(0.004),
+            total_cost_usd: Some(0.006),
+        })
+        .await
+        .unwrap();
+
+    let summary_7d = store
+        .get_cost_summary_by_repo("owner/orch", 24 * 7)
+        .await
+        .unwrap();
+    assert_eq!(summary_7d.periods[0].label, "7d");
+    assert_eq!(summary_7d.periods[0].task_count, 1);
+    assert!((summary_7d.periods[0].total_cost_usd - 0.003).abs() < 1e-6);
+
+    let summary_30d = store
+        .get_cost_summary_by_repo("owner/orch", 24 * 30)
+        .await
+        .unwrap();
+    assert_eq!(summary_30d.periods[0].label, "30d");
+    assert_eq!(summary_30d.periods[0].task_count, 2);
+    assert!((summary_30d.periods[0].total_cost_usd - 0.009).abs() < 1e-6);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Added configurable time windows to `orch metrics` and `orch stats`, including window-aware detail sections and repo-scoped cost reporting.

### What was done

- Added `--since` support to `orch metrics` and `orch stats` with parsing for values like `24h`, `7d`, and `30d`.
- Replaced hard-coded 24h store lookups with configurable-window metrics queries, including repo-filtered summaries.
- Made metrics detail output honor the selected window for slow tasks, error distribution, and repeated review-loop reporting.
- Added configurable repo cost summaries so `orch stats` shows cost for the requested window instead of always falling back to 24h.
- Added and updated tests covering `--since` parsing/labels and windowed store behavior.
- Ran `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run`.
- Committed the change as `feat: add configurable metrics windows`.


Closes #1743

---
*Task #1743 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4`*