### PR TITLE
perf: collapse ingest_external_tasks status fan-out into a single active-issues fetch

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -330,6 +330,62 @@ impl ExternalBackend for GitHubBackend {
             .collect())
     }
 
+    /// List all open tasks with active statuses in a single API call.
+    ///
+    /// Fetches all open issues once and partitions by status label locally.
+    /// More efficient than making 6 separate `list_by_status` calls.
+    async fn list_all_active_tasks(&self) -> anyhow::Result<Vec<(ExternalTask, Status)>> {
+        let issues = self.gh.list_all_open_issues(&self.repo).await?;
+        let mut results = Vec::new();
+
+        for issue in issues {
+            if issue.pull_request.is_some() {
+                continue;
+            }
+            if !is_trusted_author(&issue) {
+                continue;
+            }
+
+            let labels: Vec<&str> = issue.labels.iter().map(|l| l.name.as_str()).collect();
+
+            // Find the status label, if any
+            let status = labels.iter().find_map(|l| {
+                if let Some(status) = l.strip_prefix("status:") {
+                    match status {
+                        "new" => Some(Status::New),
+                        "routed" => Some(Status::Routed),
+                        "in_progress" => Some(Status::InProgress),
+                        "needs_review" => Some(Status::NeedsReview),
+                        "in_review" => Some(Status::InReview),
+                        "blocked" => Some(Status::Blocked),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            });
+
+            if let Some(status) = status {
+                results.push((
+                    ExternalTask {
+                        id: ExternalId(issue.number.to_string()),
+                        title: issue.title,
+                        body: issue.body.unwrap_or_default(),
+                        state: issue.state,
+                        labels: issue.labels.into_iter().map(|l| l.name).collect(),
+                        author: issue.user.login,
+                        created_at: issue.created_at,
+                        updated_at: issue.updated_at,
+                        url: issue.html_url,
+                    },
+                    status,
+                ));
+            }
+        }
+
+        Ok(results)
+    }
+
     async fn post_comment(&self, id: &ExternalId, body: &str) -> anyhow::Result<()> {
         self.gh.add_comment(&self.repo, &id.0, body).await
     }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -217,6 +217,30 @@ pub trait ExternalBackend: Send + Sync {
         self.list_by_status(Status::New).await
     }
 
+    /// List all open tasks with active statuses (everything except Done).
+    ///
+    /// This fetches all open issues in a single API call and partitions them
+    /// by status label locally. More efficient than making 6 separate calls to
+    /// `list_by_status` for each active status.
+    async fn list_all_active_tasks(&self) -> anyhow::Result<Vec<(ExternalTask, Status)>> {
+        let statuses = [
+            Status::New,
+            Status::Routed,
+            Status::InProgress,
+            Status::NeedsReview,
+            Status::InReview,
+            Status::Blocked,
+        ];
+        let mut all_tasks = Vec::new();
+        for status in statuses {
+            let tasks = self.list_by_status(status).await?;
+            for task in tasks {
+                all_tasks.push((task, status));
+            }
+        }
+        Ok(all_tasks)
+    }
+
     /// Post a comment / activity note.
     async fn post_comment(&self, id: &ExternalId, body: &str) -> anyhow::Result<()>;
 

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1353,33 +1353,50 @@ pub(crate) async fn ingest_external_tasks(
         }
     }
 
-    // 2. All labeled active statuses — for status sync on first ingest.
-    //    All 6 calls are independent — run them in parallel to reduce sync latency.
-    let active_statuses = [
-        Status::New,
-        Status::Routed,
-        Status::InProgress,
-        Status::NeedsReview,
-        Status::InReview,
-        Status::Blocked,
-    ];
-    let status_results = futures::future::join_all(
-        active_statuses
-            .iter()
-            .map(|status| async move { (*status, backend.list_by_status(*status).await) }),
-    )
-    .await;
-    for (status, result) in status_results {
-        match result {
-            Ok(tasks) => {
-                for task in tasks {
-                    if seen.insert(task.id.0.clone()) {
-                        all_tasks.push((task, Some(status)));
-                    }
+    // 2. All labeled active statuses — fetch in a single API call when backend
+    //    supports it, otherwise fall back to per-status calls.
+    match backend.list_all_active_tasks().await {
+        Ok(active_tasks) => {
+            for (task, status) in active_tasks {
+                if seen.insert(task.id.0.clone()) {
+                    all_tasks.push((task, Some(status)));
                 }
             }
-            Err(e) => {
-                tracing::debug!(?status, ?e, "ingest: failed to list tasks");
+        }
+        Err(e) => {
+            tracing::debug!(
+                ?e,
+                "ingest: list_all_active_tasks failed, falling back to per-status calls"
+            );
+            // Fallback: parallel per-status calls for backends that don't
+            // implement list_all_active_tasks efficiently.
+            let active_statuses = [
+                Status::New,
+                Status::Routed,
+                Status::InProgress,
+                Status::NeedsReview,
+                Status::InReview,
+                Status::Blocked,
+            ];
+            let status_results = futures::future::join_all(
+                active_statuses
+                    .iter()
+                    .map(|status| async move { (*status, backend.list_by_status(*status).await) }),
+            )
+            .await;
+            for (status, result) in status_results {
+                match result {
+                    Ok(tasks) => {
+                        for task in tasks {
+                            if seen.insert(task.id.0.clone()) {
+                                all_tasks.push((task, Some(status)));
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::debug!(?status, ?e, "ingest: failed to list tasks");
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Collapsed 6 parallel GitHub API calls into a single fetch per sync tick. Added list_all_active_tasks() to the ExternalBackend trait with efficient implementation in GitHubBackend that fetches all open issues once and partitions by status label locally.

### What was done

- Added list_all_active_tasks() method to ExternalBackend trait with default fallback implementation
- Implemented efficient single-fetch in GitHubBackend using list_all_open_issues() and local status label partitioning
- Updated ingest in sync.rs to use the new method with fallback for non-GitHub backends
- All sync and backend tests pass
- Code compiles with no warnings, formatting passes


Closes #1998

---
*Task #1998 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*