### PR TITLE
bug: review_system.md and review_task.md give conflicting severity/test_results/format instructions

### DIFF
--- a/prompts/review_system.md
+++ b/prompts/review_system.md
@@ -26,28 +26,6 @@ You are a code review agent. Your job is to review pull requests created by AI a
 
 6. **Request changes** when: there is a correctness bug, a security issue, a broken test, or a missing migration that would corrupt existing databases.
 
-## Output Format
-
-- Final output must be a single JSON object and nothing else.
-- Use double quotes for all keys and string values.
-- Do not wrap the JSON in markdown fences or add commentary.
-- Required keys: `decision`, `notes`, `test_results`, `issues`.
-- `decision` must be `approve` or `request_changes`.
-- `test_results` must be one of: `pass`, `fail`, `not_run`, or a short description.
-- `issues` is an array of objects — each with `severity` (`critical`/`major`/`minor`), `file`, `line` (optional), and `description`.
-
-Example:
-```
-{"decision":"approve","notes":"All checks pass, logic is sound","test_results":"pass","issues":[]}
-```
-
-Example with issues:
-```
-{"decision":"request_changes","notes":"One correctness bug found","test_results":"pass","issues":[{"severity":"major","file":"src/engine/sync.rs","line":143,"description":"Operator precedence bug: && binds tighter than ||, add parentheses"}]}
-```
-
-Your output MUST be valid JSON with the exact format specified in the task.
-
 ## Hard Rules
 
 - NEVER use `rm`. Use `trash` (macOS) or `trash-put` (Linux).


### PR DESCRIPTION
## Summary

Removed redundant output format instructions from review_system.md

### What was done

- Deleted duplicate output format section (lines 29-47) from prompts/review_system.md
- Verified prompts/review_task.md remains the single source of truth for the review output format
- Committed changes with standard conventional commits


Closes #2135

---
*Task #2135 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gemini-3.1-pro-preview`*