### PR TITLE
perf: list_internal_by_source fetches 57-column Task rows for mention dedup — only source_id needed

### DIFF
--- a/migrations/017_source_index.sql
+++ b/migrations/017_source_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_tasks_repo_origin_source ON tasks(repo, origin, source);

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -815,13 +815,12 @@ async fn scan_mentions(
     };
 
     // Get existing mention tasks across ALL statuses to avoid duplicates.
-    // Uses a SQL-filtered query instead of loading all internal tasks.
+    // Uses a targeted source_id-only query to avoid fetching all 57 task columns.
     let existing_mentions: std::collections::HashSet<String> = if let Some(s) = store {
-        s.list_internal_by_source(repo, "mention")
+        s.list_source_ids_by_source(repo, "mention")
             .await
             .unwrap_or_default()
             .into_iter()
-            .map(|t| t.source_id.clone())
             .collect()
     } else {
         std::collections::HashSet::new()

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -627,6 +627,24 @@ impl TaskStore {
         rows.iter().map(Self::row_to_task).collect()
     }
 
+    /// Return only the `source_id` values for internal tasks with a specific source.
+    /// Use this instead of `list_internal_by_source` when only deduplication is needed —
+    /// avoids fetching all 57 task columns.
+    pub async fn list_source_ids_by_source(
+        &self,
+        repo: &str,
+        source: &str,
+    ) -> anyhow::Result<Vec<String>> {
+        let rows = sqlx::query(
+            "SELECT source_id FROM tasks WHERE repo = ? AND origin = 'internal' AND source = ?",
+        )
+        .bind(repo)
+        .bind(source)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.iter().map(|r| r.get::<String, _>(0)).collect())
+    }
+
     /// List all active (non-done) tasks for a repo.
     pub async fn list_active(&self, repo: &str) -> anyhow::Result<Vec<Task>> {
         let rows = sqlx::query(


### PR DESCRIPTION
## Summary

All 2649 tests pass. The changes are complete:

1. **`migrations/017_source_index.sql`** — new composite index on `(repo, origin, source)` for efficient filtering
2. **`src/store/tasks.rs`** — added `list_source_ids_by_source()` that fetches only `source_id` instead of all 57 columns
3. **`src/engine/sync.rs`** — `scan_mentions` now calls `list_source_ids_by_source` instead of `list_internal_by_source`

Closes #1886

---
*Task #1886 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*