### PR TITLE
bug: batch_reset_failure_counters is dead code and omits needs_review_refires unlike reset_failure_counters

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1408,6 +1408,7 @@ impl TaskStore {
             auto_unblock_last_reason = '',
             ci_recovery_count = 0,
             no_code_reroutes = 0,
+            needs_review_refires = 0,
             updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
          WHERE id IN ({placeholders})",
             );

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -5452,6 +5452,7 @@ async fn batch_reset_failure_counters_preserves_review_cycles() {
         store.increment(id, "review_cycles").await.unwrap();
         store.increment(id, "ci_merge_failures").await.unwrap();
         store.increment(id, "merge_conflict_retries").await.unwrap();
+        store.increment(id, "needs_review_refires").await.unwrap();
     }
 
     store
@@ -5463,6 +5464,10 @@ async fn batch_reset_failure_counters_preserves_review_cycles() {
         let t = store.get(id).await.unwrap();
         assert_eq!(t.attempts, 0);
         assert_eq!(t.merge_conflict_retries, 0);
+        assert_eq!(
+            t.needs_review_refires, 0,
+            "needs_review_refires must be reset"
+        );
         assert_eq!(t.review_cycles, 1, "review_cycles must be preserved");
         assert_eq!(
             t.ci_merge_failures, 1,


### PR DESCRIPTION
## Summary

All checks pass. The fix is complete:

**Changes made:**

1. `src/store/tasks.rs:1410` — Added `needs_review_refires = 0` to `batch_reset_failure_counters`'s UPDATE statement, making it consistent with `reset_failure_counters`.

2. `src/store/tests.rs` — Updated `batch_reset_failure_counters_preserves_review_cycles` to also increment and assert `needs_review_refires` is reset to 0.

The function was already `#[cfg(test)]` so no production callers needed updating. The inconsistency was purely

Closes #2216

---
*Task #2216 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*