### PR TITLE
bug: assemble_context swallows DB failures silently — AI operates with empty context after store errors

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -237,7 +237,10 @@ pub async fn assemble_context(store: &TaskStore, session_id: &str) -> Result<Cha
         .bind(&memory_prefix)
         .fetch_all(store.pool())
         .await
-        .unwrap_or_default();
+        .unwrap_or_else(|e| {
+            tracing::warn!(session_id, error = %e, "failed to load control memories from store");
+            Vec::new()
+        });
     let memories = if memory_rows.is_empty() {
         "(none)".to_string()
     } else {
@@ -257,7 +260,10 @@ pub async fn assemble_context(store: &TaskStore, session_id: &str) -> Result<Cha
     let summaries = store
         .control_recent_summaries(session_id, 20)
         .await
-        .unwrap_or_default();
+        .unwrap_or_else(|e| {
+            tracing::warn!(session_id, error = %e, "failed to load control summaries from store");
+            Vec::new()
+        });
     let recent_summaries = if summaries.is_empty() {
         "(no recent conversation)".to_string()
     } else {


### PR DESCRIPTION
## Summary

Done! I've successfully fixed the bug in `src/control.rs` where database failures were silently swallowed.

## Summary

**Changes made:**
- Replaced `.unwrap_or_default()` with `.unwrap_or_else()` on the memory query (line 240-242)
- Replaced `.unwrap_or_default()` with `.unwrap_or_else()` on the summaries query (line 263-265)
- Both now log warnings at warn level when database operations fail

**Quality gates:**
- ✅ cargo fmt 
- ✅ cargo clippy
- ✅ cargo nextest (2657 tests passed)

The fi

Closes #1913

---
*Task #1913 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*