### PR TITLE
bug: all orch comments should have a footer

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -5,7 +5,7 @@
 //! - [`handle_review_changes`]: re-dispatch agent to address review feedback
 //! - [`dedup_reviews`]: deduplicate GitHub reviews by reviewer (keep latest)
 //! - [`any_changes_requested_in_reviews`]: check if any reviewer's latest review blocks merge
-//! - [`attribution_footer`]: standard "Commented/Reviewed by bot" footer for GitHub comments
+//! - [`crate::engine::attribution_footer`]: standard "Commented/Reviewed by bot" footer for GitHub comments
 
 use crate::backends::{ExternalBackend, ExternalTask, Status};
 use crate::config;
@@ -102,16 +102,6 @@ fn required_checks_state(
     };
 
     (state, total, passing, failing, pending)
-}
-
-/// Build a standard attribution footer for GitHub comments posted by orch bots.
-///
-/// `verb` is "Reviewed" or "Commented" depending on context.
-pub(crate) fn attribution_footer(verb: &str, agent: &str, model: &str) -> String {
-    format!(
-        "\n\n---\n*{} {}[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `{}`*",
-        verb, agent, model
-    )
 }
 
 /// Deduplicate GitHub reviews by reviewer, keeping only the latest per reviewer.
@@ -592,7 +582,11 @@ pub(crate) async fn auto_merge_pr(
                 )
                 .await;
                 let comment = format!("Auto-merge failed after {} rebase attempts: {}", retries, e);
-                let footer = attribution_footer("Commented", review_agent, review_model);
+                let footer = crate::engine::attribution_footer(
+                    "Commented",
+                    review_agent,
+                    Some(review_model),
+                );
                 let _ = gh
                     .add_comment(
                         repo,
@@ -823,7 +817,8 @@ pub(crate) async fn auto_merge_pr(
                 &[("block_reason", serde_json::json!(block_reason))],
             )
             .await;
-            let footer = attribution_footer("Commented", review_agent, review_model);
+            let footer =
+                crate::engine::attribution_footer("Commented", review_agent, Some(review_model));
             if let Err(e) = gh
                 .add_comment(
                     repo,
@@ -858,7 +853,8 @@ pub(crate) async fn auto_merge_pr(
         )
         .await;
         let comment = format!("Auto-merge failed: {}", e);
-        let footer = attribution_footer("Commented", review_agent, review_model);
+        let footer =
+            crate::engine::attribution_footer("Commented", review_agent, Some(review_model));
         if let Err(e) = gh
             .add_comment(
                 repo,
@@ -903,7 +899,7 @@ pub(crate) async fn auto_merge_pr(
 
     // 8. Post final comment on the PR
     let comment = "✅ PR reviewed, approved, and merged.";
-    let footer = attribution_footer("Reviewed", review_agent, review_model);
+    let footer = crate::engine::attribution_footer("Reviewed", review_agent, Some(review_model));
     if let Err(e) = gh
         .add_comment(
             repo,
@@ -1186,7 +1182,7 @@ pub(crate) async fn handle_review_changes(
                             "🔄 Auto-recovery: required CI checks pass. \
                             The review agent may have been blocked by a non-required check failure. \
                             Resetting review cycles and re-triggering review.{}",
-                            attribution_footer("Commented", review_agent, review_model)
+                            crate::engine::attribution_footer("Commented", review_agent, Some(review_model))
                         );
                         if let Err(e) = gh.add_comment(repo, &pr_num_str, &recovery_comment).await {
                             tracing::warn!(
@@ -1259,7 +1255,8 @@ pub(crate) async fn handle_review_changes(
             "🔍 Review agent requested changes after {} cycles. Escalating to human.\n\n**Review Notes:**\n{}",
             review_cycles, notes
         );
-        let footer = attribution_footer("Commented", review_agent, review_model);
+        let footer =
+            crate::engine::attribution_footer("Commented", review_agent, Some(review_model));
         if let Err(e) = gh
             .add_comment(repo, &pr_num_str, &format!("{}{}", escalation, footer))
             .await

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -37,6 +37,22 @@ pub fn orch_footer() -> &'static str {
     "\n\n---\n*Posted by [Orch](https://github.com/gabrielkoerich/orch)*"
 }
 
+/// Build a standard attribution footer for GitHub comments posted by orch bots.
+///
+/// `verb` is "Created", "Reviewed", or "Commented" depending on context.
+pub fn attribution_footer(verb: &str, agent: &str, model: Option<&str>) -> String {
+    match model {
+        Some(m) => format!(
+            "\n\n---\n*{} by {}[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `{}`*",
+            verb, agent, m
+        ),
+        None => format!(
+            "\n\n---\n*{} by {}[bot] via [Orch](https://github.com/gabrielkoerich/orch)*",
+            verb, agent
+        ),
+    }
+}
+
 use crate::backends::{ExternalBackend, ExternalId};
 use crate::channels::capture::CaptureService;
 use crate::channels::discord_ws::DiscordGateway;

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -43,10 +43,8 @@ pub(crate) fn parse_pr_number_from_url(url: &str) -> Option<u64> {
 }
 
 fn review_started_comment(review_agent: &str, review_model: &str) -> String {
-    format!(
-        "🔍 Automated review started (agent: {}, model: {})",
-        review_agent, review_model
-    )
+    let footer = attribution_footer("Review started", review_agent, Some(review_model));
+    format!("🔍 Automated review started{}", footer)
 }
 
 fn should_skip_no_code_reroute_increment(last_error: &str) -> bool {
@@ -56,7 +54,8 @@ fn should_skip_no_code_reroute_increment(last_error: &str) -> bool {
 use crate::backends::{ExternalBackend, ExternalTask, Status};
 use crate::cmd::CommandErrorContext;
 use crate::config;
-use crate::engine::auto_merge::{attribution_footer, auto_merge_pr, handle_review_changes};
+use crate::engine::attribution_footer;
+use crate::engine::auto_merge::{auto_merge_pr, handle_review_changes};
 use crate::engine::runner;
 use crate::engine::runner::worktree;
 use crate::engine::tasks::TaskManager;
@@ -1682,7 +1681,7 @@ pub(crate) async fn review_and_merge(
     };
 
     if !pr_comment.is_empty() {
-        let footer = attribution_footer("Reviewed", &review_agent, review_model_str);
+        let footer = attribution_footer("Reviewed", &review_agent, Some(review_model_str));
         let pr_comment_with_footer = format!("{}{}", pr_comment, footer);
         if let Err(e) = gh
             .add_comment(repo, &pr_number_early.to_string(), &pr_comment_with_footer)
@@ -2073,10 +2072,9 @@ mod tests {
 
     #[test]
     fn review_started_comment_includes_agent_and_model() {
-        assert_eq!(
-            review_started_comment("kimi", "opus"),
-            "🔍 Automated review started (agent: kimi, model: opus)"
-        );
+        let expected_footer = attribution_footer("Review started", "kimi", Some("opus"));
+        let expected = format!("🔍 Automated review started{}", expected_footer);
+        assert_eq!(review_started_comment("kimi", "opus"), expected);
     }
 
     #[test]

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -1123,10 +1123,8 @@ impl TaskRunner {
         }
 
         // Append visible attribution footer (matches PR body style)
-        let model_str = model.map(|m| format!(" using `{m}`")).unwrap_or_default();
-        raw_comment.push_str(&format!(
-            "\n\n---\n*Created by {agent_name}[bot] via [Orch](https://github.com/gabrielkoerich/orch){model_str}*"
-        ));
+        let footer = crate::engine::attribution_footer("Created", &agent_name, model);
+        raw_comment.push_str(&footer);
 
         // Scan for leaked secrets and redact if needed
         let comment = if security::has_leaks(&raw_comment) {

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -625,8 +625,12 @@ async fn post_review_failure_comment(
     };
 
     let comment = format!(
-        "⚠️ Review agent failed (attempt {}/{})\n\n**Reason:** {}\n\n{}",
-        failures, MAX_REVIEW_AGENT_FAILURES, reason, status,
+        "⚠️ Review agent failed (attempt {}/{})\n\n**Reason:** {}\n\n{}{}",
+        failures,
+        MAX_REVIEW_AGENT_FAILURES,
+        reason,
+        status,
+        crate::engine::orch_footer()
     );
 
     let gh = match GhHttp::new() {

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1630,7 +1630,7 @@ pub(crate) async fn ingest_external_tasks(
 
                     if should_dedupe {
                         let comment = format!(
-                            "Duplicate of #{id} — closing to avoid duplicate work.\n\n---\n{footer}",
+                            "Duplicate of #{id} — closing to avoid duplicate work.{footer}",
                             id = target.id,
                             footer = crate::engine::orch_footer()
                         );


### PR DESCRIPTION
## Summary

---
## Goal

Fix issue #2131: Ensure all comments made by Orch in a GitHub issue or PR include an attribution footer specifying the agent and model used (e.g., `by <agent> via Orch using <model>`).

## Instructions

- Identify all locations where Orch posts comments to GitHub issues and PRs (such as automated review start messages, approvals, escalation messages, etc.).
- Ensure the footer is consistently appended to all these comments.

## Discoveries

- There are existing footer functions in t

Closes #2131

---
*Task #2131 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gemini-3.1-pro-preview`*