### PR TITLE
bug: auto_merge failure comments silently dropped — blocked tasks appear with no PR explanation

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -679,13 +679,21 @@ pub(crate) async fn auto_merge_pr(
                 e
             );
             let footer = attribution_footer("Commented", review_agent, review_model);
-            let _ = gh
+            if let Err(e) = gh
                 .add_comment(
                     repo,
                     &pr_number.to_string(),
                     &format!("{}{}", comment, footer),
                 )
-                .await;
+                .await
+            {
+                tracing::warn!(
+                    task_id = task.id.0,
+                    pr_number,
+                    err = %e,
+                    "auto-merge: failed to post merge conflict failure comment on PR"
+                );
+            }
             return Ok(());
         }
 
@@ -696,13 +704,21 @@ pub(crate) async fn auto_merge_pr(
             .await?;
         let comment = format!("Auto-merge failed: {}", e);
         let footer = attribution_footer("Commented", review_agent, review_model);
-        let _ = gh
+        if let Err(e) = gh
             .add_comment(
                 repo,
                 &pr_number.to_string(),
                 &format!("{}{}", comment, footer),
             )
-            .await;
+            .await
+        {
+            tracing::warn!(
+                task_id = task.id.0,
+                pr_number,
+                err = %e,
+                "auto-merge: failed to post merge failure comment on PR"
+            );
+        }
         return Ok(());
     }
 
@@ -726,13 +742,21 @@ pub(crate) async fn auto_merge_pr(
     // 8. Post final comment on the PR
     let comment = "✅ PR reviewed, approved, and merged.";
     let footer = attribution_footer("Reviewed", review_agent, review_model);
-    let _ = gh
+    if let Err(e) = gh
         .add_comment(
             repo,
             &pr_number.to_string(),
             &format!("{}{}", comment, footer),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(
+            task_id = task.id.0,
+            pr_number,
+            err = %e,
+            "auto-merge: failed to post success comment on PR"
+        );
+    }
 
     tracing::info!(task_id = task.id.0, "auto-merge completed");
 


### PR DESCRIPTION
## Summary

## Summary

I've fixed the silent error dropping issue in `src/engine/auto_merge.rs`. The changes replace three instances of `let _ = gh.add_comment(...).await` with proper error logging using `tracing::warn!()`:

### Changes Made

1. **Lines 682-696** (merge conflict failure): Added logging when the merge conflict failure comment fails to post
2. **Lines 707-721** (non-conflict merge failure): Added logging when the general merge failure comment fails to post  
3. **Lines 745-759** (success cas

Closes #1839

---
*Task #1839 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*