### PR TITLE
bug: PendingPick entries never pruned from memory — unbounded HashMap growth

### DIFF
--- a/src/engine/channel_handler.rs
+++ b/src/engine/channel_handler.rs
@@ -654,6 +654,8 @@ pub(super) async fn handle_channel_message(
                 {
                     let key = format!("{channel}:{}", msg.id);
                     let mut picks = pending_picks.lock().await;
+                    // Evict expired entries to prevent unbounded growth.
+                    picks.retain(|_, v| !v.is_expired());
                     picks.insert(key, PendingPick::new(msg.body.clone()));
                 }
 


### PR DESCRIPTION
## Summary

All 2649 tests pass. The fix is a one-liner at `src/engine/channel_handler.rs:656` — adding `picks.retain(|_, v| !v.is_expired());` before each insertion. This evicts expired entries on every insert (O(n) sweep amortized to near O(1) since the map stays small), preventing unbounded growth without needing a background task or LRU cache.

Closes #1891

---
*Task #1891 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*