### PR TITLE
perf: scan_comments re-introduces serial is_pull_request calls — regression from #2342 fix

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -526,63 +526,6 @@ async fn handle_slash_command(
     }
 }
 
-/// What to do with a comment in the unified scan loop.
-#[derive(Debug, PartialEq)]
-pub(crate) enum CommentAction {
-    /// Already processed or not relevant — skip.
-    Skip,
-    /// Slash command without @mention — execute the command.
-    ExecuteCommand {
-        command: crate::engine::commands::OwnerCommand,
-        issue_num: String,
-    },
-    /// @mention with a slash command — execute and record sentinel task.
-    ExecuteCommandForMention {
-        command: crate::engine::commands::OwnerCommand,
-        issue_num: String,
-    },
-    /// @mention without command — create internal task for agent to respond.
-    CreateMentionTask { issue_num: Option<String> },
-}
-
-/// Classify a comment into the appropriate action.
-///
-/// Pure function — no I/O, no async. Determines what the scan loop should do
-/// with each comment based on its content and whether it was already processed.
-pub(crate) fn classify_comment(
-    body: &str,
-    issue_url: Option<&str>,
-    current_user: &str,
-    already_processed: bool,
-) -> CommentAction {
-    if already_processed {
-        return CommentAction::Skip;
-    }
-
-    let is_mention =
-        body.contains(current_user) || body.contains("@orch") || body.contains("@orchestrator");
-    let command = parse_command(body);
-    let issue_num = issue_url.and_then(extract_issue_number_from_url);
-
-    match (command, is_mention, issue_num) {
-        (Some(cmd), true, Some(num)) => CommentAction::ExecuteCommandForMention {
-            command: cmd,
-            issue_num: num,
-        },
-        (Some(cmd), false, Some(num)) => CommentAction::ExecuteCommand {
-            command: cmd,
-            issue_num: num,
-        },
-        // Command but no issue URL — if it's a mention, create task; otherwise skip
-        (Some(_), true, None) => CommentAction::CreateMentionTask { issue_num: None },
-        (Some(_), false, None) => CommentAction::Skip,
-        // Mention without command — create task for agent
-        (None, true, issue_num) => CommentAction::CreateMentionTask { issue_num },
-        // Neither mention nor command — skip
-        (None, false, _) => CommentAction::Skip,
-    }
-}
-
 fn auto_unblock_cooldown_elapsed(count: i32, last_at: &str) -> bool {
     if count == 0 {
         return true;

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -526,6 +526,63 @@ async fn handle_slash_command(
     }
 }
 
+/// What to do with a comment in the unified scan loop.
+#[derive(Debug, PartialEq)]
+pub(crate) enum CommentAction {
+    /// Already processed or not relevant — skip.
+    Skip,
+    /// Slash command without @mention — execute the command.
+    ExecuteCommand {
+        command: crate::engine::commands::OwnerCommand,
+        issue_num: String,
+    },
+    /// @mention with a slash command — execute and record sentinel task.
+    ExecuteCommandForMention {
+        command: crate::engine::commands::OwnerCommand,
+        issue_num: String,
+    },
+    /// @mention without command — create internal task for agent to respond.
+    CreateMentionTask { issue_num: Option<String> },
+}
+
+/// Classify a comment into the appropriate action.
+///
+/// Pure function — no I/O, no async. Determines what the scan loop should do
+/// with each comment based on its content and whether it was already processed.
+pub(crate) fn classify_comment(
+    body: &str,
+    issue_url: Option<&str>,
+    current_user: &str,
+    already_processed: bool,
+) -> CommentAction {
+    if already_processed {
+        return CommentAction::Skip;
+    }
+
+    let is_mention =
+        body.contains(current_user) || body.contains("@orch") || body.contains("@orchestrator");
+    let command = parse_command(body);
+    let issue_num = issue_url.and_then(extract_issue_number_from_url);
+
+    match (command, is_mention, issue_num) {
+        (Some(cmd), true, Some(num)) => CommentAction::ExecuteCommandForMention {
+            command: cmd,
+            issue_num: num,
+        },
+        (Some(cmd), false, Some(num)) => CommentAction::ExecuteCommand {
+            command: cmd,
+            issue_num: num,
+        },
+        // Command but no issue URL — if it's a mention, create task; otherwise skip
+        (Some(_), true, None) => CommentAction::CreateMentionTask { issue_num: None },
+        (Some(_), false, None) => CommentAction::Skip,
+        // Mention without command — create task for agent
+        (None, true, issue_num) => CommentAction::CreateMentionTask { issue_num },
+        // Neither mention nor command — skip
+        (None, false, _) => CommentAction::Skip,
+    }
+}
+
 fn auto_unblock_cooldown_elapsed(count: i32, last_at: &str) -> bool {
     if count == 0 {
         return true;
@@ -1183,13 +1240,10 @@ pub(crate) async fn sync_tick(
 /// Scan for @mentions and handle them.
 ///
 /// Checks recent issue comments for @orch (and legacy @orchestrator) mentions.
-/// If a mention contains a slash command and the author is authorized, executes it.
-/// Otherwise, creates an internal task for the mention.
 /// Unified comment scanner — handles both @mentions and slash commands in one pass.
 ///
 /// For each comment, classifies it via [`classify_comment`] and dispatches:
-/// - Slash commands without @mention → validate + execute
-/// - Slash commands on @mentions → validate + execute + record sentinel task
+/// - Slash commands → validate + execute (with sentinel task if it was an @mention)
 /// - @mentions without commands → create internal task for agent to respond
 /// - Everything else → skip
 async fn scan_comments(
@@ -1219,7 +1273,6 @@ async fn scan_comments(
             Some(ts) => ts,
             None => fallback.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
         };
-
         match backend.get_mentions(&since_str).await {
             Ok(m) => m,
             Err(e) => {
@@ -1229,7 +1282,7 @@ async fn scan_comments(
         }
     };
 
-    // Dedup set for mention tasks already created (by source_id).
+    // Dedup set: mention tasks already created (by source_id).
     let existing_mentions: std::collections::HashSet<String> = if let Some(s) = store {
         match s.list_source_ids_by_source(repo, "mention").await {
             Ok(ids) => ids.into_iter().collect(),
@@ -1244,39 +1297,55 @@ async fn scan_comments(
 
     let gh = crate::github::http::GhHttp::new()?;
 
-    // Pre-compute action + is_pr for each comment. Running is_pull_request
-    // checks in parallel (join_all) avoids N serial API calls.
-    let actions_and_is_pr: Vec<(CommentAction, bool)> = {
-        let futs: Vec<_> = comments
-            .iter()
-            .map(|c| {
-                let action = classify_comment(
-                    &c.body,
-                    c.issue_url.as_deref(),
-                    &current_user,
-                    existing_mentions.contains(&c.id),
-                );
-                let num_opt = c
-                    .issue_url
-                    .as_deref()
-                    .and_then(extract_issue_number_from_url);
-                let gh = &gh;
-                async move {
-                    let is_pr = if let Some(ref num) = num_opt {
-                        gh.is_pull_request(repo, num).await
-                    } else {
-                        false
-                    };
-                    (action, is_pr)
-                }
-            })
-            .collect();
-        futures::future::join_all(futs).await
-    };
+    // Pre-classify all comments up front so we can batch the is_pull_request
+    // checks for CreateMentionTask entries before entering the main loop.
+    let actions: Vec<CommentAction> = comments
+        .iter()
+        .map(|c| {
+            classify_comment(
+                &c.body,
+                c.issue_url.as_deref(),
+                &current_user,
+                existing_mentions.contains(&c.id),
+            )
+        })
+        .collect();
+
+    // Collect (comment_index, issue_num) for all CreateMentionTask entries that
+    // need an is_pull_request check, then resolve them all concurrently with
+    // join_all to avoid N × RTT serial API calls inside the loop.
+    let pr_check_inputs: Vec<(usize, String)> = actions
+        .iter()
+        .enumerate()
+        .filter_map(|(i, action)| {
+            if let CommentAction::CreateMentionTask {
+                issue_num: Some(ref num),
+            } = action
+            {
+                Some((i, num.clone()))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let is_pr_values: Vec<bool> =
+        futures::future::join_all(pr_check_inputs.iter().map(|(_, num)| {
+            let gh = &gh;
+            async move { gh.is_pull_request(repo, num).await }
+        }))
+        .await;
+
+    // Build a lookup map: comment_index → is_pr.
+    let is_pr_map: std::collections::HashMap<usize, bool> = pr_check_inputs
+        .iter()
+        .map(|(i, _)| *i)
+        .zip(is_pr_values)
+        .collect();
 
     let mut last_success_ts: Option<String> = None;
 
-    for (comment, (action, is_pr)) in comments.iter().zip(actions_and_is_pr.into_iter()) {
+    for (comment_idx, (comment, action)) in comments.iter().zip(actions).enumerate() {
         match action {
             CommentAction::Skip => {
                 advance_cursor(&mut last_success_ts, &comment.created_at);
@@ -1324,6 +1393,9 @@ async fn scan_comments(
                 if let Err(e) = backend.acknowledge_mention(&comment.id).await {
                     tracing::debug!(err = %e, mention_id = %comment.id, "failed to acknowledge mention");
                 }
+
+                // Use the pre-fetched value — no serial API call here.
+                let is_pr = is_pr_map.get(&comment_idx).copied().unwrap_or(false);
 
                 let (title, task_body) = match (&issue_num, is_pr) {
                     (Some(num), false) => (


### PR DESCRIPTION
## Summary

Fixed the regression in scan_comments where is_pull_request was called serially inside the for loop for each CreateMentionTask comment. Applied the refactor commit (6b23660c) via cherry-pick with conflicts resolved by integrating the join_all optimization: pre-classify all comments, collect issue_nums for CreateMentionTask entries, batch-fetch all is_pull_request checks concurrently with futures::future::join_all before the loop, then look up from a HashMap in the loop body. All 1385 tests pass, clippy clean, fmt passes.

Closes #2361

---
*Task #2361 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*