### PR TITLE
bug: store_reset_counters silently drops errors — no warning log, unlike store_set

### DIFF
--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -148,7 +148,9 @@ pub async fn store_increment(
 pub async fn store_reset_counters(store: &Option<Arc<TaskStore>>, repo: &str, task_id: &str) {
     if let Some(ref store) = store {
         if let Ok(Some(store_id)) = store.resolve_task_id(repo, task_id).await {
-            let _ = store.reset_counters(store_id).await;
+            if let Err(e) = store.reset_counters(store_id).await {
+                tracing::warn!(task_id, err = %e, "store reset_counters failed");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Perfect! The fix is complete and committed. Here's a summary:

## Fix Summary

I've fixed the bug in `store_reset_counters` (src/store/helpers.rs:148-154) where errors were being silently discarded instead of logged.

### Changes Made
- **Before**: `let _ = store.reset_counters(store_id).await;` silently dropped any errors
- **After**: Added proper error logging:
  ```rust
  if let Err(e) = store.reset_counters(store_id).await {
      tracing::warn!(task_id, err = %e, "store reset_counters faile

Closes #1890

---
*Task #1890 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*