### PR TITLE
fix: remove duplicate needs_review_refires entry in set_fields allowlist

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -870,8 +870,6 @@ impl TaskStore {
             "auto_unblock_count",
             "auto_unblock_last_at",
             "auto_unblock_last_reason",
-            // allow resetting the needs_review_refires counter when tasks transition
-            "needs_review_refires",
             "ci_recovery_count",
             "no_code_reroutes",
             "network_retries",


### PR DESCRIPTION
## Summary
Removes a duplicate `needs_review_refires` field from the `set_fields` ALLOWED column allowlist in `src/store/tasks.rs`. The second entry at line 874 had a misleading comment implying it served a distinct "reset-only" purpose, but duplicate entries in a `contains()` check have no special effect.

## Changes
- Removed the duplicate `"needs_review_refires"` entry (line 874)
- Removed the misleading comment about "resetting the counter when tasks transition"

## Test Plan
- ✅ cargo fmt check passed
- ✅ cargo clippy check passed
- ✅ All 2715 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task #2110 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*