### PR TITLE
refactor: decompose review_and_merge into testable phases — 1490-line monolith blocks safe review pipeline changes

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -114,6 +114,1195 @@ enum EnsurePrResult {
     EarlyReturn(ReviewDecision),
 }
 
+enum ReviewPhase<T> {
+    Ready(T),
+    EarlyReturn(ReviewDecision),
+}
+
+struct ReviewContext {
+    store_id: Option<i64>,
+    had_prev_push_failure: bool,
+    review_attempt: u32,
+    worktree_path: std::path::PathBuf,
+    branch_name: String,
+    pr_number: u64,
+    default_branch: String,
+    review_agent: String,
+    review_model: Option<String>,
+    review_task_id: String,
+    review_attempt_dir: std::path::PathBuf,
+    output_file: std::path::PathBuf,
+    invocation: runner::agent::AgentInvocation,
+}
+
+impl ReviewContext {
+    fn review_model_str(&self) -> &str {
+        self.review_model.as_deref().unwrap_or("")
+    }
+}
+
+struct ReviewRun {
+    run_id: Option<i64>,
+}
+
+struct ParsedReview {
+    run_id: Option<i64>,
+    exit_code: i32,
+    stderr: String,
+    raw_output: String,
+    text_for_review: String,
+    token_usage: RunTokenUsage,
+    review_notes_for_comment: String,
+    decision: ReviewDecision,
+}
+
+fn build_review_disallowed_tools(worktree_path: &std::path::Path) -> Vec<String> {
+    let mut tools = vec![
+        "Bash(rm *)".to_string(),
+        "Bash(rm -*)".to_string(),
+        "Bash(git push*)".to_string(),
+    ];
+    let orch_yml = worktree_path.join(".orch.yml");
+    let orch_yml_str = orch_yml.to_string_lossy();
+    tools.extend([
+        format!("Write({orch_yml_str})"),
+        format!("Edit({orch_yml_str})"),
+    ]);
+    if let Ok(orch_home) = crate::home::orch_home() {
+        for path in [
+            orch_home.join("config.yml"),
+            orch_home.join("config.example.yml"),
+        ] {
+            let path_str = path.to_string_lossy();
+            tools.extend([
+                format!("Read({path_str})"),
+                format!("Write({path_str})"),
+                format!("Edit({path_str})"),
+            ]);
+        }
+    }
+    tools
+}
+
+async fn select_review_agent(
+    task_id: &str,
+    task_agent: &str,
+    store_id: Option<i64>,
+    router: &Arc<RwLock<Router>>,
+    store: &Arc<TaskStore>,
+) -> (String, Option<String>) {
+    let mut exclude_set: HashSet<String> = HashSet::new();
+    if !task_agent.is_empty() {
+        exclude_set.insert(task_agent.to_string());
+    }
+    if let Some(store_id) = store_id {
+        if let Ok(failed) = store.previous_review_agents(store_id).await {
+            for agent in failed {
+                exclude_set.insert(agent);
+            }
+        }
+    }
+
+    let mut r = router.write().await;
+    let mut tried_agents: HashSet<String> = HashSet::new();
+    let mut chosen_agent: Option<String> = None;
+    let mut chosen_model: Option<String> = None;
+    let available_count = r.available_agents.len().max(1);
+
+    loop {
+        let tmp_exclude_refs: Vec<&str> = exclude_set.iter().map(|s| s.as_str()).collect();
+        let agent = match r.next_round_robin_agent(&tmp_exclude_refs) {
+            Some(a) => a,
+            None => break,
+        };
+
+        if tried_agents.contains(&agent) {
+            break;
+        }
+        tried_agents.insert(agent.clone());
+
+        let model = r.config.model_for_complexity(&agent, "review", task_id);
+        if model.is_some() {
+            chosen_agent = Some(agent);
+            chosen_model = model;
+            break;
+        }
+
+        exclude_set.insert(agent);
+        if exclude_set.len() >= available_count {
+            break;
+        }
+    }
+
+    if let Some(agent) = chosen_agent {
+        (agent, chosen_model)
+    } else {
+        let final_exclude_refs: Vec<&str> = exclude_set.iter().map(|s| s.as_str()).collect();
+        let fallback_agent = r
+            .next_round_robin_agent(&final_exclude_refs)
+            .unwrap_or_else(|| "claude".to_string());
+        let fallback_model = r
+            .config
+            .model_for_complexity(&fallback_agent, "review", task_id);
+        (fallback_agent, fallback_model)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn build_review_context(
+    task: &ExternalTask,
+    repo: &str,
+    router: &Arc<RwLock<Router>>,
+    task_manager: &Arc<TaskManager>,
+    store: &Arc<TaskStore>,
+) -> anyhow::Result<ReviewPhase<ReviewContext>> {
+    let stored_task = store
+        .get_by_external_id(repo, &task.id.0)
+        .await
+        .with_context(|| format!("store lookup failed for task {}", task.id.0))?;
+
+    let store_id: Option<i64> = stored_task.as_ref().map(|t| t.id);
+    let had_prev_push_failure = stored_task
+        .as_ref()
+        .is_some_and(|t| t.last_error.contains("push failed"));
+    let review_attempt: u32 = match store_increment(
+        &Some(Arc::clone(store)),
+        repo,
+        &task.id.0,
+        "review_invocations",
+    )
+    .await
+    {
+        Ok(v) => v as u32,
+        Err(e) => {
+            tracing::warn!(task_id = task.id.0, err = %e, "failed to increment review_invocations — using fallback attempt=1");
+            1
+        }
+    };
+
+    let mut worktree_path = match stored_task.as_ref().map(|t| t.worktree.as_str()) {
+        Some(w) if !w.is_empty() => std::path::PathBuf::from(w),
+        _ => {
+            tracing::warn!(task_id = task.id.0, "no worktree found for review");
+            return Ok(ReviewPhase::EarlyReturn(ReviewDecision::Failed(
+                "no worktree found".to_string(),
+            )));
+        }
+    };
+
+    let mut branch_name = match stored_task.as_ref().map(|t| t.branch.as_str()) {
+        Some(b) if !b.is_empty() => b.to_string(),
+        _ => {
+            tracing::warn!(task_id = task.id.0, "no branch found for review");
+            return Ok(ReviewPhase::EarlyReturn(ReviewDecision::Failed(
+                "no branch found".to_string(),
+            )));
+        }
+    };
+
+    let mut missing_worktree_recovered = false;
+    if !worktree_path.exists() {
+        match recover_missing_review_worktree(task, repo, store).await {
+            Ok(recovered) => {
+                branch_name = recovered.branch;
+                worktree_path = recovered.work_dir;
+                missing_worktree_recovered = true;
+            }
+            Err(e) => {
+                let reason = format!("missing review worktree recovery failed: {e}");
+                tracing::error!(task_id = task.id.0, error = %reason, "cannot recover review worktree");
+                store_set(
+                    &Some(Arc::clone(store)),
+                    repo,
+                    &task.id.0,
+                    &[("last_error", serde_json::json!(reason.clone()))],
+                )
+                .await;
+                return Ok(ReviewPhase::EarlyReturn(ReviewDecision::Blocked(reason)));
+            }
+        }
+    }
+
+    if missing_worktree_recovered {
+        store_set(
+            &Some(Arc::clone(store)),
+            repo,
+            &task.id.0,
+            &[("last_error", serde_json::json!(""))],
+        )
+        .await;
+    }
+
+    let agent_summary = stored_task
+        .as_ref()
+        .map(|t| t.summary.clone())
+        .unwrap_or_default();
+    let stored_pr_number = stored_task
+        .as_ref()
+        .and_then(|t| t.pr_number)
+        .map(|n| n as u64)
+        .filter(|&n| n > 0);
+
+    let pr_number = match ensure_pr_exists(
+        task,
+        &branch_name,
+        &worktree_path,
+        repo,
+        &agent_summary,
+        store,
+        task_manager,
+        stored_pr_number,
+    )
+    .await?
+    {
+        EnsurePrResult::Ready(n) => n,
+        EnsurePrResult::EarlyReturn(decision) => return Ok(ReviewPhase::EarlyReturn(decision)),
+    };
+
+    if let Err(e) = Command::new("git")
+        .args(["fetch", "origin", "--prune"])
+        .current_dir(&worktree_path)
+        .output_with_context()
+        .await
+    {
+        tracing::warn!(
+            task_id = task.id.0,
+            error = %e,
+            "review: git fetch failed — diff/log may use stale remote refs"
+        );
+    }
+
+    let default_branch = runner::worktree::detect_default_branch(&worktree_path).await;
+    let git_diff = runner::context::build_git_diff(&worktree_path, &default_branch).await;
+    let git_log = runner::context::build_git_log(&worktree_path, &default_branch).await;
+    let review_prompt = runner::agent::build_review_prompt(
+        task,
+        &agent_summary,
+        &git_diff,
+        &git_log,
+        &default_branch,
+        pr_number,
+    );
+
+    let task_agent = stored_task
+        .as_ref()
+        .and_then(|t| t.agent.clone())
+        .unwrap_or_default();
+    let (review_agent, review_model) =
+        select_review_agent(&task.id.0, &task_agent, store_id, router, store).await;
+
+    tracing::info!(
+        task_id = task.id.0,
+        agent = %review_agent,
+        model = ?review_model,
+        "spawning review agent"
+    );
+
+    let review_task_id = format!("{}-review", task.id.0);
+    let review_attempt_dir =
+        crate::home::task_attempt_dir_async(repo, &review_task_id, review_attempt).await?;
+    let output_file = review_attempt_dir.join("output.json");
+
+    let git_name =
+        crate::config::get("git.name").unwrap_or_else(|_| format!("{review_agent}[bot]"));
+    let git_email = crate::config::get("git.email")
+        .unwrap_or_else(|_| format!("{review_agent}[bot]@users.noreply.github.com"));
+    let review_timeout_secs: u64 = crate::config::get("workflow.review_timeout_seconds")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| {
+            crate::config::get("workflow.timeout_seconds")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(1800)
+        })
+        .max(1800);
+
+    let invocation = runner::agent::AgentInvocation {
+        agent: review_agent.clone(),
+        model: review_model.clone(),
+        work_dir: worktree_path.clone(),
+        system_prompt: runner::agent::review_system_prompt(),
+        agent_message: review_prompt,
+        task_id: review_task_id.clone(),
+        disallowed_tools: build_review_disallowed_tools(&worktree_path),
+        git_author_name: git_name,
+        git_author_email: git_email,
+        output_file: output_file.clone(),
+        timeout_seconds: review_timeout_secs,
+        repo: repo.to_string(),
+        attempt: review_attempt,
+    };
+
+    Ok(ReviewPhase::Ready(ReviewContext {
+        store_id,
+        had_prev_push_failure,
+        review_attempt,
+        worktree_path,
+        branch_name,
+        pr_number,
+        default_branch,
+        review_agent,
+        review_model,
+        review_task_id,
+        review_attempt_dir,
+        output_file,
+        invocation,
+    }))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn complete_review_run(
+    store: &Arc<TaskStore>,
+    run_id: Option<i64>,
+    exit_code: Option<i32>,
+    stdout: &str,
+    stderr: &str,
+    parsed: &str,
+    outcome: &str,
+    error: &str,
+    tokens: RunTokenUsage,
+) {
+    if let Some(run_id) = run_id {
+        let _ = store
+            .complete_run(&CompleteRun {
+                run_id,
+                exit_code,
+                stdout,
+                stderr,
+                parsed,
+                outcome,
+                error,
+                tokens,
+            })
+            .await;
+    }
+}
+
+async fn invoke_review_agent(
+    task: &ExternalTask,
+    tmux: &Arc<TmuxManager>,
+    ctx: &ReviewContext,
+    repo: &str,
+    store: &Arc<TaskStore>,
+) -> ReviewPhase<ReviewRun> {
+    let run_id = if let Some(sid) = ctx.store_id {
+        store
+            .start_run(&StartRun {
+                task_id: sid,
+                attempt: ctx.review_attempt as i32,
+                run_type: "review",
+                agent: &ctx.review_agent,
+                model: ctx.review_model.as_deref().unwrap_or(""),
+                command: "",
+                prompt: "",
+            })
+            .await
+            .ok()
+    } else {
+        None
+    };
+
+    let session = match runner::agent::spawn_in_tmux(tmux, &ctx.invocation).await {
+        Ok(session) => session,
+        Err(e) => {
+            tracing::error!(task_id = task.id.0, error = %e, "failed to spawn review agent");
+            return ReviewPhase::EarlyReturn(ReviewDecision::Failed(format!("spawn failed: {e}")));
+        }
+    };
+
+    let start_comment = review_started_comment(&ctx.review_agent, ctx.review_model_str());
+    match GhHttp::new() {
+        Ok(gh) => {
+            if let Err(e) = gh
+                .add_comment(repo, &ctx.pr_number.to_string(), &start_comment)
+                .await
+            {
+                tracing::debug!(
+                    task_id = task.id.0,
+                    pr_number = ctx.pr_number,
+                    error = %e,
+                    "failed to post review-started comment"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::debug!(
+                task_id = task.id.0,
+                pr_number = ctx.pr_number,
+                error = %e,
+                "failed to create GitHub client for review-started comment"
+            );
+        }
+    }
+
+    let poll_interval = std::time::Duration::from_secs(5);
+    let timeout_duration = std::time::Duration::from_secs(ctx.invocation.timeout_seconds);
+    let wait_result = tokio::time::timeout(
+        timeout_duration,
+        tmux.wait_for_completion(&session, poll_interval),
+    )
+    .await;
+
+    match wait_result {
+        Ok(Ok(_)) => {
+            tracing::info!(task_id = task.id.0, "review agent completed");
+            let _ = tmux.kill_session(&session).await;
+            ReviewPhase::Ready(ReviewRun { run_id })
+        }
+        Ok(Err(e)) => {
+            tracing::error!(task_id = task.id.0, error = %e, "review agent error");
+            let _ = tmux.kill_session(&session).await;
+            complete_review_run(
+                store,
+                run_id,
+                Some(-1),
+                "",
+                &e.to_string(),
+                "",
+                "failed",
+                &format!("agent error: {e}"),
+                RunTokenUsage::default(),
+            )
+            .await;
+            ReviewPhase::EarlyReturn(ReviewDecision::Failed(format!("agent error: {e}")))
+        }
+        Err(_) => {
+            tracing::error!(task_id = task.id.0, "review agent timed out");
+            let _ = tmux.kill_session(&session).await;
+            complete_review_run(
+                store,
+                run_id,
+                Some(-1),
+                "",
+                "timeout",
+                "",
+                "timeout",
+                "timeout",
+                RunTokenUsage::default(),
+            )
+            .await;
+            ReviewPhase::EarlyReturn(ReviewDecision::Failed("timeout".to_string()))
+        }
+    }
+}
+
+async fn record_review_agent_failure(
+    task_id: &str,
+    review_agent: &str,
+    err: &runner::agents::AgentError,
+) {
+    match err {
+        runner::agents::AgentError::RateLimit { message }
+        | runner::agents::AgentError::Auth { message } => {
+            tracing::warn!(
+                task_id,
+                agent = %review_agent,
+                "review agent hit error — adding to cooldown"
+            );
+            if let Some(reason) = crate::engine::cooldown::detect_credit_exhaustion(message) {
+                crate::engine::cooldown::record_credit_exhaustion(review_agent, reason).await;
+            } else {
+                runner::response::record_agent_failure_with_message(review_agent, &err.to_string())
+                    .await;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn review_decision_from_response(
+    review_response: runner::response::ReviewResponse,
+) -> ReviewDecision {
+    match review_response.decision.as_str() {
+        "approve" => ReviewDecision::Approve,
+        "request_changes" => ReviewDecision::RequestChanges {
+            notes: review_response.notes,
+            issues: review_response.issues,
+        },
+        _ => ReviewDecision::Failed(format!("unknown decision: {}", review_response.decision)),
+    }
+}
+
+fn review_decision_name(decision: &ReviewDecision) -> &'static str {
+    match decision {
+        ReviewDecision::Approve => "approve",
+        ReviewDecision::RequestChanges { .. } => "request_changes",
+        ReviewDecision::Failed(_) => "failed",
+        ReviewDecision::Blocked(_) => "blocked",
+        ReviewDecision::Skipped => "skipped",
+    }
+}
+
+async fn parse_review_output(
+    task: &ExternalTask,
+    repo: &str,
+    ctx: &ReviewContext,
+    run: ReviewRun,
+    store: &Arc<TaskStore>,
+) -> ReviewPhase<ParsedReview> {
+    let (file_exists, file_size, exit_code, stderr) = {
+        let output_file_clone = ctx.output_file.clone();
+        let review_attempt_dir_clone = ctx.review_attempt_dir.clone();
+        match tokio::task::spawn_blocking(move || {
+            let file_exists = output_file_clone.exists();
+            let file_size = std::fs::metadata(&output_file_clone)
+                .map(|m| m.len())
+                .unwrap_or(0);
+            let exit_code = std::fs::read_to_string(review_attempt_dir_clone.join("exit.txt"))
+                .ok()
+                .and_then(|s| s.trim().parse::<i32>().ok())
+                .unwrap_or(-1);
+            let stderr = std::fs::read_to_string(review_attempt_dir_clone.join("stderr.txt"))
+                .unwrap_or_default();
+            (file_exists, file_size, exit_code, stderr)
+        })
+        .await
+        {
+            Ok(tuple) => tuple,
+            Err(e) => {
+                tracing::error!(
+                    task_id = task.id.0,
+                    error = %e,
+                    "spawn_blocking panicked reading review output metadata"
+                );
+                (false, 0, -1, format!("spawn_blocking failed: {e}"))
+            }
+        }
+    };
+
+    tracing::info!(
+        task_id = task.id.0,
+        path = %ctx.output_file.display(),
+        file_exists,
+        file_size,
+        "reading review agent output"
+    );
+
+    let raw_output =
+        runner::response::read_output_file(&ctx.review_task_id, &ctx.output_file, repo).await;
+    let agent_runner = runner::agents::get_runner(&ctx.review_agent);
+    let agent_result_for_tokens = runner::agents::find_agent_result(&ctx.review_agent, &raw_output);
+    let token_usage = RunTokenUsage {
+        input_tokens: agent_result_for_tokens
+            .as_ref()
+            .and_then(|r| r.input_tokens)
+            .unwrap_or(0),
+        output_tokens: agent_result_for_tokens
+            .as_ref()
+            .and_then(|r| r.output_tokens)
+            .unwrap_or(0),
+        total_cost_usd: agent_result_for_tokens
+            .as_ref()
+            .and_then(|r| r.cost_usd)
+            .unwrap_or(0.0),
+        duration_secs: 0.0,
+    };
+
+    let result_is_error = raw_output
+        .lines()
+        .rev()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .find(|value| value.get("type").and_then(|t| t.as_str()) == Some("result"))
+        .and_then(|value| value.get("is_error").and_then(|e| e.as_bool()))
+        .unwrap_or(false);
+    let agent_result_is_error = agent_result_for_tokens
+        .as_ref()
+        .map(|r| r.is_error)
+        .unwrap_or(false);
+    let is_hard_failure = raw_output.is_empty() || result_is_error || agent_result_is_error;
+
+    if is_hard_failure {
+        tracing::warn!(
+            task_id = task.id.0,
+            exit_code,
+            raw_output_len = raw_output.len(),
+            stderr_len = stderr.len(),
+            "review agent: entering error path"
+        );
+        let err = agent_runner.classify_error(exit_code, &raw_output, &stderr);
+        record_review_agent_failure(&task.id.0, &ctx.review_agent, &err).await;
+        tracing::error!(task_id = task.id.0, error = %err, "review agent failed");
+        complete_review_run(
+            store,
+            run.run_id,
+            Some(exit_code),
+            &raw_output,
+            &stderr,
+            "",
+            outcome_for_agent_error(&err),
+            &err.to_string(),
+            token_usage,
+        )
+        .await;
+        return ReviewPhase::EarlyReturn(ReviewDecision::Failed(format!("agent error: {err}")));
+    }
+
+    let text_for_review = agent_result_for_tokens
+        .as_ref()
+        .map(|r| r.result_text.clone())
+        .filter(|text| !text.is_empty())
+        .unwrap_or_else(|| {
+            tracing::debug!(
+                task_id = task.id.0,
+                agent = %ctx.review_agent,
+                "review agent: per-agent extractor returned no text, using raw output"
+            );
+            raw_output.clone()
+        });
+
+    let review_response = match runner::response::parse_review_response(&text_for_review) {
+        Ok(response) => response,
+        Err(e) => {
+            if let Some(response) = runner::response::infer_review_response(&text_for_review) {
+                tracing::warn!(
+                    task_id = task.id.0,
+                    agent = %ctx.review_agent,
+                    "review response parsed via keyword fallback"
+                );
+                response
+            } else {
+                let already_errored = agent_result_for_tokens
+                    .as_ref()
+                    .map(|r| r.is_error)
+                    .unwrap_or(false);
+                if already_errored {
+                    let err = agent_runner.classify_error(exit_code, &raw_output, &stderr);
+                    record_review_agent_failure(&task.id.0, &ctx.review_agent, &err).await;
+                    tracing::error!(
+                        task_id = task.id.0,
+                        error = %err,
+                        "review agent error from per-agent extractor"
+                    );
+                    complete_review_run(
+                        store,
+                        run.run_id,
+                        Some(exit_code),
+                        &raw_output,
+                        &stderr,
+                        &text_for_review,
+                        outcome_for_agent_error(&err),
+                        &format!("per-agent error: {err}"),
+                        token_usage,
+                    )
+                    .await;
+                    return ReviewPhase::EarlyReturn(ReviewDecision::Failed(format!(
+                        "per-agent error: {err}"
+                    )));
+                }
+
+                if let Some(runner::agents::AgentError::RateLimit { message }) =
+                    runner::agents::patterns::detect_rate_limit(&text_for_review)
+                {
+                    tracing::warn!(
+                        task_id = task.id.0,
+                        agent = %ctx.review_agent,
+                        "review agent hit rate limit — adding to cooldown"
+                    );
+                    runner::response::record_agent_failure_with_message(
+                        &ctx.review_agent,
+                        &message,
+                    )
+                    .await;
+                    complete_review_run(
+                        store,
+                        run.run_id,
+                        Some(exit_code),
+                        &raw_output,
+                        &stderr,
+                        &text_for_review,
+                        "rate_limit",
+                        &format!("rate limit: {message}"),
+                        token_usage,
+                    )
+                    .await;
+                    return ReviewPhase::EarlyReturn(ReviewDecision::Failed(format!(
+                        "rate limit: {message}"
+                    )));
+                }
+
+                if let Some(runner::agents::AgentError::Auth { message }) =
+                    runner::agents::patterns::detect_auth_error(&text_for_review)
+                {
+                    tracing::warn!(
+                        task_id = task.id.0,
+                        agent = %ctx.review_agent,
+                        "review agent hit auth error — adding to cooldown"
+                    );
+                    runner::response::record_agent_failure_with_message(
+                        &ctx.review_agent,
+                        &message,
+                    )
+                    .await;
+                    complete_review_run(
+                        store,
+                        run.run_id,
+                        Some(exit_code),
+                        &raw_output,
+                        &stderr,
+                        &text_for_review,
+                        "auth_error",
+                        &format!("auth error: {message}"),
+                        token_usage,
+                    )
+                    .await;
+                    return ReviewPhase::EarlyReturn(ReviewDecision::Failed(format!(
+                        "auth error: {message}"
+                    )));
+                }
+
+                tracing::error!(
+                    task_id = task.id.0,
+                    error = %e,
+                    agent = %ctx.review_agent,
+                    output = %text_for_review.chars().take(300).collect::<String>(),
+                    raw_output = %raw_output.chars().take(1000).collect::<String>(),
+                    "failed to parse review response"
+                );
+                complete_review_run(
+                    store,
+                    run.run_id,
+                    Some(exit_code),
+                    &raw_output,
+                    &stderr,
+                    &text_for_review,
+                    "parse_error",
+                    &format!("parse error: {e}"),
+                    token_usage,
+                )
+                .await;
+                return ReviewPhase::EarlyReturn(ReviewDecision::Failed(format!(
+                    "parse error: {e}"
+                )));
+            }
+        }
+    };
+
+    let review_notes_for_comment = review_response.notes.clone();
+    let decision = review_decision_from_response(review_response);
+
+    tracing::info!(
+        task_id = task.id.0,
+        pr_number = ctx.pr_number,
+        decision = ?decision,
+        "review agent decision received"
+    );
+    store_log_activity(
+        &Some(Arc::clone(store)),
+        repo,
+        &task.id.0,
+        "review_decision",
+        None,
+        None,
+        Some(&ctx.review_agent),
+        ctx.review_model.as_deref(),
+        Some(&serde_json::json!({
+            "decision": review_decision_name(&decision),
+            "pr_number": ctx.pr_number,
+        })),
+    )
+    .await;
+
+    ReviewPhase::Ready(ParsedReview {
+        run_id: run.run_id,
+        exit_code,
+        stderr,
+        raw_output,
+        text_for_review,
+        token_usage,
+        review_notes_for_comment,
+        decision,
+    })
+}
+
+async fn finalize_review_run(
+    task: &ExternalTask,
+    ctx: &ReviewContext,
+    parsed: &ParsedReview,
+    store: &Arc<TaskStore>,
+) {
+    let outcome = match &parsed.decision {
+        ReviewDecision::Approve
+        | ReviewDecision::RequestChanges { .. }
+        | ReviewDecision::Skipped => "success",
+        ReviewDecision::Failed(_) | ReviewDecision::Blocked(_) => "failed",
+    };
+    let error = match &parsed.decision {
+        ReviewDecision::Failed(error) | ReviewDecision::Blocked(error) => error.as_str(),
+        _ => "",
+    };
+
+    complete_review_run(
+        store,
+        parsed.run_id,
+        Some(parsed.exit_code),
+        &parsed.raw_output,
+        &parsed.stderr,
+        &parsed.text_for_review,
+        outcome,
+        error,
+        parsed.token_usage,
+    )
+    .await;
+
+    if let Some(store_id) = ctx.store_id {
+        if parsed.token_usage.input_tokens > 0 || parsed.token_usage.output_tokens > 0 {
+            let model = if ctx.review_model_str().is_empty() {
+                "unknown"
+            } else {
+                ctx.review_model_str()
+            };
+            if let Err(e) = store
+                .store_tokens(
+                    store_id,
+                    parsed.token_usage.input_tokens,
+                    parsed.token_usage.output_tokens,
+                    model,
+                )
+                .await
+            {
+                tracing::warn!(
+                    task_id = task.id.0,
+                    ?e,
+                    "failed to store review agent token usage"
+                );
+            }
+        }
+    }
+}
+
+async fn restore_review_config_if_needed(
+    task_id: &str,
+    worktree_path: &std::path::Path,
+    default_branch: &str,
+) {
+    let _ = Command::new("git")
+        .args(["checkout", "HEAD", "--", ".orch.yml"])
+        .current_dir(worktree_path)
+        .status()
+        .await;
+
+    let merge_base = Command::new("git")
+        .args(["merge-base", "HEAD", default_branch])
+        .current_dir(worktree_path)
+        .output()
+        .await
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default();
+
+    if merge_base.is_empty() {
+        return;
+    }
+
+    let orch_yml_changed = Command::new("git")
+        .args([
+            "diff",
+            "--name-only",
+            &merge_base,
+            "HEAD",
+            "--",
+            ".orch.yml",
+        ])
+        .current_dir(worktree_path)
+        .output()
+        .await
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| !output.stdout.is_empty())
+        .unwrap_or(false);
+
+    if !orch_yml_changed {
+        return;
+    }
+
+    tracing::warn!(
+        task_id,
+        "review agent modified .orch.yml (forbidden); restoring to merge-base version"
+    );
+    let restore_ok = Command::new("git")
+        .args(["checkout", &merge_base, "--", ".orch.yml"])
+        .current_dir(worktree_path)
+        .status()
+        .await
+        .map(|status| status.success())
+        .unwrap_or(false);
+
+    if !restore_ok {
+        return;
+    }
+
+    let staged = Command::new("git")
+        .args(["diff", "--cached", "--name-only", "--", ".orch.yml"])
+        .current_dir(worktree_path)
+        .output()
+        .await
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| !output.stdout.is_empty())
+        .unwrap_or(false);
+
+    if staged {
+        let _ = Command::new("git")
+            .args([
+                "commit",
+                "-m",
+                "revert: restore .orch.yml (review agent must not modify project config)",
+            ])
+            .current_dir(worktree_path)
+            .status()
+            .await;
+    }
+}
+
+async fn push_review_branch(
+    task: &ExternalTask,
+    repo: &str,
+    ctx: &ReviewContext,
+    store: &Arc<TaskStore>,
+) -> Result<(), String> {
+    match runner::git_ops::push_branch(&ctx.worktree_path, &ctx.branch_name, &ctx.default_branch)
+        .await
+    {
+        Ok(_) => {
+            store_log_activity(
+                &Some(Arc::clone(store)),
+                repo,
+                &task.id.0,
+                "push",
+                None,
+                None,
+                Some(&ctx.review_agent),
+                ctx.review_model.as_deref(),
+                Some(&serde_json::json!({
+                    "status": "ok",
+                    "branch": ctx.branch_name.clone(),
+                    "default_branch": ctx.default_branch.clone(),
+                    "phase": "review",
+                })),
+            )
+            .await;
+            if ctx.had_prev_push_failure {
+                store_set(
+                    &Some(Arc::clone(store)),
+                    repo,
+                    &task.id.0,
+                    &[
+                        ("last_error", serde_json::json!("")),
+                        ("push_failures", serde_json::json!(0)),
+                    ],
+                )
+                .await;
+            }
+            Ok(())
+        }
+        Err(e) => {
+            store_log_activity(
+                &Some(Arc::clone(store)),
+                repo,
+                &task.id.0,
+                "push",
+                None,
+                None,
+                Some(&ctx.review_agent),
+                ctx.review_model.as_deref(),
+                Some(&serde_json::json!({
+                    "status": "error",
+                    "branch": ctx.branch_name.clone(),
+                    "default_branch": ctx.default_branch.clone(),
+                    "phase": "review",
+                    "error": e.to_string(),
+                })),
+            )
+            .await;
+            tracing::error!(
+                task_id = task.id.0,
+                branch = %ctx.branch_name,
+                error = %e,
+                "review push failed"
+            );
+            store_set(
+                &Some(Arc::clone(store)),
+                repo,
+                &task.id.0,
+                &[("last_error", serde_json::json!(format!("push failed: {e}")))],
+            )
+            .await;
+            Err(e.to_string())
+        }
+    }
+}
+
+fn build_pr_review_comment(decision: &ReviewDecision, review_notes_for_comment: &str) -> String {
+    match decision {
+        ReviewDecision::Approve => {
+            format!(
+                "## Automated Review \u{2014} Approve\n\n{}",
+                review_notes_for_comment
+            )
+        }
+        ReviewDecision::RequestChanges { notes, issues } => {
+            let mut body = format!(
+                "## Automated Review \u{2014} Changes Requested\n\n{}\n",
+                notes
+            );
+            if !issues.is_empty() {
+                body.push_str("\n**Issues Found:**\n");
+                for issue in issues {
+                    body.push_str(&format!(
+                        "- `{}` line {}: {} [{}]\n",
+                        issue.file,
+                        issue
+                            .line
+                            .map(|line| line.to_string())
+                            .unwrap_or_else(|| "?".to_string()),
+                        issue.description,
+                        issue.severity
+                    ));
+                }
+            }
+            body
+        }
+        _ => String::new(),
+    }
+}
+
+async fn post_review_comment(
+    task: &ExternalTask,
+    repo: &str,
+    ctx: &ReviewContext,
+    decision: &ReviewDecision,
+    review_notes_for_comment: &str,
+) -> anyhow::Result<()> {
+    let gh = GhHttp::new()?;
+    let pr_comment = build_pr_review_comment(decision, review_notes_for_comment);
+
+    if !pr_comment.is_empty() {
+        let footer =
+            attribution_footer("Reviewed", &ctx.review_agent, Some(ctx.review_model_str()));
+        let pr_comment_with_footer = format!("{}{}", pr_comment, footer);
+        if let Err(e) = gh
+            .add_comment(repo, &ctx.pr_number.to_string(), &pr_comment_with_footer)
+            .await
+        {
+            tracing::warn!(
+                task_id = task.id.0,
+                pr_number = ctx.pr_number,
+                error = %e,
+                "failed to post automated review comment on PR"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn apply_review_decision(
+    task: &ExternalTask,
+    backend: &Arc<dyn ExternalBackend>,
+    repo: &str,
+    task_manager: &Arc<TaskManager>,
+    store: &Arc<TaskStore>,
+    ctx: &ReviewContext,
+    parsed: &ParsedReview,
+) -> anyhow::Result<ReviewDecision> {
+    restore_review_config_if_needed(&task.id.0, &ctx.worktree_path, &ctx.default_branch).await;
+
+    if let Err(e) = push_review_branch(task, repo, ctx, store).await {
+        return Ok(ReviewDecision::Failed(format!("push failed: {e}")));
+    }
+
+    post_review_comment(
+        task,
+        repo,
+        ctx,
+        &parsed.decision,
+        &parsed.review_notes_for_comment,
+    )
+    .await?;
+
+    match &parsed.decision {
+        ReviewDecision::Approve => {
+            let auto_merge = crate::config::get("workflow.auto_close_task_on_approval")
+                .or_else(|_| crate::config::get("workflow.auto_close"))
+                .or_else(|_| crate::config::get("workflow.auto_merge"))
+                .map(|value| value.eq_ignore_ascii_case("true"))
+                .unwrap_or(false);
+
+            if auto_merge {
+                if let Err(e) = auto_merge_pr(
+                    task,
+                    &ctx.branch_name,
+                    backend,
+                    repo,
+                    &ctx.review_agent,
+                    ctx.review_model_str(),
+                    task_manager,
+                    store,
+                )
+                .await
+                {
+                    let error_msg = e.to_string();
+                    if error_msg.contains("not yet computed") {
+                        tracing::warn!(
+                            task_id = task.id.0,
+                            pr_number = ctx.pr_number,
+                            branch = %ctx.branch_name,
+                            error = %e,
+                            "auto-merge deferred — PR mergeability not yet computed"
+                        );
+                    } else {
+                        tracing::error!(
+                            task_id = task.id.0,
+                            pr_number = ctx.pr_number,
+                            branch = %ctx.branch_name,
+                            error = %e,
+                            "auto-merge failed"
+                        );
+                    }
+                    return Ok(ReviewDecision::Failed(format!("merge failed: {e}")));
+                }
+            } else {
+                tracing::info!(
+                    task_id = task.id.0,
+                    pr_number = ctx.pr_number,
+                    "review approved, PR left open for human merge — marking task done"
+                );
+                if let Err(e) = task_manager
+                    .update_task_status(&task.id, Status::Done)
+                    .await
+                {
+                    tracing::error!(
+                        task_id = task.id.0,
+                        err = %e,
+                        "update_task_status(Done) failed — task may be stuck in InReview"
+                    );
+                }
+            }
+            Ok(ReviewDecision::Approve)
+        }
+        ReviewDecision::RequestChanges { notes, issues } => {
+            handle_review_changes(
+                task,
+                notes,
+                issues,
+                backend,
+                repo,
+                ctx.pr_number,
+                &ctx.review_agent,
+                ctx.review_model_str(),
+                task_manager,
+                store,
+            )
+            .await?;
+            Ok(parsed.decision.clone())
+        }
+        _ => Ok(parsed.decision.clone()),
+    }
+}
+
 async fn recover_missing_review_worktree(
     task: &ExternalTask,
     repo: &str,
@@ -780,1086 +1969,24 @@ pub(crate) async fn review_and_merge(
 ) -> anyhow::Result<ReviewDecision> {
     set_review_session_expected(store, repo, &task.id.0, true).await;
 
-    // 2. Load worktree path, branch, summary, and pr_number from store.
-    let stored_task = store
-        .get_by_external_id(repo, &task.id.0)
-        .await
-        .with_context(|| format!("store lookup failed for task {}", task.id.0))?;
-
-    let store_id: Option<i64> = stored_task.as_ref().map(|t| t.id);
-    // Snapshot push-failure state from the stored task so we can clear it after a
-    // successful push without an extra store load.
-    let had_prev_push_failure = stored_task
-        .as_ref()
-        .is_some_and(|t| t.last_error.contains("push failed"));
-    // Increment a per-invocation counter so every review agent run gets a unique
-    // attempt directory, regardless of whether a previous attempt failed without
-    // producing a `request_changes` decision (which is the only time review_cycles
-    // increments). Stale output.json files from crashed attempts can no longer be
-    // silently reused.
-    let review_attempt: u32 = {
-        match store_increment(
-            &Some(Arc::clone(store)),
-            repo,
-            &task.id.0,
-            "review_invocations",
-        )
-        .await
-        {
-            Ok(v) => v as u32,
-            Err(e) => {
-                tracing::warn!(task_id = task.id.0, err = %e, "failed to increment review_invocations — using fallback attempt=1");
-                1
-            }
-        }
+    let ctx = match build_review_context(task, repo, router, task_manager, store).await? {
+        ReviewPhase::Ready(ctx) => ctx,
+        ReviewPhase::EarlyReturn(decision) => return Ok(decision),
     };
 
-    let mut worktree_path = match stored_task.as_ref().map(|t| t.worktree.as_str()) {
-        Some(w) if !w.is_empty() => std::path::PathBuf::from(w),
-        _ => {
-            tracing::warn!(task_id = task.id.0, "no worktree found for review");
-            return Ok(ReviewDecision::Failed("no worktree found".to_string()));
-        }
+    let run = match invoke_review_agent(task, tmux, &ctx, repo, store).await {
+        ReviewPhase::Ready(run) => run,
+        ReviewPhase::EarlyReturn(decision) => return Ok(decision),
     };
 
-    let mut branch_name = match stored_task.as_ref().map(|t| t.branch.as_str()) {
-        Some(b) if !b.is_empty() => b.to_string(),
-        _ => {
-            tracing::warn!(task_id = task.id.0, "no branch found for review");
-            return Ok(ReviewDecision::Failed("no branch found".to_string()));
-        }
+    let parsed = match parse_review_output(task, repo, &ctx, run, store).await {
+        ReviewPhase::Ready(parsed) => parsed,
+        ReviewPhase::EarlyReturn(decision) => return Ok(decision),
     };
 
-    let mut missing_worktree_recovered = false;
-    if !worktree_path.exists() {
-        match recover_missing_review_worktree(task, repo, store).await {
-            Ok(recovered) => {
-                branch_name = recovered.branch;
-                worktree_path = recovered.work_dir;
-                missing_worktree_recovered = true;
-            }
-            Err(e) => {
-                let reason = format!("missing review worktree recovery failed: {e}");
-                tracing::error!(task_id = task.id.0, error = %reason, "cannot recover review worktree");
-                store_set(
-                    &Some(Arc::clone(store)),
-                    repo,
-                    &task.id.0,
-                    &[("last_error", serde_json::json!(reason.clone()))],
-                )
-                .await;
-                return Ok(ReviewDecision::Blocked(reason));
-            }
-        }
-    }
+    finalize_review_run(task, &ctx, &parsed, store).await;
 
-    if missing_worktree_recovered {
-        store_set(
-            &Some(Arc::clone(store)),
-            repo,
-            &task.id.0,
-            &[("last_error", serde_json::json!(""))],
-        )
-        .await;
-    }
-
-    let agent_summary = stored_task
-        .as_ref()
-        .map(|t| t.summary.clone())
-        .unwrap_or_default();
-
-    // 2b. Verify an open PR exists before running the (expensive) review agent.
-    let stored_pr_number = stored_task
-        .as_ref()
-        .and_then(|t| t.pr_number)
-        .map(|n| n as u64)
-        .filter(|&n| n > 0);
-
-    let pr_number_early = match ensure_pr_exists(
-        task,
-        &branch_name,
-        &worktree_path,
-        repo,
-        &agent_summary,
-        store,
-        task_manager,
-        stored_pr_number,
-    )
-    .await?
-    {
-        EnsurePrResult::Ready(n) => n,
-        EnsurePrResult::EarlyReturn(d) => return Ok(d),
-    };
-
-    // 3. Fetch latest remote refs before building diff context.
-    // Without this, build_git_diff and build_git_log operate on stale
-    // origin/{default_branch}, producing false diffs and incorrect baselines.
-    if let Err(e) = Command::new("git")
-        .args(["fetch", "origin", "--prune"])
-        .current_dir(&worktree_path)
-        .output_with_context()
-        .await
-    {
-        tracing::warn!(
-            task_id = task.id.0,
-            error = %e,
-            "review: git fetch failed — diff/log may use stale remote refs"
-        );
-    }
-
-    // 4. Build diff context
-    let default_branch = runner::worktree::detect_default_branch(&worktree_path).await;
-    let git_diff = runner::context::build_git_diff(&worktree_path, &default_branch).await;
-    let git_log = runner::context::build_git_log(&worktree_path, &default_branch).await;
-
-    // 4. Build review prompt
-    let review_prompt = runner::agent::build_review_prompt(
-        task,
-        &agent_summary,
-        &git_diff,
-        &git_log,
-        &default_branch,
-        pr_number_early,
-    );
-
-    // 5. Pick review agent via round-robin, excluding the agent that did the work
-    let task_agent = stored_task
-        .as_ref()
-        .and_then(|t| t.agent.clone())
-        .unwrap_or_default();
-    let (review_agent, review_model) = {
-        // Exclude the task agent AND any agents that previously failed review
-        // for this task, so we don't retry the same broken agent.
-        let mut exclude_set: HashSet<String> = HashSet::new();
-        if !task_agent.is_empty() {
-            exclude_set.insert(task_agent.clone());
-        }
-        if let Ok(Some(store_id)) = store.resolve_task_id(repo, &task.id.0).await {
-            if let Ok(failed) = store.previous_review_agents(store_id).await {
-                for agent in failed {
-                    exclude_set.insert(agent);
-                }
-            }
-        }
-        let mut r = router.write().await;
-        // Pick a review agent via round-robin, but skip agents whose entire
-        // model pool is currently cooled (model_for_complexity -> None).
-        // If all agents are exhausted, fall back to the first candidate and
-        // allow a None model (caller treats empty model as unspecified).
-        let mut tried_agents: HashSet<String> = HashSet::new();
-        let mut chosen_agent: Option<String> = None;
-        let mut chosen_model: Option<String> = None;
-        let available_count = r.available_agents.len().max(1);
-        loop {
-            // Build a temporary exclude slice for the round-robin helper.
-            let tmp_exclude_refs: Vec<&str> = exclude_set.iter().map(|s| s.as_str()).collect();
-            let agent = match r.next_round_robin_agent(&tmp_exclude_refs) {
-                Some(a) => a,
-                None => break,
-            };
-
-            // Avoid infinite loops — stop if we've tried every available agent
-            if tried_agents.contains(&agent) {
-                break;
-            }
-            tried_agents.insert(agent.clone());
-
-            let model = r.config.model_for_complexity(&agent, "review", &task.id.0);
-            if model.is_some() {
-                chosen_agent = Some(agent);
-                chosen_model = model;
-                break;
-            }
-
-            // Model pool for this agent is exhausted/cooled — exclude and retry
-            exclude_set.insert(agent);
-            // If we've excluded all known agents, stop searching
-            if exclude_set.len() >= available_count {
-                break;
-            }
-        }
-
-        // If no suitable agent/model pair was found, fall back to a single
-        // pick using the router's round-robin (preserves previous behaviour).
-        let (agent, model) = if let Some(a) = chosen_agent {
-            (a, chosen_model)
-        } else {
-            let final_exclude_refs: Vec<&str> = exclude_set.iter().map(|s| s.as_str()).collect();
-            let fallback_agent = r
-                .next_round_robin_agent(&final_exclude_refs)
-                .unwrap_or_else(|| "claude".to_string());
-
-            let fallback_model =
-                r.config
-                    .model_for_complexity(&fallback_agent, "review", &task.id.0);
-
-            (fallback_agent, fallback_model)
-        };
-        (agent, model)
-    };
-    // Derive a &str view for call sites that require a concrete string (e.g. attribution,
-    // activity logging). An empty string is used when no model is configured so that
-    // downstream code does not silently use a hardcoded model name.
-    let review_model_str = review_model.as_deref().unwrap_or("");
-
-    tracing::info!(
-        task_id = task.id.0,
-        agent = %review_agent,
-        model = ?review_model,
-        "spawning review agent"
-    );
-
-    // 6. Build agent invocation for review
-    let review_task_id = format!("{}-review", task.id.0);
-    let review_attempt_dir =
-        crate::home::task_attempt_dir_async(repo, &review_task_id, review_attempt).await?;
-    let output_file = review_attempt_dir.join("output.json");
-
-    let git_name =
-        crate::config::get("git.name").unwrap_or_else(|_| format!("{review_agent}[bot]"));
-    let git_email = crate::config::get("git.email")
-        .unwrap_or_else(|_| format!("{review_agent}[bot]@users.noreply.github.com"));
-
-    // Review timeout: enforce a minimum of 1800 seconds (30 minutes)
-    let review_timeout_secs: u64 = crate::config::get("workflow.review_timeout_seconds")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or_else(|| {
-            crate::config::get("workflow.timeout_seconds")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(1800)
-        })
-        .max(1800);
-
-    let system_prompt = runner::agent::review_system_prompt();
-
-    // Build sandbox rules for the review agent — mirrors task_init protections.
-    let review_disallowed_tools = {
-        let mut tools = vec![
-            "Bash(rm *)".to_string(),
-            "Bash(rm -*)".to_string(),
-            "Bash(git push*)".to_string(),
-        ];
-        // Block .orch.yml project config (settled architecture: agents must not modify it)
-        let orch_yml = worktree_path.join(".orch.yml");
-        let orch_yml_str = orch_yml.to_string_lossy();
-        tools.extend([
-            format!("Write({orch_yml_str})"),
-            format!("Edit({orch_yml_str})"),
-        ]);
-        // Block global config files
-        if let Ok(orch_home) = crate::home::orch_home() {
-            for path in [
-                orch_home.join("config.yml"),
-                orch_home.join("config.example.yml"),
-            ] {
-                let path_str = path.to_string_lossy();
-                tools.extend([
-                    format!("Read({path_str})"),
-                    format!("Write({path_str})"),
-                    format!("Edit({path_str})"),
-                ]);
-            }
-        }
-        tools
-    };
-
-    let invocation = runner::agent::AgentInvocation {
-        agent: review_agent.clone(),
-        model: review_model.clone(),
-        work_dir: worktree_path.clone(),
-        system_prompt,
-        agent_message: review_prompt,
-        task_id: review_task_id.clone(),
-        disallowed_tools: review_disallowed_tools,
-        git_author_name: git_name,
-        git_author_email: git_email,
-        output_file: output_file.clone(),
-        timeout_seconds: review_timeout_secs,
-        repo: repo.to_string(),
-        attempt: review_attempt,
-    };
-
-    // 7. Start run tracking before spawning review agent
-    let run_id = if let Some(sid) = store_id {
-        store
-            .start_run(&StartRun {
-                task_id: sid,
-                attempt: review_attempt as i32,
-                run_type: "review",
-                agent: &review_agent,
-                model: review_model.as_deref().unwrap_or(""),
-                command: "",
-                prompt: "",
-            })
-            .await
-            .ok()
-    } else {
-        None
-    };
-
-    // 8. Spawn review agent in tmux
-    let session = match runner::agent::spawn_in_tmux(tmux, &invocation).await {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::error!(task_id = task.id.0, error = %e, "failed to spawn review agent");
-            return Ok(ReviewDecision::Failed(format!("spawn failed: {e}")));
-        }
-    };
-
-    let start_comment = review_started_comment(&review_agent, review_model_str);
-    match GhHttp::new() {
-        Ok(gh) => {
-            if let Err(e) = gh
-                .add_comment(repo, &pr_number_early.to_string(), &start_comment)
-                .await
-            {
-                tracing::debug!(
-                    task_id = task.id.0,
-                    pr_number = pr_number_early,
-                    error = %e,
-                    "failed to post review-started comment"
-                );
-            }
-        }
-        Err(e) => {
-            tracing::debug!(
-                task_id = task.id.0,
-                pr_number = pr_number_early,
-                error = %e,
-                "failed to create GitHub client for review-started comment"
-            );
-        }
-    }
-
-    // 8. Wait for completion
-    let poll_interval = std::time::Duration::from_secs(5);
-    let timeout_duration = std::time::Duration::from_secs(review_timeout_secs);
-
-    let wait_result = tokio::time::timeout(
-        timeout_duration,
-        tmux.wait_for_completion(&session, poll_interval),
-    )
-    .await;
-
-    match wait_result {
-        Ok(Ok(_)) => {
-            tracing::info!(task_id = task.id.0, "review agent completed");
-            let _ = tmux.kill_session(&session).await;
-        }
-        Ok(Err(e)) => {
-            tracing::error!(task_id = task.id.0, error = %e, "review agent error");
-            let _ = tmux.kill_session(&session).await;
-            if let Some(rid) = run_id {
-                let _ = store
-                    .complete_run(&CompleteRun {
-                        run_id: rid,
-                        exit_code: Some(-1),
-                        stdout: "",
-                        stderr: &e.to_string(),
-                        parsed: "",
-                        outcome: "failed",
-                        error: &format!("agent error: {e}"),
-                        tokens: RunTokenUsage::default(),
-                    })
-                    .await;
-            }
-            return Ok(ReviewDecision::Failed(format!("agent error: {e}")));
-        }
-        Err(_) => {
-            tracing::error!(task_id = task.id.0, "review agent timed out");
-            let _ = tmux.kill_session(&session).await;
-            if let Some(rid) = run_id {
-                let _ = store
-                    .complete_run(&CompleteRun {
-                        run_id: rid,
-                        exit_code: Some(-1),
-                        stdout: "",
-                        stderr: "timeout",
-                        parsed: "",
-                        outcome: "timeout",
-                        error: "timeout",
-                        tokens: RunTokenUsage::default(),
-                    })
-                    .await;
-            }
-            return Ok(ReviewDecision::Failed("timeout".to_string()));
-        }
-    }
-
-    // 9. Read and parse response
-    let (file_exists, file_size, exit_code, stderr) = {
-        let output_file_clone = output_file.clone();
-        let review_attempt_dir_clone = review_attempt_dir.clone();
-        match tokio::task::spawn_blocking(move || {
-            let file_exists = output_file_clone.exists();
-            let file_size = std::fs::metadata(&output_file_clone)
-                .map(|m| m.len())
-                .unwrap_or(0);
-            let exit_code = std::fs::read_to_string(review_attempt_dir_clone.join("exit.txt"))
-                .ok()
-                .and_then(|s| s.trim().parse::<i32>().ok())
-                .unwrap_or(-1);
-            let stderr = std::fs::read_to_string(review_attempt_dir_clone.join("stderr.txt"))
-                .unwrap_or_default();
-            (file_exists, file_size, exit_code, stderr)
-        })
-        .await
-        {
-            Ok(tuple) => tuple,
-            Err(e) => {
-                tracing::error!(
-                    task_id = task.id.0,
-                    error = %e,
-                    "spawn_blocking panicked reading review output metadata"
-                );
-                (false, 0, -1, format!("spawn_blocking failed: {e}"))
-            }
-        }
-    };
-    tracing::info!(
-        task_id = task.id.0,
-        path = %output_file.display(),
-        file_exists,
-        file_size,
-        "reading review agent output"
-    );
-    let raw_output = runner::response::read_output_file(&review_task_id, &output_file, repo).await;
-    let agent_runner = runner::agents::get_runner(&review_agent);
-
-    // Extract token usage and agent result in one call — reused below for review parsing.
-    let agent_result_for_tokens = runner::agents::find_agent_result(&review_agent, &raw_output);
-    let agent_token_usage = RunTokenUsage {
-        input_tokens: agent_result_for_tokens
-            .as_ref()
-            .and_then(|r| r.input_tokens)
-            .unwrap_or(0),
-        output_tokens: agent_result_for_tokens
-            .as_ref()
-            .and_then(|r| r.output_tokens)
-            .unwrap_or(0),
-        total_cost_usd: agent_result_for_tokens
-            .as_ref()
-            .and_then(|r| r.cost_usd)
-            .unwrap_or(0.0),
-        duration_secs: 0.0,
-    };
-
-    // Check the NDJSON result event for is_error flag.
-    // Agents like kimi return exit 0 but is_error:true in the result event.
-    let result_is_error = raw_output
-        .lines()
-        .rev()
-        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
-        .find(|v| v.get("type").and_then(|t| t.as_str()) == Some("result"))
-        .and_then(|v| v.get("is_error").and_then(|e| e.as_bool()))
-        .unwrap_or(false);
-    // Also treat per-agent extractor is_error as a hard failure — this catches codex/opencode
-    // auth errors that emit exit 0 with is_error:true but no claude-style result event.
-    let agent_result_is_error = agent_result_for_tokens
-        .as_ref()
-        .map(|r| r.is_error)
-        .unwrap_or(false);
-    let is_hard_failure = raw_output.is_empty() || result_is_error || agent_result_is_error;
-    if is_hard_failure {
-        tracing::warn!(
-            task_id = task.id.0,
-            exit_code,
-            raw_output_len = raw_output.len(),
-            stderr_len = stderr.len(),
-            "review agent: entering error path"
-        );
-        let err = agent_runner.classify_error(exit_code, &raw_output, &stderr);
-        match &err {
-            runner::agents::AgentError::RateLimit { message }
-            | runner::agents::AgentError::Auth { message } => {
-                tracing::warn!(
-                    task_id = task.id.0,
-                    agent = %review_agent,
-                    "review agent hit rate limit — adding to cooldown"
-                );
-                if let Some(reason) = crate::engine::cooldown::detect_credit_exhaustion(message) {
-                    crate::engine::cooldown::record_credit_exhaustion(&review_agent, reason).await;
-                } else {
-                    runner::response::record_agent_failure_with_message(
-                        &review_agent,
-                        &err.to_string(),
-                    )
-                    .await;
-                }
-            }
-            _ => {}
-        }
-        tracing::error!(task_id = task.id.0, error = %err, "review agent failed");
-        if let Some(rid) = run_id {
-            let _ = store
-                .complete_run(&CompleteRun {
-                    run_id: rid,
-                    exit_code: Some(exit_code),
-                    stdout: &raw_output,
-                    stderr: &stderr,
-                    parsed: "",
-                    outcome: outcome_for_agent_error(&err),
-                    error: &err.to_string(),
-                    tokens: agent_token_usage,
-                })
-                .await;
-        }
-        return Ok(ReviewDecision::Failed(format!("agent error: {err}")));
-    }
-
-    // Step 1: reuse the agent result already extracted above for token usage.
-    // is_error cases are already handled by the hard-failure block above.
-
-    // Step 2: get the text to parse — prefer the clean result_text from the
-    // per-agent extractor; fall back to raw output if extraction yielded nothing.
-    let text_for_review = agent_result_for_tokens
-        .as_ref()
-        .map(|r| r.result_text.clone())
-        .filter(|t| !t.is_empty())
-        .unwrap_or_else(|| {
-            tracing::debug!(
-                task_id = task.id.0,
-                agent = %review_agent,
-                "review agent: per-agent extractor returned no text, using raw output"
-            );
-            raw_output.clone()
-        });
-
-    // Step 3: parse once — no fallback needed because per-agent extractors
-    // guarantee we have the clean result text.
-    let review_response = match runner::response::parse_review_response(&text_for_review) {
-        Ok(r) => r,
-        Err(e) => {
-            // Keyword heuristic fallback for plain-text decisions.
-            if let Some(r) = runner::response::infer_review_response(&text_for_review) {
-                tracing::warn!(
-                    task_id = task.id.0,
-                    agent = %review_agent,
-                    "review response parsed via keyword fallback"
-                );
-                r
-            } else {
-                // Per-agent extractor already detected is_error — use the classifier
-                // to get the proper error type (rate limit, auth, etc.) instead of
-                // re-scanning with generic pattern matchers.
-                let already_errored = agent_result_for_tokens
-                    .as_ref()
-                    .map(|r| r.is_error)
-                    .unwrap_or(false);
-                if already_errored {
-                    let err = agent_runner.classify_error(exit_code, &raw_output, &stderr);
-                    match &err {
-                        runner::agents::AgentError::RateLimit { message }
-                        | runner::agents::AgentError::Auth { message } => {
-                            tracing::warn!(
-                                task_id = task.id.0,
-                                agent = %review_agent,
-                                "review agent hit error (from per-agent extractor) — adding to cooldown"
-                            );
-                            if let Some(reason) =
-                                crate::engine::cooldown::detect_credit_exhaustion(message)
-                            {
-                                crate::engine::cooldown::record_credit_exhaustion(
-                                    &review_agent,
-                                    reason,
-                                )
-                                .await;
-                            } else {
-                                runner::response::record_agent_failure_with_message(
-                                    &review_agent,
-                                    &err.to_string(),
-                                )
-                                .await;
-                            }
-                        }
-                        _ => {}
-                    }
-                    tracing::error!(
-                        task_id = task.id.0,
-                        error = %err,
-                        "review agent error from per-agent extractor"
-                    );
-                    if let Some(rid) = run_id {
-                        let _ = store
-                            .complete_run(&CompleteRun {
-                                run_id: rid,
-                                exit_code: Some(exit_code),
-                                stdout: &raw_output,
-                                stderr: &stderr,
-                                parsed: &text_for_review,
-                                outcome: outcome_for_agent_error(&err),
-                                error: &format!("per-agent error: {err}"),
-                                tokens: agent_token_usage,
-                            })
-                            .await;
-                    }
-                    return Ok(ReviewDecision::Failed(format!("per-agent error: {err}")));
-                }
-
-                // Fall back to generic pattern detection only when the per-agent
-                // extractor didn't flag an error.
-                if let Some(runner::agents::AgentError::RateLimit { message }) =
-                    runner::agents::patterns::detect_rate_limit(&text_for_review)
-                {
-                    tracing::warn!(
-                        task_id = task.id.0,
-                        agent = %review_agent,
-                        "review agent hit rate limit — adding to cooldown"
-                    );
-                    runner::response::record_agent_failure_with_message(&review_agent, &message)
-                        .await;
-
-                    if let Some(rid) = run_id {
-                        let _ = store
-                            .complete_run(&CompleteRun {
-                                run_id: rid,
-                                exit_code: Some(exit_code),
-                                stdout: &raw_output,
-                                stderr: &stderr,
-                                parsed: &text_for_review,
-                                outcome: "rate_limit",
-                                error: &format!("rate limit: {message}"),
-                                tokens: agent_token_usage,
-                            })
-                            .await;
-                    }
-                    return Ok(ReviewDecision::Failed(format!("rate limit: {message}")));
-                }
-                if let Some(runner::agents::AgentError::Auth { message }) =
-                    runner::agents::patterns::detect_auth_error(&text_for_review)
-                {
-                    tracing::warn!(
-                        task_id = task.id.0,
-                        agent = %review_agent,
-                        "review agent hit auth error — adding to cooldown"
-                    );
-                    runner::response::record_agent_failure_with_message(&review_agent, &message)
-                        .await;
-
-                    if let Some(rid) = run_id {
-                        let _ = store
-                            .complete_run(&CompleteRun {
-                                run_id: rid,
-                                exit_code: Some(exit_code),
-                                stdout: &raw_output,
-                                stderr: &stderr,
-                                parsed: &text_for_review,
-                                outcome: "auth_error",
-                                error: &format!("auth error: {message}"),
-                                tokens: agent_token_usage,
-                            })
-                            .await;
-                    }
-                    return Ok(ReviewDecision::Failed(format!("auth error: {message}")));
-                }
-
-                tracing::error!(
-                    task_id = task.id.0,
-                    error = %e,
-                    agent = %review_agent,
-                    output = %text_for_review.chars().take(300).collect::<String>(),
-                    raw_output = %raw_output.chars().take(1000).collect::<String>(),
-                    "failed to parse review response"
-                );
-                if let Some(rid) = run_id {
-                    let _ = store
-                        .complete_run(&CompleteRun {
-                            run_id: rid,
-                            exit_code: Some(exit_code),
-                            stdout: &raw_output,
-                            stderr: &stderr,
-                            parsed: &text_for_review,
-                            outcome: "parse_error",
-                            error: &format!("parse error: {e}"),
-                            tokens: agent_token_usage,
-                        })
-                        .await;
-                }
-                return Ok(ReviewDecision::Failed(format!("parse error: {e}")));
-            }
-        }
-    };
-
-    // 10. Build automated review comment for the PR (before moving fields)
-    let review_notes_for_comment = review_response.notes.clone();
-
-    // 11. Convert to ReviewDecision
-    let decision = match review_response.decision.as_str() {
-        "approve" => ReviewDecision::Approve,
-        "request_changes" => ReviewDecision::RequestChanges {
-            notes: review_response.notes,
-            issues: review_response.issues,
-        },
-        _ => ReviewDecision::Failed(format!("unknown decision: {}", review_response.decision)),
-    };
-
-    tracing::info!(
-        task_id = task.id.0,
-        pr_number = pr_number_early,
-        decision = ?decision,
-        "review agent decision received"
-    );
-    let decision_name = match &decision {
-        ReviewDecision::Approve => "approve",
-        ReviewDecision::RequestChanges { .. } => "request_changes",
-        ReviewDecision::Failed(_) => "failed",
-        ReviewDecision::Blocked(_) => "blocked",
-        ReviewDecision::Skipped => "skipped",
-    };
-    store_log_activity(
-        &Some(Arc::clone(store)),
-        repo,
-        &task.id.0,
-        "review_decision",
-        None,
-        None,
-        Some(&review_agent),
-        review_model.as_deref(),
-        Some(&serde_json::json!({
-            "decision": decision_name,
-            "pr_number": pr_number_early,
-        })),
-    )
-    .await;
-
-    // 12a. Guard: restore .orch.yml if the review agent modified it despite the disallowed_tools
-    // fence. Defence-in-depth — the primary prevention is the disallowed_tools list above.
-    {
-        // Restore any uncommitted working-tree changes first.
-        let _ = Command::new("git")
-            .args(["checkout", "HEAD", "--", ".orch.yml"])
-            .current_dir(&worktree_path)
-            .status()
-            .await;
-
-        // Then check for committed changes since the branch diverged from the default branch.
-        let merge_base = Command::new("git")
-            .args(["merge-base", "HEAD", &default_branch])
-            .current_dir(&worktree_path)
-            .output()
-            .await
-            .ok()
-            .filter(|o| o.status.success())
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|s| s.trim().to_string())
-            .unwrap_or_default();
-
-        if !merge_base.is_empty() {
-            let orch_yml_changed = Command::new("git")
-                .args([
-                    "diff",
-                    "--name-only",
-                    &merge_base,
-                    "HEAD",
-                    "--",
-                    ".orch.yml",
-                ])
-                .current_dir(&worktree_path)
-                .output()
-                .await
-                .ok()
-                .filter(|o| o.status.success())
-                .map(|o| !o.stdout.is_empty())
-                .unwrap_or(false);
-
-            if orch_yml_changed {
-                tracing::warn!(
-                    task_id = task.id.0,
-                    "review agent modified .orch.yml (forbidden); restoring to merge-base version"
-                );
-                let restore_ok = Command::new("git")
-                    .args(["checkout", &merge_base, "--", ".orch.yml"])
-                    .current_dir(&worktree_path)
-                    .status()
-                    .await
-                    .map(|s| s.success())
-                    .unwrap_or(false);
-
-                if restore_ok {
-                    let staged = Command::new("git")
-                        .args(["diff", "--cached", "--name-only", "--", ".orch.yml"])
-                        .current_dir(&worktree_path)
-                        .output()
-                        .await
-                        .ok()
-                        .filter(|o| o.status.success())
-                        .map(|o| !o.stdout.is_empty())
-                        .unwrap_or(false);
-
-                    if staged {
-                        let _ = Command::new("git")
-                            .args([
-                                "commit",
-                                "-m",
-                                "revert: restore .orch.yml (review agent must not modify project config)",
-                            ])
-                            .current_dir(&worktree_path)
-                            .status()
-                            .await;
-                    }
-                }
-            }
-        }
-    }
-
-    // 12. Push the rebased branch before posting the review decision so the
-    // comment references code that's already on the PR.
-    match runner::git_ops::push_branch(&worktree_path, &branch_name, &default_branch).await {
-        Ok(_) => {
-            store_log_activity(
-                &Some(Arc::clone(store)),
-                repo,
-                &task.id.0,
-                "push",
-                None,
-                None,
-                Some(&review_agent),
-                review_model.as_deref(),
-                Some(&serde_json::json!({
-                    "status": "ok",
-                    "branch": branch_name.clone(),
-                    "default_branch": default_branch.clone(),
-                    "phase": "review",
-                })),
-            )
-            .await;
-            if had_prev_push_failure {
-                store_set(
-                    &Some(Arc::clone(store)),
-                    repo,
-                    &task.id.0,
-                    &[
-                        ("last_error", serde_json::json!("")),
-                        ("push_failures", serde_json::json!(0)),
-                    ],
-                )
-                .await;
-            }
-        }
-        Err(e) => {
-            store_log_activity(
-                &Some(Arc::clone(store)),
-                repo,
-                &task.id.0,
-                "push",
-                None,
-                None,
-                Some(&review_agent),
-                review_model.as_deref(),
-                Some(&serde_json::json!({
-                    "status": "error",
-                    "branch": branch_name.clone(),
-                    "default_branch": default_branch.clone(),
-                    "phase": "review",
-                    "error": e.to_string(),
-                })),
-            )
-            .await;
-            tracing::error!(
-                task_id = task.id.0,
-                branch = %branch_name,
-                error = %e,
-                "review push failed"
-            );
-            store_set(
-                &Some(Arc::clone(store)),
-                repo,
-                &task.id.0,
-                &[("last_error", serde_json::json!(format!("push failed: {e}")))],
-            )
-            .await;
-            return Ok(ReviewDecision::Failed(format!("push failed: {e}")));
-        }
-    }
-
-    // 13. Post automated review comment on the PR
-    let gh = GhHttp::new()?;
-    let pr_comment = match &decision {
-        ReviewDecision::Approve => {
-            format!(
-                "## Automated Review \u{2014} Approve\n\n{}",
-                review_notes_for_comment
-            )
-        }
-        ReviewDecision::RequestChanges { notes, issues } => {
-            let mut body = format!(
-                "## Automated Review \u{2014} Changes Requested\n\n{}\n",
-                notes
-            );
-            if !issues.is_empty() {
-                body.push_str("\n**Issues Found:**\n");
-                for issue in issues {
-                    body.push_str(&format!(
-                        "- `{}` line {}: {} [{}]\n",
-                        issue.file,
-                        issue
-                            .line
-                            .map(|l| l.to_string())
-                            .unwrap_or_else(|| "?".to_string()),
-                        issue.description,
-                        issue.severity
-                    ));
-                }
-            }
-            body
-        }
-        _ => String::new(),
-    };
-
-    if !pr_comment.is_empty() {
-        let footer = attribution_footer("Reviewed", &review_agent, Some(review_model_str));
-        let pr_comment_with_footer = format!("{}{}", pr_comment, footer);
-        if let Err(e) = gh
-            .add_comment(repo, &pr_number_early.to_string(), &pr_comment_with_footer)
-            .await
-        {
-            tracing::warn!(
-                task_id = task.id.0,
-                pr_number = pr_number_early,
-                error = %e,
-                "failed to post automated review comment on PR"
-            );
-        }
-    }
-
-    // 14. Complete run tracking
-    if let Some(run_id) = run_id {
-        let outcome = match &decision {
-            ReviewDecision::Approve => "success",
-            ReviewDecision::RequestChanges { .. } => "success",
-            ReviewDecision::Failed(_) => "failed",
-            ReviewDecision::Blocked(_) => "failed",
-            ReviewDecision::Skipped => "success",
-        };
-        let error = match &decision {
-            ReviewDecision::Failed(e) => e.as_str(),
-            ReviewDecision::Blocked(e) => e.as_str(),
-            _ => "",
-        };
-        let _ = store
-            .complete_run(&CompleteRun {
-                run_id,
-                exit_code: Some(exit_code),
-                stdout: &raw_output,
-                stderr: &stderr,
-                parsed: &text_for_review,
-                outcome,
-                error,
-                tokens: agent_token_usage,
-            })
-            .await;
-    }
-
-    // Store token usage on the task so `orch cost` reflects review agent spend.
-    if let Some(sid) = store_id {
-        if agent_token_usage.input_tokens > 0 || agent_token_usage.output_tokens > 0 {
-            let model = if review_model_str.is_empty() {
-                "unknown"
-            } else {
-                review_model_str
-            };
-            if let Err(e) = store
-                .store_tokens(
-                    sid,
-                    agent_token_usage.input_tokens,
-                    agent_token_usage.output_tokens,
-                    model,
-                )
-                .await
-            {
-                tracing::warn!(
-                    task_id = task.id.0,
-                    ?e,
-                    "failed to store review agent token usage"
-                );
-            }
-        }
-    }
-
-    // 15. Handle the decision
-    match decision {
-        ReviewDecision::Approve => {
-            let auto_merge = crate::config::get("workflow.auto_close_task_on_approval")
-                .or_else(|_| crate::config::get("workflow.auto_close"))
-                .or_else(|_| crate::config::get("workflow.auto_merge"))
-                .map(|v| v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
-
-            if auto_merge {
-                if let Err(e) = auto_merge_pr(
-                    task,
-                    &branch_name,
-                    backend,
-                    repo,
-                    &review_agent,
-                    review_model_str,
-                    task_manager,
-                    store,
-                )
-                .await
-                {
-                    let error_msg = e.to_string();
-                    if error_msg.contains("not yet computed") {
-                        tracing::warn!(
-                            task_id = task.id.0,
-                            pr_number = pr_number_early,
-                            branch = %branch_name,
-                            error = %e,
-                            "auto-merge deferred — PR mergeability not yet computed"
-                        );
-                    } else {
-                        tracing::error!(
-                            task_id = task.id.0,
-                            pr_number = pr_number_early,
-                            branch = %branch_name,
-                            error = %e,
-                            "auto-merge failed"
-                        );
-                    }
-                    return Ok(ReviewDecision::Failed(format!("merge failed: {e}")));
-                }
-            } else {
-                tracing::info!(
-                    task_id = task.id.0,
-                    pr_number = pr_number_early,
-                    "review approved, PR left open for human merge — marking task done"
-                );
-                if let Err(e) = task_manager
-                    .update_task_status(&task.id, Status::Done)
-                    .await
-                {
-                    tracing::error!(
-                        task_id = task.id.0,
-                        err = %e,
-                        "update_task_status(Done) failed — task may be stuck in InReview"
-                    );
-                }
-            }
-            Ok(ReviewDecision::Approve)
-        }
-        ReviewDecision::RequestChanges {
-            ref notes,
-            ref issues,
-        } => {
-            handle_review_changes(
-                task,
-                notes,
-                issues,
-                backend,
-                repo,
-                pr_number_early,
-                &review_agent,
-                review_model_str,
-                task_manager,
-                store,
-            )
-            .await?;
-            Ok(decision)
-        }
-        _ => Ok(decision),
-    }
+    apply_review_decision(task, backend, repo, task_manager, store, &ctx, &parsed).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Decomposed `review_and_merge` into explicit review pipeline phases in `src/engine/review.rs`, preserving existing behavior while making the flow easier to reason about and test.

### What was done

- Extracted review context setup into `build_review_context`, including stored task loading, worktree recovery, PR verification, diff/log preparation, review agent selection, and invocation construction.
- Extracted review agent execution into `invoke_review_agent`, keeping run tracking, tmux lifecycle handling, timeout/error handling, and review-start comment posting intact.
- Extracted review output parsing into `parse_review_output`, preserving hard-failure detection, cooldown/error recording, response parsing/fallback logic, token extraction, and review decision activity logging.
- Extracted decision application into helpers including config restoration, push handling, PR comment generation/posting, and final decision application via `apply_review_decision`.
- Added focused internal helper types (`ReviewPhase`, `ReviewContext`, `ReviewRun`, `ParsedReview`) so the top-level `review_and_merge` now acts as a thin orchestrator across the extracted phases.
- Ran the required quality gates successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run`.
- Committed the refactor as `7807bdae` with message `refactor(review): decompose review_and_merge phases`.


Closes #2197

---
*Task #2197 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5.4`*