### PR TITLE
bug: detect_rate_limit misses Alibaba-style rate limit message — review_agent_failures inflated, tasks blocked after 3 vendor rate limits

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -672,6 +672,7 @@ pub(crate) mod patterns {
             "rate limit",
             "rate_limit",
             "ratelimit",
+            "rate increased too quickly", // Alibaba / Qwen via OpenCode
             "too many requests",
             "usage limit",
             "quota exceeded",
@@ -1115,6 +1116,10 @@ mod tests {
         assert!(patterns::detect_rate_limit("Error: rate limit exceeded").is_some());
         assert!(patterns::detect_rate_limit("HTTP 429 Too Many Requests").is_some());
         assert!(patterns::detect_rate_limit("You've hit your usage limit").is_some());
+        assert!(patterns::detect_rate_limit(
+            "Upstream error from Alibaba: Request rate increased too quickly. \
+             To ensure system stability, please adjust your client logic to scale requests more smoothly over time."
+        ).is_some());
         assert!(patterns::detect_rate_limit("all good").is_none());
     }
 


### PR DESCRIPTION
## Summary

Added 'rate increased too quickly' pattern to detect_rate_limit so Alibaba/Qwen rate limits are correctly classified

### What was done

- Added 'rate increased too quickly' pattern to detect_rate_limit patterns list in src/engine/runner/agents/mod.rs:675
- Added test assertion for the full Alibaba error string in pattern_detect_rate_limit test
- Verified compilation passes (cargo check clean)


Closes #2023

---
*Task #2023 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*