### PR TITLE
bug: response_handler logs "skipping PR creation due to push failure" when no commits were made

### DIFF
--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -298,8 +298,10 @@ pub async fn handle_success(
         };
 
         // Create PR (skip if push failed or repo is unknown)
-        if !push_ok {
+        if has_commits && !push_ok {
             tracing::warn!(task_id, "skipping PR creation due to push failure");
+        } else if !push_ok {
+            // no commits — already logged "no commits ahead, skipping push + PR" at INFO level above
         } else if repo.is_empty() {
             tracing::warn!(
                 task_id,


### PR DESCRIPTION
## Summary

Let me show the exact diff of my changes only
</parameter>
</function>
</tool_call>

Closes #1862

---
*Task #1862 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/nemotron-3-super-free`*