### PR TITLE
bug: block_reason fire-and-forget write before blocking enables incorrect auto-unblock cycles

### DIFF
--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -441,27 +441,32 @@ pub(crate) async fn review_open_prs(
                             retries,
                             "PR approved but merge conflict retry limit reached — blocking for human review"
                         );
-                        store_set_by_id(
+                        let fields = [
+                            (
+                                "block_reason",
+                                serde_json::json!(format!(
+                                    "merge conflict retry limit ({}) reached",
+                                    MAX_MERGE_CONFLICT_RETRIES
+                                )),
+                            ),
+                            (
+                                "last_error",
+                                serde_json::json!(format!(
+                                    "PR approved but has unresolved merge conflicts after {} retries",
+                                    retries
+                                )),
+                            ),
+                        ];
+                        if let Err(e) = store_set_result_by_id(
                             &Some(Arc::clone(store)),
                             task_info.store_id,
-                            &[
-                                (
-                                    "block_reason",
-                                    serde_json::json!(format!(
-                                        "merge conflict retry limit ({}) reached",
-                                        MAX_MERGE_CONFLICT_RETRIES
-                                    )),
-                                ),
-                                (
-                                    "last_error",
-                                    serde_json::json!(format!(
-                                        "PR approved but has unresolved merge conflicts after {} retries",
-                                        retries
-                                    )),
-                                ),
-                            ],
+                            &fields,
                         )
-                        .await;
+                        .await
+                        {
+                            tracing::error!(task_id, err = %e, "failed to write block_reason — skipping block to avoid silent auto-unblock loop");
+                            continue;
+                        }
                         if let Err(e) = task_manager
                             .update_task_status(&task.id, Status::Blocked)
                             .await

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -815,25 +815,32 @@ pub(crate) async fn sync_tick(
                     new_refires,
                     "escalating NeedsReview task to Blocked after repeated refires"
                 );
-                // Write block reason and last_error (best-effort)
-                crate::store::store_set(
+                // Write block reason and last_error — must succeed before blocking
+                // to prevent the auto-unblock loop (block_reason.is_none() gate in
+                // auto_unblock_blocked_tasks would otherwise re-dispatch the task).
+                let fields = [
+                    (
+                        "block_reason",
+                        serde_json::json!(
+                            "review agent rebroadcast escalated after repeated retries"
+                        ),
+                    ),
+                    (
+                        "last_error",
+                        serde_json::json!(format!("escalated after {} retries", new_refires)),
+                    ),
+                ];
+                if let Err(e) = crate::store::store_set_result(
                     &Some(Arc::clone(store)),
                     repo,
                     task.task_id(),
-                    &[
-                        (
-                            "block_reason",
-                            serde_json::json!(
-                                "review agent rebroadcast escalated after repeated retries"
-                            ),
-                        ),
-                        (
-                            "last_error",
-                            serde_json::json!(format!("escalated after {} retries", new_refires)),
-                        ),
-                    ],
+                    &fields,
                 )
-                .await;
+                .await
+                {
+                    tracing::error!(task_id = task.task_id(), err = %e, "failed to write block_reason — skipping block to avoid silent auto-unblock loop");
+                    continue;
+                }
                 if let Err(e) = task_manager
                     .update_task_status(&task.external.id, Status::Blocked)
                     .await


### PR DESCRIPTION
## Summary

All 2741 tests pass. The fix is clean.

**Summary of changes:**

- **`src/engine/review_poll.rs:444-471`**: Replaced fire-and-forget `store_set_by_id` with `store_set_result_by_id`. If the write fails, logs an error and `continue`s (skips the block) instead of proceeding to `Status::Blocked` with a `NULL` `block_reason`.

- **`src/engine/sync.rs:819-843`**: Same pattern — replaced `crate::store::store_set` (fire-and-forget) with `crate::store::store_set_result`. Updated the comment to explain 

Closes #2176

---
*Task #2176 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*