### PR TITLE
refactor: extract shared AgentProfile/RouteResult construction from routing strategies

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -64,6 +64,43 @@ pub struct AgentProfile {
     pub constraints: Vec<String>,
 }
 
+impl AgentProfile {
+    /// Build the default "general" profile from router config.
+    pub fn default_from_config(config: &RouterConfig) -> Self {
+        Self {
+            role: "general".to_string(),
+            skills: vec![],
+            tools: config.allowed_tools.clone(),
+            constraints: vec![],
+        }
+    }
+}
+
+impl RouteResult {
+    /// Build a standard route result from the three task-specific values.
+    ///
+    /// Fills `profile`, `selected_skills`, and `warning` with router-config
+    /// defaults so call sites only need to supply what varies per task.
+    pub fn from_config(
+        agent: String,
+        complexity: String,
+        reason: String,
+        config: &RouterConfig,
+        task_id: &str,
+    ) -> Self {
+        let model = config.model_for_complexity(&agent, &complexity, task_id);
+        Self {
+            agent,
+            model,
+            complexity,
+            reason,
+            profile: AgentProfile::default_from_config(config),
+            selected_skills: config.default_skills.clone(),
+            warning: None,
+        }
+    }
+}
+
 /// The agent router.
 pub struct Router {
     /// Router configuration
@@ -519,28 +556,23 @@ impl Router {
                     // routing logic so the LLM or round-robin can pick an
                     // appropriate agent/model.
                     if model.is_some() {
-                        let profile = AgentProfile {
-                            role: format!("{} specialist", agent),
-                            skills: vec![],
-                            tools: self.config.allowed_tools.clone(),
-                            constraints: vec![],
-                        };
-
                         tracing::debug!(
                             task_id = %task.id.0,
                             agent = %agent,
                             complexity = %complexity,
                             "routed via label"
                         );
-                        let result = RouteResult {
-                            agent: agent.clone(),
-                            model: model.clone(),
-                            complexity: complexity.clone(),
-                            reason: format!("label agent:{agent}"),
-                            profile,
-                            selected_skills: self.config.default_skills.clone(),
-                            warning: None,
-                        };
+                        let mut result = RouteResult::from_config(
+                            agent.clone(),
+                            complexity.clone(),
+                            format!("label agent:{agent}"),
+                            &self.config,
+                            &task.id.0,
+                        );
+                        // Label routing uses agent-specific role and the
+                        // resolved model (may differ from from_config's default).
+                        result.profile.role = format!("{} specialist", agent);
+                        result.model = model.clone();
                         self.log_route_activity(store, repo, &task.id.0, &result, None)
                             .await;
                         return Ok(result);

--- a/src/engine/router/strategies.rs
+++ b/src/engine/router/strategies.rs
@@ -15,7 +15,7 @@ use crate::backends::ExternalTask;
 
 use super::config::RouterConfig;
 use super::weights::AgentWeights;
-use super::{AgentProfile, RouteResult};
+use super::RouteResult;
 
 /// Extract an explicit `agent:*` label from the task, if present and valid.
 ///
@@ -67,22 +67,13 @@ pub(super) fn route_via_round_robin(
     let agent_idx = task_num % agents.len();
     let agent = agents[agent_idx].clone();
 
-    let profile = AgentProfile {
-        role: "general".to_string(),
-        skills: vec![],
-        tools: config.allowed_tools.clone(),
-        constraints: vec![],
-    };
-
-    Ok(RouteResult {
-        agent: agent.clone(),
-        model: config.model_for_complexity(&agent, "medium", &task.id.0),
-        complexity: "medium".to_string(),
-        reason: format!("round_robin (task {} % {} agents)", task.id.0, agents.len()),
-        profile,
-        selected_skills: config.default_skills.clone(),
-        warning: None,
-    })
+    Ok(RouteResult::from_config(
+        agent,
+        "medium".to_string(),
+        format!("round_robin (task {} % {} agents)", task.id.0, agents.len()),
+        config,
+        &task.id.0,
+    ))
 }
 
 /// Stateful round-robin: cycles through agents using a persistent index,
@@ -133,28 +124,18 @@ pub(super) fn route_via_round_robin_stateful(
     *last_agent = Some(agent.clone());
 
     let complexity = extract_complexity_from_labels(&task.labels);
-    let model = config.model_for_complexity(&agent, &complexity, &task.id.0);
 
-    let profile = AgentProfile {
-        role: "general".to_string(),
-        skills: vec![],
-        tools: config.allowed_tools.clone(),
-        constraints: vec![],
-    };
-
-    Ok(RouteResult {
-        agent: agent.clone(),
-        model,
+    Ok(RouteResult::from_config(
+        agent,
         complexity,
-        reason: format!(
+        format!(
             "round_robin (index {} of {} agents)",
             agent_idx,
             agents.len()
         ),
-        profile,
-        selected_skills: config.default_skills.clone(),
-        warning: None,
-    })
+        config,
+        &task.id.0,
+    ))
 }
 
 /// Weighted round-robin: selects an agent based on capacity weights.
@@ -190,7 +171,6 @@ pub(super) fn route_via_weighted_round_robin(
 
     let weight = weights.get_weight(&agent);
     let complexity = extract_complexity_from_labels(&task.labels);
-    let model = config.model_for_complexity(&agent, &complexity, &task.id.0);
 
     let weight_summary: Vec<String> = weights
         .snapshot()
@@ -198,13 +178,6 @@ pub(super) fn route_via_weighted_round_robin(
         .filter(|(a, _, _)| agents.contains(a))
         .map(|(a, w, _)| format!("{a}={w:.2}"))
         .collect();
-
-    let profile = AgentProfile {
-        role: "general".to_string(),
-        skills: vec![],
-        tools: config.allowed_tools.clone(),
-        constraints: vec![],
-    };
 
     *last_agent = Some(agent.clone());
 
@@ -220,15 +193,9 @@ pub(super) fn route_via_weighted_round_robin(
         "weighted round-robin selected agent"
     );
 
-    Ok(RouteResult {
-        agent,
-        model,
-        complexity,
-        reason,
-        profile,
-        selected_skills: config.default_skills.clone(),
-        warning: None,
-    })
+    Ok(RouteResult::from_config(
+        agent, complexity, reason, config, &task.id.0,
+    ))
 }
 
 /// Fallback routing when LLM fails.
@@ -276,22 +243,12 @@ pub(super) fn route_via_fallback(
     };
 
     let complexity = extract_complexity_from_labels(&task.labels);
-    let model = config.model_for_complexity(&agent, &complexity, &task.id.0);
 
-    let profile = AgentProfile {
-        role: "general".to_string(),
-        skills: vec![],
-        tools: config.allowed_tools.clone(),
-        constraints: vec![],
-    };
-
-    Ok(RouteResult {
-        agent: agent.clone(),
-        model,
+    Ok(RouteResult::from_config(
+        agent.clone(),
         complexity,
-        reason: format!("router failed; fallback to {agent}"),
-        profile,
-        selected_skills: config.default_skills.clone(),
-        warning: None,
-    })
+        format!("router failed; fallback to {agent}"),
+        config,
+        &task.id.0,
+    ))
 }


### PR DESCRIPTION
## Summary

All 2681 tests pass. The refactoring is complete:

**Changes made:**

- `src/engine/router/mod.rs`: Added `AgentProfile::default_from_config(config)` and `RouteResult::from_config(agent, complexity, reason, config, task_id)` constructors. Updated label-based routing to use `from_config` (with a post-construction override for the agent-specific role and resolved model).

- `src/engine/router/strategies.rs`: All 4 strategy functions now call `RouteResult::from_config(...)` instead of manually cons

Closes #1984

---
*Task #1984 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*