### PR TITLE
bug: stuck-task recovery resets in_progress task to New while response_handler is still processing after session ends

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -442,6 +442,13 @@ impl TaskRunner {
         )
         .await;
 
+        // Touch updated_at immediately after session exit so the stuck-task recovery
+        // timer resets before response_handler post-processing (git push, PR creation,
+        // status update) begins.  Without this, a session that ran longer than
+        // no_session_stuck_timeout (default 10 min) would be re-dispatched by the tick
+        // while the runner is still writing results.
+        store::store_touch_updated_at(&self.store, &self.repo, task_id).await;
+
         // If silence detection (tick phase1b) already rerouted this task while the
         // session was running, skip all fallback/review processing. Without this check the
         // runner would call `fallback::handle_error` on the empty output, exhaust fallback

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -52,6 +52,19 @@ pub async fn store_set(
     }
 }
 
+/// Touch `updated_at` to now so the stuck-task timer is reset after a session exits.
+///
+/// No-op when the store is unavailable or the task cannot be resolved.
+pub async fn store_touch_updated_at(store: &Option<Arc<TaskStore>>, repo: &str, task_id: &str) {
+    if let Some(ref s) = store {
+        if let Ok(Some(store_id)) = s.resolve_task_id(repo, task_id).await {
+            if let Err(e) = s.touch_updated_at(store_id).await {
+                tracing::warn!(task_id, error = %e, "store touch_updated_at failed");
+            }
+        }
+    }
+}
+
 /// Append a lifecycle activity event to a task timeline.
 #[allow(clippy::too_many_arguments)]
 pub async fn store_log_activity(

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -42,6 +42,7 @@ pub use helpers::{
     get_cost_estimate, get_recent_memory, get_token_summary, get_token_usage, get_total_tokens,
     opt_store_get_task, review_session_expected, set_review_session_expected, store_increment,
     store_log_activity, store_reset_counters, store_reset_failure_counters, store_set,
+    store_touch_updated_at,
 };
 #[allow(unused_imports)]
 pub use jobs::JobState;

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -487,6 +487,23 @@ impl TaskStore {
         Ok(())
     }
 
+    /// Touch `updated_at` to now without changing any other field.
+    ///
+    /// Called by the runner immediately after a tmux session exits so that the
+    /// stuck-task recovery timer is reset before response_handler post-processing
+    /// (git push, PR creation, status update) begins.  Without this, a session
+    /// that ran longer than `no_session_stuck_timeout` (default 10 min) would be
+    /// re-dispatched by the tick while the runner is still writing results.
+    pub async fn touch_updated_at(&self, id: i64) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE tasks SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+        )
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Reset a task back to `new`.
     pub async fn reset_to_new(&self, id: i64) -> anyhow::Result<()> {
         let previous = sqlx::query("SELECT status, agent, model FROM tasks WHERE id = ?")


### PR DESCRIPTION
## Summary

The fix is committed. Here's a summary of what was done:

## Fix

**Root cause:** `run_agent_session()` awaits the tmux session. When it returns, `updated_at` still reflects when the task was *dispatched* (T+0). If the session ran >10 min, the tick's phase-2 stuck-task recovery fires the instant the session exits — before `response_handler` can push/PR/update status.

**Fix:** Call `store_touch_updated_at()` immediately after `run_agent_session()` returns. This resets `updated_at` to now, givi

Closes #1864

---
*Task #1864 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*