### PR TITLE
bug: tmux final-output capture logs errors for normal session teardown

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -162,9 +162,13 @@ impl TmuxManager {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            // "can't find pane" / "can't find session" are expected teardown races —
-            // the session was cleaned up between the caller's activity check and this call.
-            if stderr.contains("can't find pane") || stderr.contains("can't find session") {
+            // "can't find pane" / "can't find session" / "no server running" are expected
+            // teardown races — the session was cleaned up between the caller's activity
+            // check and this call, or the tmux server exited entirely.
+            if stderr.contains("can't find pane")
+                || stderr.contains("can't find session")
+                || stderr.contains("no server running")
+            {
                 tracing::debug!(
                     session,
                     "capture_pane: session/pane already gone (teardown race)"


### PR DESCRIPTION
## Summary

All done. Here's a summary of what was changed:

**`src/tmux.rs`** — two fixes:

1. **`capture_pane()`** (line 165): Now detects `can't find pane` / `can't find session` in stderr and returns `Ok(String::new())` at `debug` level instead of propagating an error. This is the root fix — the race condition was in `wait_for_completion()` where `is_session_active()` returns false but the session gets cleaned up before `capture_pane` runs.

2. **`wait_for_completion()`** (line 427-437): Updated com

Closes #2083

---
*Task #2083 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*