### PR TITLE
bug: "review outcome discarded" WARN fires on every auto-merged task, masking real failures

### DIFF
--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -385,11 +385,25 @@ pub fn spawn(
                         .await;
 
                         if !matches!(current_status, Some(crate::store::TaskStatus::InReview)) {
-                            tracing::warn!(
-                                task_id = tid,
-                                current_status = current_status.as_ref().map(|s| s.as_str()).unwrap_or("unknown"),
-                                "review outcome discarded — task is no longer in_review (stale review agent result)"
+                            let expected = matches!(
+                                current_status,
+                                Some(crate::store::TaskStatus::Done)
+                                    | Some(crate::store::TaskStatus::Routed)
+                                    | Some(crate::store::TaskStatus::New)
                             );
+                            if expected {
+                                tracing::debug!(
+                                    task_id = tid,
+                                    current_status = current_status.as_ref().map(|s| s.as_str()).unwrap_or("unknown"),
+                                    "review outcome discarded — task transitioned away from in_review (expected)"
+                                );
+                            } else {
+                                tracing::warn!(
+                                    task_id = tid,
+                                    current_status = current_status.as_ref().map(|s| s.as_str()).unwrap_or("unknown"),
+                                    "review outcome discarded — task is no longer in_review (stale review agent result)"
+                                );
+                            }
                             drop(permit);
                             return;
                         }


### PR DESCRIPTION
## Summary

Done! I've successfully fixed the bug in issue #1860.

## Summary

The fix categorizes review outcome state transitions by expected-ness, preventing false-alarm WARNs from drowning out real errors:

**What changed:**
- Modified `src/engine/subscribers/review.rs:387-395` to check if the task's current status is an expected transition
- Expected statuses (`Done`, `Routed`, `New`) now log at **debug** level with message "expected"
- Unexpected statuses log at **warn** level with the original messag

Closes #1860

---
*Task #1860 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*