### PR TITLE
docs: add implementation checklist to review-reliability plan

### DIFF
--- a/docs/plans/2026-03-25-review-reliability.md
+++ b/docs/plans/2026-03-25-review-reliability.md
@@ -90,6 +90,17 @@ let review_attempt_dir = task_attempt_dir(repo, &review_task_id, review_attempts
 
 In `src/engine/subscribers/review.rs`, move `set_review_session_expected(true)` to BEFORE `spawn_in_tmux`, not after.
 
+## Implementation Status
+
+| Task | Description | Status | Reference |
+|------|-------------|--------|-----------|
+| 1 | Read SQLite for startup InReview reset | ✅ Done | `src/engine/mod.rs:1200` |
+| 2 | Per-agent review response extraction | ❌ Blocked | Issue #2032 |
+| 3 | Fix attempt numbering for reviews | ✅ Done | `src/engine/review.rs:768` |
+| 4 | Set review_session_expected before spawn | ✅ Done | `src/engine/review.rs:172` |
+| 5 | Integration test for full review cycle | ❌ Not done | - |
+| 6 | Startup worktree reconciliation | ✅ Done | - |
+
 ### Task 5: Integration test for full review cycle
 
 Extend `tests/integration_review.rs`:


### PR DESCRIPTION
## Summary

Added implementation checklist to review-reliability plan

### What was done

- Updated docs/plans/2026-03-25-review-reliability.md with implementation status table
- Added status tracking for all 6 tasks in the plan
- Marked tasks 1, 3, 4, and 6 as done, task 2 as blocked (issue #2032), and task 5 as not done
- Committed and pushed changes to the repository


Closes #2033

---
*Task #2033 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/nemotron-3-super-free`*