### PR TITLE
atomic_write uses deterministic tmp filename; concurrent flushes can collide

### DIFF
--- a/src/channels/github.rs
+++ b/src/channels/github.rs
@@ -300,7 +300,7 @@ fn atomic_write(path: &Path, content: &str) -> std::io::Result<()> {
         std::fs::create_dir_all(parent)?;
     }
 
-    let tmp_path = path.with_extension(format!("db.tmp.{}", std::process::id()));
+    let tmp_path = path.with_extension(format!("db.tmp.{}", uuid::Uuid::new_v4()));
     let mut file = std::fs::File::create(&tmp_path)?;
     file.write_all(content.as_bytes())?;
     file.sync_all()?;


### PR DESCRIPTION
## Summary

All 2621 tests pass. The fix replaces `std::process::id()` with `uuid::Uuid::new_v4()` in the tmp filename — each call to `atomic_write` now gets a unique random suffix, eliminating the race condition for concurrent flushes. The `uuid` crate with `v4` feature was already a dependency.

Closes #1804

---
*Task #1804 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*