### PR TITLE
bug: review path applies short backoff on billing cycle exhaustion — misses credit exhaustion detector

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1272,18 +1272,22 @@ pub(crate) async fn review_and_merge(
         );
         let err = agent_runner.classify_error(exit_code, &raw_output, &stderr);
         match &err {
-            runner::agents::AgentError::RateLimit { .. }
-            | runner::agents::AgentError::Auth { .. } => {
+            runner::agents::AgentError::RateLimit { message }
+            | runner::agents::AgentError::Auth { message } => {
                 tracing::warn!(
                     task_id = task.id.0,
                     agent = %review_agent,
                     "review agent hit rate limit — adding to cooldown"
                 );
-                runner::response::record_agent_failure_with_message(
-                    &review_agent,
-                    &err.to_string(),
-                )
-                .await;
+                if let Some(reason) = crate::engine::cooldown::detect_credit_exhaustion(message) {
+                    crate::engine::cooldown::record_credit_exhaustion(&review_agent, reason).await;
+                } else {
+                    runner::response::record_agent_failure_with_message(
+                        &review_agent,
+                        &err.to_string(),
+                    )
+                    .await;
+                }
             }
             _ => {}
         }
@@ -1347,18 +1351,28 @@ pub(crate) async fn review_and_merge(
                 if already_errored {
                     let err = agent_runner.classify_error(exit_code, &raw_output, &stderr);
                     match &err {
-                        runner::agents::AgentError::RateLimit { .. }
-                        | runner::agents::AgentError::Auth { .. } => {
+                        runner::agents::AgentError::RateLimit { message }
+                        | runner::agents::AgentError::Auth { message } => {
                             tracing::warn!(
                                 task_id = task.id.0,
                                 agent = %review_agent,
                                 "review agent hit error (from per-agent extractor) — adding to cooldown"
                             );
-                            runner::response::record_agent_failure_with_message(
-                                &review_agent,
-                                &err.to_string(),
-                            )
-                            .await;
+                            if let Some(reason) =
+                                crate::engine::cooldown::detect_credit_exhaustion(message)
+                            {
+                                crate::engine::cooldown::record_credit_exhaustion(
+                                    &review_agent,
+                                    reason,
+                                )
+                                .await;
+                            } else {
+                                runner::response::record_agent_failure_with_message(
+                                    &review_agent,
+                                    &err.to_string(),
+                                )
+                                .await;
+                            }
                         }
                         _ => {}
                     }


### PR DESCRIPTION
## Summary

Only `review.rs` was modified. The 3 test failures are in `tick.rs` and `tmux.rs` — pre-existing, unrelated to this fix.

The fix is complete. Here's a summary of what was done:

**Both error-handling sites in `src/engine/review.rs` now mirror the `fallback.rs` pattern:**

1. **Hard-failure path** (line ~1275): `RateLimit`/`Auth` match arm now destructures `message` and calls `detect_credit_exhaustion(message)` first. If it's billing cycle exhaustion → `record_credit_exhaustion()` (24h→7d 

Closes #2158

---
*Task #2158 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*