### PR TITLE
bug: review tmux session orphaned when auto_merge wins the race

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -739,6 +739,13 @@ pub(crate) async fn auto_merge_pr(
         tracing::warn!(task_id = task.id.0, err = %e, "post-merge cleanup failed");
     }
 
+    // Kill any orphaned review session that might be racing us
+    let tmux = crate::tmux::TmuxManager::new();
+    let stale_session = tmux.session_name(repo, &format!("{}-review", task.id.0));
+    if let Err(e) = tmux.kill_session(&stale_session).await {
+        tracing::debug!(task_id = task.id.0, error = %e, "failed to kill stale review session after auto-merge");
+    }
+
     // 8. Post final comment on the PR
     let comment = "✅ PR reviewed, approved, and merged.";
     let footer = attribution_footer("Reviewed", review_agent, review_model);

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -404,6 +404,13 @@ pub fn spawn(
                                     "review outcome discarded — task is no longer in_review (stale review agent result)"
                                 );
                             }
+
+                            // Kill the orphaned review session
+                            let stale_session = tmux_c.session_name(&repo_s, &format!("{}-review", tid));
+                            if let Err(e) = tmux_c.kill_session(&stale_session).await {
+                                tracing::debug!(task_id = tid, error = %e, "failed to kill stale review session");
+                            }
+
                             drop(permit);
                             return;
                         }


### PR DESCRIPTION
## Summary

Fixed orphaned review tmux sessions when auto_merge wins the race by killing the session during both the `auto_merge` step and the early return of `review` subscriber's freshness guard.

### What was done

- Added tmux session cleanup logic in `src/engine/subscribers/review.rs` when the freshness guard short-circuits due to a stale `in_review` state.
- Added a belt-and-suspenders tmux session cleanup in `src/engine/auto_merge.rs` after the PR is merged and the task is moved to `Done`.


Closes #1869

---
*Task #1869 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gemini-3.1-pro-preview`*