### PR TITLE
scan_mentions advances cursor mid-loop for policy-skipped mentions, can permanently skip later mentions in the same batch

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -873,13 +873,12 @@ async fn scan_mentions(
                             command = %command,
                             "ignoring slash command in mention on non-open issue"
                         );
-                        // Still mark as processed so we don't keep trying
-                        kv_set_prefer_store(
-                            &store,
-                            "mentions_last_checked",
-                            &chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
-                        )
-                        .await;
+                        // Do NOT advance the global mentions cursor here. Leaving the
+                        // cursor update until after the full batch (end of function)
+                        // prevents permanently skipping other mentions in the same
+                        // fetched batch when timestamps are non-monotonic or clocks
+                        // are skewed. The mention will be re-fetched on the next tick
+                        // and re-evaluated (idempotent skip).
                         continue;
                     }
                     Ok(_) => {}
@@ -903,13 +902,10 @@ async fn scan_mentions(
                             issue = %issue_num,
                             "ignoring slash command in mention from non-collaborator"
                         );
-                        // Still mark as processed
-                        kv_set_prefer_store(
-                            &store,
-                            "mentions_last_checked",
-                            &chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
-                        )
-                        .await;
+                        // Do NOT advance the global mentions cursor here for the same
+                        // reason described above. Let the final cursor update at the
+                        // end of the function handle batch progression so later
+                        // mentions in this fetch are not skipped.
                         continue;
                     }
                     Err(e) => {


### PR DESCRIPTION
## Summary

Removed mid-loop cursor updates in scan_mentions to avoid permanently skipping later mentions in the same fetched batch.

### What was done

- Searched for usages of mentions_last_checked and inspected src/engine/sync.rs
- Removed two in-loop calls to kv_set_prefer_store that advanced mentions_last_checked when skipping policy-ignored mentions (closed issue or non-collaborator)
- Added clarifying comments explaining why the cursor should only be updated once after the loop completes
- Ran the test suite and committed the change


### Remaining

- Address the three unrelated failing tests observed during cargo test (engine::cooldown::tests::github_circuit_sliding_window_ages_out, engine::cooldown::tests::github_circuit_stays_closed_below_threshold, engine::cooldown::tests::record_agent_success_resets_backoff). These failures appeared when running the full test suite but are unrelated to the mentions cursor change.


Closes #1812

---
*Task #1812 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*