### PR TITLE
Bug: SQL injection risk in set_fields

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -623,6 +623,10 @@ impl TaskStore {
 
         let mut block_reason_in_updates = false;
         for (col, val) in updates {
+            anyhow::ensure!(
+                ALLOWED_FIELDS.contains(col),
+                "column {col} is not in the update allowlist"
+            );
             if *col == "block_reason" {
                 block_reason_in_updates = true;
             }
@@ -1066,6 +1070,10 @@ impl TaskStore {
         let mut values: Vec<Option<String>> = Vec::new();
 
         for (col, val) in updates {
+            anyhow::ensure!(
+                ALLOWED_FIELDS.contains(col),
+                "column {col} is not in the update allowlist"
+            );
             set_parts.push(format!("{col} = ?"));
             match val {
                 serde_json::Value::String(s) => values.push(Some(s.clone())),


### PR DESCRIPTION
## Summary

Added `ALLOWED_FIELDS` allowlist validation inside the SQL-building loops in both `update_status_and_fields` (line ~629) and `set_fields` (line ~1069) in `src/store/tasks.rs`. Previously validation only occurred in a pre-loop, leaving the dynamic SQL construction unguarded against future refactoring bypasses. All 2801 tests pass.

Closes #2336

---
*Task #2336 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*