### PR TITLE
bug: auto-merge logged at ERROR and misclassified for transient 'mergeability not yet computed' case

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1800,13 +1800,24 @@ pub(crate) async fn review_and_merge(
                 )
                 .await
                 {
-                    tracing::error!(
-                        task_id = task.id.0,
-                        pr_number = pr_number_early,
-                        branch = %branch_name,
-                        error = %e,
-                        "auto-merge failed"
-                    );
+                    let error_msg = e.to_string();
+                    if error_msg.contains("not yet computed") {
+                        tracing::warn!(
+                            task_id = task.id.0,
+                            pr_number = pr_number_early,
+                            branch = %branch_name,
+                            error = %e,
+                            "auto-merge deferred — PR mergeability not yet computed"
+                        );
+                    } else {
+                        tracing::error!(
+                            task_id = task.id.0,
+                            pr_number = pr_number_early,
+                            branch = %branch_name,
+                            error = %e,
+                            "auto-merge failed"
+                        );
+                    }
                     return Ok(ReviewDecision::Failed(format!("merge failed: {e}")));
                 }
             } else {

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -531,6 +531,17 @@ async fn classify_review_failure(
         return ReviewOutcome::Reset;
     }
 
+    // Transient mergeability check: GitHub hasn't finished computing yet.
+    // This is a normal, expected transient state for freshly-pushed PRs.
+    if lower_reason.contains("not yet computed") {
+        tracing::warn!(
+            task_id,
+            reason,
+            "{context} PR mergeability check still pending — deferring for retry"
+        );
+        return ReviewOutcome::Reset;
+    }
+
     // Merge conflicts are infrastructure failures, not review agent failures.
     // The merge_conflict_retries counter handles these separately.
     if lower_reason.contains("merge conflict")


### PR DESCRIPTION
## Summary

## Summary

I've successfully fixed the bug in issue #2164 where auto-merge failures due to GitHub's transient mergeability state were being logged incorrectly and misclassified as merge conflicts.

### Changes Made

**1. Fixed spurious ERROR log in `src/engine/review.rs:1789`**
- Added check to detect the "not yet computed" case
- This case now logs at WARN level (appropriate for a transient state that will resolve)
- Actual merge failures still log at ERROR level
- More accurate log message: "

Closes #2164

---
*Task #2164 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*