### PR TITLE
fix: pop stash and bail when rev-parse fails after git stash succeeds

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -689,7 +689,7 @@ pub(crate) async fn auto_merge_pr(
                                                 .current_dir(&wt_path)
                                                 .output()
                                                 .await;
-                                            ref_out
+                                            let stash_hash = ref_out
                                                 .ok()
                                                 .filter(|o| o.status.success())
                                                 .map(|o| {
@@ -697,7 +697,23 @@ pub(crate) async fn auto_merge_pr(
                                                         .trim()
                                                         .to_string()
                                                 })
-                                                .filter(|s| !s.is_empty())
+                                                .filter(|s| !s.is_empty());
+                                            if stash_hash.is_none() {
+                                                // Stash was created but we can't track its ref.
+                                                // Pop immediately to avoid orphaning the changes,
+                                                // then bail — the next tick will retry.
+                                                tracing::warn!(
+                                                    task_id = task.id.0,
+                                                    "git stash succeeded but rev-parse failed — popping stash and skipping rebase"
+                                                );
+                                                let _ = tokio::process::Command::new("git")
+                                                    .args(["stash", "pop"])
+                                                    .current_dir(&wt_path)
+                                                    .output()
+                                                    .await;
+                                                return Ok(());
+                                            }
+                                            stash_hash
                                         }
                                         _ => None,
                                     }


### PR DESCRIPTION
## Summary

- When `git stash --include-untracked` succeeds but the subsequent `git rev-parse refs/stash@{0}` fails, the stash reference is lost while the stash exists in git
- Previously the code would proceed with the rebase, leaving the stash permanently orphaned and agent work-in-progress changes silently lost
- Fix: if `rev-parse` fails after a successful stash, immediately pop the stash and return early — the next tick will retry the rebase

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo nextest run` — 2889/2889 tests pass

Fixes #2382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task #2382 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*