### PR TITLE
bug: ingest_external_tasks silently skips status sync on batch-get failure with no log

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1647,7 +1647,13 @@ pub(crate) async fn ingest_external_tasks(
     // (e.g., store has Routed but GitHub still shows New labels).
     if !id_status_pairs.is_empty() {
         let all_ids: Vec<i64> = id_status_pairs.iter().map(|(id, _)| *id).collect();
-        let existing_map = store.get_batch(&all_ids).await.unwrap_or_default();
+        let existing_map = match store.get_batch(&all_ids).await {
+            Ok(map) => map,
+            Err(e) => {
+                tracing::warn!(err = %e, task_count = all_ids.len(), "ingest: get_batch failed — skipping initial status sync for newly ingested tasks this tick");
+                return Ok(());
+            }
+        };
         for (store_id, status) in id_status_pairs {
             if let Some(existing) = existing_map.get(&store_id) {
                 if existing.status == TaskStatus::New {


### PR DESCRIPTION
## Summary

## Summary

✅ **Fixed issue #2077** — Added proper error handling to `ingest_external_tasks()` in `src/engine/sync.rs:1645`

### The Problem
The code was using `unwrap_or_default()` on a batch store query, causing silent failures. If `get_batch()` failed, it would return an empty `HashMap`, and no status sync would happen for newly ingested tasks — with no log message to alert operators.

### The Solution
Replaced the silent failure with explicit error handling:
- Added a `match` expressio

Closes #2077

---
*Task #2077 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*