### PR TITLE
bug: auto_unblock_blocked_tasks silently skips all tasks when get_runs_batch fails

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -255,7 +255,13 @@ async fn auto_unblock_blocked_tasks(
 
     // Batch-load all runs for blocked tasks in a single query instead of N individual queries.
     let task_ids: Vec<i64> = blocked.iter().map(|t| t.id).collect();
-    let mut runs_by_task = store.get_runs_batch(&task_ids).await.unwrap_or_default();
+    let mut runs_by_task = match store.get_runs_batch(&task_ids).await {
+        Ok(map) => map,
+        Err(e) => {
+            tracing::warn!(err = %e, "get_runs_batch failed — skipping auto-unblock this tick");
+            return Ok(());
+        }
+    };
 
     for task in blocked {
         if task.block_reason.is_some() {


### PR DESCRIPTION
## Summary

## Summary

✅ **Fixed issue #1854: auto_unblock_blocked_tasks silently skips all tasks when get_runs_batch fails**

### The Problem
When `store.get_runs_batch()` returned an error in `src/engine/sync.rs:258`, the code silently converted it to an empty `HashMap` via `unwrap_or_default()`. This caused every blocked task to appear to have no run history, making them all skip the auto-unblock logic with zero logging.

### The Solution
Replaced the silent error conversion with explicit error handli

Closes #1854

---
*Task #1854 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*