### PR TITLE
bug: security scanner skips markdown bullet lines, bypassing leak detection

### DIFF
--- a/src/security.rs
+++ b/src/security.rs
@@ -123,12 +123,8 @@ static LEAK_PATTERNS: LazyLock<Vec<(&str, Regex, bool)>> =
 /// - `//` (C-style comments)
 /// - `#` (shell/Python comments)
 /// - `<!--` (HTML comments)
-/// - `* ` (markdown bullets)
 fn is_comment_line(trimmed: &str) -> bool {
-    trimmed.starts_with("//")
-        || trimmed.starts_with('#')
-        || trimmed.starts_with("<!--")
-        || trimmed.starts_with("* ")
+    trimmed.starts_with("//") || trimmed.starts_with('#') || trimmed.starts_with("<!--")
 }
 
 /// Scan text for potential leaked secrets.
@@ -253,10 +249,11 @@ mod tests {
     }
 
     #[test]
-    fn ignores_markdown_bullets() {
+    fn scans_markdown_bullets() {
+        // Markdown bullet lines must NOT be skipped — they're content, not code comments.
         let text = "* token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij";
         let matches = scan(text);
-        assert!(matches.is_empty());
+        assert!(!matches.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Removed `* ` from `is_comment_line` in `src/security.rs` so markdown bullet lines are no longer skipped by the leak scanner. Updated the `ignores_markdown_bullets` test (renamed to `scans_markdown_bullets`) to assert bullets ARE scanned. The 3 pre-existing timing-sensitive tmux/engine test failures are unrelated to this change.

Closes #2348

---
*Task #2348 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*