### PR TITLE
bug: parse error in review should re-route instead of blocking task — no actual review feedback

### DIFF
--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -519,6 +519,18 @@ async fn classify_review_failure(
     // attempt to an available agent.
     let lower_reason = reason.to_lowercase();
 
+    // Parse errors are orch's fault, not review feedback. Re-route for retry
+    // without counting toward the failure threshold, so parse errors don't
+    // incorrectly block tasks that have no actual review feedback.
+    if lower_reason.contains("parse error") {
+        tracing::warn!(
+            task_id,
+            reason,
+            "{context} hit parse error — re-routing for retry without counting as failure"
+        );
+        return ReviewOutcome::Reset;
+    }
+
     // Merge conflicts are infrastructure failures, not review agent failures.
     // The merge_conflict_retries counter handles these separately.
     if lower_reason.contains("merge conflict")


### PR DESCRIPTION
## Summary

All 2717 tests pass. The fix is already in place and working correctly.

**Summary of the fix** (in `src/engine/subscribers/review.rs:522-532`):

The `classify_review_failure()` function now checks for parse errors **before** incrementing the failure counter. When a parse error is detected (case-insensitive), it returns `ReviewOutcome::Reset` — which re-routes the task back to `NeedsReview` for retry — **without** incrementing `review_agent_failures`. This prevents orch's own parsing bugs fr

Closes #2043

---
*Task #2043 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*