### PR TITLE
perf: tmux snapshot() spawns N+1 subprocesses per tick — batch_session_active() exists but is unused

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -148,17 +148,19 @@ struct StuckTaskTiming {
     threshold: u64,
 }
 
-async fn stuck_task_timing(
+#[allow(clippy::too_many_arguments)]
+fn stuck_task_timing_from_map(
     tmux: &Arc<TmuxManager>,
     repo: &str,
-    task_id: &str,
     session_task_id: &str,
     updated_at: &str,
     config: &EngineConfig,
     parse_error_message: &'static str,
+    session_map: &std::collections::HashMap<String, bool>,
 ) -> Option<StuckTaskTiming> {
     let session_name = tmux.session_name(repo, session_task_id);
-    let has_session = tmux.session_is_running(&session_name).await;
+    // A session is "running" if it appears in the map with alive=true.
+    let has_session = session_map.get(&session_name).copied().unwrap_or(false);
     let threshold = if has_session {
         config.stuck_timeout
     } else {
@@ -169,7 +171,7 @@ async fn stuck_task_timing(
         Ok(dt) => dt.with_timezone(&chrono::Utc),
         Err(e) => {
             tracing::warn!(
-                task_id,
+                task_id = session_task_id,
                 updated_at,
                 ?e,
                 error_message = parse_error_message,
@@ -452,6 +454,9 @@ pub(crate) async fn tick_recover_stuck_tasks(
     store: &Arc<TaskStore>,
 ) -> anyhow::Result<()> {
     let _span = tracing::info_span!("engine.tick.phase2.stuck_tasks").entered();
+    // Fetch all session statuses once (single `list-panes -a` call) and reuse
+    // throughout this function instead of spawning one subprocess per task.
+    let session_map = tmux.batch_session_active().await;
     let in_progress = match task_manager
         .list_external_by_status(Status::InProgress)
         .await
@@ -463,17 +468,15 @@ pub(crate) async fn tick_recover_stuck_tasks(
         }
     };
     for task in &in_progress {
-        let Some(timing) = stuck_task_timing(
+        let Some(timing) = stuck_task_timing_from_map(
             tmux,
             repo,
-            &task.id.0,
             &task.id.0,
             &task.updated_at,
             config,
             "cannot parse updated_at, skipping stuck-task check",
-        )
-        .await
-        else {
+            &session_map,
+        ) else {
             continue;
         };
 
@@ -584,17 +587,15 @@ pub(crate) async fn tick_recover_stuck_tasks(
     };
     for task in &internal_in_progress {
         let task_id = task.id.0.clone();
-        let Some(timing) = stuck_task_timing(
+        let Some(timing) = stuck_task_timing_from_map(
             tmux,
             repo,
-            &task_id,
             &task_id,
             &task.updated_at,
             config,
             "cannot parse updated_at, skipping stuck internal-task check",
-        )
-        .await
-        else {
+            &session_map,
+        ) else {
             continue;
         };
 
@@ -655,17 +656,15 @@ pub(crate) async fn tick_recover_stuck_tasks(
         }
 
         let review_task_id = format!("{}-review", task.id.0);
-        let Some(timing) = stuck_task_timing(
+        let Some(timing) = stuck_task_timing_from_map(
             tmux,
             repo,
-            &task.id.0,
             &review_task_id,
             &task.updated_at,
             config,
             "cannot parse updated_at, skipping stuck in_review check",
-        )
-        .await
-        else {
+            &session_map,
+        ) else {
             continue;
         };
 
@@ -752,17 +751,15 @@ pub(crate) async fn tick_recover_stuck_tasks(
         }
 
         let review_task_id = format!("{}-review", task_id);
-        let Some(timing) = stuck_task_timing(
+        let Some(timing) = stuck_task_timing_from_map(
             tmux,
             repo,
-            &task_id,
             &review_task_id,
             &task.updated_at,
             config,
             "cannot parse updated_at, skipping stuck internal in_review check",
-        )
-        .await
-        else {
+            &session_map,
+        ) else {
             continue;
         };
 
@@ -1006,6 +1003,10 @@ pub(crate) async fn tick_dispatch_tasks(
         0
     };
 
+    // Fetch all session pane-alive statuses once (single `list-panes -a` call) and
+    // reuse throughout the dispatch loop instead of spawning 2 subprocesses per task.
+    let dispatch_session_map = tmux.batch_session_active().await;
+
     for (idx, task) in dispatchable.into_iter().enumerate() {
         // In degraded mode, add delay between dispatches to pace the system
         if idx > 0 && is_degraded {
@@ -1036,7 +1037,10 @@ pub(crate) async fn tick_dispatch_tasks(
 
         // Check if already running (has active session)
         let session_name = tmux.session_name(repo, &task.id.0);
-        if tmux.session_blocks_dispatch(&session_name).await {
+        if tmux
+            .session_blocks_dispatch_from_map(&session_name, &dispatch_session_map)
+            .await
+        {
             tracing::warn!(
                 task_id = task.id.0,
                 session_name,
@@ -2068,16 +2072,16 @@ mod tests {
             - chrono::Duration::seconds(config.no_session_stuck_timeout as i64 + 5))
         .to_rfc3339();
 
-        let timing = stuck_task_timing(
+        let session_map = tmux.batch_session_active().await;
+        let timing = stuck_task_timing_from_map(
             &tmux,
             repo,
-            task_id,
             task_id,
             &updated_at,
             &config,
             "parse failure",
+            &session_map,
         )
-        .await
         .expect("dead session should be treated as missing");
 
         assert!(!timing.has_session);

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -191,6 +191,7 @@ impl TmuxManager {
     }
 
     /// Check whether a session exists and still has a live pane process.
+    #[cfg(test)]
     pub async fn session_is_running(&self, session: &str) -> bool {
         self.session_exists(session).await && self.is_session_active(session).await
     }
@@ -217,6 +218,37 @@ impl TmuxManager {
         }
 
         false
+    }
+
+    /// Batch variant of `session_blocks_dispatch` that uses a pre-fetched session map.
+    ///
+    /// `session_map` is the result of `batch_session_active()`. Sessions absent from the
+    /// map do not exist (→ no block). Sessions present with `alive=true` block dispatch.
+    /// Sessions present with `alive=false` have a dead pane and are cleaned up eagerly.
+    pub async fn session_blocks_dispatch_from_map(
+        &self,
+        session: &str,
+        session_map: &std::collections::HashMap<String, bool>,
+    ) -> bool {
+        match session_map.get(session).copied() {
+            None => false,      // session does not exist → no block
+            Some(true) => true, // session exists and pane is alive → block
+            Some(false) => {
+                // Session exists but pane is dead — clean up eagerly.
+                tracing::warn!(
+                    session,
+                    "found stale tmux session with dead pane; cleaning up"
+                );
+                if let Err(err) = self.kill_session(session).await {
+                    tracing::debug!(
+                        session,
+                        error = %err,
+                        "failed to clean up stale tmux session"
+                    );
+                }
+                false
+            }
+        }
     }
 
     /// Parse a session name into (project, task_id).
@@ -441,6 +473,9 @@ impl TmuxManager {
     ///
     /// Returns a vector of (Session, alive) so callers can operate on the
     /// actual session name instead of reconstructing one from repo+task_id.
+    ///
+    /// Uses `batch_session_active()` internally to fetch all pane-dead statuses
+    /// in a single subprocess call instead of one call per session (N+1 → 2).
     pub async fn snapshot(&self) -> Vec<(Session, bool)> {
         let sessions = match self.list_sessions().await {
             Ok(s) => s,
@@ -449,12 +484,16 @@ impl TmuxManager {
                 Vec::new()
             }
         };
-        let mut out = Vec::new();
-        for s in sessions {
-            let active = self.is_session_active(&s.name).await;
-            out.push((s, active));
-        }
-        out
+        // Fetch all pane-dead statuses in a single `list-panes -a` call.
+        let active_map = self.batch_session_active().await;
+        sessions
+            .into_iter()
+            .map(|s| {
+                // Sessions absent from the map are treated as dead (pane missing).
+                let active = active_map.get(&s.name).copied().unwrap_or(false);
+                (s, active)
+            })
+            .collect()
     }
 
     // ── Environment variable helpers ───────────────────────────────────


### PR DESCRIPTION
## Summary

Done. Here's a summary of what was changed:

**`src/tmux.rs`**
- `snapshot()` now uses `batch_session_active()` internally — one `list-panes -a` call replaces N per-session `is_session_active()` calls
- Added `session_blocks_dispatch_from_map()` — batch variant that accepts a pre-fetched session map instead of spawning 2 subprocesses per task
- Marked `session_is_running()` `#[cfg(test)]` since it's only used in test polling loops

**`src/engine/tick.rs`**
- `stuck_task_timing_from_map()` (s

Closes #2132

---
*Task #2132 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*