### PR TITLE
bug: ci broken on main branch

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -692,9 +692,9 @@ pub(crate) async fn delete_branches(task_id: &str, br: &str, repo_root: &std::pa
     }
 
     // Delete remote branch
-    let auth_args = crate::engine::runner::git_ops::build_git_auth_args();
+    let auth_env = crate::engine::runner::git_ops::build_git_auth_env();
     let remote_delete = Command::new("git")
-        .args(&auth_args)
+        .envs(auth_env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
         .args([
             "-C",
             repo_root_str.as_ref(),


### PR DESCRIPTION
## Summary

The fix is committed. The issue was in `src/engine/cleanup.rs:695` — commit `efd25fbe` (which added auth headers to remote branch deletion) used the wrong function name `build_git_auth_args()` (doesn't exist) instead of `build_git_auth_env()`, and also incorrectly used `.args()` instead of `.envs()` to apply the credentials.

Closes #2047

---
*Task #2047 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*