### PR TITLE
bug: delete_branches in cleanup.rs missing auth headers — remote branch deletion silently fails in HTTPS-only environments

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -692,7 +692,9 @@ pub(crate) async fn delete_branches(task_id: &str, br: &str, repo_root: &std::pa
     }
 
     // Delete remote branch
+    let auth_args = crate::engine::runner::git_ops::build_git_auth_args();
     let remote_delete = Command::new("git")
+        .args(&auth_args)
         .args([
             "-C",
             repo_root_str.as_ref(),


### PR DESCRIPTION
## Summary

Done. The fix adds `build_git_auth_args()` to `delete_branches()` in `src/engine/cleanup.rs:695`, injecting the HTTPS token auth args before the `git push origin --delete` command — matching the pattern already used in `push_branch` (git_ops.rs:597) and `review.rs:257`. SSH environments are unaffected since `build_git_auth_args()` returns an empty Vec when no token is configured.

Closes #2010

---
*Task #2010 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*