### PR TITLE
fix(review): record structured outcomes for review run failures

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -14,6 +14,20 @@ pub(crate) const MAX_REVIEW_AGENT_FAILURES: u64 = 3;
 /// Maximum consecutive PR-creation failures before blocking the task.
 const MAX_PR_CREATE_FAILURES: u64 = 3;
 
+/// Map an [`AgentError`] to the structured outcome string stored in `task_runs.outcome`.
+///
+/// Mirrors the logic in `runner::classify_run_outcome` so review runs carry the
+/// same outcome fidelity as agent runs.
+fn outcome_for_agent_error(err: &runner::agents::AgentError) -> &'static str {
+    match err {
+        runner::agents::AgentError::Timeout { .. } => "timeout",
+        runner::agents::AgentError::RateLimit { .. } => "rate_limit",
+        runner::agents::AgentError::Auth { .. } => "auth_error",
+        runner::agents::AgentError::InvalidResponse { .. } => "parse_error",
+        _ => "failed",
+    }
+}
+
 /// Parse a PR number from a GitHub PR URL.
 ///
 /// Validates that the URL matches the expected GitHub PR URL format
@@ -1165,7 +1179,7 @@ pub(crate) async fn review_and_merge(
                         stdout: "",
                         stderr: "timeout",
                         parsed: "",
-                        outcome: "failed",
+                        outcome: "timeout",
                         error: "timeout",
                         tokens: RunTokenUsage::default(),
                     })
@@ -1283,7 +1297,7 @@ pub(crate) async fn review_and_merge(
                     stdout: &raw_output,
                     stderr: &stderr,
                     parsed: "",
-                    outcome: "failed",
+                    outcome: outcome_for_agent_error(&err),
                     error: &err.to_string(),
                     tokens: agent_token_usage,
                 })
@@ -1362,7 +1376,7 @@ pub(crate) async fn review_and_merge(
                                 stdout: &raw_output,
                                 stderr: &stderr,
                                 parsed: &text_for_review,
-                                outcome: "failed",
+                                outcome: outcome_for_agent_error(&err),
                                 error: &format!("per-agent error: {err}"),
                                 tokens: agent_token_usage,
                             })
@@ -1392,7 +1406,7 @@ pub(crate) async fn review_and_merge(
                                 stdout: &raw_output,
                                 stderr: &stderr,
                                 parsed: &text_for_review,
-                                outcome: "failed",
+                                outcome: "rate_limit",
                                 error: &format!("rate limit: {message}"),
                                 tokens: agent_token_usage,
                             })
@@ -1419,7 +1433,7 @@ pub(crate) async fn review_and_merge(
                                 stdout: &raw_output,
                                 stderr: &stderr,
                                 parsed: &text_for_review,
-                                outcome: "failed",
+                                outcome: "auth_error",
                                 error: &format!("auth error: {message}"),
                                 tokens: agent_token_usage,
                             })
@@ -1444,7 +1458,7 @@ pub(crate) async fn review_and_merge(
                             stdout: &raw_output,
                             stderr: &stderr,
                             parsed: &text_for_review,
-                            outcome: "failed",
+                            outcome: "parse_error",
                             error: &format!("parse error: {e}"),
                             tokens: agent_token_usage,
                         })


### PR DESCRIPTION
## Summary

Review `task_runs` were collapsing all non-success outcomes into `outcome = "failed"`, hiding rate limits, timeouts, auth errors, and parse failures from analytics and ops queries.

- Add `outcome_for_agent_error()` helper that mirrors `classify_run_outcome` in `runner/mod.rs`
- Apply it across all six `complete_run` call sites in `review.rs`:
  - timeout path → `"timeout"`
  - hard failure (`classify_error`) → `"timeout"` / `"rate_limit"` / `"auth_error"` / `"parse_error"` / `"failed"`
  - per-agent extractor error → same via helper
  - rate limit pattern detection → `"rate_limit"`
  - auth error pattern detection → `"auth_error"`
  - parse error fallthrough → `"parse_error"`

Fixes #2145.

## Test plan

- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo nextest run` — 2721 passed, 19 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task #2145 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*