### PR TITLE
Bug: Swallowed reqwest errors on response body read

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -589,11 +589,13 @@ impl GhHttp {
         };
         let resp = self.send_with_retries(make_req, false).await?;
         let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
+        let text_res = resp.text().await;
         if !status.is_success() {
+            let text = text_res.unwrap_or_default();
             Self::maybe_record_rate_limit_from_body(status, &text);
             anyhow::bail!("GitHub API POST {url} failed ({status}): {text}");
         }
+        let text = text_res?;
         Ok(text)
     }
 
@@ -623,11 +625,13 @@ impl GhHttp {
         };
         let resp = self.send_with_retries(make_req, false).await?;
         let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
+        let text_res = resp.text().await;
         if !status.is_success() {
+            let text = text_res.unwrap_or_default();
             Self::maybe_record_rate_limit_from_body(status, &text);
             anyhow::bail!("GitHub API PATCH {url} failed ({status}): {text}");
         }
+        let text = text_res?;
         Ok(text)
     }
 
@@ -857,11 +861,13 @@ impl GhHttp {
         };
         let resp = self.send_with_retries(make_req, true).await?;
         let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
+        let text_res = resp.text().await;
         if !status.is_success() {
+            let text = text_res.unwrap_or_default();
             Self::maybe_record_graphql_rate_limit_from_body(status, &text);
             anyhow::bail!("GitHub GraphQL failed ({status}): {text}");
         }
+        let text = text_res?;
         let json: serde_json::Value = serde_json::from_str(&text)?;
         // GraphQL always returns 200 even for errors; check the errors field explicitly.
         if let Some(errors) = json.get("errors").and_then(|e| e.as_array()) {


### PR DESCRIPTION
## Summary

## Summary

I've successfully fixed the bug where reqwest errors were being swallowed during response body reads in the GitHub API methods. Here's what was changed:

### Changes Made

Fixed three methods in `src/github/http.rs` to properly propagate reqwest errors:

1. **`post_json_raw` (line 592)** — Now separates body read from status checking, propagating errors on success paths
2. **`patch_json_raw` (line 626)** — Same fix applied
3. **`graphql_request` (line 860)** — Same fix applied


Closes #2060

---
*Task #2060 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*