### PR TITLE
bug: NeedsReview refire counter reads 0 on store failure — tasks re-fire indefinitely during DB degradation

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -692,10 +692,13 @@ pub(crate) async fn sync_tick(
             // touching updated_at before we know whether we will actually fire.
             let store_task =
                 crate::store::opt_store_get_task(&Some(Arc::clone(store)), repo, &task.id.0).await;
-            let current_refires = store_task
-                .as_ref()
-                .map(|t| t.needs_review_refires as u64)
-                .unwrap_or(0);
+            let current_refires = match store_task.as_ref() {
+                Some(t) => t.needs_review_refires as u64,
+                None => {
+                    tracing::warn!(task_id = task.id.0, "failed to read task from store for refire backoff — skipping re-fire this tick");
+                    continue;
+                }
+            };
             let new_refires = current_refires + 1;
 
             // If we've exceeded max attempts, escalate the task to Blocked with a clear reason.


### PR DESCRIPTION
## Summary

Perfect! ✅ Bug fixed and committed.

## Summary

Fixed the NeedsReview refire counter bug in `src/engine/sync.rs:695-702`:

**The Problem:** When `opt_store_get_task` returns `None` (DB error/missing task), the code defaulted `current_refires` to 0, causing `new_refires=1` on every tick. This bypassed exponential backoff, triggering infinite re-fires during DB degradation.

**The Fix:** Changed from `unwrap_or(0)` to a `match` statement that:
- Extracts the counter when the task is found
- Log

Closes #2075

---
*Task #2075 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*