### PR TITLE
bug: spawn_blocking JoinError (panic) silently converted to exit code -1 in collect_output — crashes invisible in logs

### DIFF
--- a/src/engine/runner/session.rs
+++ b/src/engine/runner/session.rs
@@ -113,15 +113,21 @@ async fn collect_output(
     let legacy_exit = crate::home::state_file(&format!("exit-{task_id}.txt"))
         .unwrap_or_else(|_| orch_home.join("state").join(format!("exit-{task_id}.txt")));
 
-    let exit_code: i32 = (tokio::task::spawn_blocking(move || {
+    let exit_code: i32 = match tokio::task::spawn_blocking(move || {
         std::fs::read_to_string(&attempt_exit)
             .or_else(|_| std::fs::read_to_string(&legacy_exit))
             .ok()
             .and_then(|s| s.trim().parse().ok())
             .unwrap_or(-1)
     })
-    .await)
-        .unwrap_or(-1);
+    .await
+    {
+        Ok(code) => code,
+        Err(e) => {
+            tracing::error!(task_id, err = ?e, "spawn_blocking panicked reading exit code");
+            -1
+        }
+    };
 
     // Read raw output (offloaded inside read_output_file) and stderr (blocking read offloaded)
     let raw_stdout =
@@ -131,13 +137,19 @@ async fn collect_output(
     let stderr_path_legacy = crate::home::state_file(&format!("stderr-{task_id}.txt"))
         .unwrap_or_else(|_| PathBuf::from(format!("/tmp/stderr-{task_id}.txt")));
 
-    let raw_stderr: String = (tokio::task::spawn_blocking(move || {
+    let raw_stderr: String = match tokio::task::spawn_blocking(move || {
         std::fs::read_to_string(&stderr_path_attempt)
             .or_else(|_| std::fs::read_to_string(&stderr_path_legacy))
             .unwrap_or_default()
     })
-    .await)
-        .unwrap_or_default();
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(task_id, err = ?e, "spawn_blocking panicked reading stderr");
+            String::new()
+        }
+    };
 
     SessionOutput {
         exit_code,


### PR DESCRIPTION
## Summary

## Summary

I've successfully fixed the bug where `JoinError` panics from `spawn_blocking` were silently discarded in `collect_output`.

### Changes Made

**File: `src/engine/runner/session.rs`**

Applied explicit error handling to both `spawn_blocking` calls that read exit code and stderr:

1. **Exit code reading (lines 116-130)**: Changed from `.await.unwrap_or(-1)` to a match expression that logs the error with `tracing::error!` before falling back to -1
2. **Stderr reading (lines 140-152)**:

Closes #2103

---
*Task #2103 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*