### PR TITLE
bug: get_json discards response body on JSON parse failure — makes GitHub API errors undebuggable

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -15,6 +15,7 @@ use super::types::{
     GitHubReviewComment,
 };
 use crate::engine::cooldown as engine_cooldown;
+use anyhow::Context;
 use reqwest::{header, Client, Response, StatusCode};
 use serde::Serialize;
 use std::sync::{
@@ -519,7 +520,9 @@ impl GhHttp {
             Self::maybe_record_rate_limit_from_body(status, &body);
             anyhow::bail!("GitHub API GET {url} failed ({status}): {body}");
         }
-        Ok(serde_json::from_str(&resp.text().await?)?)
+        let body = resp.text().await?;
+        serde_json::from_str(&body)
+            .with_context(|| format!("failed to parse GitHub API response from GET {url}: {body}"))
     }
 
     /// GET raw bytes (for endpoints that return non-JSON or we parse manually).
@@ -570,7 +573,9 @@ impl GhHttp {
             Self::maybe_record_rate_limit_from_body(status, &body);
             anyhow::bail!("GitHub API GET {url} failed ({status}): {body}");
         }
-        Ok(serde_json::from_str(&resp.text().await?)?)
+        let body = resp.text().await?;
+        serde_json::from_str(&body)
+            .with_context(|| format!("failed to parse GitHub API response from GET {url}: {body}"))
     }
 
     /// POST with JSON body, returns raw response text.
@@ -798,7 +803,10 @@ impl GhHttp {
                 );
             }
 
-            let wrapper: serde_json::Value = serde_json::from_str(&resp.text().await?)?;
+            let body = resp.text().await?;
+            let wrapper: serde_json::Value = serde_json::from_str(&body).with_context(|| {
+                format!("failed to parse wrapper response from {current_url}: {body}")
+            })?;
             let items = wrapper
                 .get(array_field)
                 .and_then(|v| v.as_array())


### PR DESCRIPTION
## Summary

## Summary

I've successfully fixed the bug where `get_json` discards response body on JSON parse failure. The issue affected three locations in `src/github/http.rs`:

**Changes:**
1. **get_json (line 522)**: Capture response body before deserialization
2. **get_with_query (line 573)**: Same fix for query-based requests
3. **get_all_pages_from_wrapper (line 801)**: Same fix for paginated wrapper responses
4. **Added import** for `anyhow::Context` trait to support `.with_context()`

**Before:**
`

Closes #2101

---
*Task #2101 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*