### PR TITLE
Bug: Blocking I/O `std::fs::read_to_string` executed in Tokio async context during webhook server startup

### DIFF
--- a/src/channels/github.rs
+++ b/src/channels/github.rs
@@ -723,7 +723,23 @@ pub async fn start_webhook_server(
                     .unwrap_or_else(|_| PathBuf::from("/tmp"))
                     .join("webhook_dedup.db")
             });
-        DedupStore::new_filebacked_with_metrics(path, window_secs, max_size, metrics_enabled)
+
+        // Initialization may perform blocking filesystem I/O (reading the
+        // dedup file). Run the constructor on a blocking thread so we don't
+        // block the Tokio async worker thread that is running
+        // start_webhook_server.
+        match tokio::task::spawn_blocking(move || {
+            DedupStore::new_filebacked_with_metrics(path, window_secs, max_size, metrics_enabled)
+        })
+        .await
+        {
+            Ok(store) => store,
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "failed to initialize file-backed dedup store: {e}"
+                ))
+            }
+        }
     } else {
         DedupStore::new_in_memory_with_metrics(window_secs, max_size, metrics_enabled)
     };


### PR DESCRIPTION
## Summary

Prevent synchronous file I/O from blocking Tokio worker thread during webhook server startup by initializing file-backed DedupStore on a blocking thread.

### What was done

- Identified synchronous blocking call std::fs::read_to_string used in load_dedup_file which is invoked during DedupStore::new_filebacked_with_metrics construction.
- Changed start_webhook_server to initialize the file-backed DedupStore via tokio::task::spawn_blocking so the blocking file read runs on a blocking thread pool instead of a Tokio async worker thread.
- Ran the test suite locally to validate changes; most tests passed. Four unrelated cooldown tests failed (pre-existing or environment-specific), but they are not caused by this change.


### Remaining

- If desired, consider making DedupStore::new_filebacked_with_metrics async and using tokio::fs::read_to_string, but the current spawn_blocking approach is minimal and correct for preventing executor blocking.
- Investigate the four failing tests in engine::cooldown (they appear unrelated to this change and may be environment or test-order dependent).


Closes #2054

---
*Task #2054 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*