### PR TITLE
bug: classify_from_text missing detect_stale_session — control sessions stuck after session expiry

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -990,6 +990,9 @@ pub(crate) mod patterns {
         if let Some(e) = detect_auth_error(text) {
             return e;
         }
+        if let Some(e) = detect_stale_session(text) {
+            return e;
+        }
 
         AgentError::Unknown {
             exit_code,
@@ -1265,6 +1268,25 @@ mod tests {
         assert!(
             matches!(err, AgentError::RateLimit { .. }),
             "real rate limit at tail must be detected, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_from_text_detects_stale_session() {
+        // Regression test for issue #1800: classify_from_text must call
+        // detect_stale_session to catch "No conversation found with session ID"
+        // errors. Without this, the error would be misclassified as Unknown and
+        // the control.rs recovery code would not trigger.
+        let text = "No conversation found with session ID: 2be572c4-57bb-4f86-bc03-b593c329177c";
+        let err = patterns::classify_from_text(1, text);
+        assert!(
+            matches!(err, AgentError::StaleSession { .. }),
+            "stale session must be detected via classify_from_text, got: {err:?}"
+        );
+        // Verify the Display format matches what control.rs expects
+        assert!(
+            err.to_string().contains("stale session"),
+            "error display must contain 'stale session' for recovery code to trigger"
         );
     }
 


### PR DESCRIPTION
## Summary

## Summary

I've successfully fixed the bug where control sessions were stuck indefinitely when a session ID expired. Here's what was done:

### The Problem
When a Claude control session agent invocation returned exit code 1 with `"No conversation found with session ID: <uuid>"`, the stale-session recovery code in `control.rs` never fired. The error was incorrectly classified as `Unknown` instead of `StaleSession`, so the recovery logic that resets the UUID never triggered.

### Root Cause
The `

Closes #1800

---
*Task #1800 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*