### PR TITLE
fix: gate scan_commands by GitHub 5xx circuit breaker

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -728,10 +728,13 @@ pub(crate) async fn sync_tick(
     }
 
     // 6. Scan for owner /slash commands in issue comments
-    if let Err(e) =
-        super::commands::scan_commands(backend, repo, &Some(Arc::clone(store)), task_manager).await
-    {
-        tracing::warn!(err = %e, "owner command scan failed");
+    if !gh_circuit_open {
+        if let Err(e) =
+            super::commands::scan_commands(backend, repo, &Some(Arc::clone(store)), task_manager)
+                .await
+        {
+            tracing::warn!(err = %e, "owner command scan failed");
+        }
     }
 
     // 7. Sync skill repositories


### PR DESCRIPTION
## Summary

During GitHub 5xx outages, the circuit breaker was open for most operations, but `scan_commands` continued firing every tick for each configured repo. This caused spurious warnings to flood the logs:

```
WARN orch::engine::commands: failed to fetch comments for command scanning err=GitHub API transient 5xx circuit-breaker active for 235s
```

With 3 repos and a 10s tick, that's ~18 warnings/minute for the entire duration of an outage.

## Root Cause

In `src/engine/sync.rs`, steps 0–4 were all gated with `if !gh_circuit_open { ... }`, but step 6 (`scan_commands`) at line 732 was not.

## Fix

Wrapped step 6 in the same circuit breaker gate as steps 0-4:

```rust
if !gh_circuit_open {
    if let Err(e) = super::commands::scan_commands(...).await {
        tracing::warn!(err = %e, "owner command scan failed");
    }
}
```

## Testing

- ✅ cargo fmt
- ✅ cargo clippy (no issues)
- ✅ cargo nextest run (2621 passed, 19 skipped)

Fixes #1799

🤖 Generated with Claude Code

---
*Task #1799 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*