### PR TITLE
bug: mention dedup query failure silently creates duplicate tasks

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -896,12 +896,17 @@ async fn scan_mentions(
 
     // Get existing mention tasks across ALL statuses to avoid duplicates.
     // Uses a targeted source_id-only query to avoid fetching all 57 task columns.
+    // If the DB query fails, log and skip the mention scan for this tick to
+    // avoid treating every historical mention as new (which would create
+    // duplicate internal tasks during transient DB failures).
     let existing_mentions: std::collections::HashSet<String> = if let Some(s) = store {
-        s.list_source_ids_by_source(repo, "mention")
-            .await
-            .unwrap_or_default()
-            .into_iter()
-            .collect()
+        match s.list_source_ids_by_source(repo, "mention").await {
+            Ok(ids) => ids.into_iter().collect(),
+            Err(e) => {
+                tracing::warn!(err = %e, "failed to load existing mention source IDs — skipping mention scan this tick to prevent duplicates");
+                return Ok(());
+            }
+        }
     } else {
         std::collections::HashSet::new()
     };


### PR DESCRIPTION
## Summary

Prevent duplicate internal tasks when mention-dedup DB query fails by skipping the mention scan and logging a warning.

### What was done

- Inspected src/engine/sync.rs and located scan_mentions implementation
- Replaced silent unwrap_or_default() on list_source_ids_by_source with explicit match
- On DB error: emit a warning and return early from scan_mentions to skip the mention scan (prevents creating duplicates)
- Ran cargo check (timed out in this environment) but the change is a minimal control-flow fix and preserves types


### Remaining

- Run full local build/tests (cargo fmt, clippy, nextest/cargo test) in your environment to verify the change compiles in CI and passes tests
- Consider adding a DB-level UNIQUE constraint (migration) for (repo, origin, source, source_id) as a defensive measure; this requires a new migration file and review


Closes #2074

---
*Task #2074 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*