### PR TITLE
bug: scheduled job executes after pre-run state persistence failure — violates restart-safety invariant

### DIFF
--- a/src/engine/jobs.rs
+++ b/src/engine/jobs.rs
@@ -370,8 +370,9 @@ pub async fn tick(
                 tracing::error!(
                     job_id = job.id,
                     ?e,
-                    "failed to persist job state before execution"
+                    "failed to persist job state before execution — skipping this tick to preserve restart safety"
                 );
+                continue; // retry next tick instead of risking duplicate execution
             }
         }
 


### PR DESCRIPTION
## Summary

All 2759 tests pass. The fix is a one-liner `continue` in `src/engine/jobs.rs:375` — when the pre-run state write fails, execution is now skipped for that tick rather than proceeding and risking duplicate job execution on crash-restart cycles.

Closes #2214

---
*Task #2214 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*