### PR TITLE
bug: ingest_external_tasks silently swallows list_routable() errors with no log

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1369,11 +1369,19 @@ pub(crate) async fn ingest_external_tasks(
 
     // 1. Routable tasks (unlabeled + status:new) — these are the ones that
     //    were previously missed because the per-status loop skipped them.
-    if let Ok(routable) = backend.list_routable().await {
-        for task in routable {
-            if seen.insert(task.id.0.clone()) {
-                all_tasks.push((task, None));
+    match backend.list_routable().await {
+        Ok(routable) => {
+            for task in routable {
+                if seen.insert(task.id.0.clone()) {
+                    all_tasks.push((task, None));
+                }
             }
+        }
+        Err(e) => {
+            tracing::debug!(
+                ?e,
+                "ingest: failed to list routable tasks — unlabeled new issues may be delayed"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Done! I've fixed issue #1892 by adding proper error logging to the `ingest_external_tasks` function in `src/engine/sync.rs`.

**What was changed:**
- Replaced the silent `if let Ok` pattern (lines 1372-1378) with a `match` statement
- Added a `tracing::debug!` log in the error case, consistent with the subsequent per-status query error handling

**Why this matters:**
When `backend.list_routable()` fails (GitHub 5xx, rate limit, etc.), newly-created GitHub issues without status labels will now be

Closes #1892

---
*Task #1892 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*