### PR TITLE
fix: orch log shows 'No log files found' when service is running

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -182,6 +182,19 @@ pub fn log(lines: &str) -> anyhow::Result<()> {
                 .unwrap_or(false)
         {
             log_files.push(path.clone());
+        } else {
+            // Fall back to rotated log files (orch.log.1, orch.log.2, ...) if primary is empty
+            for n in 1..=5 {
+                let rotated = std::path::PathBuf::from(format!("{}.{}", path.display(), n));
+                if rotated.exists()
+                    && std::fs::metadata(&rotated)
+                        .map(|m| m.len() > 0)
+                        .unwrap_or(false)
+                {
+                    log_files.push(rotated);
+                    break;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixed `orch log` showing 'No log files found' by adding rotated log file fallback. When a primary log (e.g. orch.log) is 0 bytes, the command now checks orch.log.1 through orch.log.5 and uses the first non-empty rotated file.

### Files changed

- `src/cli/mod.rs`


Closes #2343

---
*Task #2343 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*