### PR TITLE
bug: strip_workflow_files leaves dirty staged index on git commit failure — worktree stuck on retry

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -560,6 +560,14 @@ async fn strip_workflow_files(dir: &Path, default_branch: &str) -> anyhow::Resul
 
     if !commit.status.success() {
         let stderr = String::from_utf8_lossy(&commit.stderr);
+        // Recovery: restore the original commits so the worktree isn't stuck
+        if let Some((original_head, _)) = commits.last() {
+            let _ = Command::new("git")
+                .args(["reset", "--hard", original_head])
+                .current_dir(dir)
+                .output_with_context()
+                .await;
+        }
         anyhow::bail!("git commit failed during workflow file stripping: {stderr}");
     }
 


### PR DESCRIPTION
## Summary

Perfect! I've successfully implemented the fix for issue #2116. Here's what was done:

## Summary

**Problem**: `strip_workflow_files` left the worktree in a dirty state when `git commit` failed, causing permanent failure on retry.

**Solution**: Added recovery code (8 lines) in the commit-failure error path to reset back to the original HEAD using the known commit hash from `commits.last()`.

**Changes**:
- Added `git reset --hard` recovery in the error path at lines 563-570
- Matches the exist

Closes #2116

---
*Task #2116 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*