### PR TITLE
bug: router LLM selects degraded agents causing wasted reroutes — filters cooldown but not degraded

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -940,13 +940,13 @@ impl Router {
         task: &ExternalTask,
         repo: &str,
     ) -> anyhow::Result<RouteResult> {
-        // Filter out cooled agents so the LLM only sees available ones.
-        // Fall back to the full list if all agents are cooled.
+        // Filter out cooled and degraded agents so the LLM only sees available ones.
+        // Fall back to the full list if all agents are cooled/degraded.
         // Cloned to avoid borrow conflict with &mut self in the loop.
         let uncooled_agents: Vec<String> = self
             .available_agents
             .iter()
-            .filter(|a| !is_agent_in_cooldown(a))
+            .filter(|a| !is_agent_in_cooldown(a) && !is_agent_degraded(a))
             .cloned()
             .collect();
         if uncooled_agents.is_empty() {


### PR DESCRIPTION
## Summary

Perfect! The fix has been implemented, tested, and committed. Here's a summary:

## Summary

**Fixed bug #2221**: Router LLM now filters degraded agents alongside cooldown agents.

### The Problem
The LLM routing path in `src/engine/router/mod.rs` was only filtering **cooldown-only** agents before asking the LLM to select the best agent. However, it failed to filter **degraded** agents (those with recent rate limits). This caused the LLM to waste a call selecting a degraded agent (like `opencode

Closes #2221

---
*Task #2221 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*