### PR TITLE
bug: router LLM pool exhausts and forces fallback routing for scheduled tasks

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -798,10 +798,12 @@ impl Router {
                     if let Some(err) = e.downcast_ref::<AllCooledError>() {
                         let scope = err.scope.as_str();
                         tracing::warn!(scope = %scope, "router cooldown gate tripped");
-                        let scope_opt = if scope == "all agents" {
-                            None
-                        } else {
-                            Some(scope)
+                        // "router pool" scope means all router LLM pool entries were pre-cooled.
+                        // Pass None so wait_for_cooldown queries all agent+model cooldowns generically
+                        // (no complexity-specific pool lookup, which would fail for "router pool").
+                        let scope_opt = match scope {
+                            "all agents" | "router pool" => None,
+                            _ => Some(scope),
                         };
                         self.wait_for_cooldown(scope_opt).await?;
                         continue;


### PR DESCRIPTION
## Summary

## Summary

**Root cause**: In `route_with_llm()` (mod.rs:924), when all router LLM pool entries were pre-cooled, the loop would skip all entries and immediately return an "all pool entries exhausted" error with no cooldown gate. This caused every subsequent scheduled task to cascade into fallback round-robin routing — not because the router was unhealthy, but because no cooldown gate existed between iterations.

**Fix** (2 changes to `src/engine/router/mod.rs`):

1. **Added `attempted_any` fl

Closes #2183

---
*Task #2183 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*