### PR TITLE
bug: orch task publish loses issue linkage and marks the source task done

### DIFF
--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -673,7 +673,8 @@ impl TaskManager {
             .backend
             .create_task(&task.title, &task.body, labels)
             .await?;
-        store.update_status(id, TaskStatus::Done).await?;
+        store.update_external_id(id, &ext_id.0).await?;
+        store.update_status(id, TaskStatus::New).await?;
         Ok(ext_id)
     }
 }

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -561,6 +561,18 @@ impl TaskStore {
         Ok(())
     }
 
+    /// Persist the external_id (e.g. a newly-created GitHub issue number) onto an existing task row.
+    pub async fn update_external_id(&self, id: i64, external_id: &str) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE tasks SET external_id = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?",
+        )
+        .bind(external_id)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Conditionally update the status of a task only if it currently has `expected` status.
     ///
     /// Returns `true` if the row was updated, `false` if the current status did not match


### PR DESCRIPTION
## Summary

All 2747 tests pass. The fix is done.

**Changes made:**

1. **`src/store/tasks.rs`** — Added `update_external_id(id, external_id)` method that persists the GitHub issue ID onto the existing task row.

2. **`src/engine/tasks.rs:672-677`** — In `publish_task()`, after `backend.create_task()` succeeds:
   - Call `store.update_external_id()` to link the local task to the created GitHub issue
   - Transition status to `New` (instead of `Done`) so the engine picks it up and routes it normally

Th

Closes #2190

---
*Task #2190 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*