### PR TITLE
bug: task_runs default outcome='' makes in-progress runs look like failures in analytics

### DIFF
--- a/migrations/021_task_runs_null_outcome.sql
+++ b/migrations/021_task_runs_null_outcome.sql
@@ -1,0 +1,8 @@
+-- Fix in-flight task_runs that have outcome='' instead of NULL.
+-- Rows with completed_at IS NULL are still running; their outcome
+-- should be NULL (not '') so analytics queries can reliably filter
+-- on completed_at IS NOT NULL to exclude them.
+UPDATE task_runs
+SET outcome = NULL
+WHERE completed_at IS NULL
+  AND outcome = '';

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1462,11 +1462,12 @@ impl TaskStore {
     /// Start a new run, returning its ID.
     pub async fn start_run(&self, run: &StartRun<'_>) -> anyhow::Result<i64> {
         let row = sqlx::query(
-            "INSERT INTO task_runs (task_id, attempt, run_type, agent, model, command, prompt)
-         VALUES (?, ?, ?, ?, ?, ?, ?)
+            "INSERT INTO task_runs (task_id, attempt, run_type, agent, model, command, prompt, outcome)
+         VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
          ON CONFLICT(task_id, attempt, run_type) DO UPDATE SET
             agent = excluded.agent, model = excluded.model,
             command = excluded.command, prompt = excluded.prompt,
+            outcome = NULL,
             started_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
          RETURNING id",
         )


### PR DESCRIPTION
## Summary

All checks pass. Let me summarize what was done:

## Changes

**`migrations/021_task_runs_null_outcome.sql`** (new file)  
Updates any existing in-flight rows (`completed_at IS NULL AND outcome = ''`) to `outcome = NULL`. This cleans up the live database on next startup.

**`src/store/tasks.rs:1487`** (`start_run()`)  
Explicitly inserts `outcome = NULL` and resets it to NULL on conflict (retry). Previously the column used the schema default `''`, making in-flight runs indistinguishable from a f

Closes #2147

---
*Task #2147 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*