### PR TITLE
Silently swallowed errors in error paths mask root causes

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -978,7 +978,9 @@ impl TaskRunner {
                 // set_labels (add_labels) fails with 422 if the label doesn't exist
                 // in the repo yet — ensure_label creates it first.
                 let old_label = format!("agent:{agent_name}");
-                backend.remove_label(&task.id, &old_label).await.ok();
+                if let Err(e) = backend.remove_label(&task.id, &old_label).await {
+                    tracing::warn!(task_id = ?task.id, label = old_label, error = %e, "failed to remove old agent label during re-route");
+                }
                 let new_label = format!("agent:{new_agent}");
                 match crate::github::http::GhHttp::new() {
                     Ok(gh) => {

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -187,8 +187,18 @@ pub(crate) async fn tick_detect_silent_agents(
         let use_backend = should_use_backend(&task_id);
         // Look up agent + model from the store so we can cooldown the right model.
         let store_task = match store.resolve_task_id(repo, &task_id).await {
-            Ok(Some(store_id)) => store.get(store_id).await.ok(),
-            _ => None,
+            Ok(Some(store_id)) => match store.get(store_id).await {
+                Ok(task) => Some(task),
+                Err(e) => {
+                    tracing::warn!(task_id, error = %e, "failed to fetch task from store during silence detection");
+                    None
+                }
+            },
+            Ok(None) => None,
+            Err(e) => {
+                tracing::warn!(task_id, error = %e, "failed to resolve task id during silence detection");
+                None
+            }
         };
         let agent_name = store_task
             .as_ref()
@@ -304,7 +314,9 @@ pub(crate) async fn tick_detect_silent_agents(
                         || label.starts_with("complexity:")
                         || label.starts_with("model:")
                     {
-                        backend.remove_label(&task_eid, label).await.ok();
+                        if let Err(e) = backend.remove_label(&task_eid, label).await {
+                            tracing::warn!(task_id, label, error = %e, "failed to remove label during silence detection re-route");
+                        }
                     }
                 }
             }

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -17,8 +17,21 @@ pub async fn opt_store_get_task(
     task_id: &str,
 ) -> Option<Task> {
     let s = store.as_ref()?;
-    let store_id = s.resolve_task_id(repo, task_id).await.ok()??;
-    s.get(store_id).await.ok()
+    let store_id = match s.resolve_task_id(repo, task_id).await {
+        Ok(Some(id)) => id,
+        Ok(None) => return None,
+        Err(e) => {
+            tracing::warn!(task_id, error = %e, "failed to resolve task id in store");
+            return None;
+        }
+    };
+    match s.get(store_id).await {
+        Ok(task) => Some(task),
+        Err(e) => {
+            tracing::warn!(task_id, error = %e, "failed to fetch task from store");
+            None
+        }
+    }
 }
 
 /// Write fields to the task store.


### PR DESCRIPTION
## Summary

All 2623 tests pass. The changes are complete:

**Summary of fixes:**

1. **`src/engine/tick.rs:190`** — `store.get().await.ok()` replaced with explicit match that logs `warn!` on error and returns `None`

2. **`src/engine/tick.rs:317`** (was 307) — `backend.remove_label().await.ok()` replaced with `if let Err(e) = ...` that logs the failure with task_id and label context

3. **`src/engine/runner/mod.rs:981`** — same pattern: `remove_label().await.ok()` → logged warning on failure

4. **

Closes #1822

---
*Task #1822 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*