### PR TITLE
scan_mentions propagates create_internal error with ?, aborting the full batch and causing duplicate tasks on retry

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -991,10 +991,19 @@ async fn scan_mentions(
         let task_body = format!("Mention by @{}:\n\n{}", mention.author, mention.body);
 
         if let Some(s) = store {
-            let task_id = s
+            match s
                 .create_internal(repo, &title, &task_body, "mention", &mention.id)
-                .await?;
-            tracing::info!(task_id, mention_id = %mention.id, "created mention task");
+                .await
+            {
+                Ok(task_id) => {
+                    tracing::info!(task_id, mention_id = %mention.id, "created mention task")
+                }
+                Err(e) => tracing::warn!(
+                    mention_id = %mention.id,
+                    err = %e,
+                    "failed to create mention task — skipping"
+                ),
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

All 2623 tests pass. The fix is clean — replaced `await?` with a `match` that logs a warning and continues the loop on error, letting the cursor advance normally and the rest of the batch proceed.

Closes #1815

---
*Task #1815 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*