### PR TITLE
bug: merge_conflict_retries increment failure allows infinite conflict retries past MAX_MERGE_CONFLICT_RETRIES

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -675,7 +675,8 @@ pub(crate) async fn auto_merge_pr(
                                     )
                                     .await
                                     {
-                                        tracing::warn!(task_id = task.id.0, err = %e, "failed to increment merge_conflict_retries — retry count may be inaccurate");
+                                        tracing::warn!(task_id = task.id.0, err = %e, "failed to increment merge_conflict_retries — skipping dispatch to avoid bypassing retry limit");
+                                        return Ok(());
                                     }
                                     // Enable auto-merge — GitHub merges once CI passes.
                                     // If auto-merge isn't available, keep task in InReview
@@ -757,7 +758,8 @@ pub(crate) async fn auto_merge_pr(
                         )
                         .await
                         {
-                            tracing::warn!(task_id = task.id.0, err = %e, "failed to increment merge_conflict_retries — retry count may be inaccurate");
+                            tracing::warn!(task_id = task.id.0, err = %e, "failed to increment merge_conflict_retries — skipping dispatch to avoid bypassing retry limit");
+                            return Ok(());
                         }
                         store_set(
                             &Some(Arc::clone(store)),

--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -505,7 +505,8 @@ pub(crate) async fn review_open_prs(
                     )
                     .await
                     {
-                        tracing::warn!(task_id, err = %e, "failed to increment merge_conflict_retries — retry count may be inaccurate");
+                        tracing::warn!(task_id, err = %e, "failed to increment merge_conflict_retries — skipping dispatch to avoid bypassing retry limit");
+                        continue;
                     }
                     if let Err(e) = task_manager
                         .update_task_status(&task.id, Status::NeedsReview)
@@ -626,7 +627,8 @@ pub(crate) async fn review_open_prs(
                     )
                     .await
                     {
-                        tracing::warn!(task_id, err = %e, "failed to increment merge_conflict_retries — retry count may be inaccurate");
+                        tracing::warn!(task_id, err = %e, "failed to increment merge_conflict_retries — skipping dispatch to avoid bypassing retry limit");
+                        continue;
                     }
                     if let Err(e) = task_manager
                         .update_task_status(&task.id, Status::NeedsReview)


### PR DESCRIPTION
## Summary

All 2681 tests pass. The fix is complete.

**Summary of changes:**

All four `merge_conflict_retries` increment sites now use an early-return pattern instead of falling through to dispatch on failure:

- **`review_poll.rs` (site 1, ~line 508)**: `continue` instead of warning + dispatch
- **`review_poll.rs` (site 2, ~line 629)**: `continue` instead of warning + dispatch  
- **`auto_merge.rs` (site 1, ~line 678)**: `return Ok(())` instead of warning + enable-auto-merge
- **`auto_merge.rs` (site 2,

Closes #1975

---
*Task #1975 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*