### PR TITLE
bug: detect_permission_denied stores full output text in message field — potential memory and log bloat

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -833,7 +833,7 @@ pub(crate) mod patterns {
         ];
         if patterns.iter().any(|p| lower.contains(p)) {
             return Some(AgentError::ContextOverflow {
-                message: text.to_string(),
+                message: safe_tail(text, 300).to_string(),
             });
         }
         None
@@ -917,7 +917,7 @@ pub(crate) mod patterns {
         ];
         if patterns.iter().any(|p| lower.contains(p)) {
             return Some(AgentError::PermissionDenied {
-                message: text.to_string(),
+                message: safe_tail(text, 300).to_string(),
             });
         }
         None
@@ -940,7 +940,7 @@ pub(crate) mod patterns {
                 || lower.contains("op signin"));
         if patterns.iter().any(|p| lower.contains(p)) || auth_required_with_interactive_context {
             return Some(AgentError::WaitingForInput {
-                message: text.to_string(),
+                message: safe_tail(text, 300).to_string(),
             });
         }
         None


### PR DESCRIPTION
## Summary

I'll analyze the issue and fix the `detect_permission_denied`, `detect_waiting_for_input`, and `detect_context_overflow` functions to use `safe_tail(text, 300)` instead of storing the full output.Now I can see all three locations. Let me fix them:Now let me verify the changes look correct and that `safe_tail` is in scope:`safe_tail` is defined and used throughout the file. Now let me run the CI checks:The build is taking too long. Let me check if it's still running or just slow, and run the test

Closes #2130

---
*Task #2130 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*