### PR TITLE
Blocking file I/O in webhook dedup check_and_insert blocks Tokio threads

### DIFF
--- a/src/channels/github.rs
+++ b/src/channels/github.rs
@@ -186,8 +186,11 @@ impl DedupStore {
         };
 
         // Flush outside the mutex to keep the critical section short.
+        // Use spawn_blocking so that the blocking std::fs calls (File::create,
+        // write_all, sync_all, rename) do not occupy a Tokio async worker thread.
         if let (Some(path), Some(entries)) = (&self.file_path, flush_entries) {
-            flush_dedup_file(path, &entries);
+            let path = path.clone();
+            let _ = tokio::task::spawn_blocking(move || flush_dedup_file(&path, &entries)).await;
         }
 
         is_new


### PR DESCRIPTION
## Summary

All 227 tests pass. The fix is clean — one extra line to clone the `PathBuf` and wrap the blocking call in `spawn_blocking`:

```rust
// Before:
flush_dedup_file(path, &entries);

// After:
let path = path.clone();
let _ = tokio::task::spawn_blocking(move || flush_dedup_file(&path, &entries)).await;
```

This offloads `File::create`, `write_all`, `sync_all`, and `rename` to Tokio's dedicated blocking thread pool instead of occupying an async worker thread.

Closes #1803

---
*Task #1803 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*