### PR TITLE
bug: attempts counter uses fire-and-forget store_set — max_attempts guard bypassable on transient DB write failure

### DIFF
--- a/src/engine/runner/task_init.rs
+++ b/src/engine/runner/task_init.rs
@@ -347,14 +347,15 @@ pub async fn prepare_task(
         attempt: next_attempt,
     };
 
-    // Increment attempts counter
-    store::store_set(
+    // Increment attempts counter — must succeed so max_attempts guard cannot be bypassed
+    store::store_set_result(
         store,
         repo,
         task_id,
         &[("attempts", serde_json::json!(next_attempt))],
     )
-    .await;
+    .await
+    .map_err(|e| anyhow::anyhow!("failed to persist attempts counter: {e}"))?;
 
     Ok(TaskInitResult {
         agent_name,

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -107,7 +107,6 @@ pub async fn store_set_result_by_id(
 /// Unlike `store_set`, this variant propagates failures so callers can
 /// abort further processing when a critical write (e.g. a watermark) fails.
 /// Returns `Ok(())` when `store` is `None` (store not yet initialized).
-#[allow(dead_code)]
 pub async fn store_set_result(
     store: &Option<Arc<TaskStore>>,
     repo: &str,


### PR DESCRIPTION
## Summary

Done. The fix:

1. **`src/engine/runner/task_init.rs`**: Replaced `store_set` with `store_set_result` + `?` so a DB write failure aborts `prepare_task` instead of silently proceeding with a stale counter.

2. **`src/store/helpers.rs`**: Removed `#[allow(dead_code)]` from `store_set_result` since it's now actively used.

All 2685 tests pass, clippy clean, formatting OK.

Closes #1990

---
*Task #1990 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*