### PR TITLE
bug: capture.rs tests use unwrap() on HashMap lookups that could panic

### DIFF
--- a/src/channels/capture.rs
+++ b/src/channels/capture.rs
@@ -483,7 +483,9 @@ mod tests {
         {
             let skey = session_key(repo, "silent-task");
             let mut buffers = svc.buffers.write().await;
-            let buf = buffers.get_mut(&skey).unwrap();
+            let buf = buffers
+                .get_mut(&skey)
+                .expect("buffer should exist for registered silent-task session");
             buf.registered_at = Utc::now() - chrono::Duration::seconds(200);
         }
 
@@ -493,7 +495,9 @@ mod tests {
         {
             let skey = session_key(repo, "active-task");
             let mut buffers = svc.buffers.write().await;
-            let buf = buffers.get_mut(&skey).unwrap();
+            let buf = buffers
+                .get_mut(&skey)
+                .expect("buffer should exist for registered active-task session");
             buf.registered_at = Utc::now() - chrono::Duration::seconds(200);
             buf.has_output = true;
         }
@@ -527,7 +531,9 @@ mod tests {
         {
             let skey = session_key(repo, "never-seen-task");
             let mut buffers = svc.buffers.write().await;
-            let buf = buffers.get_mut(&skey).unwrap();
+            let buf = buffers
+                .get_mut(&skey)
+                .expect("buffer should exist for registered never-seen-task session");
             buf.registered_at = Utc::now() - chrono::Duration::seconds(500);
             // seen_alive = false (default), has_output = false
         }
@@ -538,7 +544,9 @@ mod tests {
         {
             let skey = session_key(repo, "seen-but-quiet-task");
             let mut buffers = svc.buffers.write().await;
-            let buf = buffers.get_mut(&skey).unwrap();
+            let buf = buffers
+                .get_mut(&skey)
+                .expect("buffer should exist for registered seen-but-quiet-task session");
             buf.registered_at = Utc::now() - chrono::Duration::seconds(500);
             buf.seen_alive = true; // capture_pane succeeded at least once
                                    // has_output = false (empty terminal, but session IS alive)
@@ -569,9 +577,13 @@ mod tests {
             let skey_a = session_key("owner/repo-a", "task-a");
             let skey_b = session_key("owner/repo-b", "task-b");
             let mut buffers = svc.buffers.write().await;
-            let buf_a = buffers.get_mut(&skey_a).unwrap();
+            let buf_a = buffers
+                .get_mut(&skey_a)
+                .expect("buffer should exist for registered task-a session");
             buf_a.registered_at = Utc::now() - chrono::Duration::seconds(200);
-            let buf_b = buffers.get_mut(&skey_b).unwrap();
+            let buf_b = buffers
+                .get_mut(&skey_b)
+                .expect("buffer should exist for registered task-b session");
             buf_b.registered_at = Utc::now() - chrono::Duration::seconds(200);
         }
 
@@ -604,8 +616,12 @@ mod tests {
         let skey_b = session_key("owner/repo-b", "42");
 
         let buffers = svc.buffers.read().await;
-        let buf_a = buffers.get(&skey_a).unwrap();
-        let buf_b = buffers.get(&skey_b).unwrap();
+        let buf_a = buffers
+            .get(&skey_a)
+            .expect("buffer should exist for repo-a session");
+        let buf_b = buffers
+            .get(&skey_b)
+            .expect("buffer should exist for repo-b session");
 
         assert_eq!(buf_a.session, "orch-a-42");
         assert_eq!(buf_b.session, "orch-b-42");


### PR DESCRIPTION
## Summary

Fixed all 8 `.unwrap()` calls in `src/channels/capture.rs` tests:

**Changes made:**
- Lines 486, 496: `get_silent_sessions_returns_only_no_output_past_grace`
- Lines 530, 541: `get_silent_sessions_excludes_seen_alive_sessions`  
- Lines 572, 574: `get_silent_sessions_filters_by_repo`
- Lines 607, 608: `same_task_id_different_repos_capture_buffers_isolated`

Each `.unwrap()` was replaced with `.expect()` containing a descriptive message indicating which session buffer was expected. For example:


### What was done

- Changes made:**
- Lines 486, 496: `get_silent_sessions_returns_only_no_output_past_grace`
- Lines 530, 541: `get_silent_sessions_excludes_seen_alive_sessions`
- Lines 572, 574: `get_silent_sessions_filters_by_repo`
- Lines 607, 608: `same_task_id_different_repos_capture_buffers_isolated`
- `cargo fmt`: clean
- `cargo clippy --all-targets`: no issues
- `cargo test capture::`: 45 tests passed


### Files changed

- `src/channels/capture.rs`


Closes #2324

---
*Task #2324 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*