### PR TITLE
bug: store.get().ok() in tick dispatch treats transient errors as 'no PR' — tasks skip review

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -1248,12 +1248,16 @@ pub(crate) async fn tick_dispatch_tasks(
                                 .resolve_task_id(&repo_owned, &task_id)
                                 .await
                             {
-                                Ok(Some(store_id)) => store_for_spawn
+                                Ok(Some(store_id)) => match store_for_spawn
                                     .get(store_id)
                                     .await
-                                    .ok()
-                                    .and_then(|t| t.pr_number)
-                                    .is_some(),
+                                {
+                                    Ok(t) => t.pr_number.is_some(),
+                                    Err(e) => {
+                                        tracing::warn!(task_id, err = %e, "store.get() failed — defaulting to needs_review");
+                                        true
+                                    }
+                                },
                                 Ok(None) => false,
                                 Err(e) => {
                                     tracing::warn!(task_id, err = %e, "failed to check PR status — defaulting to needs_review");


### PR DESCRIPTION
## Summary

Fixed store.get() error handling in tick.rs:1251-1260. Replaced `.ok().and_then(|t| t.pr_number).is_some()` with an explicit match that logs a warning and returns `true` (needs_review) on error, consistent with the `resolve_task_id` error branch above it. All 2889 tests pass.

Closes #2383

---
*Task #2383 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*