### PR TITLE
bug: increment/increment_no_ts swallow try_get type errors — counter returns 0, blocking thresholds become unreachable

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -944,7 +944,7 @@ impl TaskStore {
 
         let row = sqlx::query(&sql).bind(id).fetch_one(&self.pool).await?;
 
-        Ok(row.try_get("val").unwrap_or(0))
+        Ok(row.try_get("val")?)
     }
 
     /// Increment a counter in the task store **without** updating `updated_at`.
@@ -966,7 +966,7 @@ impl TaskStore {
 
         let row = sqlx::query(&sql).bind(id).fetch_one(&self.pool).await?;
 
-        Ok(row.try_get("val").unwrap_or(0))
+        Ok(row.try_get("val")?)
     }
 
     /// Reset all failure/retry counters to zero.

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -220,6 +220,50 @@ async fn increment_and_reset_counters() {
 }
 
 #[tokio::test]
+async fn increment_propagates_returned_value_decode_errors() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let id = store
+        .create(&NewTask {
+            external_id: None,
+            repo: "owner/repo".to_string(),
+            origin: "internal".to_string(),
+            title: "Test".to_string(),
+            body: "".to_string(),
+            source: "manual".to_string(),
+            source_id: "".to_string(),
+            author: "".to_string(),
+            url: "".to_string(),
+            labels: vec![],
+        })
+        .await
+        .unwrap();
+
+    store
+        .set_fields(id, &[("push_failures", serde_json::json!(i32::MAX))])
+        .await
+        .unwrap();
+    let err = store.increment(id, "push_failures").await.unwrap_err();
+    assert!(
+        err.to_string().contains("out of range") || err.to_string().contains("decode"),
+        "unexpected error: {err:#}"
+    );
+
+    store
+        .set_fields(id, &[("needs_review_refires", serde_json::json!(i32::MAX))])
+        .await
+        .unwrap();
+    let err = store
+        .increment_no_ts(id, "needs_review_refires")
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("out of range") || err.to_string().contains("decode"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[tokio::test]
 async fn helper_get_token_usage_from_store() {
     let store = Arc::new(TaskStore::open_memory().await.unwrap());
     let id = store


### PR DESCRIPTION
## Summary

Propagated task counter decode errors from `increment` and `increment_no_ts` instead of silently returning 0, and added a regression test covering the overflow/decode-failure path.

### What was done

- Replaced `unwrap_or(0)` with `?` in `TaskStore::increment` and `TaskStore::increment_no_ts` so inconsistent `RETURNING` values surface as errors.
- Added a regression test that forces returned counter values past `i32` range and verifies both increment paths now fail instead of swallowing the decode error.
- Ran validation: targeted counter tests, `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run`.
- Committed the change as `fix: propagate task counter decode errors`.


Closes #2102

---
*Task #2102 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4`*