### PR TITLE
bug: reconcile_closed_tasks cleans worktrees even when update_task_status fails — tasks stranded without worktree

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -130,22 +130,21 @@ async fn reconcile_closed_tasks(
                 labels = ?labels,
                 "closed issue with stale status label — reconciling to done and cleaning up"
             );
-            if let Err(e) = task_manager.update_task_status(&id, Status::Done).await {
-                tracing::warn!(
-                    task_id = task_id_str,
-                    err = %e,
-                    "failed to reconcile closed issue status to done"
-                );
+            match task_manager.update_task_status(&id, Status::Done).await {
+                Ok(()) => Some(task_id_str),
+                Err(e) => {
+                    tracing::warn!(
+                        task_id = task_id_str,
+                        err = %e,
+                        "failed to reconcile closed issue status to done"
+                    );
+                    None
+                }
             }
         });
     }
-    futures::future::join_all(futs).await;
-    task_ids.extend(
-        needs_reconcile
-            .iter()
-            .take(MAX_RECONCILE_PER_CYCLE)
-            .map(|t| t.id.0.clone()),
-    );
+    let results = futures::future::join_all(futs).await;
+    task_ids.extend(results.into_iter().flatten());
 }
 
 /// Cleanup worktrees for completed tasks with explicit options.


### PR DESCRIPTION
## Summary

## Summary

I've successfully fixed the bug in `src/engine/cleanup.rs`. Here's what was wrong and how I fixed it:

### The Bug
In `reconcile_closed_tasks`, task worktrees were being cleaned up unconditionally, even when `update_task_status` failed. This left tasks stranded without worktrees, unable to continue or be retried without manual intervention.

### The Fix
Changed the async block to return `Option<String>`:
- **Success case**: Returns `Some(task_id_str)` when status update succeeds
- **

Closes #1987

---
*Task #1987 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*