### PR TITLE
perf: review should update status and task in the same query

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -15,9 +15,7 @@ use crate::engine::tasks::TaskManager;
 use crate::github::http::GhHttp;
 use crate::github::types::GitHubReview;
 use crate::store::TaskStore;
-use crate::store::{
-    opt_store_get_task, store_increment, store_reset_failure_counters, store_set, store_set_result,
-};
+use crate::store::{opt_store_get_task, store_increment, store_reset_failure_counters, store_set};
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 use tokio::sync::Semaphore;
@@ -428,15 +426,13 @@ pub(crate) async fn auto_merge_pr(
                             MAX_CI_MERGE_FAILURES
                         )),
                     )];
-                    if let Err(e) =
-                        store_set_result(&Some(Arc::clone(store)), repo, &task.id.0, &fields).await
+                    if let Err(e) = task_manager
+                        .update_task_status_and_result(&task.id, Status::Blocked, &fields)
+                        .await
                     {
-                        tracing::error!(task_id = task.id.0, err = %e, "failed to write block_reason — skipping block to avoid silent auto-unblock loop");
+                        tracing::error!(task_id = task.id.0, err = %e, "failed to write block_reason and set Blocked");
                         return Ok(());
                     }
-                    task_manager
-                        .update_task_status(&task.id, Status::Blocked)
-                        .await?;
                 } else {
                     tracing::warn!(
                         task_id = task.id.0,
@@ -485,16 +481,13 @@ pub(crate) async fn auto_merge_pr(
                                 MAX_CI_MERGE_FAILURES
                             )),
                         )];
-                        if let Err(e) =
-                            store_set_result(&Some(Arc::clone(store)), repo, &task.id.0, &fields)
-                                .await
+                        if let Err(e) = task_manager
+                            .update_task_status_and_result(&task.id, Status::Blocked, &fields)
+                            .await
                         {
-                            tracing::error!(task_id = task.id.0, err = %e, "failed to write block_reason — skipping block to avoid silent auto-unblock loop");
+                            tracing::error!(task_id = task.id.0, err = %e, "failed to write block_reason and set Blocked");
                             return Ok(());
                         }
-                        task_manager
-                            .update_task_status(&task.id, Status::Blocked)
-                            .await?;
                     } else {
                         tracing::warn!(
                             task_id = task.id.0,
@@ -582,15 +575,13 @@ pub(crate) async fn auto_merge_pr(
                         MAX_MERGE_CONFLICT_RETRIES
                     )),
                 )];
-                if let Err(e) =
-                    store_set_result(&Some(Arc::clone(store)), repo, &task.id.0, &fields).await
+                if let Err(e) = task_manager
+                    .update_task_status_and_result(&task.id, Status::Blocked, &fields)
+                    .await
                 {
-                    tracing::error!(task_id = task.id.0, err = %e, "failed to write block_reason — skipping block to avoid silent auto-unblock loop");
+                    tracing::error!(task_id = task.id.0, err = %e, "failed to write block_reason and set Blocked");
                     return Ok(());
                 }
-                task_manager
-                    .update_task_status(&task.id, Status::Blocked)
-                    .await?;
                 let comment = format!("Auto-merge failed after {} rebase attempts: {}", retries, e);
                 let footer = crate::engine::attribution_footer(
                     "Commented",
@@ -821,15 +812,13 @@ pub(crate) async fn auto_merge_pr(
                 format!("auto-merge rebase failed after merge conflict: {}", e)
             };
             let fields = [("block_reason", serde_json::json!(block_reason))];
-            if let Err(e) =
-                store_set_result(&Some(Arc::clone(store)), repo, &task.id.0, &fields).await
+            if let Err(e) = task_manager
+                .update_task_status_and_result(&task.id, Status::Blocked, &fields)
+                .await
             {
-                tracing::error!(task_id = task.id.0, err = %e, "failed to write block_reason — skipping block to avoid silent auto-unblock loop");
+                tracing::error!(task_id = task.id.0, err = %e, "failed to write block_reason and set Blocked");
                 return Ok(());
             }
-            task_manager
-                .update_task_status(&task.id, Status::Blocked)
-                .await?;
             let footer =
                 crate::engine::attribution_footer("Commented", review_agent, Some(review_model));
             if let Err(e) = gh
@@ -859,14 +848,13 @@ pub(crate) async fn auto_merge_pr(
             "block_reason",
             serde_json::json!(format!("auto-merge failed: {}", e)),
         )];
-        if let Err(e) = store_set_result(&Some(Arc::clone(store)), repo, &task.id.0, &fields).await
+        if let Err(e) = task_manager
+            .update_task_status_and_result(&task.id, Status::Blocked, &fields)
+            .await
         {
-            tracing::error!(task_id = task.id.0, err = %e, "failed to write block_reason — skipping block to avoid silent auto-unblock loop");
+            tracing::error!(task_id = task.id.0, err = %e, "failed to write block_reason and set Blocked");
             return Ok(());
         }
-        task_manager
-            .update_task_status(&task.id, Status::Blocked)
-            .await?;
         let comment = format!("Auto-merge failed: {}", e);
         let footer =
             crate::engine::attribution_footer("Commented", review_agent, Some(review_model));
@@ -1240,16 +1228,11 @@ pub(crate) async fn handle_review_changes(
             "block_reason",
             serde_json::json!(format!("max review cycles ({}) reached", max_cycles)),
         )];
-        if let Err(e) = store_set_result(&Some(Arc::clone(store)), repo, &task.id.0, &fields).await
-        {
-            tracing::error!(task_id = task.id.0, err = %e, "failed to write block_reason — skipping block to avoid silent auto-unblock loop");
-            return Ok(());
-        }
         // A transient store failure here must not be counted as a review-agent
-        // crash.  Log and return Ok — the next tick will re-check the task and
+        // crash. Log and return Ok — the next tick will re-check the task and
         // can retry the status transition.
         if let Err(e) = task_manager
-            .update_task_status(&task.id, Status::Blocked)
+            .update_task_status_and_result(&task.id, Status::Blocked, &fields)
             .await
         {
             tracing::warn!(
@@ -1372,8 +1355,18 @@ pub(crate) async fn handle_review_changes(
             )
             .await;
 
+            let fields = [
+                (
+                    "review_cycles",
+                    serde_json::json!((review_cycles + 1) as i64),
+                ),
+                (
+                    "review_agent_failures",
+                    serde_json::json!(0), // reset failures for the new review round
+                ),
+            ];
             if let Err(e) = task_manager
-                .update_task_status(&task.id, Status::Routed)
+                .update_task_status_and_result(&task.id, Status::Routed, &fields)
                 .await
             {
                 tracing::warn!(
@@ -1383,28 +1376,6 @@ pub(crate) async fn handle_review_changes(
                 );
                 return Ok(());
             }
-
-            // Increment review_cycles only AFTER successful status transition.
-            // This prevents premature escalation if the transition fails.
-            // Use the "_result" variant so failures are propagated to the caller
-            // and the outer caller (review_poll) can retry instead of silently
-            // allowing the task to bypass the max-review guard.
-            store_set_result(
-                &Some(Arc::clone(store)),
-                repo,
-                &task.id.0,
-                &[
-                    (
-                        "review_cycles",
-                        serde_json::json!((review_cycles + 1) as i64),
-                    ),
-                    (
-                        "review_agent_failures",
-                        serde_json::json!(0), // reset failures for the new review round
-                    ),
-                ],
-            )
-            .await?;
 
             tracing::info!(
                 task_id = task.id.0,
@@ -1431,7 +1402,20 @@ pub(crate) async fn handle_review_changes(
             )
             .await;
 
-            if let Err(e) = task_manager.update_task_status(&task.id, Status::New).await {
+            let fields = [
+                (
+                    "review_cycles",
+                    serde_json::json!((review_cycles + 1) as i64),
+                ),
+                (
+                    "review_agent_failures",
+                    serde_json::json!(0), // reset failures for the new review round
+                ),
+            ];
+            if let Err(e) = task_manager
+                .update_task_status_and_result(&task.id, Status::New, &fields)
+                .await
+            {
                 tracing::warn!(
                     task_id = task.id.0,
                     err = %e,
@@ -1439,28 +1423,6 @@ pub(crate) async fn handle_review_changes(
                 );
                 return Ok(());
             }
-
-            // Increment review_cycles only AFTER successful status transition.
-            // This prevents premature escalation if the transition fails.
-            // Use the "_result" variant so failures are propagated to the caller
-            // and the outer caller (review_poll) can retry instead of silently
-            // allowing the task to bypass the max-review guard.
-            store_set_result(
-                &Some(Arc::clone(store)),
-                repo,
-                &task.id.0,
-                &[
-                    (
-                        "review_cycles",
-                        serde_json::json!((review_cycles + 1) as i64),
-                    ),
-                    (
-                        "review_agent_failures",
-                        serde_json::json!(0), // reset failures for the new review round
-                    ),
-                ],
-            )
-            .await?;
 
             tracing::info!(
                 task_id = task.id.0,

--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -457,21 +457,11 @@ pub(crate) async fn review_open_prs(
                                 )),
                             ),
                         ];
-                        if let Err(e) = store_set_result_by_id(
-                            &Some(Arc::clone(store)),
-                            task_info.store_id,
-                            &fields,
-                        )
-                        .await
-                        {
-                            tracing::error!(task_id, err = %e, "failed to write block_reason — skipping block to avoid silent auto-unblock loop");
-                            continue;
-                        }
                         if let Err(e) = task_manager
-                            .update_task_status(&task.id, Status::Blocked)
+                            .update_task_status_and_result(&task.id, Status::Blocked, &fields)
                             .await
                         {
-                            tracing::warn!(task_id, err = %e, "failed to set Blocked");
+                            tracing::error!(task_id, err = %e, "failed to write block_reason and set Blocked");
                         }
                         continue;
                     }
@@ -612,21 +602,11 @@ pub(crate) async fn review_open_prs(
                                 )),
                             ),
                         ];
-                        if let Err(e) = store_set_result_by_id(
-                            &Some(Arc::clone(store)),
-                            task_info.store_id,
-                            &fields,
-                        )
-                        .await
-                        {
-                            tracing::error!(task_id, err = %e, "failed to write block_reason — skipping block to avoid silent auto-unblock loop");
-                            continue;
-                        }
                         if let Err(e) = task_manager
-                            .update_task_status(&task.id, Status::Blocked)
+                            .update_task_status_and_result(&task.id, Status::Blocked, &fields)
                             .await
                         {
-                            tracing::warn!(task_id, err = %e, "failed to set Blocked");
+                            tracing::error!(task_id, err = %e, "failed to write block_reason and set Blocked");
                         }
                         continue;
                     }

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -9,7 +9,7 @@ use crate::engine::router::Router;
 use crate::engine::tasks::TaskManager;
 use crate::github::http::GhHttp;
 use crate::repo_context::REPO_CONTEXT;
-use crate::store::{opt_store_get_task, store_set_result, TaskStore};
+use crate::store::{opt_store_get_task, TaskStore};
 use crate::tmux::TmuxManager;
 use dashmap::DashSet;
 use std::sync::Arc;
@@ -465,25 +465,15 @@ pub fn spawn(
                                      ),
                                      ("last_error", serde_json::json!(reason)),
                                  ];
-                                 if let Err(e) = store_set_result(
-                                     &Some(store_c.clone()),
-                                     &repo_s,
-                                     &tid,
-                                     &fields,
-                                 )
-                                 .await
+                                 if let Err(e) = task_manager_c
+                                     .update_task_status_and_result(
+                                         &ExternalId(tid.clone()),
+                                         Status::Blocked,
+                                         &fields,
+                                     )
+                                     .await
                                  {
-                                     tracing::error!(task_id = %tid, err = %e, "failed to write block_reason — skipping block to avoid silent auto-unblock loop");
-                                 } else {
-                                     if let Err(e) = task_manager_c
-                                         .update_task_status(
-                                             &ExternalId(tid.clone()),
-                                             Status::Blocked,
-                                         )
-                                         .await
-                                     {
-                                         tracing::error!(task_id = %tid, err = %e, "update_task_status(Blocked) failed — task may be stuck in InReview");
-                                     }
+                                     tracing::error!(task_id = %tid, err = %e, "update_task_status_and_result(Blocked) failed — task may be stuck in InReview");
                                  }
                              }
                             ReviewOutcome::Ok => {}

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -416,6 +416,59 @@ impl TaskManager {
         Ok(())
     }
 
+    pub async fn update_task_status_and_result(
+        &self,
+        id: &ExternalId,
+        status: Status,
+        updates: &[(&str, serde_json::Value)],
+    ) -> anyhow::Result<()> {
+        let task_status = status_to_task_status(status);
+
+        // Read pre-update snapshot from the store (old_status + context fields).
+        let (pre_snapshot, snapshot_store_id) = self.read_task_snapshot(&id.0).await;
+
+        if is_internal_id(&id.0) {
+            // Internal tasks: store is the single source of truth
+            let store = self
+                .store
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("store required for internal task status update"))?;
+            let store_id = snapshot_store_id
+                .ok_or_else(|| anyhow::anyhow!("internal task {} not found in store", id.0))?;
+
+            store
+                .update_status_and_fields(store_id, task_status, updates)
+                .await?;
+            // Publish event to bus only after confirmed update
+            self.publish_event(id, status, &pre_snapshot, None);
+            return Ok(());
+        }
+
+        // External tasks: store-first, then mirror to backend.
+        if let Some(ref store) = self.store {
+            if let Some(store_id) = snapshot_store_id {
+                store
+                    .update_status_and_fields(store_id, task_status, updates)
+                    .await?;
+            }
+        }
+
+        // Mirror to backend (GitHub labels).
+        if let Err(e) = self.backend.update_status(id, status).await {
+            tracing::warn!(
+                task_id = id.0,
+                ?status,
+                err = %e,
+                "failed to mirror status to backend — store is authoritative"
+            );
+        }
+
+        // Publish event to bus
+        self.publish_event(id, status, &pre_snapshot, None);
+
+        Ok(())
+    }
+
     /// Update the status of a task only if it is currently in `expected_status`.
     ///
     /// Returns `Ok(true)` if the update was applied, `Ok(false)` if the task had

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -566,6 +566,77 @@ impl TaskStore {
     // Status
     // ---------------------------------------------------------------
 
+    pub async fn update_status_and_fields(
+        &self,
+        id: i64,
+        status: TaskStatus,
+        updates: &[(&str, serde_json::Value)],
+    ) -> anyhow::Result<()> {
+        for (col, _) in updates {
+            anyhow::ensure!(
+                ALLOWED_FIELDS.contains(col),
+                "column {col} is not in the update allowlist"
+            );
+        }
+
+        let previous = sqlx::query("SELECT status, agent, model FROM tasks WHERE id = ?")
+            .bind(id)
+            .fetch_one(&self.pool)
+            .await?;
+        let from_status: String = previous.try_get("status").unwrap_or_default();
+        let agent: Option<String> = previous.try_get("agent").unwrap_or(None);
+        let model: Option<String> = previous.try_get("model").unwrap_or(None);
+
+        let mut set_parts = Vec::new();
+        let mut values: Vec<Option<String>> = Vec::new();
+
+        set_parts.push("status = ?".to_string());
+        values.push(Some(status.as_str().to_string()));
+
+        let mut block_reason_in_updates = false;
+        for (col, val) in updates {
+            if *col == "block_reason" {
+                block_reason_in_updates = true;
+            }
+            set_parts.push(format!("{col} = ?"));
+            match val {
+                serde_json::Value::String(s) => values.push(Some(s.clone())),
+                serde_json::Value::Number(n) => values.push(Some(n.to_string())),
+                serde_json::Value::Bool(b) => {
+                    values.push(Some(if *b { "1" } else { "0" }.to_string()));
+                }
+                serde_json::Value::Null => values.push(None),
+                other => values.push(Some(serde_json::to_string(other)?)),
+            }
+        }
+
+        if !block_reason_in_updates && status != TaskStatus::Blocked {
+            set_parts.push("block_reason = NULL".to_string());
+        }
+
+        set_parts.push("updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')".to_string());
+        let sql = format!("UPDATE tasks SET {} WHERE id = ?", set_parts.join(", "));
+
+        let mut query = sqlx::query(&sql);
+        for v in &values {
+            query = query.bind(v.as_deref());
+        }
+        query = query.bind(id);
+        query.execute(&self.pool).await?;
+
+        self.append_activity(
+            id,
+            "status_change",
+            Some(from_status.as_str()),
+            Some(status.as_str()),
+            agent.as_deref(),
+            model.as_deref(),
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+
     /// Update the status of a task.
     pub async fn update_status(&self, id: i64, status: TaskStatus) -> anyhow::Result<()> {
         let previous = sqlx::query("SELECT status, agent, model FROM tasks WHERE id = ?")


### PR DESCRIPTION
## Summary

## Goal

Fix a performance issue (#2212) where updating task results and status currently executes two separate SQLite updates (`store_set_result` and `update_task_status`). These should be combined into a single query to reduce database load.

## Instructions

- Create a unified method to update both a task's status and its fields in a single query.
- Replace instances where `store_set_result` (or `store_set_result_by_id`) is immediately followed by `update_task_status` with the new unified met

Closes #2212

---
*Task #2212 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gemini-3.1-pro-preview`*