### PR TITLE
bug: scan_mentions command-executed path silently drops sentinel creation failure with no log

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1008,9 +1008,16 @@ async fn scan_mentions(
                         "Mention by @{}:\n\n{}\n\n**Status:** Command executed",
                         mention.author, mention.body
                     );
-                    let _ = s
+                    if let Err(e) = s
                         .create_internal(repo, &title, &task_body, "mention", &mention.id)
-                        .await;
+                        .await
+                    {
+                        tracing::warn!(
+                            mention_id = %mention.id,
+                            err = %e,
+                            "failed to create sentinel for command-executed mention — mention untracked in DB"
+                        );
+                    }
                 }
                 // Command was executed (or error-replied) — mention is handled.
                 if last_success_ts.as_deref() < Some(mention.created_at.as_str()) {


### PR DESCRIPTION
## Summary

Done! I've successfully fixed issue #1925. Here's what was completed:

## Summary

**Problem**: In `src/engine/sync.rs`, the `scan_mentions` function silently dropped sentinel creation failures for command-executed mentions with no logging. This meant:
- DB write failures had zero visibility
- Cursor still advanced (hiding the failure)
- If cursor was reset, the mention could be re-fetched and command re-executed with no way to detect it

**Solution**: Added a warning log when sentinel creation 

Closes #1925

---
*Task #1925 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*