### PR TITLE
bug: dedup_reviews variable named 'dominated' has inverted semantics — logic trap for future refactors

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -114,10 +114,10 @@ pub(crate) fn dedup_reviews<'a>(reviews: &'a [GitHubReview]) -> HashMap<String, 
         if review.state != "APPROVED" && review.state != "CHANGES_REQUESTED" {
             continue;
         }
-        let dominated = by_reviewer
+        let is_newer_or_first = by_reviewer
             .get(&review.user.login)
             .is_none_or(|prev| review.submitted_at > prev.submitted_at);
-        if dominated {
+        if is_newer_or_first {
             by_reviewer.insert(review.user.login.clone(), review);
         }
     }


### PR DESCRIPTION
## Summary

Done. Renamed `dominated` → `is_newer_or_first` at `src/engine/auto_merge.rs:117-120`.

Closes #2178

---
*Task #2178 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*