### PR TITLE
bug: stale model not cleared from DB after discard in get_route_result — repeated WARN every dispatch

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -1122,6 +1122,15 @@ pub async fn get_route_result(
         valid
     });
 
+    // If a stale model was discarded, update the database to clear it.
+    // This prevents repeated warnings on subsequent dispatches (#1907).
+    let original_model = task.model.clone().filter(|m| !m.is_empty());
+    if original_model.is_some() && model.is_none() {
+        let _ = store
+            .set_fields(store_id, &[("model", serde_json::json!(""))])
+            .await;
+    }
+
     Ok(RouteResult {
         agent,
         model,


### PR DESCRIPTION
## Summary

Perfect! I've fixed the issue. Here's what I did:

## Summary

**Problem:** When `get_route_result()` discarded a stale/invalid model (e.g., `opus` for an `opencode` agent that has no opus pool), the database was never updated. This caused the same stale model to persist in `tasks.model`, so every subsequent dispatch would:
1. Read the same stale model from the DB
2. Discard it again
3. Log the same warning again

**Solution:** Added a 5-line fix in `src/engine/router/mod.rs:1125-1132` that:
1. 

Closes #1907

---
*Task #1907 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*