### PR TITLE
bug: auto_unblock_blocked_tasks silently skips all work when list_by_status fails

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -244,10 +244,13 @@ async fn auto_unblock_blocked_tasks(
     store: &Arc<TaskStore>,
     dispatching: &Arc<DashSet<String>>,
 ) -> anyhow::Result<()> {
-    let blocked = store
-        .list_by_status(repo, TaskStatus::Blocked)
-        .await
-        .unwrap_or_default();
+    let blocked = match store.list_by_status(repo, TaskStatus::Blocked).await {
+        Ok(tasks) => tasks,
+        Err(e) => {
+            tracing::warn!(err = %e, "failed to list blocked tasks — skipping auto-unblock this tick");
+            return Ok(());
+        }
+    };
 
     if blocked.is_empty() {
         return Ok(());


### PR DESCRIPTION
## Summary

Fix applied at `src/engine/sync.rs:247-253`. Replaced `unwrap_or_default()` with a `match` that logs a warning and returns early on error, matching the existing pattern for `get_runs_batch` at lines 258-264.

Closes #1923

---
*Task #1923 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/qwen3.6-plus-free`*