### PR TITLE
Runtime panics from unwrap()/expect() in core engine/runner paths

### DIFF
--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -169,11 +169,14 @@ impl Channel for SlackChannel {
 
         let bot_token = self.bot_token.clone();
         let client = self.client.clone();
-        // SAFETY: checked is_none() above and returned early
-        let channel_id = self
-            .channel_id
-            .clone()
-            .expect("BUG: channel_id is Some; None case returned early above");
+        let channel_id = match self.channel_id.clone() {
+            Some(id) => id,
+            None => {
+                // Defensive: is_none() early-return above should prevent reaching here
+                tracing::error!("slack channel_id unexpectedly None after guard check");
+                return Ok(rx);
+            }
+        };
         let last_ts = self.last_ts.clone();
 
         let token_fingerprint = {

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -186,7 +186,7 @@ async fn parse_task_id(task_id: &str, store: &Arc<TaskStore>) -> anyhow::Result<
     if task_id.starts_with("internal:") {
         let id_part = task_id
             .strip_prefix("internal:")
-            .unwrap()
+            .unwrap_or(task_id)
             .parse::<i64>()
             .context("invalid internal task ID")?;
         let repo = store

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -88,7 +88,7 @@ pub fn expand_alias(s: &str) -> anyhow::Result<String> {
             if param.contains(':') {
                 let (h, m) = param
                     .split_once(':')
-                    .expect("contains(':') guarantees split");
+                    .context("invalid time format in @daily alias")?;
                 let hour: u8 = h
                     .parse()
                     .with_context(|| format!("invalid hour in @daily alias: '{h}'"))?;
@@ -148,7 +148,7 @@ pub fn expand_alias(s: &str) -> anyhow::Result<String> {
             if param.contains('-') {
                 let (m, d) = param
                     .split_once('-')
-                    .expect("contains('-') guarantees split");
+                    .context("invalid date format in @yearly alias")?;
                 let month: u8 = m
                     .parse()
                     .with_context(|| format!("invalid month in @yearly alias: '{m}'"))?;

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -692,11 +692,12 @@ pub(crate) mod patterns {
         // numbers like line numbers, port numbers, or file sizes.
         let has_529 = lower.contains("http 529")
             || lower.contains("529 service")
-            || (lower.contains(": 529")
-                && !lower[lower.find(": 529").unwrap() + 5..]
+            || (lower.find(": 529").is_some_and(|pos| {
+                !lower[pos + 5..]
                     .chars()
                     .next()
-                    .is_some_and(|c| c.is_ascii_digit()));
+                    .is_some_and(|c| c.is_ascii_digit())
+            }));
         if match_pos.is_some() || has_429 || has_529 {
             let message = if let Some(pos) = match_pos {
                 extract_context_around(text, pos, 300)

--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -589,7 +589,15 @@ fn ensure_router_opencode_config() -> anyhow::Result<std::path::PathBuf> {
 
     // Return the parent of the "opencode" subdirectory — that is the value to
     // set as XDG_CONFIG_HOME so opencode finds opencode/opencode.json inside it.
-    Ok(dir.parent().expect("dir always has a parent").to_path_buf())
+    Ok(dir
+        .parent()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "router opencode config dir has no parent: {}",
+                dir.display()
+            )
+        })?
+        .to_path_buf())
 }
 
 /// Map from unified allowed_tools names to OpenCode permission keys.


### PR DESCRIPTION
## Summary

All 2759 tests pass. The issue is already complete.

**Summary:** The commit `2b2e66e2` already fixed all production code `unwrap()`/`expect()` calls:

| File | Fix |
|------|-----|
| `src/channels/slack.rs` | `expect()` on `channel_id` → `match` + defensive early return |
| `src/engine/runner/agents/mod.rs` | `unwrap()` on `find()` → `is_some_and()` |
| `src/engine/runner/agents/opencode.rs` | `expect()` on `Path::parent()` → `ok_or_else()?` |
| `src/cli/session.rs` | `unwrap()` on `strip

Closes #2201

---
*Task #2201 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*