### PR TITLE
bug: review agent rate-limit via exit-0 text not detected — no cooldown applied, failure counter incremented

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1258,6 +1258,36 @@ pub(crate) async fn review_and_merge(
                 );
                 r
             } else {
+                // Check if the text contains a rate limit message before returning parse error.
+                // Rate limits should trigger a cooldown, not increment the failure counter.
+                if let Some(runner::agents::AgentError::RateLimit { message }) =
+                    runner::agents::patterns::detect_rate_limit(&text_for_review)
+                {
+                    tracing::warn!(
+                        task_id = task.id.0,
+                        agent = %review_agent,
+                        "review agent hit rate limit — adding to cooldown"
+                    );
+                    runner::response::record_agent_failure_with_message(&review_agent, &message)
+                        .await;
+
+                    if let Some(rid) = run_id {
+                        let _ = store
+                            .complete_run(&CompleteRun {
+                                run_id: rid,
+                                exit_code: Some(exit_code),
+                                stdout: &raw_output,
+                                stderr: &stderr,
+                                parsed: &text_for_review,
+                                outcome: "failed",
+                                error: &format!("rate limit: {message}"),
+                                tokens: agent_token_usage,
+                            })
+                            .await;
+                    }
+                    return Ok(ReviewDecision::Failed(format!("rate limit: {message}")));
+                }
+
                 tracing::error!(
                     task_id = task.id.0,
                     error = %e,


### PR DESCRIPTION
## Summary

## Summary

I've successfully fixed the bug where review agents hitting rate limits with exit code 0 were not being detected, resulting in missing cooldowns and incorrect failure counter increments.

### The Problem
When a review agent (e.g., codex) exits with code 0 but returns rate-limit text as plain output:
- The rate-limit detection was bypassed (`is_hard_failure` check only triggered for empty output or `is_error:true`)
- No cooldown was applied to the agent
- The `review_agent_failures` c

Closes #1949

---
*Task #1949 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*