### PR TITLE
Bug: Blocking std::fs operations in async contexts

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,7 +12,7 @@
 use anyhow::Context;
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 use tokio::sync::broadcast;
@@ -117,6 +117,36 @@ fn watch_file(path: &PathBuf) {
     }
 }
 
+fn read_file_to_string(path: &Path) -> anyhow::Result<String> {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            Ok(tokio::task::block_in_place(|| {
+                handle.block_on(tokio::fs::read_to_string(path))
+            })?)
+        }
+        _ => Ok(std::fs::read_to_string(path)?),
+    }
+}
+
+fn load_cached_root(path: &PathBuf) -> anyhow::Result<serde_yml::Value> {
+    if let Ok(cache) = CACHE.read() {
+        if let Some(cached) = cache.get(path) {
+            return Ok(cached.clone());
+        }
+    }
+
+    let content =
+        read_file_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let parsed: serde_yml::Value =
+        serde_yml::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
+
+    if let Ok(mut cache) = CACHE.write() {
+        cache.insert(path.clone(), parsed.clone());
+    }
+
+    Ok(parsed)
+}
+
 /// Resolve the global config path: `~/.orch/config.yml`
 fn global_config_path() -> anyhow::Result<PathBuf> {
     crate::home::config_path()
@@ -167,24 +197,7 @@ pub fn get_list(key: &str) -> anyhow::Result<Vec<String>> {
 fn resolve_list(path: &PathBuf, key: &str) -> anyhow::Result<Vec<String>> {
     watch_file(path);
 
-    let root = {
-        if let Ok(cache) = CACHE.read() {
-            if let Some(cached) = cache.get(path) {
-                return extract_list(cached, key);
-            }
-        }
-
-        let content =
-            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-        let parsed: serde_yml::Value =
-            serde_yml::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
-
-        if let Ok(mut cache) = CACHE.write() {
-            cache.insert(path.clone(), parsed.clone());
-        }
-
-        parsed
-    };
+    let root = load_cached_root(path)?;
 
     extract_list(&root, key)
 }
@@ -413,26 +426,7 @@ pub fn get_skills() -> anyhow::Result<Vec<SkillConfig>> {
         return Ok(vec![]);
     }
 
-    let root = {
-        // Try to get from cache first (read lock)
-        if let Ok(cache) = CACHE.read() {
-            if let Some(cached) = cache.get(&global_path) {
-                return extract_skills_list(cached);
-            }
-        }
-
-        // Not in cache, load and cache it (write lock)
-        let content = std::fs::read_to_string(&global_path)
-            .with_context(|| format!("reading {}", global_path.display()))?;
-        let parsed: serde_yml::Value = serde_yml::from_str(&content)
-            .with_context(|| format!("parsing {}", global_path.display()))?;
-
-        if let Ok(mut cache) = CACHE.write() {
-            cache.insert(global_path.clone(), parsed.clone());
-        }
-
-        parsed
-    };
+    let root = load_cached_root(&global_path)?;
 
     extract_skills_list(&root)
 }
@@ -466,26 +460,7 @@ fn resolve_projects_list(path: &PathBuf, key: &str) -> anyhow::Result<Vec<String
     // First, ensure we're watching this file for changes
     watch_file(path);
 
-    let root = {
-        // Try to get from cache first (read lock)
-        if let Ok(cache) = CACHE.read() {
-            if let Some(cached) = cache.get(path) {
-                return extract_projects_list(cached, key);
-            }
-        }
-
-        // Not in cache, load and cache it (write lock)
-        let content =
-            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-        let parsed: serde_yml::Value =
-            serde_yml::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
-
-        if let Ok(mut cache) = CACHE.write() {
-            cache.insert(path.clone(), parsed.clone());
-        }
-
-        parsed
-    };
+    let root = load_cached_root(path)?;
 
     // Try to extract projects list - if key doesn't exist, return empty vector
     match extract_projects_list(&root, key) {
@@ -530,29 +505,10 @@ fn extract_projects_list(root: &serde_yml::Value, key: &str) -> anyhow::Result<V
 /// Caches the parsed YAML so repeated lookups don't re-read disk.
 /// Sets up file watching for hot reload when first loading.
 fn resolve_key(path: &PathBuf, key: &str) -> anyhow::Result<String> {
-    let root = {
-        // First, ensure we're watching this file for changes
-        watch_file(path);
+    // First, ensure we're watching this file for changes
+    watch_file(path);
 
-        // Try to get from cache first (read lock)
-        if let Ok(cache) = CACHE.read() {
-            if let Some(cached) = cache.get(path) {
-                return extract_value(cached, key);
-            }
-        }
-
-        // Not in cache, load and cache it (write lock)
-        let content =
-            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-        let parsed: serde_yml::Value =
-            serde_yml::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
-
-        if let Ok(mut cache) = CACHE.write() {
-            cache.insert(path.clone(), parsed.clone());
-        }
-
-        parsed
-    };
+    let root = load_cached_root(path)?;
 
     extract_value(&root, key)
 }

--- a/src/engine/events.rs
+++ b/src/engine/events.rs
@@ -125,12 +125,19 @@ impl EventBus {
         listener.set_nonblocking(true)?;
         let listener = TcpListener::from_std(listener)?;
 
-        // Write port file
-        std::fs::write(ws_port_path()?, port.to_string())?;
+        // Write port file without blocking the runtime thread.
+        let port_path = ws_port_path()?;
+        if let Some(parent) = port_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::write(&port_path, port.to_string()).await?;
 
         // Write service version file so `orch version` can detect CLI/service drift
         if let Ok(path) = crate::home::service_version_path() {
-            let _ = std::fs::write(path, env!("ORCH_VERSION"));
+            if let Some(parent) = path.parent() {
+                let _ = tokio::fs::create_dir_all(parent).await;
+            }
+            let _ = tokio::fs::write(path, env!("ORCH_VERSION")).await;
         }
 
         let tx = self.tx.clone();
@@ -251,9 +258,7 @@ pub fn cleanup_version_file() {
 
 fn ws_port_path() -> anyhow::Result<std::path::PathBuf> {
     if cfg!(test) {
-        let dir = std::env::temp_dir().join("orch-test-state");
-        std::fs::create_dir_all(&dir)?;
-        Ok(dir.join("ws.port"))
+        Ok(std::env::temp_dir().join("orch-test-state").join("ws.port"))
     } else {
         Ok(crate::home::state_dir()?.join("ws.port"))
     }

--- a/src/home.rs
+++ b/src/home.rs
@@ -5,10 +5,21 @@
 //! run side by side without conflicts.
 
 use anyhow::Context;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// The home directory name.
 const HOME_DIR: &str = ".orch";
+
+fn ensure_dir(path: &Path) -> anyhow::Result<()> {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(|| handle.block_on(tokio::fs::create_dir_all(path)))?;
+        }
+        _ => std::fs::create_dir_all(path)?,
+    }
+
+    Ok(())
+}
 
 /// Get the orch home directory path (~/.orch/).
 ///
@@ -17,13 +28,13 @@ const HOME_DIR: &str = ".orch";
 pub fn orch_home() -> anyhow::Result<PathBuf> {
     if let Ok(dir) = std::env::var("ORCH_HOME") {
         let path = PathBuf::from(dir);
-        std::fs::create_dir_all(&path)?;
+        ensure_dir(&path)?;
         return Ok(path);
     }
     let home =
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))?;
     let path = home.join(HOME_DIR);
-    std::fs::create_dir_all(&path)?;
+    ensure_dir(&path)?;
     Ok(path)
 }
 
@@ -34,7 +45,7 @@ pub fn orch_home() -> anyhow::Result<PathBuf> {
 pub fn state_dir() -> anyhow::Result<PathBuf> {
     let home = orch_home()?;
     let state = home.join("state");
-    std::fs::create_dir_all(&state)?;
+    ensure_dir(&state)?;
     Ok(state)
 }
 
@@ -114,28 +125,28 @@ pub fn service_version_path() -> anyhow::Result<std::path::PathBuf> {
 /// Get the path to the worktrees directory (~/.orch/worktrees/).
 pub fn worktrees_dir() -> anyhow::Result<PathBuf> {
     let dir = orch_home()?.join("worktrees");
-    std::fs::create_dir_all(&dir)?;
+    ensure_dir(&dir)?;
     Ok(dir)
 }
 
 /// Get the path to the contexts directory (~/.orch/contexts/).
 pub fn contexts_dir() -> anyhow::Result<PathBuf> {
     let dir = orch_home()?.join("contexts");
-    std::fs::create_dir_all(&dir)?;
+    ensure_dir(&dir)?;
     Ok(dir)
 }
 
 /// Get the path to the projects directory (~/.orch/projects/).
 pub fn projects_dir() -> anyhow::Result<PathBuf> {
     let dir = orch_home()?.join("projects");
-    std::fs::create_dir_all(&dir)?;
+    ensure_dir(&dir)?;
     Ok(dir)
 }
 
 /// Get the path to the skills directory (~/.orch/skills/).
 pub fn skills_dir() -> anyhow::Result<PathBuf> {
     let dir = orch_home()?.join("skills");
-    std::fs::create_dir_all(&dir)?;
+    ensure_dir(&dir)?;
     Ok(dir)
 }
 
@@ -145,7 +156,7 @@ pub fn skills_dir() -> anyhow::Result<PathBuf> {
 pub fn repo_state_dir(repo: &str) -> anyhow::Result<PathBuf> {
     let state = state_dir()?;
     let dir = state.join(repo.replace('/', std::path::MAIN_SEPARATOR_STR));
-    std::fs::create_dir_all(&dir)?;
+    ensure_dir(&dir)?;
     Ok(dir)
 }
 
@@ -154,7 +165,7 @@ pub fn repo_state_dir(repo: &str) -> anyhow::Result<PathBuf> {
 /// Creates the directory on demand.
 pub fn task_dir(repo: &str, task_id: &str) -> anyhow::Result<PathBuf> {
     let dir = repo_state_dir(repo)?.join("tasks").join(task_id);
-    std::fs::create_dir_all(&dir)?;
+    ensure_dir(&dir)?;
     Ok(dir)
 }
 
@@ -165,7 +176,7 @@ pub fn task_attempt_dir(repo: &str, task_id: &str, attempt: u32) -> anyhow::Resu
     let dir = task_dir(repo, task_id)?
         .join("attempts")
         .join(attempt.to_string());
-    std::fs::create_dir_all(&dir)?;
+    ensure_dir(&dir)?;
     Ok(dir)
 }
 


### PR DESCRIPTION
## Summary

Replaced blocking filesystem work in the reported async hot paths by using Tokio filesystem APIs in the websocket startup path and runtime-aware non-blocking cache-miss directory/file helpers for home/config access.

### What was done

- Updated `src/engine/events.rs` so `start_ws_server()` writes `ws.port` and `service.version` with `tokio::fs`, including async parent directory creation.
- Refactored `src/config/mod.rs` cache-miss loading through shared helpers so config reads no longer call `std::fs::read_to_string` directly from async call paths; the helper uses Tokio file reads when running on the multithreaded runtime.
- Updated `src/home.rs` directory-ensuring helpers to avoid direct blocking `std::fs::create_dir_all` on Tokio worker threads by using a runtime-aware helper that switches to Tokio directory creation inside async runtime contexts.
- Ran `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` successfully.
- Committed the change as `e251ac9c fix: avoid blocking fs work on async paths`.


### Remaining

- Automated review pass.


Closes #2059

---
*Task #2059 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4`*