### PR TITLE
bug: remove_label errors silently discarded in stuck-task recovery and re-routing paths

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -551,7 +551,9 @@ pub(crate) async fn tick_recover_stuck_tasks(
         // Remove stale agent/model labels so the LLM router re-routes properly
         for label in &task.labels {
             if label.starts_with("agent:") || label.starts_with("model:") {
-                backend.remove_label(&task.id, label).await.ok();
+                if let Err(e) = backend.remove_label(&task.id, label).await {
+                    tracing::warn!(task_id = task.id.0, label, error = %e, "failed to remove stale routing label during stuck-task recovery");
+                }
             }
         }
         if let Ok(Some(store_id)) = store.resolve_task_id(repo, &task.id.0).await {
@@ -957,7 +959,9 @@ pub(crate) async fn tick_route_tasks(
                             || label.starts_with("complexity:")
                             || label.starts_with("model:")
                         {
-                            backend.remove_label(&task.id, label).await.ok();
+                            if let Err(e) = backend.remove_label(&task.id, label).await {
+                                tracing::warn!(task_id = task.id.0, label, error = %e, "failed to remove stale routing label during re-route");
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Summary

## Summary

Fixed silent error handling in label removal operations in `src/engine/tick.rs`. The issue had two problematic code paths that discarded errors using `.await.ok()`, which meant when label removal failed (transient GitHub errors, permissions, rate limits), the stale routing labels would remain on tasks.

### Changes Made

1. **Line 554** (stuck-task recovery): Added proper error logging when removing stale `agent:` and `model:` labels
2. **Line 960** (routing re-route): Added proper e

Closes #2215

---
*Task #2215 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*