### PR TITLE
bug: GhHttp::new() failure in post_review_comment escalates to review agent failure after push already succeeded

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1176,7 +1176,17 @@ async fn post_review_comment(
     decision: &ReviewDecision,
     review_notes_for_comment: &str,
 ) -> anyhow::Result<()> {
-    let gh = GhHttp::new()?;
+    let gh = match GhHttp::new() {
+        Ok(gh) => gh,
+        Err(e) => {
+            tracing::warn!(
+                task_id = task.id.0,
+                error = %e,
+                "failed to create GH client for review comment"
+            );
+            return Ok(());
+        }
+    };
     let pr_comment = build_pr_review_comment(decision, review_notes_for_comment);
 
     if !pr_comment.is_empty() {


### PR DESCRIPTION
## Summary

Fixed. The change converts the `GhHttp::new()` constructor failure in `post_review_comment` from a hard error (propagated via `?`) to a soft error (warn log + `return Ok(())`), matching the pattern already used for the `add_comment` call itself.

**Before:**
```rust
let gh = GhHttp::new()?;
```

**After:**
```rust
let gh = match GhHttp::new() {
    Ok(gh) => gh,
    Err(e) => {
        tracing::warn!(task_id = task.id.0, error = %e, "failed to create GH client for review comment");
        retur

Closes #2207

---
*Task #2207 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*