### PR TITLE
prompt: review_task.md lacks concrete output examples — agents trigger multi-layer parse fallbacks

### DIFF
--- a/prompts/review_task.md
+++ b/prompts/review_task.md
@@ -97,6 +97,18 @@ Do NOT respond with prose summaries.
 }
 ```
 
+### Examples
+
+**Example 1: Approve with no issues**
+```json
+{"decision":"approve","notes":"CI passes, code follows existing patterns, no issues found.","test_results":"pass","issues":[]}
+```
+
+**Example 2: Request changes with issues**
+```json
+{"decision":"request_changes","notes":"Off-by-one in loop bound causes panic on empty input.","test_results":"fail","issues":[{"file":"src/engine/tick.rs","line":142,"severity":"error","description":"Loop iterates to `len` instead of `len-1`, causing index-out-of-bounds on the last element."}]}
+```
+
 Decision rules:
 - **approve**: Required GitHub CI checks pass, branch is rebased, code meets requirements, no major issues
 - **request_changes**: Required GitHub CI checks fail on PR-related code, there are bugs, scope creep, or the code doesn't meet requirements


### PR DESCRIPTION
## Summary

✅ **Complete!** 

I've successfully added two concrete JSON examples to `prompts/review_task.md` immediately after the schema block:

**Changes made:**
- **Example 1** — Approve with no issues: Shows minimal valid response with empty `issues: []` array
- **Example 2** — Request changes with issues: Shows substantive feedback with detailed issue objects

**Why this fixes the problem:**
The original prompt showed only the schema without concrete instances. This forced agents to infer the for

Closes #2187

---
*Task #2187 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*