### PR TITLE
Collapse ingest status fan-out into single active-issues fetch

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -344,60 +344,49 @@ impl ExternalBackend for GitHubBackend {
             .collect())
     }
 
-    /// List all open tasks with active statuses in a single API call.
-    ///
-    /// Fetches all open issues once and partitions by status label locally.
-    /// More efficient than making 6 separate `list_by_status` calls.
-    async fn list_all_active_tasks(&self) -> anyhow::Result<Vec<(ExternalTask, Status)>> {
+    /// Single-call override: fetches all open issues once and partitions by status label locally,
+    /// replacing the 1 (list_routable) + 5 (list_by_status per active status) fan-out with a
+    /// single `list_all_open_issues` request.
+    async fn list_active_open_issues(
+        &self,
+    ) -> anyhow::Result<Vec<(ExternalTask, Option<crate::backends::Status>)>> {
         let issues = self.gh.list_all_open_issues(&self.repo).await?;
-        let mut results = Vec::new();
 
-        for issue in issues {
-            if issue.pull_request.is_some() {
-                continue;
+        let active_status_from_label = |label: &str| -> Option<crate::backends::Status> {
+            match label {
+                "status:routed" => Some(crate::backends::Status::Routed),
+                "status:in_progress" => Some(crate::backends::Status::InProgress),
+                "status:needs_review" => Some(crate::backends::Status::NeedsReview),
+                "status:in_review" => Some(crate::backends::Status::InReview),
+                "status:blocked" => Some(crate::backends::Status::Blocked),
+                _ => None,
             }
-            if !is_trusted_author(&issue) {
-                continue;
-            }
+        };
 
-            let labels: Vec<&str> = issue.labels.iter().map(|l| l.name.as_str()).collect();
-
-            // Find the status label, if any
-            let status = labels.iter().find_map(|l| {
-                if let Some(status) = l.strip_prefix("status:") {
-                    match status {
-                        "new" => Some(Status::New),
-                        "routed" => Some(Status::Routed),
-                        "in_progress" => Some(Status::InProgress),
-                        "needs_review" => Some(Status::NeedsReview),
-                        "in_review" => Some(Status::InReview),
-                        "blocked" => Some(Status::Blocked),
-                        _ => None,
-                    }
-                } else {
-                    None
-                }
-            });
-
-            if let Some(status) = status {
-                results.push((
-                    ExternalTask {
-                        id: ExternalId(issue.number.to_string()),
-                        title: issue.title,
-                        body: issue.body.unwrap_or_default(),
-                        state: issue.state,
-                        labels: issue.labels.into_iter().map(|l| l.name).collect(),
-                        author: issue.user.login,
-                        created_at: issue.created_at,
-                        updated_at: issue.updated_at,
-                        url: issue.html_url,
-                    },
-                    status,
-                ));
-            }
-        }
-
-        Ok(results)
+        Ok(issues
+            .into_iter()
+            .filter(|issue| issue.pull_request.is_none()) // Exclude PRs
+            .filter(is_trusted_author) // Only trusted authors
+            .map(|issue| {
+                // Detect active (non-new) status from labels; None = unlabeled or status:new.
+                let status = issue
+                    .labels
+                    .iter()
+                    .find_map(|l| active_status_from_label(&l.name));
+                let task = ExternalTask {
+                    id: ExternalId(issue.number.to_string()),
+                    title: issue.title,
+                    body: issue.body.unwrap_or_default(),
+                    state: issue.state,
+                    labels: issue.labels.into_iter().map(|l| l.name).collect(),
+                    author: issue.user.login,
+                    created_at: issue.created_at,
+                    updated_at: issue.updated_at,
+                    url: issue.html_url,
+                };
+                (task, status)
+            })
+            .collect())
     }
 
     async fn post_comment(&self, id: &ExternalId, body: &str) -> anyhow::Result<()> {

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -217,28 +217,45 @@ pub trait ExternalBackend: Send + Sync {
         self.list_by_status(Status::New).await
     }
 
-    /// List all open tasks with active statuses (everything except Done).
+    /// Fetch all open issues for ingest in a single logical call, returning each issue paired
+    /// with its detected status (`None` = unlabeled/routable, `Some(s)` = has status label `s`).
     ///
-    /// This fetches all open issues in a single API call and partitions them
-    /// by status label locally. More efficient than making 6 separate calls to
-    /// `list_by_status` for each active status.
-    async fn list_all_active_tasks(&self) -> anyhow::Result<Vec<(ExternalTask, Status)>> {
-        let statuses = [
-            Status::New,
+    /// The default implementation calls `list_routable()` followed by `list_by_status()` for
+    /// each active non-new status, deduplicating by ID.  Backends that support bulk listing
+    /// (e.g. GitHub) should override this to fetch all open issues in one API call and
+    /// partition locally, eliminating the 1 + N fan-out.
+    async fn list_active_open_issues(&self) -> anyhow::Result<Vec<(ExternalTask, Option<Status>)>> {
+        let mut seen = std::collections::HashSet::new();
+        let mut result = Vec::new();
+
+        // Routable tasks: unlabeled issues + status:new → no status sync needed.
+        if let Ok(routable) = self.list_routable().await {
+            for task in routable {
+                if seen.insert(task.id.0.clone()) {
+                    result.push((task, None));
+                }
+            }
+        }
+
+        // Remaining active statuses (non-new) that require status sync on first ingest.
+        let active_non_new = [
             Status::Routed,
             Status::InProgress,
             Status::NeedsReview,
             Status::InReview,
             Status::Blocked,
         ];
-        let mut all_tasks = Vec::new();
-        for status in statuses {
-            let tasks = self.list_by_status(status).await?;
-            for task in tasks {
-                all_tasks.push((task, status));
+        for status in active_non_new {
+            if let Ok(tasks) = self.list_by_status(status).await {
+                for task in tasks {
+                    if seen.insert(task.id.0.clone()) {
+                        result.push((task, Some(status)));
+                    }
+                }
             }
         }
-        Ok(all_tasks)
+
+        Ok(result)
     }
 
     /// Post a comment / activity note.

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1453,80 +1453,23 @@ pub(crate) async fn ingest_external_tasks(
         }
     }
 
-    // Fetch all open issues in one call (includes unlabeled issues).
-    // Also fetch routable tasks which catches unlabeled issues on backends
-    // where list_all_tasks only returns labeled ones.
-    let mut seen = std::collections::HashSet::new();
-    let mut all_tasks: Vec<(crate::backends::ExternalTask, Option<Status>)> = Vec::new();
-
-    // 1. Routable tasks (unlabeled + status:new) — these are the ones that
-    //    were previously missed because the per-status loop skipped them.
-    match backend.list_routable().await {
-        Ok(routable) => {
-            for task in routable {
-                if seen.insert(task.id.0.clone()) {
-                    all_tasks.push((task, None));
-                }
+    // Fetch all open issues in a single backend call and partition by status label locally.
+    // The GitHub backend overrides list_active_open_issues() to use one list_all_open_issues()
+    // request instead of a routable call + N per-status calls.
+    let all_tasks: Vec<(crate::backends::ExternalTask, Option<Status>)> =
+        match backend.list_active_open_issues().await {
+            Ok(tasks) => tasks,
+            Err(e) => {
+                tracing::debug!(
+                    ?e,
+                    "ingest: failed to list active open issues — skipping this cycle"
+                );
+                return Ok(());
             }
-        }
-        Err(e) => {
-            tracing::debug!(
-                ?e,
-                "ingest: failed to list routable tasks — unlabeled new issues may be delayed"
-            );
-        }
-    }
+        };
 
-    // 2. All labeled active statuses — fetch in a single API call when backend
-    //    supports it, otherwise fall back to per-status calls.
-    match backend.list_all_active_tasks().await {
-        Ok(active_tasks) => {
-            for (task, status) in active_tasks {
-                if seen.insert(task.id.0.clone()) {
-                    all_tasks.push((task, Some(status)));
-                }
-            }
-        }
-        Err(e) => {
-            tracing::debug!(
-                ?e,
-                "ingest: list_all_active_tasks failed, falling back to per-status calls"
-            );
-            // Fallback: parallel per-status calls for backends that don't
-            // implement list_all_active_tasks efficiently.
-            let active_statuses = [
-                Status::New,
-                Status::Routed,
-                Status::InProgress,
-                Status::NeedsReview,
-                Status::InReview,
-                Status::Blocked,
-            ];
-            let status_results = futures::future::join_all(
-                active_statuses
-                    .iter()
-                    .map(|status| async move { (*status, backend.list_by_status(*status).await) }),
-            )
-            .await;
-            for (status, result) in status_results {
-                match result {
-                    Ok(tasks) => {
-                        for task in tasks {
-                            if seen.insert(task.id.0.clone()) {
-                                all_tasks.push((task, Some(status)));
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tracing::debug!(?status, ?e, "ingest: failed to list tasks");
-                    }
-                }
-            }
-        }
-    }
-
-    // 3. Upsert into the store, collecting store IDs for batch status check.
-    //    Also acknowledge newly detected issues (eyes reaction).
+    // Upsert into the store, collecting store IDs for batch status check.
+    // Also acknowledge newly detected issues (eyes reaction).
     let mut id_status_pairs: Vec<(i64, crate::backends::Status)> = Vec::new();
     // Pre-load existing external IDs for this repo to avoid N+1 queries
     // (each get_by_external_id call is an individual SQL query). If the
@@ -1745,6 +1688,26 @@ mod tests {
         }
         async fn list_routable(&self) -> anyhow::Result<Vec<ExternalTask>> {
             Ok(vec![])
+        }
+        async fn list_active_open_issues(
+            &self,
+        ) -> anyhow::Result<Vec<(ExternalTask, Option<Status>)>> {
+            let mut result = Vec::new();
+            for (label, tasks) in &self.tasks {
+                let status = match label.as_str() {
+                    "status:new" => None,
+                    "status:routed" => Some(Status::Routed),
+                    "status:in_progress" => Some(Status::InProgress),
+                    "status:needs_review" => Some(Status::NeedsReview),
+                    "status:in_review" => Some(Status::InReview),
+                    "status:blocked" => Some(Status::Blocked),
+                    _ => None,
+                };
+                for task in tasks {
+                    result.push((task.clone(), status));
+                }
+            }
+            Ok(result)
         }
         async fn post_comment(&self, id: &ExternalId, body: &str) -> anyhow::Result<()> {
             self.comments
@@ -2017,6 +1980,106 @@ mod tests {
             "sync_to_project must be called exactly once (for new task only), got: {syncs:?}"
         );
         assert_eq!(syncs[0].0, "11", "sync_to_project must target the new task");
+    }
+
+    #[tokio::test]
+    async fn ingest_handles_mixed_labeled_and_unlabeled_open_issues() {
+        // Simulate a backend where some issues have no status label (routable/unlabeled)
+        // and others carry active status labels.  Both kinds must be ingested and the
+        // store status must reflect the label where present.
+        struct MixedBackend;
+
+        #[async_trait]
+        impl ExternalBackend for MixedBackend {
+            fn name(&self) -> &str {
+                "mixed"
+            }
+            async fn create_task(
+                &self,
+                _: &str,
+                _: &str,
+                _: &[String],
+            ) -> anyhow::Result<ExternalId> {
+                Ok(ExternalId("x".into()))
+            }
+            async fn get_task(&self, _: &ExternalId) -> anyhow::Result<ExternalTask> {
+                anyhow::bail!("not implemented")
+            }
+            async fn list_by_status(&self, _: Status) -> anyhow::Result<Vec<ExternalTask>> {
+                Ok(vec![])
+            }
+            /// Return a mix: one unlabeled (no status) + one labeled in_progress.
+            async fn list_active_open_issues(
+                &self,
+            ) -> anyhow::Result<Vec<(ExternalTask, Option<Status>)>> {
+                Ok(vec![
+                    (make_ext_task("100", "Unlabeled routable"), None),
+                    (
+                        make_ext_task("101", "In progress issue"),
+                        Some(Status::InProgress),
+                    ),
+                ])
+            }
+            async fn post_comment(&self, _: &ExternalId, _: &str) -> anyhow::Result<()> {
+                Ok(())
+            }
+            async fn set_labels(&self, _: &ExternalId, _: &[String]) -> anyhow::Result<()> {
+                Ok(())
+            }
+            async fn remove_label(&self, _: &ExternalId, _: &str) -> anyhow::Result<()> {
+                Ok(())
+            }
+            async fn get_sub_issues(&self, _: &ExternalId) -> anyhow::Result<Vec<ExternalId>> {
+                Ok(vec![])
+            }
+            async fn health_check(&self) -> anyhow::Result<()> {
+                Ok(())
+            }
+            async fn get_mentions(&self, _: &str) -> anyhow::Result<Vec<Mention>> {
+                Ok(vec![])
+            }
+            async fn update_status(&self, _: &ExternalId, _: Status) -> anyhow::Result<()> {
+                Ok(())
+            }
+            async fn has_open_issue_with_title(&self, _: &str, _: &str) -> anyhow::Result<bool> {
+                Ok(false)
+            }
+            async fn sync_to_project(&self, _: &ExternalId, _: Status) -> anyhow::Result<()> {
+                Ok(())
+            }
+        }
+
+        let backend: Arc<dyn ExternalBackend> = Arc::new(MixedBackend);
+        let store = Arc::new(TaskStore::open_memory().await.unwrap());
+
+        ingest_external_tasks(&backend, "owner/repo", &store)
+            .await
+            .unwrap();
+
+        let all = store.list_all("owner/repo").await.unwrap();
+        assert_eq!(all.len(), 2, "both issues must be ingested");
+
+        let unlabeled = store
+            .get_by_external_id("owner/repo", "100")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            unlabeled.status,
+            crate::store::TaskStatus::New,
+            "unlabeled issue should start as New"
+        );
+
+        let in_progress = store
+            .get_by_external_id("owner/repo", "101")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            in_progress.status,
+            crate::store::TaskStatus::InProgress,
+            "labeled in_progress issue must be synced to InProgress"
+        );
     }
 
     // ── kv_get_prefer_store / kv_set_prefer_store ────────────────────


### PR DESCRIPTION
## Summary

All done. Here's a summary of what was implemented:

**Changes made:**

1. **`src/backends/mod.rs`** — Added `list_active_open_issues()` default method to `ExternalBackend` trait. It calls `list_routable()` (for unlabeled/`status:new` issues → `None` status) then `list_by_status()` for each active non-new status sequentially, deduplicating by ID. This preserves backward compatibility for non-GitHub backends.

2. **`src/backends/github.rs`** — Overrode `list_active_open_issues()` in the Git

Closes #2001

---
*Task #2001 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*