### PR TITLE
bug: auto_unblock silently drops append_activity failure — no warning on audit trail loss

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -395,7 +395,7 @@ async fn auto_unblock_blocked_tasks(
         } else {
             "new"
         };
-        let _ = store
+        if let Err(e) = store
             .append_activity(
                 task.id,
                 "auto_unblock",
@@ -409,7 +409,10 @@ async fn auto_unblock_blocked_tasks(
                     "failures": failures.iter().map(|f| format!("{f:?}")).collect::<Vec<_>>(),
                 })),
             )
-            .await;
+            .await
+        {
+            tracing::warn!(task_id = task.id, err = %e, "failed to log auto_unblock activity");
+        }
 
         if let Err(e) = task_manager
             .update_task_status(&crate::backends::ExternalId(ext_id), new_status)


### PR DESCRIPTION
## Summary

Done! I've fixed issue #1924 by replacing the silent error discard in `auto_unblock_blocked_tasks` with proper error logging.

**Summary of changes:**
- **File**: `src/engine/sync.rs` (lines 395-412)
- **Change**: Replaced `let _ = store.append_activity(...)` with proper error handling that logs a warning when the activity log write fails
- **Pattern**: Matches the error handling pattern used elsewhere in the code (e.g., `update_task_status` at lines 414-422)

**What this fixes:**
- Previously, 

Closes #1924

---
*Task #1924 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*