### PR TITLE
bug: cleaned_external_ids query fails to filter NULL external_id — defeats batch cleanup optimization

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1447,7 +1447,7 @@ impl TaskStore {
         repo: &str,
     ) -> anyhow::Result<std::collections::HashSet<String>> {
         let rows: Vec<(String,)> =
-            sqlx::query_as("SELECT external_id FROM tasks WHERE repo = ? AND worktree_cleaned = 1")
+            sqlx::query_as("SELECT external_id FROM tasks WHERE repo = ? AND worktree_cleaned = 1 AND external_id IS NOT NULL")
                 .bind(repo)
                 .fetch_all(&self.pool)
                 .await?;


### PR DESCRIPTION
## Summary

Perfect! ✓ The fix is complete and committed.

## Summary

**Fixed:** Bug #2155 — `cleaned_external_ids` query failing to filter NULL external_id values

### The Issue
The `cleaned_external_ids()` function at `src/store/tasks.rs:1450` didn't filter NULL values, causing SQLx to fail when decoding NULL into `String` (internal tasks have no external_id). The error was silently swallowed by `unwrap_or_default()`, leaving `already_cleaned` empty and forcing re-processing of all cleaned tasks on e

Closes #2155

---
*Task #2155 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*