### PR TITLE
bug: completed tmux sessions can still be reclaimed as stuck before runner notices exit

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -76,7 +76,9 @@ async fn startup_cleanup(tmux: &TmuxManager) {
 }
 
 use super::EngineConfig;
-use crate::store::{review_session_expected, set_review_session_expected, store_set_by_id};
+use crate::store::{
+    review_session_expected, set_review_session_expected, store_set_by_id, store_touch_updated_at,
+};
 
 /// Phase 1 of tick: poll tmux for finished sessions and clean them up.
 pub(crate) async fn tick_check_session_completions(
@@ -106,8 +108,23 @@ pub(crate) async fn tick_check_session_completions(
             // reclaim this task while the runner is still finishing
             // post-processing (race: session observed dead → tick reclaim).
             // Best-effort: no-ops if the task isn't present in the store.
-            crate::store::store_touch_updated_at(&Some(Arc::clone(store)), repo, &session.task_id)
-                .await;
+            //
+            // session.task_id uses hyphens (e.g. "internal-63714") because the
+            // tmux session name sanitizes colons to hyphens. resolve_task_id only
+            // handles "internal:" prefix, so we must convert back before touching.
+            // Review sessions carry a "-review" suffix tracked under the main task.
+            let store_task_id = {
+                let base = session
+                    .task_id
+                    .strip_suffix("-review")
+                    .unwrap_or(&session.task_id);
+                if let Some(n) = base.strip_prefix("internal-") {
+                    format!("internal:{n}")
+                } else {
+                    base.to_string()
+                }
+            };
+            store_touch_updated_at(&Some(Arc::clone(store)), repo, &store_task_id).await;
             // Unregister from capture service using the task id the capture service
             // was registered under (task id without project prefix).
             capture.unregister_session(repo, &session.task_id).await;
@@ -1911,6 +1928,71 @@ mod tests {
             ),
             "internal task should be routed to fallback or needs_review, got {:?}",
             task.status
+        );
+    }
+
+    /// Regression test for the race between Phase 1 (tick_check_session_completions)
+    /// and Phase 2 (tick_recover_stuck_tasks).
+    ///
+    /// Before the fix, Phase 1 killed the tmux session without touching updated_at.
+    /// Phase 2 could then see status=in_progress, has_session=false, and an old
+    /// updated_at, and would reset the task to New — even though the runner's
+    /// wait_for_completion() poll had not yet returned.
+    ///
+    /// The fix: Phase 1 touches updated_at as soon as it detects the session is done.
+    /// This test verifies that after the touch, Phase 2 does NOT reclaim the task.
+    #[tokio::test]
+    async fn phase1_session_completion_touch_prevents_phase2_reclaim() {
+        let store = Arc::new(TaskStore::open_memory().await.unwrap());
+        let mock = MockBackend::new();
+        let backend: Arc<dyn ExternalBackend> = Arc::new(mock);
+        let task_manager = Arc::new(TaskManager::with_store(
+            backend.clone(),
+            store.clone(),
+            "owner/repo".to_string(),
+        ));
+        let tmux = Arc::new(TmuxManager::new());
+        let config = EngineConfig {
+            no_session_stuck_timeout: 600,
+            stuck_timeout: 1800,
+            ..EngineConfig::default()
+        };
+
+        // Create an in-progress internal task with old updated_at.
+        // Without the fix this task would be reclaimed by Phase 2 (age >> threshold,
+        // no session running in the test environment).
+        let id = store
+            .create_internal("owner/repo", "Completed task", "", "cron", "1")
+            .await
+            .unwrap();
+        store
+            .update_status(id, crate::store::TaskStatus::InProgress)
+            .await
+            .unwrap();
+        set_task_updated_at_past(&store, id).await;
+
+        // Simulate Phase 1: touch updated_at when the session is detected as done.
+        // In production this happens inside tick_check_session_completions.
+        let task_id = format!("internal:{id}");
+        store_touch_updated_at(&Some(Arc::clone(&store)), "owner/repo", &task_id).await;
+
+        // Phase 2 runs — updated_at is fresh so the task must NOT be reclaimed.
+        tick_recover_stuck_tasks(
+            &backend,
+            &tmux,
+            "owner/repo",
+            &task_manager,
+            &config,
+            &store,
+        )
+        .await
+        .unwrap();
+
+        let task = store.get(id).await.unwrap();
+        assert_eq!(
+            task.status,
+            crate::store::TaskStatus::InProgress,
+            "Phase 2 must not reclaim a task whose updated_at was just touched by Phase 1"
         );
     }
 


### PR DESCRIPTION
## Summary

**Extends PR #2009** — the core race fix in #2009 only works for external tasks; internal tasks remain vulnerable.

### Root Cause of the Remaining Bug

PR #2009 (\`b2eca437\`) fixed the race by calling \`store_touch_updated_at(&session.task_id)\` in \`tick_check_session_completions\`. However:

- \`session.task_id\` comes from \`parse_session_name()\` which returns \`"internal-{n}"\` (hyphen, because tmux session names sanitize colons)
- \`resolve_task_id\` only handles the \`"internal:"\` prefix (colon form)
- For internal tasks, the touch silently no-ops — \`resolve_task_id\` returns \`Ok(None)\` and the race remains

The evidence in issue #1999 was for task \`internal:63714\` — an internal task. PR #2009's test used an external task, so it passed without catching the gap.

### Fix

In \`tick_check_session_completions\`, convert \`session.task_id\` back to the store form before calling \`store_touch_updated_at\`:

- Strip the \`"-review"\` suffix (review sessions are tracked under the main task)  
- Convert \`"internal-{n}"\` → \`"internal:{n}"\`

### Regression Test

Added \`phase1_session_completion_touch_prevents_phase2_reclaim\` which:
1. Creates an **internal** task in \`InProgress\` with a stale \`updated_at\`
2. Simulates Phase 1 touching \`updated_at\` via \`store_touch_updated_at\`
3. Runs Phase 2 stuck-task recovery
4. Asserts the task is **not** reclaimed

Closes #1999

---
*Task #1999 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*