### PR TITLE
bug: classify_from_text detector ordering causes API errors to be misclassified as PermissionDenied or WaitingForInput

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -754,6 +754,7 @@ pub(crate) mod patterns {
         let lower = text.to_lowercase();
         let patterns = [
             "unauthorized",
+            "authentication required",
             "invalid api",
             "invalid key",
             "invalid token",
@@ -770,7 +771,14 @@ pub(crate) mod patterns {
         ];
         let http_401 = contains_http_status(&lower, "401");
         let http_403 = contains_http_status(&lower, "403");
-        if patterns.iter().any(|p| lower.contains(p)) || http_401 || http_403 {
+        let http_407 = contains_http_status(&lower, "407");
+        let proxy_auth_required = lower.contains("proxy authentication required");
+        if patterns.iter().any(|p| lower.contains(p))
+            || http_401
+            || http_403
+            || http_407
+            || proxy_auth_required
+        {
             return Some(AgentError::Auth {
                 message: safe_tail(text, 300).to_string(),
             });
@@ -924,9 +932,13 @@ pub(crate) mod patterns {
             "op signin",
             "ssh passphrase",
             "password:",
-            "authentication required",
         ];
-        if patterns.iter().any(|p| lower.contains(p)) {
+        let auth_required_with_interactive_context = lower.contains("authentication required")
+            && (lower.contains("ssh")
+                || lower.contains("passphrase")
+                || lower.contains("1password")
+                || lower.contains("op signin"));
+        if patterns.iter().any(|p| lower.contains(p)) || auth_required_with_interactive_context {
             return Some(AgentError::WaitingForInput {
                 message: text.to_string(),
             });
@@ -1001,12 +1013,6 @@ pub(crate) mod patterns {
         if let Some(e) = detect_missing_tool(text) {
             return e;
         }
-        if let Some(e) = detect_waiting_for_input(text) {
-            return e;
-        }
-        if let Some(e) = detect_permission_denied(text) {
-            return e;
-        }
         if let Some(e) = detect_worktree_missing(text) {
             return e;
         }
@@ -1030,6 +1036,12 @@ pub(crate) mod patterns {
             return e;
         }
         if let Some(e) = detect_auth_error(scan_tail) {
+            return e;
+        }
+        if let Some(e) = detect_waiting_for_input(text) {
+            return e;
+        }
+        if let Some(e) = detect_permission_denied(text) {
             return e;
         }
         if let Some(e) = detect_stale_session(text) {
@@ -1161,6 +1173,8 @@ mod tests {
         assert!(patterns::detect_auth_error("error: 401").is_some());
         assert!(patterns::detect_auth_error("403 Forbidden").is_some());
         assert!(patterns::detect_auth_error("HTTP 403").is_some());
+        assert!(patterns::detect_auth_error("HTTP 407 Authentication Required").is_some());
+        assert!(patterns::detect_auth_error("407 Proxy Authentication Required").is_some());
         assert!(patterns::detect_auth_error("invalid api key").is_some());
         assert!(patterns::detect_auth_error("billing expired").is_some());
         assert!(patterns::detect_auth_error("task done").is_none());
@@ -1230,6 +1244,13 @@ mod tests {
     fn pattern_detect_waiting_for_input() {
         assert!(patterns::detect_waiting_for_input("Enter passphrase for key").is_some());
         assert!(patterns::detect_waiting_for_input("1Password CLI required").is_some());
+        assert!(
+            patterns::detect_waiting_for_input("SSH authentication required for deploy key")
+                .is_some()
+        );
+        assert!(
+            patterns::detect_waiting_for_input("HTTP 407 Proxy Authentication Required").is_none()
+        );
         assert!(patterns::detect_waiting_for_input("done").is_none());
     }
 
@@ -1355,6 +1376,24 @@ mod tests {
         assert!(
             matches!(err, AgentError::Auth { .. }),
             "real auth error at tail must be detected, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_from_text_prefers_auth_over_permission_denied() {
+        let err = patterns::classify_from_text(1, "HTTP 403 access denied: invalid token");
+        assert!(
+            matches!(err, AgentError::Auth { .. }),
+            "auth errors must outrank permission denied, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_from_text_prefers_auth_over_waiting_for_input() {
+        let err = patterns::classify_from_text(1, "HTTP 407 Proxy Authentication Required");
+        assert!(
+            matches!(err, AgentError::Auth { .. }),
+            "HTTP auth failures must not be treated as waiting for input, got: {err:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fix classifier ordering in agent error detection so API auth/rate-limit errors outrank local permission/waiting-for-input patterns; tighten matching for "authentication required" and add regression tests.

### What was done

- Reordered detectors in patterns::classify_from_text so detect_rate_limit and detect_auth_error run before detect_waiting_for_input and detect_permission_denied. This ensures API-level errors are classified correctly and not shadowed by local filesystem/interactive patterns.
- Expanded detect_auth_error to consider HTTP 407 and explicit proxy auth phrases (e.g. "proxy authentication required").
- Tightened detect_waiting_for_input so the phrase "authentication required" is only treated as WaitingForInput when it appears with interactive context (ssh, passphrase, 1Password, op signin).
- Added unit tests covering the regressions: classification prefers Auth over PermissionDenied, and Auth over WaitingForInput; ensured HTTP 407/Proxy Authentication cases are detected as Auth and not WaitingForInput.
- Verified repository working tree is clean and commits exist on the feature branch.


### Remaining

- Run full CI (clippy / nextest) in CI environment to confirm unrelated failing DB-backed tests are not caused by these changes (local cargo test showed three failures in engine::cooldown tests related to DB state/setup - these are unrelated to the classifier edits).
- Monitor task runs to ensure fallback/recovery flows now behave as expected in real workloads (rate-limit → failover/cooldown; auth → agent cooldown/credit handling; waiting-for-input → needs_review only for true interactive prompts).
- If further false-positives appear in logs, consider adding a few more targeted exclusion tests to other detectors or expanding context-based heuristics.


Closes #2124

---
*Task #2124 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*