### PR TITLE
bug: git fetch failure in auto_merge misclassified as rebase content conflict

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -582,7 +582,16 @@ pub(crate) async fn auto_merge_pr(
                                 .output()
                                 .await
                         }
-                        Ok(out) => Ok(out),
+                        Ok(out) => {
+                            // fetch failed — not a content conflict; leave task in InReview for retry
+                            let stderr = String::from_utf8_lossy(&out.stderr);
+                            tracing::warn!(
+                                task_id = task.id.0,
+                                stderr = %stderr,
+                                "git fetch failed before rebase — skipping rebase"
+                            );
+                            return Ok(());
+                        }
                         Err(err) => Err(err),
                     };
 


### PR DESCRIPTION
## Summary

## Summary

I've successfully fixed the bug in `src/engine/auto_merge.rs`. Here's what was done:

### The Problem
When `git fetch origin` failed, its error output was incorrectly passed as a rebase result, causing network/auth failures to be misclassified as rebase content conflicts. This led to:
- Consuming the `merge_conflict_retries` counter unnecessarily
- Misleading error messages to agents
- Permanent task blocking after 3 retries

### The Fix
Modified the fetch-rebase logic (lines 585-594

Closes #1911

---
*Task #1911 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*