### PR TITLE
bug: is_collaborator API errors silently swallowed in review_poll batch loop

### DIFF
--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -348,10 +348,16 @@ pub(crate) async fn review_open_prs(
     let collab_logins: Vec<String> = unique_users.into_iter().collect();
     let collab_results =
         futures::future::join_all(collab_logins.iter().map(|u| gh.is_collaborator(repo, u))).await;
-    let collab_cache: HashMap<String, bool> = collab_logins
+    let collab_cache: HashMap<String, Option<bool>> = collab_logins
         .into_iter()
         .zip(collab_results.into_iter())
-        .map(|(u, r)| (u, r.unwrap_or(false)))
+        .map(|(u, r)| match r {
+            Ok(v) => (u, Some(v)),
+            Err(e) => {
+                tracing::warn!(user = %u, error = %e, "is_collaborator check failed; skipping review comment");
+                (u, None)
+            }
+        })
         .collect();
 
     // ─── Phase 6: Process each task using batch data ──────────────────────────
@@ -829,7 +835,7 @@ pub(crate) async fn review_open_prs(
 /// additional REST calls.
 fn automated_review_from_comments(
     issue_comments: &[GitHubComment],
-    collab_cache: &HashMap<String, bool>,
+    collab_cache: &HashMap<String, Option<bool>>,
     pr_number: u64,
 ) -> Option<String> {
     // Find the newest automated review comment authored by a collaborator.
@@ -838,13 +844,24 @@ fn automated_review_from_comments(
         if !c.body.starts_with("## Automated Review") {
             continue;
         }
-        if !collab_cache.get(&c.user.login).copied().unwrap_or(false) {
-            tracing::warn!(
-                user = %c.user.login,
-                pr_number,
-                "ignoring automated review comment from non-collaborator"
-            );
-            continue;
+        match collab_cache.get(&c.user.login).copied().flatten() {
+            None if collab_cache.contains_key(&c.user.login) => {
+                tracing::warn!(
+                    user = %c.user.login,
+                    pr_number,
+                    "skipping automated review comment: collaborator check unavailable"
+                );
+                continue;
+            }
+            None | Some(false) => {
+                tracing::warn!(
+                    user = %c.user.login,
+                    pr_number,
+                    "ignoring automated review comment from non-collaborator"
+                );
+                continue;
+            }
+            Some(true) => {}
         }
         match newest {
             None => newest = Some(c),


### PR DESCRIPTION
## Summary

All 2659 tests pass. Here's a summary of the changes made:

**`src/engine/review_poll.rs`:**

1. **Line 351–355** (batch cache build): Changed `HashMap<String, bool>` to `HashMap<String, Option<bool>>`. On `Err`, logs a warning with the actual error and stores `None` instead of silently mapping to `false`.

2. **Line 832** (function signature): Updated `automated_review_from_comments` to accept `&HashMap<String, Option<bool>>`.

3. **Lines 841–847** (comment filter): Replaced the single `unw

Closes #1951

---
*Task #1951 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*