### PR TITLE
bug: get_route_result clears stale model with let _ — failure re-triggers repeated warnings on every dispatch

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -1126,9 +1126,13 @@ pub async fn get_route_result(
     // This prevents repeated warnings on subsequent dispatches (#1907).
     let original_model = task.model.clone().filter(|m| !m.is_empty());
     if original_model.is_some() && model.is_none() {
-        let _ = store
+        if let Err(e) = store
             .set_fields(store_id, &[("model", serde_json::json!(""))])
-            .await;
+            .await
+        {
+            // Log the error so transient DB failures are visible and diagnosable.
+            tracing::warn!(task_id = %task_id, error = %e, "failed to clear stale model from store — will retry on next dispatch");
+        }
     }
 
     Ok(RouteResult {


### PR DESCRIPTION
## Summary

Replace silent discard of DB errors when clearing stale model with explicit tracing::warn logging; commit change.

### What was done

- Updated src/engine/router/mod.rs to log errors instead of discarding them when clearing a stale model from the task store
- Added a tracing::warn with task_id and error details so transient DB failures are visible and diagnosable
- Committed the change on the current worktree branch


### Remaining

- Monitor logs after deployment to ensure the warning provides actionable information if the DB write fails again
- If failures are frequent, consider adding retry/backoff logic or investigating the underlying DB lock/contention


Closes #1912

---
*Task #1912 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*