### PR TITLE
Blocking sync I/O and improper block_in_place usage risks stalling Tokio runtime

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -162,7 +162,7 @@ fn read_file_to_string(path: &Path) -> anyhow::Result<String> {
     match tokio::runtime::Handle::try_current() {
         Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
             Ok(tokio::task::block_in_place(|| {
-                handle.block_on(tokio::fs::read_to_string(path))
+                std::fs::read_to_string(path)
             })?)
         }
         _ => Ok(std::fs::read_to_string(path)?),

--- a/src/home.rs
+++ b/src/home.rs
@@ -13,7 +13,7 @@ const HOME_DIR: &str = ".orch";
 fn ensure_dir(path: &Path) -> anyhow::Result<()> {
     match tokio::runtime::Handle::try_current() {
         Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
-            tokio::task::block_in_place(|| handle.block_on(tokio::fs::create_dir_all(path)))?;
+            tokio::task::block_in_place(|| std::fs::create_dir_all(path))?;
         }
         _ => std::fs::create_dir_all(path)?,
     }


### PR DESCRIPTION
## Summary

The fix has already been applied in commit `d1923e09`. The changes are:

1. **`src/home.rs:16`** — Removed the incorrect `handle.block_on(tokio::fs::create_dir_all(path))` nested inside `block_in_place`. Replaced with `std::fs::create_dir_all(path)` so `block_in_place` correctly offloads the synchronous work to Tokio's blocking thread pool.

2. **`src/config/mod.rs:164`** — Same pattern: removed `handle.block_on(tokio::fs::read_to_string(path))` and replaced with `std::fs::read_to_string(pat

Closes #2202

---
*Task #2202 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*