### PR TITLE
bug: run_agent_session ignores invocation.timeout_seconds — per-complexity timeout unimplementable

### DIFF
--- a/src/engine/runner/session.rs
+++ b/src/engine/runner/session.rs
@@ -3,7 +3,6 @@
 //! Extracted from `runner/mod.rs`. Handles the tmux session lifecycle:
 //! spawning the agent, waiting for completion, reading output files, and cleanup.
 
-use crate::config;
 use crate::tmux::TmuxManager;
 use std::path::{Path, PathBuf};
 use tokio::time::{timeout, Duration};
@@ -28,16 +27,10 @@ pub async fn run_agent_session(
     attempt_dir: &Path,
     orch_home: &Path,
 ) -> (TmuxManager, String, SessionOutput) {
-    // Read workflow.timeout_seconds from config with default of 1800 (30 minutes).
-    // Enforce a minimum of 1800 seconds (30 minutes) to ensure tasks have sufficient time.
-    let task_timeout_secs: u64 = config::get("workflow.timeout_seconds")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(1800)
-        .max(1800);
-
+    // Use the pre-computed timeout from the invocation (set by task_init.rs, which
+    // reads workflow.timeout_seconds and applies per-complexity overrides).
     // Add 120s grace so the shell timeout (in runner.sh) fires before Tokio kills the session.
-    let task_timeout = Duration::from_secs(task_timeout_secs + 120);
+    let task_timeout = Duration::from_secs(invocation.timeout_seconds + 120);
 
     let tmux = TmuxManager::new();
 

--- a/src/engine/runner/task_init.rs
+++ b/src/engine/runner/task_init.rs
@@ -331,12 +331,27 @@ pub async fn prepare_task(
         ]);
     }
 
-    // Timeout: enforce a minimum of 1800 seconds (30 minutes)
-    let timeout_seconds: u64 = config::get("workflow.timeout_seconds")
+    // Timeout: read base from workflow.timeout_seconds (min 1800s), then apply per-complexity
+    // override from workflow.timeout_by_complexity.{simple,medium,complex} if configured.
+    // The per-complexity value is also floored at the base to prevent accidental regression.
+    let base_timeout: u64 = config::get("workflow.timeout_seconds")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(1800)
         .max(1800);
+    let timeout_seconds: u64 = match complexity.as_deref() {
+        Some("complex") => config::get("workflow.timeout_by_complexity.complex")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(base_timeout)
+            .max(base_timeout),
+        Some("medium") => config::get("workflow.timeout_by_complexity.medium")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(base_timeout)
+            .max(base_timeout),
+        _ => base_timeout,
+    };
 
     // Build agent invocation
     let invocation = agent::AgentInvocation {


### PR DESCRIPTION
## Summary

Fixed `run_agent_session` ignoring `invocation.timeout_seconds` and added per-complexity timeout support.

Closes #2357

---
*Task #2357 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*