### PR TITLE
bug: tick_route_tasks transitions task to Routed even when store_route_result fails, causing no-agent re-routing churn

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -824,7 +824,12 @@ pub(crate) async fn tick_route_tasks(
                     .store_route_result(&task.id.0, &result, store, repo)
                     .await
                 {
-                    tracing::warn!(task_id = task.id.0, ?e, "failed to store route result");
+                    tracing::warn!(
+                        task_id = task.id.0,
+                        ?e,
+                        "failed to store route result; skipping Routed transition"
+                    );
+                    continue;
                 }
 
                 if is_internal_id(&task.id.0) {


### PR DESCRIPTION
## Summary

Updated tick routing so tasks remain in New when persisting the route result fails, preventing Routed tasks without agent metadata from bouncing through no-agent re-routing churn.

### What was done

- Changed `tick_route_tasks` in `src/engine/tick.rs` to `continue` immediately when `router.store_route_result(...)` fails.
- Updated the warning log message to make the skipped Routed transition explicit.
- Ran the required verification commands successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run`.
- Committed the fix as `df579966` with message `fix: skip routed transition when route persistence fails`.


### Remaining

- Automated review pass.


Closes #2088

---
*Task #2088 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4`*