### PR TITLE
fix: add allowlist validation inside SQL-building loop in batch_set_fields

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1371,6 +1371,10 @@ impl TaskStore {
             let mut set_parts = Vec::new();
             let mut values: Vec<Option<String>> = Vec::new();
             for (col, val) in *entry_updates {
+                anyhow::ensure!(
+                    ALLOWED_FIELDS.contains(col),
+                    "column {col} is not in the update allowlist"
+                );
                 set_parts.push(format!("{col} = ?"));
                 match val {
                     serde_json::Value::String(s) => values.push(Some(s.clone())),


### PR DESCRIPTION
## Summary

- Add defense-in-depth column validation inside the SQL construction loop of `batch_set_fields`, matching the fix already applied to `set_fields` and `update_status_and_fields` in c6cdfc86

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run` (2801 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task #2337 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*