### PR TITLE
bug: expect() on spawn_blocking in review.rs — panic leaves task stuck in InReview forever

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1159,7 +1159,7 @@ pub(crate) async fn review_and_merge(
     let (file_exists, file_size, exit_code, stderr) = {
         let output_file_clone = output_file.clone();
         let review_attempt_dir_clone = review_attempt_dir.clone();
-        tokio::task::spawn_blocking(move || {
+        match tokio::task::spawn_blocking(move || {
             let file_exists = output_file_clone.exists();
             let file_size = std::fs::metadata(&output_file_clone)
                 .map(|m| m.len())
@@ -1173,7 +1173,17 @@ pub(crate) async fn review_and_merge(
             (file_exists, file_size, exit_code, stderr)
         })
         .await
-        .expect("spawn_blocking panicked reading review output metadata")
+        {
+            Ok(tuple) => tuple,
+            Err(e) => {
+                tracing::error!(
+                    task_id = task.id.0,
+                    error = %e,
+                    "spawn_blocking panicked reading review output metadata"
+                );
+                (false, 0, -1, format!("spawn_blocking failed: {e}"))
+            }
+        }
     };
     tracing::info!(
         task_id = task.id.0,


### PR DESCRIPTION
## Summary

Replaced .expect() on spawn_blocking with graceful error handling in review.rs so a panic in the closure no longer leaves the task stuck in InReview forever

### What was done

- Replaced .expect() at review.rs:1176 with a match expression that catches JoinError on panic
- Added tracing::error! log with task_id and error details when spawn_blocking fails
- Returns safe fallback values (false, 0, -1, stderr message) so pipeline continues to its error path
- Verified formatting (cargo fmt --check passes) and lints (cargo clippy --all-targets -- -D warnings passes)


Closes #2008

---
*Task #2008 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*