### PR TITLE
perf: store helpers re-resolve task_id on every call — redundant SQL in hot paths

### DIFF
--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -30,7 +30,8 @@ use crate::github::http::GhHttp;
 use crate::github::types::{GitHubComment, GitHubReviewComment, PullRequestReview};
 use crate::store::TaskStore;
 use crate::store::{
-    opt_store_get_task, store_increment, store_reset_failure_counters, store_set, store_set_result,
+    opt_store_get_task_by_id, store_increment_by_id, store_reset_failure_counters, store_set_by_id,
+    store_set_result_by_id,
 };
 use dashmap::DashSet;
 use std::collections::HashMap;
@@ -80,6 +81,7 @@ pub(crate) async fn review_open_prs(
 
     struct ReadyTask {
         task: crate::backends::ExternalTask,
+        store_id: i64,
         stored: crate::store::Task,
         branch: String,
         /// `Some` = already stored in DB, `None` = needs REST lookup.
@@ -101,7 +103,38 @@ pub(crate) async fn review_open_prs(
             continue;
         }
 
-        let stored = opt_store_get_task(&Some(Arc::clone(store)), repo, task_id).await;
+        let store_id = match store.resolve_task_id(repo, task_id).await {
+            Ok(Some(id)) => id,
+            Ok(None) => {
+                tracing::warn!(
+                    task_id,
+                    "in_review task missing from store — setting needs_review"
+                );
+                if let Err(e) = task_manager
+                    .update_task_status(&task.id, Status::NeedsReview)
+                    .await
+                {
+                    tracing::warn!(task_id, err = %e, "failed to update status");
+                }
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    task_id,
+                    err = %e,
+                    "failed to resolve in_review task in store — setting needs_review"
+                );
+                if let Err(e) = task_manager
+                    .update_task_status(&task.id, Status::NeedsReview)
+                    .await
+                {
+                    tracing::warn!(task_id, err = %e, "failed to update status");
+                }
+                continue;
+            }
+        };
+
+        let stored = opt_store_get_task_by_id(&Some(Arc::clone(store)), store_id).await;
         let stored = match stored {
             Some(t) => t,
             None => {
@@ -138,6 +171,7 @@ pub(crate) async fn review_open_prs(
         let stored_pr_number = stored.pr_number.map(|n| n as u64);
         ready_tasks.push(ReadyTask {
             task,
+            store_id,
             stored,
             branch,
             pr_number: stored_pr_number,
@@ -173,10 +207,9 @@ pub(crate) async fn review_open_prs(
             match result {
                 Ok(Some(n)) => {
                     ready_tasks[task_idx].pr_number = Some(*n);
-                    store_set(
+                    store_set_by_id(
                         &Some(Arc::clone(store)),
-                        repo,
-                        &task_id,
+                        ready_tasks[task_idx].store_id,
                         &[("pr_number", serde_json::json!(*n as i64))],
                     )
                     .await;
@@ -262,10 +295,9 @@ pub(crate) async fn review_open_prs(
                     continue;
                 }
 
-                let reroutes = match store_increment(
+                let reroutes = match store_increment_by_id(
                     &Some(Arc::clone(store)),
-                    repo,
-                    task_id,
+                    task_info.store_id,
                     "no_code_reroutes",
                 )
                 .await
@@ -288,10 +320,9 @@ pub(crate) async fn review_open_prs(
                         "no PR or code changes after {}/{} reroute attempts",
                         reroutes, max_reroutes
                     );
-                    store_set(
+                    store_set_by_id(
                         &Some(Arc::clone(store)),
-                        repo,
-                        task_id,
+                        task_info.store_id,
                         &[
                             ("agent", serde_json::json!(null)),
                             ("model", serde_json::json!(null)),
@@ -387,10 +418,9 @@ pub(crate) async fn review_open_prs(
         };
 
         // Persist PR number (idempotent if already stored).
-        store_set(
+        store_set_by_id(
             &Some(Arc::clone(store)),
-            repo,
-            task_id,
+            task_info.store_id,
             &[("pr_number", serde_json::json!(pr_number as i64))],
         )
         .await;
@@ -461,10 +491,9 @@ pub(crate) async fn review_open_prs(
                             retries,
                             "PR approved but merge conflict retry limit reached — blocking for human review"
                         );
-                        store_set(
+                        store_set_by_id(
                             &Some(Arc::clone(store)),
-                            repo,
-                            task_id,
+                            task_info.store_id,
                             &[
                                 (
                                     "block_reason",
@@ -497,10 +526,9 @@ pub(crate) async fn review_open_prs(
                         retries,
                         "PR approved but has merge conflicts — re-triggering review agent to rebase"
                     );
-                    if let Err(e) = store_increment(
+                    if let Err(e) = store_increment_by_id(
                         &Some(Arc::clone(store)),
-                        repo,
-                        task_id,
+                        task_info.store_id,
                         "merge_conflict_retries",
                     )
                     .await
@@ -619,10 +647,9 @@ pub(crate) async fn review_open_prs(
                         continue;
                     }
                     tracing::info!(task_id, pr_number, retries, "PR approved but has merge conflicts — re-triggering review agent to rebase (auto_close disabled)");
-                    if let Err(e) = store_increment(
+                    if let Err(e) = store_increment_by_id(
                         &Some(Arc::clone(store)),
-                        repo,
-                        task_id,
+                        task_info.store_id,
                         "merge_conflict_retries",
                     )
                     .await
@@ -808,7 +835,8 @@ pub(crate) async fn review_open_prs(
             if let Some(ref ts) = new_comment_review_ts {
                 fields.push(("last_comment_review_ts", serde_json::json!(ts)));
             }
-            if let Err(e) = store_set_result(&Some(Arc::clone(store)), repo, task_id, &fields).await
+            if let Err(e) =
+                store_set_result_by_id(&Some(Arc::clone(store)), task_info.store_id, &fields).await
             {
                 tracing::warn!(
                     task_id,

--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -182,6 +182,21 @@ pub async fn handle_success(
         "agent completed successfully"
     );
 
+    // Resolve numeric store_id once so we can reuse it for multiple store ops
+    // in this hot path and avoid repeated external_id -> store_id SQL lookups.
+    let store_id_opt: Option<i64> = if let Some(ref st) = store {
+        match st.resolve_task_id(repo, task_id).await {
+            Ok(Some(id)) => Some(id),
+            Ok(None) => None,
+            Err(e) => {
+                tracing::warn!(task_id, error = %e, "failed to resolve task id for store operations");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // Auto-commit, push, create PR
     let mut has_pr = false;
     let mut has_pushed = false;
@@ -192,13 +207,18 @@ pub async fn handle_success(
         {
             tracing::error!(task_id, error = ?e, "auto commit failed");
             let msg = format!("auto commit failed: {e}");
-            store::store_set(
-                store,
-                repo,
-                task_id,
-                &[("last_error", serde_json::json!(msg))],
-            )
-            .await;
+            if let Some(store_id) = store_id_opt {
+                store::store_set_by_id(store, store_id, &[("last_error", serde_json::json!(msg))])
+                    .await;
+            } else {
+                store::store_set(
+                    store,
+                    repo,
+                    task_id,
+                    &[("last_error", serde_json::json!(msg))],
+                )
+                .await;
+            }
         }
 
         // Skip push + PR if there are no commits ahead of the default branch.
@@ -212,18 +232,34 @@ pub async fn handle_success(
             );
             // Clear stale push failure from previous runs
             // Load stored task once to inspect last_error (avoid repeated DB reads)
-            let last_err = store::opt_store_get_task(store, repo, task_id)
-                .await
-                .map(|t| t.last_error)
-                .unwrap_or_default();
+            let last_err = if let Some(store_id) = store_id_opt {
+                store::opt_store_get_task_by_id(store, store_id)
+                    .await
+                    .map(|t| t.last_error)
+                    .unwrap_or_default()
+            } else {
+                store::opt_store_get_task(store, repo, task_id)
+                    .await
+                    .map(|t| t.last_error)
+                    .unwrap_or_default()
+            };
             if last_err.contains("push failed") {
-                store::store_set(
-                    store,
-                    repo,
-                    task_id,
-                    &[("last_error", serde_json::json!(""))],
-                )
-                .await;
+                if let Some(store_id) = store_id_opt {
+                    store::store_set_by_id(
+                        store,
+                        store_id,
+                        &[("last_error", serde_json::json!(""))],
+                    )
+                    .await;
+                } else {
+                    store::store_set(
+                        store,
+                        repo,
+                        task_id,
+                        &[("last_error", serde_json::json!(""))],
+                    )
+                    .await;
+                }
             }
         }
 
@@ -251,63 +287,131 @@ pub async fn handle_success(
             match git_ops::push_branch(&wt.work_dir, &wt.branch, &wt.default_branch).await {
                 Ok(_) => {
                     has_pushed = true;
-                    store::store_log_activity(
-                        store,
-                        repo,
-                        task_id,
-                        "push",
-                        None,
-                        None,
-                        Some(agent_name),
-                        model_name,
-                        Some(&serde_json::json!({
-                            "status": "ok",
-                            "branch": wt.branch,
-                            "default_branch": wt.default_branch,
-                        })),
-                    )
-                    .await;
+                    if let Some(ref s) = store {
+                        if let Some(store_id) = store_id_opt {
+                            if let Err(e) = s
+                                .append_activity(
+                                    store_id,
+                                    "push",
+                                    None,
+                                    None,
+                                    Some(agent_name),
+                                    model_name,
+                                    Some(&serde_json::json!({
+                                        "status": "ok",
+                                        "branch": wt.branch,
+                                        "default_branch": wt.default_branch,
+                                    })),
+                                )
+                                .await
+                            {
+                                tracing::warn!(task_id, event_type = "push", error = %e, "store append_activity failed");
+                            }
+                        } else {
+                            store::store_log_activity(
+                                store,
+                                repo,
+                                task_id,
+                                "push",
+                                None,
+                                None,
+                                Some(agent_name),
+                                model_name,
+                                Some(&serde_json::json!({
+                                    "status": "ok",
+                                    "branch": wt.branch,
+                                    "default_branch": wt.default_branch,
+                                })),
+                            )
+                            .await;
+                        }
+                    }
                     // Clear any stale push failure from a previous run so review_and_merge
                     // does not incorrectly block an approved task.
-                    store::store_set(
-                        store,
-                        repo,
-                        task_id,
-                        &[
-                            ("last_error", serde_json::json!("")),
-                            ("push_failures", serde_json::json!(0)),
-                        ],
-                    )
-                    .await;
+                    if let Some(store_id) = store_id_opt {
+                        store::store_set_by_id(
+                            store,
+                            store_id,
+                            &[
+                                ("last_error", serde_json::json!("")),
+                                ("push_failures", serde_json::json!(0)),
+                            ],
+                        )
+                        .await;
+                    } else {
+                        store::store_set(
+                            store,
+                            repo,
+                            task_id,
+                            &[
+                                ("last_error", serde_json::json!("")),
+                                ("push_failures", serde_json::json!(0)),
+                            ],
+                        )
+                        .await;
+                    }
                     true
                 }
                 Err(e) => {
                     tracing::error!(task_id, error = ?e, "push failed");
-                    store::store_log_activity(
-                        store,
-                        repo,
-                        task_id,
-                        "push",
-                        None,
-                        None,
-                        Some(agent_name),
-                        model_name,
-                        Some(&serde_json::json!({
-                            "status": "error",
-                            "branch": wt.branch,
-                            "default_branch": wt.default_branch,
-                            "error": e.to_string(),
-                        })),
-                    )
-                    .await;
+                    if let Some(ref s) = store {
+                        if let Some(store_id) = store_id_opt {
+                            if let Err(e) = s
+                                .append_activity(
+                                    store_id,
+                                    "push",
+                                    None,
+                                    None,
+                                    Some(agent_name),
+                                    model_name,
+                                    Some(&serde_json::json!({
+                                        "status": "error",
+                                        "branch": wt.branch,
+                                        "default_branch": wt.default_branch,
+                                        "error": e.to_string(),
+                                    })),
+                                )
+                                .await
+                            {
+                                tracing::warn!(task_id, event_type = "push", error = %e, "store append_activity failed");
+                            }
+                        } else {
+                            store::store_log_activity(
+                                store,
+                                repo,
+                                task_id,
+                                "push",
+                                None,
+                                None,
+                                Some(agent_name),
+                                model_name,
+                                Some(&serde_json::json!({
+                                    "status": "error",
+                                    "branch": wt.branch,
+                                    "default_branch": wt.default_branch,
+                                    "error": e.to_string(),
+                                })),
+                            )
+                            .await;
+                        }
+                    }
                     let msg = format!("push failed: {e}");
-                    store::store_set(
-                        store,
-                        repo,
-                        task_id,
-                        &[("last_error", serde_json::json!(msg))],
-                    )
-                    .await;
+                    if let Some(store_id) = store_id_opt {
+                        store::store_set_by_id(
+                            store,
+                            store_id,
+                            &[("last_error", serde_json::json!(msg))],
+                        )
+                        .await;
+                    } else {
+                        store::store_set(
+                            store,
+                            repo,
+                            task_id,
+                            &[("last_error", serde_json::json!(msg))],
+                        )
+                        .await;
+                    }
                     false
                 }
             }
@@ -418,13 +522,22 @@ pub async fn handle_success(
 
     // Store delegations in store if present (processed by run_with_context)
     if !resp.delegations.is_empty() {
-        store::store_set(
-            store,
-            repo,
-            task_id,
-            &[("delegations", serde_json::json!(resp.delegations))],
-        )
-        .await;
+        if let Some(store_id) = store_id_opt {
+            store::store_set_by_id(
+                store,
+                store_id,
+                &[("delegations", serde_json::json!(resp.delegations))],
+            )
+            .await;
+        } else {
+            store::store_set(
+                store,
+                repo,
+                task_id,
+                &[("delegations", serde_json::json!(resp.delegations))],
+            )
+            .await;
+        }
     }
 
     // Store result in task store
@@ -441,10 +554,17 @@ pub async fn handle_success(
     // Applies regardless of agent-reported status — push failures must be
     // surfaced so task_runs records them correctly and the task is rerouted.
     // Read last_error once (reuse the value read earlier if available)
-    let stored_last_error = store::opt_store_get_task(store, repo, task_id)
-        .await
-        .map(|t| t.last_error)
-        .unwrap_or_default();
+    let stored_last_error = if let Some(store_id) = store_id_opt {
+        store::opt_store_get_task_by_id(store, store_id)
+            .await
+            .map(|t| t.last_error)
+            .unwrap_or_default()
+    } else {
+        store::opt_store_get_task(store, repo, task_id)
+            .await
+            .map(|t| t.last_error)
+            .unwrap_or_default()
+    };
 
     let push_failed = !has_pushed && has_commits && stored_last_error.contains("push failed");
 
@@ -476,14 +596,23 @@ pub async fn handle_success(
     // increment this retry counter for them so that later normal push failures
     // are not prematurely blocked.
     let push_failures: u64 = if push_failed && !is_workflow_scope_failure {
-        match store::store_increment(store, repo, task_id, "push_failures").await {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!(task_id, err = %e, "failed to increment push_failures — skipping push-failure based reroute this tick");
-                // Treat as unknown: do not escalate this tick. Use 0 as safe fallback
-                // for logging, but decision to reroute/block will be skipped earlier.
-                0
+        match store_id_opt {
+            Some(store_id) => {
+                match store::store_increment_by_id(store, store_id, "push_failures").await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::warn!(task_id, err = %e, "failed to increment push_failures — skipping push-failure based reroute this tick");
+                        0
+                    }
+                }
             }
+            None => match store::store_increment(store, repo, task_id, "push_failures").await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(task_id, err = %e, "failed to increment push_failures — skipping push-failure based reroute this tick");
+                    0
+                }
+            },
         }
     } else {
         0
@@ -517,15 +646,23 @@ pub async fn handle_success(
             max_reroutes,
             "agent reported done but produced no code changes on external task requiring PR"
         );
-        match store::store_increment(store, repo, task_id, "no_code_reroutes").await {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!(task_id, err = %e, "failed to increment no_code_reroutes — skipping reroute/block decision this tick");
-                // On DB error, avoid treating this as 0 (which would allow silent retries).
-                // Use a sentinel 0 so downstream code that compares to max will not block,
-                // and we've logged the issue so the tick can be retried later.
-                0
+        match store_id_opt {
+            Some(store_id) => {
+                match store::store_increment_by_id(store, store_id, "no_code_reroutes").await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::warn!(task_id, err = %e, "failed to increment no_code_reroutes — skipping reroute/block decision this tick");
+                        0
+                    }
+                }
             }
+            None => match store::store_increment(store, repo, task_id, "no_code_reroutes").await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(task_id, err = %e, "failed to increment no_code_reroutes — skipping reroute/block decision this tick");
+                    0
+                }
+            },
         }
     } else {
         0
@@ -557,34 +694,64 @@ pub async fn handle_success(
             "push failed: token lacks `workflow` OAuth scope — blocking immediately \
              (rerouting would not help)"
         );
-        store::store_set(
-            store,
-            repo,
-            task_id,
-            &[(
-                "last_error",
-                serde_json::json!(format!(
-                    "push failed: GitHub token lacks `workflow` OAuth scope. \
-                     The agent modified .github/workflows/ files but the token cannot push them. \
-                     Fix: add `workflow` scope to your GitHub token, or use a GitHub App for auth. \
-                     Original error: {}",
-                    stored_last_error
-                )),
-            )],
-        )
-        .await;
+        if let Some(store_id) = store_id_opt {
+            store::store_set_by_id(
+                store,
+                store_id,
+                &[(
+                    "last_error",
+                    serde_json::json!(format!(
+                        "push failed: GitHub token lacks `workflow` OAuth scope. \
+                         The agent modified .github/workflows/ files but the token cannot push them. \
+                         Fix: add `workflow` scope to your GitHub token, or use a GitHub App for auth. \
+                         Original error: {}",
+                        stored_last_error
+                    )),
+                )],
+            )
+            .await;
+        } else {
+            store::store_set(
+                store,
+                repo,
+                task_id,
+                &[(
+                    "last_error",
+                    serde_json::json!(format!(
+                        "push failed: GitHub token lacks `workflow` OAuth scope. \
+                         The agent modified .github/workflows/ files but the token cannot push them. \
+                         Fix: add `workflow` scope to your GitHub token, or use a GitHub App for auth. \
+                         Original error: {}",
+                        stored_last_error
+                    )),
+                )],
+            )
+            .await;
+        }
     } else if push_failed {
         // Clear agent and model so router picks a different one on reroute (#1604)
-        store::store_set(
-            store,
-            repo,
-            task_id,
-            &[
-                ("agent", serde_json::json!(null)),
-                ("model", serde_json::json!(null)),
-            ],
-        )
-        .await;
+        if let Some(store_id) = store_id_opt {
+            store::store_set_by_id(
+                store,
+                store_id,
+                &[
+                    ("agent", serde_json::json!(null)),
+                    ("model", serde_json::json!(null)),
+                ],
+            )
+            .await;
+        } else {
+            store::store_set(
+                store,
+                repo,
+                task_id,
+                &[
+                    ("agent", serde_json::json!(null)),
+                    ("model", serde_json::json!(null)),
+                ],
+            )
+            .await;
+        }
         if push_failures >= 3 {
             tracing::error!(
                 task_id,
@@ -627,17 +794,30 @@ pub async fn handle_success(
         } else {
             "agent completed without code changes on external task requiring PR".to_string()
         };
-        store::store_set(
-            store,
-            repo,
-            task_id,
-            &[
-                ("agent", serde_json::json!(null)),
-                ("model", serde_json::json!(null)),
-                ("last_error", serde_json::json!(msg)),
-            ],
-        )
-        .await;
+        if let Some(store_id) = store_id_opt {
+            store::store_set_by_id(
+                store,
+                store_id,
+                &[
+                    ("agent", serde_json::json!(null)),
+                    ("model", serde_json::json!(null)),
+                    ("last_error", serde_json::json!(msg)),
+                ],
+            )
+            .await;
+        } else {
+            store::store_set(
+                store,
+                repo,
+                task_id,
+                &[
+                    ("agent", serde_json::json!(null)),
+                    ("model", serde_json::json!(null)),
+                    ("last_error", serde_json::json!(msg)),
+                ],
+            )
+            .await;
+        }
     } else if resp.status == "done" && !has_pr && is_external {
         // External task with non-code labels (e.g. documentation, research) —
         // allowed to be marked done without a PR.
@@ -651,13 +831,22 @@ pub async fn handle_success(
             "internal task reported done with no PR — marking done"
         );
     }
-    store::store_set(
-        store,
-        repo,
-        task_id,
-        &[("summary", serde_json::json!(resp.summary))],
-    )
-    .await;
+    if let Some(store_id) = store_id_opt {
+        store::store_set_by_id(
+            store,
+            store_id,
+            &[("summary", serde_json::json!(resp.summary))],
+        )
+        .await;
+    } else {
+        store::store_set(
+            store,
+            repo,
+            task_id,
+            &[("summary", serde_json::json!(resp.summary))],
+        )
+        .await;
+    }
 
     // Store token usage — prefer agent-parsed tokens, fall back to response
     let input_tokens = parsed.input_tokens.or(resp.input_tokens);
@@ -665,8 +854,14 @@ pub async fn handle_success(
     if let (Some(input), Some(output)) = (input_tokens, output_tokens) {
         let model = model_name.unwrap_or("haiku");
         if let Some(ref st) = store {
-            // Resolve store_id once and reuse
-            if let Ok(Some(store_id)) = st.resolve_task_id(repo, task_id).await {
+            if let Some(store_id) = store_id_opt {
+                if let Err(e) = st
+                    .store_tokens(store_id, input as i64, output as i64, model)
+                    .await
+                {
+                    tracing::warn!(task_id, ?e, "failed to store token usage");
+                }
+            } else if let Ok(Some(store_id)) = st.resolve_task_id(repo, task_id).await {
                 if let Err(e) = st
                     .store_tokens(store_id, input as i64, output as i64, model)
                     .await
@@ -704,7 +899,29 @@ pub async fn handle_success(
     }
 
     // Query total tokens and cost estimate together (single DB read)
-    let (total_tokens, cost) = store::get_token_summary(store, repo, task_id).await;
+    let (total_tokens, cost) = if let Some(ref s) = store {
+        if let Some(store_id) = store_id_opt {
+            if let Ok(task) = s.get(store_id).await {
+                let usage = crate::store::TokenUsage {
+                    input_tokens: task.input_tokens as u64,
+                    output_tokens: task.output_tokens as u64,
+                };
+                let total = usage.total_tokens();
+                let cost = crate::store::CostEstimate {
+                    input_cost_usd: task.input_cost_usd,
+                    output_cost_usd: task.output_cost_usd,
+                    total_cost_usd: task.total_cost_usd,
+                };
+                (total, cost)
+            } else {
+                store::get_token_summary(store, repo, task_id).await
+            }
+        } else {
+            store::get_token_summary(store, repo, task_id).await
+        }
+    } else {
+        store::get_token_summary(store, repo, task_id).await
+    };
     let warning_threshold = (max_tokens as f64 * 0.8) as u64;
 
     if total_tokens > max_tokens {

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -23,7 +23,6 @@ use crate::engine::router::{get_route_result, Router};
 use crate::engine::runner::{TaskRunner, WeightSignal};
 use crate::engine::tasks::{is_internal_id, TaskManager};
 use crate::repo_context::REPO_CONTEXT;
-use crate::store;
 use crate::store::TaskStore;
 use crate::tmux::TmuxManager;
 use dashmap::DashSet;
@@ -77,7 +76,7 @@ async fn startup_cleanup(tmux: &TmuxManager) {
 }
 
 use super::EngineConfig;
-use crate::store::{review_session_expected, set_review_session_expected};
+use crate::store::{review_session_expected, set_review_session_expected, store_set_by_id};
 
 /// Phase 1 of tick: poll tmux for finished sessions and clean them up.
 pub(crate) async fn tick_check_session_completions(
@@ -317,42 +316,42 @@ pub(crate) async fn tick_detect_silent_agents(
             }
         }
 
-        if next_agent.is_some() {
-            store::store_set(
-                &Some(Arc::clone(store)),
-                repo,
-                &task_id,
-                &[
-                    ("agent", serde_json::json!("")),
-                    ("model", serde_json::json!("")),
-                    (
-                        "last_error",
-                        serde_json::json!(format!(
-                            "silence detected after {}s, clearing agent/model for re-route",
-                            config.silence_grace_period
-                        )),
-                    ),
-                ],
-            )
-            .await;
-        } else {
-            store::store_set(
-                &Some(Arc::clone(store)),
-                repo,
-                &task_id,
-                &[
-                    ("agent", serde_json::Value::Null),
-                    ("model", serde_json::Value::Null),
-                    (
-                        "last_error",
-                        serde_json::json!(format!(
-                            "silence detected after {}s, no fallback agents available",
-                            config.silence_grace_period
-                        )),
-                    ),
-                ],
-            )
-            .await;
+        if let Some(store_id) = store_task.as_ref().map(|t| t.id) {
+            if next_agent.is_some() {
+                store_set_by_id(
+                    &Some(Arc::clone(store)),
+                    store_id,
+                    &[
+                        ("agent", serde_json::json!("")),
+                        ("model", serde_json::json!("")),
+                        (
+                            "last_error",
+                            serde_json::json!(format!(
+                                "silence detected after {}s, clearing agent/model for re-route",
+                                config.silence_grace_period
+                            )),
+                        ),
+                    ],
+                )
+                .await;
+            } else {
+                store_set_by_id(
+                    &Some(Arc::clone(store)),
+                    store_id,
+                    &[
+                        ("agent", serde_json::Value::Null),
+                        ("model", serde_json::Value::Null),
+                        (
+                            "last_error",
+                            serde_json::json!(format!(
+                                "silence detected after {}s, no fallback agents available",
+                                config.silence_grace_period
+                            )),
+                        ),
+                    ],
+                )
+                .await;
+            }
         }
 
         if let Err(e) = task_manager
@@ -474,17 +473,18 @@ pub(crate) async fn tick_recover_stuck_tasks(
                 backend.remove_label(&task.id, label).await.ok();
             }
         }
-        store::store_set(
-            &Some(Arc::clone(store)),
-            repo,
-            &task.id.0,
-            &[
-                ("agent", serde_json::Value::Null),
-                ("model", serde_json::Value::Null),
-                ("route_attempts", serde_json::json!(0)),
-            ],
-        )
-        .await;
+        if let Ok(Some(store_id)) = store.resolve_task_id(repo, &task.id.0).await {
+            store_set_by_id(
+                &Some(Arc::clone(store)),
+                store_id,
+                &[
+                    ("agent", serde_json::Value::Null),
+                    ("model", serde_json::Value::Null),
+                    ("route_attempts", serde_json::json!(0)),
+                ],
+            )
+            .await;
+        }
         if let Err(e) = task_manager.update_task_status(&task.id, Status::New).await {
             tracing::warn!(task_id = task.id.0, ?e, "failed to reset stuck task status");
             continue;
@@ -590,17 +590,18 @@ pub(crate) async fn tick_recover_stuck_tasks(
         }
         // Reset routing state so the LLM router is used on the next attempt
         // (same reset that external tasks perform).
-        store::store_set(
-            &Some(Arc::clone(store)),
-            repo,
-            &task_id,
-            &[
-                ("agent", serde_json::Value::Null),
-                ("model", serde_json::Value::Null),
-                ("route_attempts", serde_json::json!(0)),
-            ],
-        )
-        .await;
+        if let Ok(Some(store_id)) = store.resolve_task_id(repo, &task_id).await {
+            store_set_by_id(
+                &Some(Arc::clone(store)),
+                store_id,
+                &[
+                    ("agent", serde_json::Value::Null),
+                    ("model", serde_json::Value::Null),
+                    ("route_attempts", serde_json::json!(0)),
+                ],
+            )
+            .await;
+        }
         if let Err(e) = task_manager
             .update_task_status(&ExternalId(task_id.clone()), Status::New)
             .await
@@ -1605,7 +1606,7 @@ mod tests {
             .update_status(id, crate::store::TaskStatus::InReview)
             .await
             .unwrap();
-        store::set_review_session_expected(&store, "owner/repo", "99", true).await;
+        set_review_session_expected(&store, "owner/repo", "99", true).await;
         set_task_updated_at_past(&store, id).await;
 
         tick_recover_stuck_tasks(
@@ -1706,7 +1707,7 @@ mod tests {
             .update_status(id, crate::store::TaskStatus::InReview)
             .await
             .unwrap();
-        store::set_review_session_expected(&store, "owner/repo", "internal:1", true).await;
+        set_review_session_expected(&store, "owner/repo", "internal:1", true).await;
         set_task_updated_at_past(&store, id).await;
 
         tick_recover_stuck_tasks(

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -12,6 +12,24 @@ use std::sync::Arc;
 ///
 /// Returns `None` if the store is unavailable, the task cannot be resolved,
 /// or the task row cannot be loaded.
+pub async fn opt_store_get_task_by_id(
+    store: &Option<Arc<TaskStore>>,
+    store_id: i64,
+) -> Option<Task> {
+    let s = store.as_ref()?;
+    match s.get(store_id).await {
+        Ok(task) => Some(task),
+        Err(e) => {
+            tracing::warn!(store_id, error = %e, "failed to fetch task from store");
+            None
+        }
+    }
+}
+
+/// Load the full `Task` record from the store.
+///
+/// Returns `None` if the store is unavailable, the task cannot be resolved,
+/// or the task row cannot be loaded.
 pub async fn opt_store_get_task(
     store: &Option<Arc<TaskStore>>,
     repo: &str,
@@ -26,11 +44,20 @@ pub async fn opt_store_get_task(
             return None;
         }
     };
-    match s.get(store_id).await {
-        Ok(task) => Some(task),
-        Err(e) => {
-            tracing::warn!(task_id, error = %e, "failed to fetch task from store");
-            None
+    opt_store_get_task_by_id(store, store_id).await
+}
+
+/// Write fields to the task store.
+///
+/// `store` may be None if the store isn't initialized yet.
+pub async fn store_set_by_id(
+    store: &Option<Arc<TaskStore>>,
+    store_id: i64,
+    store_fields: &[(&str, serde_json::Value)],
+) {
+    if let Some(ref store) = store {
+        if let Err(e) = store.set_fields(store_id, store_fields).await {
+            tracing::warn!(store_id, error = %e, "store set_fields failed");
         }
     }
 }
@@ -64,6 +91,23 @@ pub async fn store_set(
 /// Unlike `store_set`, this variant propagates failures so callers can
 /// abort further processing when a critical write (e.g. a watermark) fails.
 /// Returns `Ok(())` when `store` is `None` (store not yet initialized).
+pub async fn store_set_result_by_id(
+    store: &Option<Arc<TaskStore>>,
+    store_id: i64,
+    store_fields: &[(&str, serde_json::Value)],
+) -> anyhow::Result<()> {
+    if let Some(ref store) = store {
+        store.set_fields(store_id, store_fields).await?;
+    }
+    Ok(())
+}
+
+/// Write fields to the task store, returning an error if the write fails.
+///
+/// Unlike `store_set`, this variant propagates failures so callers can
+/// abort further processing when a critical write (e.g. a watermark) fails.
+/// Returns `Ok(())` when `store` is `None` (store not yet initialized).
+#[allow(dead_code)]
 pub async fn store_set_result(
     store: &Option<Arc<TaskStore>>,
     repo: &str,
@@ -78,6 +122,18 @@ pub async fn store_set_result(
         store.set_fields(store_id, store_fields).await?;
     }
     Ok(())
+}
+
+/// Touch `updated_at` to now so the stuck-task timer is reset after a session exits.
+///
+/// No-op when the store is unavailable or the task cannot be resolved.
+#[allow(dead_code)]
+pub async fn store_touch_updated_at_by_id(store: &Option<Arc<TaskStore>>, store_id: i64) {
+    if let Some(ref s) = store {
+        if let Err(e) = s.touch_updated_at(store_id).await {
+            tracing::warn!(store_id, error = %e, "store touch_updated_at failed");
+        }
+    }
 }
 
 /// Touch `updated_at` to now so the stuck-task timer is reset after a session exits.
@@ -171,6 +227,27 @@ pub async fn set_review_session_expected(
 /// store is unavailable, the task cannot be resolved, or the underlying
 /// SQL increment failed. Callers must handle errors explicitly — this
 /// helper no longer silently returns 0 on error.
+pub async fn store_increment_by_id(
+    store: &Option<Arc<TaskStore>>,
+    store_id: i64,
+    field: &str,
+) -> anyhow::Result<u64> {
+    let s = store
+        .as_ref()
+        .ok_or_else(|| anyhow!("task store unavailable"))?;
+    match s.increment(store_id, field).await {
+        Ok(new_val) => Ok(new_val as u64),
+        Err(e) => Err(anyhow!("store.increment failed: {}", e)),
+    }
+}
+
+/// Increment a counter in the task store.
+///
+/// Uses `store.increment()` for an atomic SQL `field + 1`.
+/// Returns `Ok(new_value)` on success or `Err(anyhow::Error)` when the
+/// store is unavailable, the task cannot be resolved, or the underlying
+/// SQL increment failed. Callers must handle errors explicitly — this
+/// helper no longer silently returns 0 on error.
 pub async fn store_increment(
     store: &Option<Arc<TaskStore>>,
     repo: &str,
@@ -181,10 +258,7 @@ pub async fn store_increment(
         .as_ref()
         .ok_or_else(|| anyhow!("task store unavailable"))?;
     match s.resolve_task_id(repo, task_id).await {
-        Ok(Some(store_id)) => match s.increment(store_id, field).await {
-            Ok(new_val) => Ok(new_val as u64),
-            Err(e) => Err(anyhow!("store.increment failed: {}", e)),
-        },
+        Ok(Some(store_id)) => store_increment_by_id(store, store_id, field).await,
         Ok(None) => Err(anyhow!("task not present in store: {}/{}", repo, task_id)),
         Err(e) => {
             tracing::warn!(task_id, error = %e, "resolve_task_id failed in store write helper");

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -40,9 +40,10 @@ pub use control::{parse_since_duration, ControlMessage, MemoryEntry};
 #[allow(unused_imports)]
 pub use helpers::{
     get_cost_estimate, get_recent_memory, get_token_summary, get_token_usage, get_total_tokens,
-    opt_store_get_task, review_session_expected, set_review_session_expected, store_increment,
-    store_log_activity, store_reset_counters, store_reset_failure_counters, store_set,
-    store_set_result, store_touch_updated_at,
+    opt_store_get_task, opt_store_get_task_by_id, review_session_expected,
+    set_review_session_expected, store_increment, store_increment_by_id, store_log_activity,
+    store_reset_counters, store_reset_failure_counters, store_set, store_set_by_id,
+    store_set_result, store_set_result_by_id, store_touch_updated_at, store_touch_updated_at_by_id,
 };
 #[allow(unused_imports)]
 pub use jobs::JobState;

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -416,6 +416,36 @@ async fn helper_store_set_writes_fields() {
 }
 
 #[tokio::test]
+async fn helper_store_set_by_id_writes_fields() {
+    let store = Arc::new(TaskStore::open_memory().await.unwrap());
+    let id = store
+        .create(&NewTask {
+            external_id: Some("90b".to_string()),
+            repo: "owner/repo".to_string(),
+            origin: "github".to_string(),
+            title: "Store set by id test".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let opt_store = Some(store.clone());
+    store_set_by_id(
+        &opt_store,
+        id,
+        &[
+            ("branch", serde_json::json!("fix-bug-by-id")),
+            ("worktree", serde_json::json!("/tmp/wt-by-id")),
+        ],
+    )
+    .await;
+
+    let task = store.get(id).await.unwrap();
+    assert_eq!(task.branch, "fix-bug-by-id");
+    assert_eq!(task.worktree, "/tmp/wt-by-id");
+}
+
+#[tokio::test]
 async fn helper_store_set_ignores_unknown_task() {
     let store = Arc::new(TaskStore::open_memory().await.unwrap());
     let opt_store = Some(store);
@@ -505,6 +535,35 @@ async fn helper_store_reset_failure_counters_preserves_review_cycles() {
     assert_eq!(task.review_invocations, 0);
     assert_eq!(task.attempts, 0);
     assert_eq!(task.merge_conflict_retries, 0);
+}
+
+#[tokio::test]
+async fn helper_store_increment_by_id_returns_new_value() {
+    let store = Arc::new(TaskStore::open_memory().await.unwrap());
+    let id = store
+        .create(&NewTask {
+            external_id: Some("73b".to_string()),
+            repo: "owner/repo".to_string(),
+            origin: "github".to_string(),
+            title: "Increment by id test".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let opt_store = Some(store.clone());
+    let v1 = store_increment_by_id(&opt_store, id, "attempts")
+        .await
+        .unwrap();
+    let v2 = store_increment_by_id(&opt_store, id, "attempts")
+        .await
+        .unwrap();
+
+    assert_eq!(v1, 1);
+    assert_eq!(v2, 2);
+
+    let task = store.get(id).await.unwrap();
+    assert_eq!(task.attempts, 2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

I'll open the store helpers and the referenced files to modify them. I'll read the relevant files first.---
## Goal

Eliminate repeated external_id → store_id SQL lookups on hot paths by adding and using "by_id" store helper variants that accept a pre-resolved numeric store row id (i64). This reduces redundant calls to TaskStore::resolve_task_id(repo, task_id) in loops that call multiple store helpers for the same task (N+1-style lookups) and thus improves sync/tick performance (review_poll, t

Closes #1983

---
*Task #1983 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*