### PR TITLE
bug: store error in tick.rs causes tasks to skip review and be marked Done

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -1096,7 +1096,11 @@ pub(crate) async fn tick_dispatch_tasks(
                                     .ok()
                                     .and_then(|t| t.pr_number)
                                     .is_some(),
-                                _ => false,
+                                Ok(None) => false,
+                                Err(e) => {
+                                    tracing::warn!(task_id, err = %e, "failed to check PR status — defaulting to needs_review");
+                                    true
+                                }
                             };
                             if has_pr {
                                 "needs_review"


### PR DESCRIPTION
## Summary

All 2615 tests pass. The fix is clean — the `_ => false` arm is now split into `Ok(None) => false` (no-op task, correctly skip review) and `Err(e) => { warn!(...); true }` (store error, safely default to requiring review).

Closes #1850

---
*Task #1850 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*