### PR TITLE
bug: auto_merge_pr proceeds when PR mergeable is null — spurious merge-conflict failures burn retry budget

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -345,8 +345,10 @@ pub(crate) async fn auto_merge_pr(
 
     // Fetch PR and required contexts once (outside the polling loop).
     let pr = gh.get_pr(repo, pr_number).await?;
-    if pr.mergeable == Some(false) {
-        anyhow::bail!("PR is not mergeable (merge conflicts present)");
+    match pr.mergeable {
+        Some(false) => anyhow::bail!("PR is not mergeable (merge conflicts present)"),
+        None => anyhow::bail!("PR mergeability not yet computed — retry"),
+        Some(true) => {} // proceed
     }
     let head_sha = pr.head.sha.clone();
     let base_branch = pr.base.ref_.clone();


### PR DESCRIPTION
## Summary

Fixed auto_merge_pr to handle null mergeable as retryable error, preventing spurious merge-conflict failures from burning retry budget

### What was done

- Identified bug in src/engine/auto_merge.rs where mergeable == None was not handled
- Fixed the mergeability check to treat None as a transient error requiring retry
- Committed the fix with detailed explanation


Closes #2011

---
*Task #2011 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/nemotron-3-super-free`*