### PR TITLE
bug: review.rs falls back to "haiku" for token cost attribution when review_model is None

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1728,7 +1728,11 @@ pub(crate) async fn review_and_merge(
     // Store token usage on the task so `orch cost` reflects review agent spend.
     if let Some(sid) = store_id {
         if agent_token_usage.input_tokens > 0 || agent_token_usage.output_tokens > 0 {
-            let model = review_model.as_deref().unwrap_or("haiku");
+            let model = if review_model_str.is_empty() {
+                "unknown"
+            } else {
+                review_model_str
+            };
             if let Err(e) = store
                 .store_tokens(
                     sid,


### PR DESCRIPTION
## Summary

Fixed token cost misattribution in review.rs by falling back to `review_model_str` or 'unknown' instead of the hardcoded 'haiku'.

### What was done

- Replaced the hardcoded 'haiku' fallback in src/engine/review.rs token cost attribution with 'unknown'
- Used the resolved 'review_model_str' instead of 'review_model.as_deref()'


Closes #2128

---
*Task #2128 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gemini-3.1-pro-preview`*