### PR TITLE
perf: tick_dispatch_tasks spawns tmux subprocess even when dispatchable queue is empty

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -1035,15 +1035,16 @@ pub(crate) async fn tick_dispatch_tasks(
 
     if dispatchable.is_empty() {
         tracing::debug!(count = 0, "dispatchable tasks found");
-    } else {
-        tracing::info!(count = dispatchable.len(), "dispatchable tasks found");
-        if is_degraded {
-            tracing::warn!(
-                healthy_agents = healthy_count,
-                threshold = threshold,
-                "degraded mode: using sequential dispatch"
-            );
-        }
+        return Ok(());
+    }
+
+    tracing::info!(count = dispatchable.len(), "dispatchable tasks found");
+    if is_degraded {
+        tracing::warn!(
+            healthy_agents = healthy_count,
+            threshold = threshold,
+            "degraded mode: using sequential dispatch"
+        );
     }
 
     let sequential_delay = if is_degraded {


### PR DESCRIPTION
## Summary

All 2741 tests pass. The fix is clean — added `return Ok(())` in the empty-queue branch so `batch_session_active()` (which spawns `tmux list-panes -a`) is only called when there are actually tasks to dispatch.

Closes #2175

---
*Task #2175 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*