### PR TITLE
bug: branch deletion after merge logs WARN on 422 "Reference does not exist" — GitHub auto-deleted it

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -2016,7 +2016,15 @@ impl GhHttp {
             if let Some(ref_name) = pr.pointer("/head/ref").and_then(|v| v.as_str()) {
                 let del_url = format!("{GITHUB_API}/repos/{repo}/git/refs/heads/{ref_name}");
                 if let Err(e) = self.delete(&del_url).await {
-                    tracing::warn!(ref_name, err = %e, "failed to delete branch after merge");
+                    let err_str = e.to_string();
+                    if err_str.contains("Reference does not exist") {
+                        tracing::debug!(
+                            ref_name,
+                            "branch already gone (GitHub auto-deleted on merge)"
+                        );
+                    } else {
+                        tracing::warn!(ref_name, err = %e, "failed to delete branch after merge");
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixed the branch deletion warning logging when GitHub auto-deletes branches on merge. Now logs at DEBUG instead of WARN when receiving 422 'Reference does not exist'.

### What was done

- Modified merge_pr in src/github/http.rs to detect 'Reference does not exist' error and log at DEBUG instead of WARN
- Verified formatting, clippy, and tests pass


Closes #1861

---
*Task #1861 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*