### PR TITLE
bug: tick_recover_stuck_tasks aborts entire recovery phase on internal in_review query failure

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -703,9 +703,19 @@ pub(crate) async fn tick_recover_stuck_tasks(
     }
 
     // Recover internal (SQLite) tasks stuck in in_review.
-    let internal_in_review = task_manager
+    let internal_in_review = match task_manager
         .list_internal_by_status(DbStatus::InReview)
-        .await?;
+        .await
+    {
+        Ok(tasks) => tasks,
+        Err(e) => {
+            tracing::warn!(
+                ?e,
+                "failed to list internal in_review tasks for stuck recovery"
+            );
+            vec![]
+        }
+    };
     for task in &internal_in_review {
         let task_id = task.id.0.clone();
         if !review_session_expected(store, repo, &task_id).await {


### PR DESCRIPTION
## Summary

Fixed the asymmetric error handling in tick_recover_stuck_tasks: changed the internal in_review query from `.await?` (propagating errors) to a match block that logs a warning and returns an empty vec on error, matching the pattern used for the external in_review query at line 616-622.

### What was done

- Changed internal in_review query at line 705-708 to gracefully handle DB errors
- Added warning log for observability when query fails
- Recovery now continues with external in_review tasks even if internal query fails


Closes #1988

---
*Task #1988 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*