### PR TITLE
bug: NetworkError retry in fallback.rs doesn't grow backoff — unbounded tight retry loop

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -692,9 +692,9 @@ pub(crate) async fn delete_branches(task_id: &str, br: &str, repo_root: &std::pa
     }
 
     // Delete remote branch
-    let auth_args = crate::engine::runner::git_ops::build_git_auth_args();
+    let auth_env = crate::engine::runner::git_ops::build_git_auth_env();
     let remote_delete = Command::new("git")
-        .args(&auth_args)
+        .envs(auth_env)
         .args([
             "-C",
             repo_root_str.as_ref(),

--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -247,6 +247,11 @@ pub async fn handle_error(
                 &[("last_error", serde_json::json!(msg))],
             )
             .await;
+            if let Some(s) = store {
+                let _ = s
+                    .kv_increment(&format!("network_error_count:{}", task_id))
+                    .await;
+            }
             // Apply backoff to pace retries
             response::wait_for_fallback_backoff(task_id, store, repo).await;
             return Ok(ErrorHandleResult::EarlyReturn {

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -100,11 +100,21 @@ pub async fn wait_for_fallback_backoff(
 ) -> u64 {
     // Get retry count from reroute chain
     let chain = get_reroute_chain(task_id, store, repo).await;
-    let retry_count = if chain.is_empty() {
+    let mut retry_count = if chain.is_empty() {
         0
     } else {
         chain.split(',').count()
     };
+
+    // Include network error count in backoff calculation
+    if let Some(s) = store {
+        let key = format!("network_error_count:{}", task_id);
+        if let Ok(Some(val)) = s.kv_get(&key).await {
+            if let Ok(count) = val.parse::<usize>() {
+                retry_count += count;
+            }
+        }
+    }
 
     let delay = calculate_backoff_delay(retry_count);
 


### PR DESCRIPTION
## Summary

## Goal

Fix issue #2042 where `NetworkError` retries in `fallback.rs` do not grow their backoff delay, resulting in an unbounded tight retry loop.

## Instructions

- The task suggested an alternative, simpler fix: add a counter to the task metadata (e.g., `network_error_count`) and use that to scale the backoff instead of mutating the `model_reroute_chain`.
- All changes must pass `cargo clippy --all-targets -- -D warnings && cargo nextest run` before completing the task.
- Do not commit direc

Closes #2042

---
*Task #2042 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gemini-3.1-pro-preview`*