### PR TITLE
bug: mention cursor (last_success_ts) never advances for already-processed or skipped mentions — re-fetches all historical mentions every tick

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -925,6 +925,13 @@ async fn scan_mentions(
     for mention in mentions {
         // Skip if already processed
         if existing_mentions.contains(&mention.id) {
+            // Advance the cursor past already-processed mentions so the scan
+            // doesn't get stuck re-fetching the same window when the latest
+            // mention is a duplicate. Only advance when the mention's
+            // timestamp is newer than our current cursor.
+            if last_success_ts.as_deref() < Some(mention.created_at.as_str()) {
+                last_success_ts = Some(mention.created_at.clone());
+            }
             continue;
         }
 
@@ -932,6 +939,13 @@ async fn scan_mentions(
             && !mention.body.contains("@orch")
             && !mention.body.contains("@orchestrator")
         {
+            // This mention batch may include comments that the backend
+            // returned but that are not actually addressed to the bot
+            // (e.g., legacy fetch semantics). Treat these as handled for
+            // cursor advancement so we don't repeatedly re-fetch them.
+            if last_success_ts.as_deref() < Some(mention.created_at.as_str()) {
+                last_success_ts = Some(mention.created_at.clone());
+            }
             continue;
         }
 
@@ -990,6 +1004,11 @@ async fn scan_mentions(
                                 .create_internal(repo, &title, &task_body, "mention", &mention.id)
                                 .await;
                         }
+                        // Advance cursor: we created a sentinel task so this mention
+                        // is considered handled and the cursor should move past it.
+                        if last_success_ts.as_deref() < Some(mention.created_at.as_str()) {
+                            last_success_ts = Some(mention.created_at.clone());
+                        }
                         continue;
                     }
                     Ok(_) => {}
@@ -1025,6 +1044,10 @@ async fn scan_mentions(
                             let _ = s
                                 .create_internal(repo, &title, &task_body, "mention", &mention.id)
                                 .await;
+                        }
+                        // Advance cursor: sentinel created for skipped non-collaborator mention
+                        if last_success_ts.as_deref() < Some(mention.created_at.as_str()) {
+                            last_success_ts = Some(mention.created_at.clone());
                         }
                         continue;
                     }


### PR DESCRIPTION
## Summary

Fixed mention-scan cursor (mentions_last_checked) getting stuck by advancing last_success_ts for all handled/skip paths so already-processed or skipped mentions no longer prevent the cursor from moving forward.

### What was done

- Located scan_mentions implementation in src/engine/sync.rs
- Updated scan logic to advance last_success_ts when mentions are handled or intentionally skipped (already-processed, not-addressed-to-bot, closed-issue skips, non-collaborator skips)
- Ensured cursor advancement uses the mention.created_at timestamp only when it's newer than the current cursor
- Ran git diff and a cargo check to validate changes compile


### Remaining

- Monitor on-service behavior to ensure no regressions in mention re-processing semantics (the change advances the cursor for skipped mentions which is intended)
- Optional: add unit/integration tests that simulate mention batches ending with skipped entries to prevent regressions in future


Closes #2115

---
*Task #2115 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*