### PR TITLE
bug: LLM router silently swallows skills catalog load error — routing degrades without logging

### DIFF
--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -599,7 +599,10 @@ impl LlmRouter {
         // Load skills catalog if available — perform blocking FS work off the async reactor.
         let skills_catalog = match self.load_skills_catalog().await {
             Ok(s) => s,
-            Err(_) => "[]".to_string(),
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to load skills catalog, routing without skills");
+                "[]".to_string()
+            }
         };
 
         // Simple template substitution


### PR DESCRIPTION
## Summary

## Summary

Fixed the silent error handling in the LLM router's skills catalog loading. The change:

1. **Modified** `src/engine/router/llm.rs:600-606` to add a `tracing::warn!` log before falling back to an empty skills catalog
2. **Error message**: `"failed to load skills catalog, routing without skills"` with the error details
3. **Impact**: Now when `load_skills_catalog()` fails, the routing quality degradation is visible in logs

The fix ensures that if the skills directory has permission i

Closes #1795

---
*Task #1795 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*