### PR TITLE
bug: record_mention_task advances cursor even when create_internal fails — mentions silently lost on DB error

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -362,12 +362,12 @@ async fn record_mention_task(
     {
         Ok(task_id) => {
             tracing::info!(task_id, mention_id = %mention.id, "created mention task");
+            advance_cursor(last_success_ts, &mention.created_at);
         }
         Err(e) => {
             tracing::warn!(mention_id = %mention.id, err = %e, "failed to create mention task");
         }
     }
-    advance_cursor(last_success_ts, &mention.created_at);
 }
 
 /// Advance the mention cursor if the timestamp is newer.


### PR DESCRIPTION
## Summary

Committed. Final state: `advance_cursor` now only runs on `Ok(task_id)`; on `Err(e)` the cursor stays put so the mention will be retried on the next sync.

```json
{
  "attempt": 1,
  "outcome": "success",
  "changes_summary": "Fixed `record_mention_task` in `src/engine/sync.rs:363-370` — moved `advance_cursor` from after the `match` block into the `Ok` arm only. When `create_internal` fails, the mention cursor no longer advances, allowing the mention to be retried on the next sync instead of 

Closes #2362

---
*Task #2362 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*