### PR TITLE
Bug: rebase_on_branch silently swallows commit count parse errors

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -220,11 +220,20 @@ pub async fn rebase_on_branch(dir: &Path, branch: &str) -> anyhow::Result<bool> 
         .await;
 
     let commit_count: usize = match count_output {
-        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
-            .trim()
-            .parse()
-            .unwrap_or(0),
-        _ => 0,
+        Ok(o) if o.status.success() => {
+            let raw = String::from_utf8_lossy(&o.stdout);
+            raw.trim().parse().map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to parse commit count from git rev-list output {:?}: {e}",
+                    raw.trim()
+                )
+            })?
+        }
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            anyhow::bail!("git rev-list --count failed: {stderr}");
+        }
+        Err(e) => anyhow::bail!("failed to run git rev-list --count: {e}"),
     };
 
     if commit_count == 0 {


### PR DESCRIPTION
## Summary

Replaced the silent .unwrap_or(0) and catch-all _ => 0 fallbacks in rebase_on_branch with explicit error propagation. Parse failures now return an anyhow error with the raw output, git command failures surface the stderr, and process spawn errors are bubbled up — all via ?. All 2801 tests pass.

### Files changed

- `src/engine/runner/git_ops.rs`


Closes #2338

---
*Task #2338 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*