### PR TITLE
bug: scan_mentions permanently loses mentions when create_internal fails — cursor advances past unprocessed items

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -818,6 +818,12 @@ async fn scan_mentions(
 
     let gh = crate::github::http::GhHttp::new()?;
 
+    // Track the latest timestamp of a successfully processed mention so the
+    // cursor only advances past mentions that were actually handled.  If a
+    // `create_internal` call fails we leave the cursor before that mention so
+    // the next tick retries it instead of permanently losing it.
+    let mut last_success_ts: Option<String> = None;
+
     for mention in mentions {
         // Skip if already processed
         if existing_mentions.contains(&mention.id) {
@@ -980,6 +986,10 @@ async fn scan_mentions(
                         .create_internal(repo, &title, &task_body, "mention", &mention.id)
                         .await;
                 }
+                // Command was executed (or error-replied) — mention is handled.
+                if last_success_ts.as_deref() < Some(mention.created_at.as_str()) {
+                    last_success_ts = Some(mention.created_at.clone());
+                }
                 continue;
             }
         }
@@ -994,7 +1004,10 @@ async fn scan_mentions(
                 .await
             {
                 Ok(task_id) => {
-                    tracing::info!(task_id, mention_id = %mention.id, "created mention task")
+                    tracing::info!(task_id, mention_id = %mention.id, "created mention task");
+                    if last_success_ts.as_deref() < Some(mention.created_at.as_str()) {
+                        last_success_ts = Some(mention.created_at.clone());
+                    }
                 }
                 Err(e) => tracing::warn!(
                     mention_id = %mention.id,
@@ -1005,9 +1018,15 @@ async fn scan_mentions(
         }
     }
 
-    // Persist cursor so the next sync tick only fetches newer comments
-    let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
-    kv_set_prefer_store(&store, "mentions_last_checked", &now).await;
+    // Persist cursor so the next sync tick only fetches newer comments.
+    // Use the latest successfully-processed mention timestamp rather than
+    // `now`, so any mention whose `create_internal` failed is retried on the
+    // next tick instead of being permanently skipped.
+    if let Some(ts) = last_success_ts {
+        kv_set_prefer_store(&store, "mentions_last_checked", &ts).await;
+    }
+    // If no mention was successfully processed, leave the cursor unchanged so
+    // the entire batch is retried on the next sync tick.
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

All 2627 tests pass. The fix is complete.

**Summary of changes** (`src/engine/sync.rs`):

1. Added `let mut last_success_ts: Option<String> = None;` before the mention loop to track the latest successfully-processed mention timestamp.

2. In the **command execution path** (line ~989): update `last_success_ts` with `mention.created_at` before `continue` — the command was executed (success or error-replied), so the mention is handled.

3. In the **non-command `create_internal` path** (line ~100

Closes #1837

---
*Task #1837 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*