### PR TITLE
bug: emit_degraded_agents_if_needed logs duplicate WARN once per project — global state check runs in per-project loop

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1487,6 +1487,12 @@ pub async fn serve() -> anyhow::Result<()> {
                                 }
                             }).await;
                         }
+                        // Emit degraded-agents metric/log once per sync cycle (global state,
+                        // not per-project) to avoid N identical WARNs with N configured projects.
+                        if let Some(first_engine) = project_engines.first() {
+                            let r = router.read().await;
+                            sync::emit_degraded_agents_if_needed(&r, Some(&first_engine.store)).await;
+                        }
                         last_sync = std::time::Instant::now();
                     }
                 }

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -936,10 +936,6 @@ pub(crate) async fn sync_tick(
         r.refresh_health(store).await;
     }
 
-    // Emit degraded-agents metric/log if needed (best-effort)
-    let r = router.read().await;
-    emit_degraded_agents_if_needed(&r, Some(store)).await;
-
     Ok(())
 }
 
@@ -1417,7 +1413,7 @@ struct DegradedAgentDetail {
 ///   names, cooled models, cooldown reasons) and a dedicated alert metric
 ///   `metrics:orch.agents_degraded.alert` is set to `"1"`. The alert is
 ///   cleared to `"0"` when the count drops below the threshold.
-async fn emit_degraded_agents_if_needed(
+pub(crate) async fn emit_degraded_agents_if_needed(
     router: &crate::engine::router::Router,
     store: Option<&Arc<TaskStore>>,
 ) {


### PR DESCRIPTION
## Summary

The fix is clean and compiles. Here's a summary of what was changed:

**`src/engine/sync.rs`**
- Removed the `emit_degraded_agents_if_needed` call from the end of `sync_tick()` (it was being called once per project)
- Changed `async fn emit_degraded_agents_if_needed` → `pub(crate) async fn emit_degraded_agents_if_needed` so it's accessible from `mod.rs`

**`src/engine/mod.rs`**
- Added a single call to `sync::emit_degraded_agents_if_needed` after the per-project sync loop, using `project_engin

Closes #2159

---
*Task #2159 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*