### PR TITLE
bug: git worktree prune errors silently swallowed in cleanup.rs — stale metadata accumulates invisibly

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -610,10 +610,13 @@ pub(crate) async fn remove_worktree_and_branch(
                 }
                 // Prune stale worktree entries from git metadata so the warning
                 // stops recurring on future `git worktree list` / cleanup cycles.
-                let _ = Command::new("git")
+                if let Err(e) = Command::new("git")
                     .args(["-C", repo_root_str.as_ref(), "worktree", "prune"])
-                    .output()
-                    .await;
+                    .output_with_context()
+                    .await
+                {
+                    tracing::warn!(task_id, err = %e, "git worktree prune failed — stale metadata may persist");
+                }
             } else {
                 tracing::warn!(task_id, err = %stderr, "failed to remove worktree");
             }
@@ -624,10 +627,13 @@ pub(crate) async fn remove_worktree_and_branch(
     }
 
     // Prune stale .git/worktrees/ entries left behind after removal.
-    let _ = Command::new("git")
+    if let Err(e) = Command::new("git")
         .args(["-C", repo_root_str.as_ref(), "worktree", "prune"])
         .output_with_context()
-        .await;
+        .await
+    {
+        tracing::warn!(task_id, err = %e, "git worktree prune failed — stale metadata may persist");
+    }
 
     // Delete local and remote branch from the main repo root (worktree is already gone).
     // When keep_remote_branch is set, only delete the local branch — the remote stays


### PR DESCRIPTION
## Summary

Fixed silent failures in git worktree prune operations during cleanup

### What was done

- Replaced output() with output_with_context() for consistency on git worktree prune calls
- Added warn-level logging when git worktree prune fails to prevent stale metadata accumulation without visibility


Closes #2090

---
*Task #2090 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gemini-3.1-pro-preview`*