### PR TITLE
bug: push_failures silently returns 0 on DB error — blocking threshold unreachable when store is flaky

### DIFF
--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -618,16 +618,24 @@ pub async fn handle_success(
                 match store::store_increment_by_id(store, store_id, "push_failures").await {
                     Ok(v) => v,
                     Err(e) => {
-                        tracing::warn!(task_id, err = %e, "failed to increment push_failures — skipping push-failure based reroute this tick");
-                        0
+                        tracing::warn!(task_id, err = %e, "failed to increment push_failures — reading current value from store");
+                        // On DB error, read current value to ensure blocking threshold is still reachable
+                        store::opt_store_get_task_by_id(store, store_id)
+                            .await
+                            .map(|t| (t.push_failures as u64) + 1)
+                            .unwrap_or(1) // assume at least 1 if we can't read either
                     }
                 }
             }
             None => match store::store_increment(store, repo, task_id, "push_failures").await {
                 Ok(v) => v,
                 Err(e) => {
-                    tracing::warn!(task_id, err = %e, "failed to increment push_failures — skipping push-failure based reroute this tick");
-                    0
+                    tracing::warn!(task_id, err = %e, "failed to increment push_failures — reading current value from store");
+                    // On DB error, read current value to ensure blocking threshold is still reachable
+                    store::opt_store_get_task(store, repo, task_id)
+                        .await
+                        .map(|t| (t.push_failures as u64) + 1)
+                        .unwrap_or(1) // assume at least 1 if we can't read either
                 }
             },
         }
@@ -668,16 +676,24 @@ pub async fn handle_success(
                 match store::store_increment_by_id(store, store_id, "no_code_reroutes").await {
                     Ok(v) => v,
                     Err(e) => {
-                        tracing::warn!(task_id, err = %e, "failed to increment no_code_reroutes — skipping reroute/block decision this tick");
-                        0
+                        tracing::warn!(task_id, err = %e, "failed to increment no_code_reroutes — reading current value from store");
+                        // On DB error, read current value to ensure blocking threshold is still reachable
+                        store::opt_store_get_task_by_id(store, store_id)
+                            .await
+                            .map(|t| (t.no_code_reroutes as u64) + 1)
+                            .unwrap_or(1) // assume at least 1 if we can't read either
                     }
                 }
             }
             None => match store::store_increment(store, repo, task_id, "no_code_reroutes").await {
                 Ok(v) => v,
                 Err(e) => {
-                    tracing::warn!(task_id, err = %e, "failed to increment no_code_reroutes — skipping reroute/block decision this tick");
-                    0
+                    tracing::warn!(task_id, err = %e, "failed to increment no_code_reroutes — reading current value from store");
+                    // On DB error, read current value to ensure blocking threshold is still reachable
+                    store::opt_store_get_task(store, repo, task_id)
+                        .await
+                        .map(|t| (t.no_code_reroutes as u64) + 1)
+                        .unwrap_or(1) // assume at least 1 if we can't read either
                 }
             },
         }


### PR DESCRIPTION
## Summary

## Fix Complete ✓

I've successfully implemented the fix for issue #2069. Here's what was done:

### Changes
Modified `src/engine/runner/response_handler.rs` to handle database errors gracefully in two counter increments:

**Before (buggy behavior):**
- DB error on increment → returns 0
- Blocking thresholds never reached → silent reroute spin loop

**After (fixed behavior):**
- DB error on increment → read current stored value → use (current + 1)
- Blocking thresholds properly enforce

Closes #2069

---
*Task #2069 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*