### PR TITLE
perf: sync_tick fetches InReview/NeedsReview task lists 3-5 times per tick — pre-fetch once and share

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -15,6 +15,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::process::Command;
 
+use super::sync::ReviewTaskSnapshot;
+
 /// Options controlling the worktree janitor.
 #[derive(Debug, Clone)]
 pub struct JanitorOptions {
@@ -868,74 +870,20 @@ pub(crate) async fn check_merged_prs(
     repo: &str,
     store: &Arc<TaskStore>,
     task_manager: &Arc<TaskManager>,
+    in_review_tasks: &[ReviewTaskSnapshot],
+    needs_review_tasks: &[ReviewTaskSnapshot],
 ) -> anyhow::Result<()> {
-    // Build a branch map from store tasks before converting to ExternalTask,
-    // so we don't need N+1 opt_store_get_task calls later to re-fetch branches.
     let mut branch_map: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
-
-    // Get all review tasks (external + internal) using store-first pattern.
-    // Branch mapping optimization: we'll build branch_map from store tasks when available.
-    let in_review_tasks: Vec<ExternalTask> = {
-        let tasks = task_manager.list_all_by_status(Status::InReview).await?;
-        // Build branch map from store tasks for optimization (avoids N+1 lookups later)
-        if let Some(store) = task_manager.store() {
-            if let Ok(store_tasks) = store
-                .list_external_by_status(task_manager.repo(), crate::store::TaskStatus::InReview)
-                .await
-            {
-                for t in &store_tasks {
-                    if !t.branch.is_empty() {
-                        let ext_id = t
-                            .external_id
-                            .clone()
-                            .unwrap_or_else(|| format!("internal:{}", t.id));
-                        branch_map.insert(ext_id, t.branch.clone());
-                    }
-                }
-            }
-        }
-        tasks
-    };
-    let needs_review_tasks: Vec<ExternalTask> = {
-        let tasks = task_manager.list_all_by_status(Status::NeedsReview).await?;
-        // Build branch map from store tasks for optimization (avoids N+1 lookups later)
-        if let Some(store) = task_manager.store() {
-            if let Ok(store_tasks) = store
-                .list_external_by_status(task_manager.repo(), crate::store::TaskStatus::NeedsReview)
-                .await
-            {
-                for t in &store_tasks {
-                    if !t.branch.is_empty() {
-                        let ext_id = t
-                            .external_id
-                            .clone()
-                            .unwrap_or_else(|| format!("internal:{}", t.id));
-                        branch_map.insert(ext_id, t.branch.clone());
-                    }
-                }
-            }
-        }
-        tasks
-    };
-    let mut all_review_tasks: Vec<_> = in_review_tasks
-        .into_iter()
-        .chain(needs_review_tasks)
+    let all_review_tasks: Vec<&ReviewTaskSnapshot> = in_review_tasks
+        .iter()
+        .chain(needs_review_tasks.iter())
         .collect();
 
-    // Also include internal (SQLite) tasks — they create real GitHub PRs
-    // and their merged PRs must be detected the same way as external tasks.
-    if let Ok(internal_in_review) = task_manager
-        .list_internal_by_status(crate::store::TaskStatus::InReview)
-        .await
-    {
-        all_review_tasks.extend(internal_in_review);
-    }
-    if let Ok(internal_needs_review) = task_manager
-        .list_internal_by_status(crate::store::TaskStatus::NeedsReview)
-        .await
-    {
-        all_review_tasks.extend(internal_needs_review);
+    for task in &all_review_tasks {
+        if !task.stored.branch.is_empty() {
+            branch_map.insert(task.external.id.0.clone(), task.stored.branch.clone());
+        }
     }
 
     tracing::debug!(
@@ -948,7 +896,7 @@ pub(crate) async fn check_merged_prs(
     // not in the map (e.g. internal tasks, backend fallback path).
     let mut task_branches: Vec<(String, String)> = Vec::new();
     for task in all_review_tasks {
-        let task_id = &task.id.0;
+        let task_id = &task.external.id.0;
         let branch = if let Some(b) = branch_map.get(task_id) {
             b.clone()
         } else {
@@ -1586,9 +1534,37 @@ mod tests {
             "owner/repo".to_string(),
         ));
 
-        check_merged_prs(&backend_dyn, "owner/repo", &store, &task_manager)
+        let in_review_tasks = store
+            .list_by_status("owner/repo", crate::store::TaskStatus::InReview)
             .await
-            .unwrap();
+            .unwrap()
+            .into_iter()
+            .map(|stored| ReviewTaskSnapshot {
+                external: crate::engine::tasks::store_task_to_external(&stored),
+                stored,
+            })
+            .collect::<Vec<_>>();
+        let needs_review_tasks = store
+            .list_by_status("owner/repo", crate::store::TaskStatus::NeedsReview)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|stored| ReviewTaskSnapshot {
+                external: crate::engine::tasks::store_task_to_external(&stored),
+                stored,
+            })
+            .collect::<Vec<_>>();
+
+        check_merged_prs(
+            &backend_dyn,
+            "owner/repo",
+            &store,
+            &task_manager,
+            &in_review_tasks,
+            &needs_review_tasks,
+        )
+        .await
+        .unwrap();
 
         let checked = backend.single_checked_branches.lock().unwrap().clone();
         assert_eq!(

--- a/src/engine/commands.rs
+++ b/src/engine/commands.rs
@@ -4,7 +4,7 @@
 //! `/close`, `/block reason`) posted by repo collaborators. Commands are
 //! executed against the issue's task and a confirmation comment is posted.
 
-use crate::backends::{ExternalBackend, ExternalId, Status};
+use crate::backends::{ExternalBackend, ExternalId, Mention, Status};
 use crate::github::http::GhHttp;
 use crate::store;
 use crate::store::TaskStore;
@@ -137,22 +137,27 @@ pub async fn scan_commands(
     repo: &str,
     store: &Option<Arc<crate::store::TaskStore>>,
     task_manager: &Arc<crate::engine::tasks::TaskManager>,
+    prefetched_comments: Option<&[Mention]>,
 ) -> anyhow::Result<()> {
     let gh = GhHttp::new()?;
 
-    // Use persisted cursor, fall back to 24h ago
-    let fallback = chrono::Utc::now() - chrono::Duration::hours(24);
-    let since_str = match kv_get(store, "owner_commands_last_checked").await {
-        Some(ts) => ts,
-        None => fallback.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
-    };
+    let comments = if let Some(comments) = prefetched_comments {
+        comments.to_vec()
+    } else {
+        // Use persisted cursor, fall back to 24h ago
+        let fallback = chrono::Utc::now() - chrono::Duration::hours(24);
+        let since_str = match kv_get(store, "owner_commands_last_checked").await {
+            Some(ts) => ts,
+            None => fallback.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        };
 
-    // Fetch recent comments (same endpoint as mentions)
-    let comments = match backend.get_mentions(&since_str).await {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::warn!(err = %e, "failed to fetch comments for command scanning");
-            return Ok(());
+        // Fetch recent comments (same endpoint as mentions)
+        match backend.get_mentions(&since_str).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(err = %e, "failed to fetch comments for command scanning");
+                return Ok(());
+            }
         }
     };
 

--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -30,18 +30,20 @@ use crate::github::http::GhHttp;
 use crate::github::types::{GitHubComment, GitHubReviewComment, PullRequestReview};
 use crate::store::TaskStore;
 use crate::store::{
-    opt_store_get_task_by_id, store_increment_by_id, store_reset_failure_counters, store_set_by_id,
-    store_set_result_by_id,
+    store_increment_by_id, store_reset_failure_counters, store_set_by_id, store_set_result_by_id,
 };
 use dashmap::DashSet;
 use std::collections::HashMap;
 use std::sync::Arc;
+
+use super::sync::ReviewTaskSnapshot;
 
 /// Review open PRs - re-dispatch agent to address review feedback.
 ///
 /// Lists tasks in review, fetches PR reviews, and re-dispatches the agent
 /// when a reviewer requests changes. The review context is stored in the
 /// store and injected into the agent prompt.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn review_open_prs(
     backend: &Arc<dyn ExternalBackend>,
     repo: &str,
@@ -50,19 +52,8 @@ pub(crate) async fn review_open_prs(
     store: &Arc<TaskStore>,
     dispatching: &Arc<DashSet<String>>,
     auto_merge_in_flight: &Arc<DashSet<String>>,
+    in_review_tasks: &[ReviewTaskSnapshot],
 ) -> anyhow::Result<()> {
-    // Get tasks that are in review (have open PRs).
-    let mut in_review_tasks = task_manager.list_all_by_status(Status::InReview).await?;
-
-    // Also include internal tasks in InReview — they create real PRs
-    // and can receive human review comments just like external tasks.
-    if let Ok(internal_in_review) = task_manager
-        .list_internal_by_status(crate::store::TaskStatus::InReview)
-        .await
-    {
-        in_review_tasks.extend(internal_in_review);
-    }
-
     if in_review_tasks.is_empty() {
         tracing::debug!(count = 0, "checking in_review tasks for PR reviews");
         return Ok(());
@@ -90,7 +81,8 @@ pub(crate) async fn review_open_prs(
 
     let mut ready_tasks: Vec<ReadyTask> = Vec::new();
 
-    for task in in_review_tasks {
+    for snapshot in in_review_tasks {
+        let task = snapshot.external.clone();
         let task_id = &task.id.0;
 
         // Skip tasks currently being processed by the main tick.
@@ -103,54 +95,8 @@ pub(crate) async fn review_open_prs(
             continue;
         }
 
-        let store_id = match store.resolve_task_id(repo, task_id).await {
-            Ok(Some(id)) => id,
-            Ok(None) => {
-                tracing::warn!(
-                    task_id,
-                    "in_review task missing from store — setting needs_review"
-                );
-                if let Err(e) = task_manager
-                    .update_task_status(&task.id, Status::NeedsReview)
-                    .await
-                {
-                    tracing::warn!(task_id, err = %e, "failed to update status");
-                }
-                continue;
-            }
-            Err(e) => {
-                tracing::warn!(
-                    task_id,
-                    err = %e,
-                    "failed to resolve in_review task in store — setting needs_review"
-                );
-                if let Err(e) = task_manager
-                    .update_task_status(&task.id, Status::NeedsReview)
-                    .await
-                {
-                    tracing::warn!(task_id, err = %e, "failed to update status");
-                }
-                continue;
-            }
-        };
-
-        let stored = opt_store_get_task_by_id(&Some(Arc::clone(store)), store_id).await;
-        let stored = match stored {
-            Some(t) => t,
-            None => {
-                tracing::warn!(
-                    task_id,
-                    "in_review task missing from store — setting needs_review"
-                );
-                if let Err(e) = task_manager
-                    .update_task_status(&task.id, Status::NeedsReview)
-                    .await
-                {
-                    tracing::warn!(task_id, err = %e, "failed to update status");
-                }
-                continue;
-            }
-        };
+        let store_id = snapshot.stored.id;
+        let stored = snapshot.stored.clone();
 
         let branch = if stored.branch.is_empty() {
             tracing::warn!(

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -9,7 +9,7 @@
 //! - Owner /slash command scanning
 //! - Skill repository syncing
 
-use crate::backends::{ExternalBackend, ExternalId, Status};
+use crate::backends::{ExternalBackend, ExternalId, Mention, Status};
 use crate::cmd::CommandErrorContext;
 use crate::config;
 use crate::engine::cooldown::{
@@ -51,6 +51,58 @@ use super::cleanup::{check_merged_prs, cleanup_done_worktrees};
 use super::commands::{execute_command, parse_command};
 use super::review_poll::review_open_prs;
 use super::EngineConfig;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReviewTaskSnapshot {
+    pub external: crate::backends::ExternalTask,
+    pub stored: crate::store::Task,
+}
+
+impl ReviewTaskSnapshot {
+    fn task_id(&self) -> &str {
+        &self.external.id.0
+    }
+}
+
+async fn prefetch_review_tasks(
+    store: &Arc<TaskStore>,
+    repo: &str,
+) -> anyhow::Result<(Vec<ReviewTaskSnapshot>, Vec<ReviewTaskSnapshot>)> {
+    let in_review = store
+        .list_by_status(repo, TaskStatus::InReview)
+        .await?
+        .into_iter()
+        .map(|stored| ReviewTaskSnapshot {
+            external: crate::engine::tasks::store_task_to_external(&stored),
+            stored,
+        })
+        .collect();
+    let needs_review = store
+        .list_by_status(repo, TaskStatus::NeedsReview)
+        .await?
+        .into_iter()
+        .map(|stored| ReviewTaskSnapshot {
+            external: crate::engine::tasks::store_task_to_external(&stored),
+            stored,
+        })
+        .collect();
+    Ok((in_review, needs_review))
+}
+
+async fn fetch_comments_since(
+    backend: &Arc<dyn ExternalBackend>,
+    since: &str,
+) -> anyhow::Result<Vec<Mention>> {
+    backend.get_mentions(since).await
+}
+
+fn filter_mentions_by_since(comments: &[Mention], since: &str) -> Vec<Mention> {
+    comments
+        .iter()
+        .filter(|comment| comment.created_at.as_str() > since)
+        .cloned()
+        .collect()
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FailureCategory {
@@ -486,34 +538,104 @@ pub(crate) async fn sync_tick(
         });
     }
 
-    // 2. Check for merged PRs (in_review → done)
+    let (mut in_review_tasks, mut needs_review_tasks) =
+        match prefetch_review_tasks(store, repo).await {
+            Ok(tasks) => tasks,
+            Err(e) => {
+                tracing::warn!(err = %e, "failed to prefetch review tasks");
+                (vec![], vec![])
+            }
+        };
+
     if !gh_circuit_open {
-        if let Err(e) = check_merged_prs(backend, repo, store, task_manager).await {
+        let mention_fallback = chrono::Utc::now() - chrono::Duration::hours(24);
+        let mention_since = kv_get_prefer_store(&Some(store), "mentions_last_checked")
+            .await
+            .unwrap_or_else(|| mention_fallback.format("%Y-%m-%dT%H:%M:%SZ").to_string());
+        let command_fallback = chrono::Utc::now() - chrono::Duration::hours(24);
+        let command_since = store
+            .kv_get("owner_commands_last_checked")
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| command_fallback.format("%Y-%m-%dT%H:%M:%SZ").to_string());
+        let shared_since = mention_since
+            .as_str()
+            .min(command_since.as_str())
+            .to_string();
+
+        let (merge_result, comments_result, review_result) = tokio::join!(
+            check_merged_prs(
+                backend,
+                repo,
+                store,
+                task_manager,
+                &in_review_tasks,
+                &needs_review_tasks,
+            ),
+            fetch_comments_since(backend, &shared_since),
+            review_open_prs(
+                backend,
+                repo,
+                config,
+                task_manager,
+                store,
+                dispatching,
+                auto_merge_in_flight,
+                &in_review_tasks,
+            )
+        );
+
+        if let Err(e) = merge_result {
             tracing::warn!(err = %e, "PR merge check failed");
         }
-    }
 
-    // 3. Scan for @mentions
-    if !gh_circuit_open {
-        if let Err(e) = scan_mentions(backend, Some(store), repo, task_manager).await {
-            tracing::warn!(err = %e, "mention scan failed");
+        match comments_result {
+            Ok(comments) => {
+                let mention_comments = filter_mentions_by_since(&comments, &mention_since);
+                let command_comments = filter_mentions_by_since(&comments, &command_since);
+
+                if let Err(e) = scan_mentions(
+                    backend,
+                    Some(store),
+                    repo,
+                    task_manager,
+                    Some(&mention_comments),
+                )
+                .await
+                {
+                    tracing::warn!(err = %e, "mention scan failed");
+                }
+
+                if let Err(e) = super::commands::scan_commands(
+                    backend,
+                    repo,
+                    &Some(Arc::clone(store)),
+                    task_manager,
+                    Some(&command_comments),
+                )
+                .await
+                {
+                    tracing::warn!(err = %e, "owner command scan failed");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(err = %e, "comment fetch failed");
+            }
         }
-    }
 
-    // 4. Review open PRs (parse review comments, create follow-ups)
-    if !gh_circuit_open {
-        if let Err(e) = review_open_prs(
-            backend,
-            repo,
-            config,
-            task_manager,
-            store,
-            dispatching,
-            auto_merge_in_flight,
-        )
-        .await
-        {
+        if let Err(e) = review_result {
             tracing::warn!(err = %e, "PR review failed");
+        }
+
+        match prefetch_review_tasks(store, repo).await {
+            Ok((latest_in_review, latest_needs_review)) => {
+                in_review_tasks = latest_in_review;
+                needs_review_tasks = latest_needs_review;
+            }
+            Err(e) => {
+                tracing::warn!(err = %e, "failed to refresh review task cache after sync work");
+            }
         }
     }
 
@@ -530,13 +652,6 @@ pub(crate) async fn sync_tick(
     if enable_review {
         // Detect stale InReview tasks (review agent crashed, no active tmux session).
         // Read from the store (includes both external and internal tasks).
-        let in_review_tasks = match task_manager.list_all_by_status(Status::InReview).await {
-            Ok(tasks) => tasks,
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to list InReview tasks for stale-session check; skipping");
-                vec![]
-            }
-        };
         // Fetch all live tmux sessions once instead of one subprocess call per task.
         let live_sessions: std::collections::HashSet<String> = tmux
             .list_sessions()
@@ -545,13 +660,13 @@ pub(crate) async fn sync_tick(
             .into_iter()
             .map(|s| s.name)
             .collect();
-        for task in in_review_tasks {
+        for task in &in_review_tasks {
             // Skip tasks currently being processed by the main tick (dispatch + review flow).
-            let dispatch_key = format!("{}/{}", repo, task.id.0);
+            let dispatch_key = format!("{}/{}", repo, task.task_id());
             {
                 if dispatching.contains(&dispatch_key) {
                     tracing::debug!(
-                        task_id = task.id.0,
+                        task_id = task.task_id(),
                         "task locked by dispatch flow, skipping stale check"
                     );
                     continue;
@@ -561,12 +676,12 @@ pub(crate) async fn sync_tick(
             // review agent to start its tmux session before treating it as stale.
             // A task is only considered stale if it has been in InReview for > 1 minute.
             const MIN_STALE_MINUTES: i64 = 1;
-            match chrono::DateTime::parse_from_rfc3339(&task.updated_at) {
+            match chrono::DateTime::parse_from_rfc3339(&task.external.updated_at) {
                 Ok(updated_at) => {
                     let age = chrono::Utc::now() - updated_at.with_timezone(&chrono::Utc);
                     if age.num_minutes() < MIN_STALE_MINUTES {
                         tracing::debug!(
-                            task_id = task.id.0,
+                            task_id = task.task_id(),
                             age_seconds = age.num_seconds(),
                             "InReview task is too young to be considered stale, skipping"
                         );
@@ -575,15 +690,15 @@ pub(crate) async fn sync_tick(
                 }
                 Err(e) => {
                     tracing::warn!(
-                        task_id = task.id.0,
-                        ts = %task.updated_at,
+                        task_id = task.task_id(),
+                        ts = %task.external.updated_at,
                         err = %e,
                         "invalid updated_at timestamp — treating task as potentially stale"
                     );
                 }
             }
 
-            let review_task_id = format!("{}-review", task.id.0);
+            let review_task_id = format!("{}-review", task.task_id());
             let review_session = tmux.session_name(repo, &review_task_id);
             if live_sessions.contains(&review_session) {
                 // Review agent is still alive — skip.
@@ -595,7 +710,7 @@ pub(crate) async fn sync_tick(
             // Reset to NeedsReview so the subscriber re-dispatches.
             {
                 tracing::warn!(
-                    task_id = task.id.0,
+                    task_id = task.task_id(),
                     session = %review_session,
                     "InReview task has no active review session — resetting to NeedsReview"
                 );
@@ -605,25 +720,26 @@ pub(crate) async fn sync_tick(
                 store::store_set(
                     &Some(Arc::clone(store)),
                     repo,
-                    &task.id.0,
+                    task.task_id(),
                     &[("review_agent_failures", serde_json::json!(0))],
                 )
                 .await;
                 match task_manager
-                    .update_task_status_if(&task.id, Status::NeedsReview, Status::InReview)
+                    .update_task_status_if(&task.external.id, Status::NeedsReview, Status::InReview)
                     .await
                 {
                     Err(e) => {
-                        tracing::error!(task_id = %task.id.0, err = %e, "failed to reset stale InReview task — task may be stuck in InReview indefinitely");
+                        tracing::error!(task_id = task.task_id(), err = %e, "failed to reset stale InReview task — task may be stuck in InReview indefinitely");
                     }
                     Ok(false) => {
                         tracing::debug!(
-                            task_id = %task.id.0,
+                            task_id = task.task_id(),
                             "stale InReview reset skipped — task already transitioned (concurrent Done/Blocked/InProgress)"
                         );
                     }
                     Ok(true) => {
-                        store::set_review_session_expected(store, repo, &task.id.0, false).await;
+                        store::set_review_session_expected(store, repo, task.task_id(), false)
+                            .await;
                     }
                 }
             }
@@ -644,14 +760,6 @@ pub(crate) async fn sync_tick(
     // re-introducing the double-trigger race fixed in issue #857 — the subscriber is still
     // the sole spawner and uses the InReview transition as its atomic guard.
     if enable_review {
-        let needs_review_tasks = match task_manager.list_all_by_status(Status::NeedsReview).await {
-            Ok(tasks) => tasks,
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to list NeedsReview tasks for stale-refire check; skipping");
-                vec![]
-            }
-        };
-
         const MIN_STALE_NEEDS_REVIEW_MINUTES: i64 = 1;
         const MAX_NEEDS_REVIEW_REFIRE_ATTEMPTS: u64 = 5; // escalate to Blocked after this many refires
         let needs_review_count = needs_review_tasks.len();
@@ -666,39 +774,30 @@ pub(crate) async fn sync_tick(
                 "sync catch-up: checking stale NeedsReview tasks"
             );
         }
-        for task in needs_review_tasks {
+        for task in &needs_review_tasks {
             // Only retry tasks that have been in NeedsReview long enough that the
             // subscriber should have handled them by now. Fresh tasks (just transitioned)
             // are likely still in flight via the event bus. Unparseable timestamps are
             // treated as stale (fall through to retry).
-            let age_minutes =
-                if let Ok(updated_at) = chrono::DateTime::parse_from_rfc3339(&task.updated_at) {
-                    let age = chrono::Utc::now() - updated_at.with_timezone(&chrono::Utc);
-                    if age.num_minutes() < MIN_STALE_NEEDS_REVIEW_MINUTES {
-                        continue;
-                    }
-                    Some(age.num_minutes())
-                } else {
-                    None
-                };
+            let age_minutes = if let Ok(updated_at) =
+                chrono::DateTime::parse_from_rfc3339(&task.external.updated_at)
+            {
+                let age = chrono::Utc::now() - updated_at.with_timezone(&chrono::Utc);
+                if age.num_minutes() < MIN_STALE_NEEDS_REVIEW_MINUTES {
+                    continue;
+                }
+                Some(age.num_minutes())
+            } else {
+                None
+            };
 
             // Skip tasks actively being dispatched (subscriber is working on them).
-            let dispatch_key = format!("{}/{}", repo, task.id.0);
+            let dispatch_key = format!("{}/{}", repo, task.task_id());
             if dispatching.contains(&dispatch_key) {
                 continue;
             }
             // Decide whether to re-fire now using exponential backoff based on a per-task counter.
-            // Fetch the store task to read the current needs_review_refires counter without
-            // touching updated_at before we know whether we will actually fire.
-            let store_task =
-                crate::store::opt_store_get_task(&Some(Arc::clone(store)), repo, &task.id.0).await;
-            let current_refires = match store_task.as_ref() {
-                Some(t) => t.needs_review_refires as u64,
-                None => {
-                    tracing::warn!(task_id = task.id.0, "failed to read task from store for refire backoff — skipping re-fire this tick");
-                    continue;
-                }
-            };
+            let current_refires = task.stored.needs_review_refires as u64;
             let new_refires = current_refires + 1;
 
             // If we've exceeded max attempts, escalate the task to Blocked with a clear reason.
@@ -707,12 +806,12 @@ pub(crate) async fn sync_tick(
                 let _ = crate::store::store_increment(
                     &Some(Arc::clone(store)),
                     repo,
-                    &task.id.0,
+                    task.task_id(),
                     "needs_review_refires",
                 )
                 .await;
                 tracing::warn!(
-                    task_id = task.id.0,
+                    task_id = task.task_id(),
                     new_refires,
                     "escalating NeedsReview task to Blocked after repeated refires"
                 );
@@ -720,7 +819,7 @@ pub(crate) async fn sync_tick(
                 crate::store::store_set(
                     &Some(Arc::clone(store)),
                     repo,
-                    &task.id.0,
+                    task.task_id(),
                     &[
                         (
                             "block_reason",
@@ -736,10 +835,10 @@ pub(crate) async fn sync_tick(
                 )
                 .await;
                 if let Err(e) = task_manager
-                    .update_task_status(&task.id, Status::Blocked)
+                    .update_task_status(&task.external.id, Status::Blocked)
                     .await
                 {
-                    tracing::warn!(task_id = task.id.0, err = %e, "failed to set Blocked during escalation");
+                    tracing::warn!(task_id = task.task_id(), err = %e, "failed to set Blocked during escalation");
                 }
                 continue;
             }
@@ -762,12 +861,12 @@ pub(crate) async fn sync_tick(
                 let _ = crate::store::store_increment_no_ts(
                     &Some(Arc::clone(store)),
                     repo,
-                    &task.id.0,
+                    task.task_id(),
                     "needs_review_refires",
                 )
                 .await;
                 tracing::debug!(
-                    task_id = task.id.0,
+                    task_id = task.task_id(),
                     age_minutes,
                     current_refires,
                     required_minutes,
@@ -781,7 +880,7 @@ pub(crate) async fn sync_tick(
             let fired_refires = match crate::store::store_increment(
                 &Some(Arc::clone(store)),
                 repo,
-                &task.id.0,
+                task.task_id(),
                 "needs_review_refires",
             )
             .await
@@ -789,7 +888,7 @@ pub(crate) async fn sync_tick(
                 Ok(v) => v,
                 Err(e) => {
                     tracing::warn!(
-                        task_id = task.id.0,
+                        task_id = task.task_id(),
                         err = %e,
                         "failed to increment needs_review_refires — proceeding with re-fire anyway"
                     );
@@ -798,7 +897,7 @@ pub(crate) async fn sync_tick(
             };
 
             tracing::info!(
-                task_id = task.id.0,
+                task_id = task.task_id(),
                 age_minutes,
                 refires = fired_refires,
                 required_minutes,
@@ -806,11 +905,11 @@ pub(crate) async fn sync_tick(
             );
 
             if let Err(e) = task_manager
-                .update_task_status(&task.id, Status::NeedsReview)
+                .update_task_status(&task.external.id, Status::NeedsReview)
                 .await
             {
                 tracing::warn!(
-                    task_id = task.id.0,
+                    task_id = task.task_id(),
                     err = %e,
                     "sync catch-up: failed to re-fire NeedsReview event"
                 );
@@ -823,17 +922,7 @@ pub(crate) async fn sync_tick(
         tracing::warn!(err = %e, "auto-unblock failed");
     }
 
-    // 6. Scan for owner /slash commands in issue comments
-    if !gh_circuit_open {
-        if let Err(e) =
-            super::commands::scan_commands(backend, repo, &Some(Arc::clone(store)), task_manager)
-                .await
-        {
-            tracing::warn!(err = %e, "owner command scan failed");
-        }
-    }
-
-    // 7. Sync skill repositories
+    // 6. Sync skill repositories
     match skills_sync().await {
         Ok(()) => {
             // Invalidate the LLM router's skills catalog cache so new/updated
@@ -868,6 +957,7 @@ async fn scan_mentions(
     store: Option<&Arc<TaskStore>>,
     repo: &str,
     task_manager: &Arc<TaskManager>,
+    prefetched_mentions: Option<&[Mention]>,
 ) -> anyhow::Result<()> {
     // Get the current user (for mention detection)
     let current_user = match backend.get_authenticated_user().await {
@@ -882,18 +972,22 @@ async fn scan_mentions(
         }
     };
 
-    // Use persisted cursor if available, otherwise fall back to 24h ago
-    let fallback = chrono::Utc::now() - chrono::Duration::hours(24);
-    let since_str = match kv_get_prefer_store(&store, "mentions_last_checked").await {
-        Some(ts) => ts,
-        None => fallback.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
-    };
+    let mentions = if let Some(mentions) = prefetched_mentions {
+        mentions.to_vec()
+    } else {
+        // Use persisted cursor if available, otherwise fall back to 24h ago
+        let fallback = chrono::Utc::now() - chrono::Duration::hours(24);
+        let since_str = match kv_get_prefer_store(&store, "mentions_last_checked").await {
+            Some(ts) => ts,
+            None => fallback.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        };
 
-    let mentions = match backend.get_mentions(&since_str).await {
-        Ok(m) => m,
-        Err(e) => {
-            tracing::warn!(err = %e, "failed to get mentions");
-            return Ok(());
+        match backend.get_mentions(&since_str).await {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(err = %e, "failed to get mentions");
+                return Ok(());
+            }
         }
     };
 

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -105,11 +105,13 @@ impl TaskManager {
     }
 
     /// Get reference to the task store (if available).
+    #[allow(dead_code)]
     pub fn store(&self) -> Option<&Arc<TaskStore>> {
         self.store.as_ref()
     }
 
     /// Get reference to the repo identifier.
+    #[allow(dead_code)]
     pub fn repo(&self) -> &str {
         &self.repo
     }


### PR DESCRIPTION
## Summary

Reduced sync tick hot-path churn by prefetching review-status task snapshots once, reusing them across merged-PR/review/stale-task flows, and sharing a single GitHub comment fetch between mention and owner-command scans.

### What was done

- Added a shared `ReviewTaskSnapshot` prefetch in `sync_tick()` for `InReview` and `NeedsReview` tasks, then passed those snapshots into merged-PR checks, review polling, and stale detection/refire logic.
- Removed redundant per-step store status queries in `check_merged_prs()` and `review_open_prs()` by consuming the prefetched review task snapshots instead of re-listing `InReview`/`NeedsReview` tasks.
- Eliminated the `NeedsReview` stale-refire N+1 store lookup by reading `needs_review_refires` and branch/status metadata from the prefetched store task snapshot.
- Merged `scan_mentions` and `scan_commands` onto a single `backend.get_mentions()` request per sync tick, partitioning the shared comment batch client-side by each cursor window.
- Parallelized the independent sync work with `tokio::join!` so merged-PR checks, review polling, and shared comment fetch run concurrently after the prefetch step.
- Updated tests and signatures to cover the new shared-data path, and kept required checks green.


Closes #2133

---
*Task #2133 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4`*