### PR TITLE
bug: review.rs fire-and-forget store_set for push_failures reset causes counter drift

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -90,9 +90,9 @@ use crate::engine::runner::worktree;
 use crate::engine::tasks::TaskManager;
 use crate::github::http::GhHttp;
 use crate::store::store_log_activity;
-use crate::store::store_set;
 use crate::store::TaskStore;
 use crate::store::{opt_store_get_task, set_review_session_expected, store_increment};
+use crate::store::{store_set, store_set_result};
 use crate::store::{CompleteRun, RunTokenUsage, StartRun};
 use crate::tmux::TmuxManager;
 use anyhow::Context;
@@ -1110,7 +1110,7 @@ async fn push_review_branch(
             )
             .await;
             if ctx.had_prev_push_failure {
-                store_set(
+                if let Err(e) = store_set_result(
                     &Some(Arc::clone(store)),
                     repo,
                     &task.id.0,
@@ -1119,7 +1119,10 @@ async fn push_review_branch(
                         ("push_failures", serde_json::json!(0)),
                     ],
                 )
-                .await;
+                .await
+                {
+                    tracing::warn!(task_id = task.id.0, err = %e, "failed to reset push_failures — counter may drift");
+                }
             }
             Ok(())
         }

--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -29,9 +29,7 @@ use crate::engine::EngineConfig;
 use crate::github::http::{GhHttp, PrReviewBatchData};
 use crate::github::types::{GitHubComment, GitHubReviewComment, PullRequestReview};
 use crate::store::TaskStore;
-use crate::store::{
-    store_increment_by_id, store_reset_failure_counters, store_set_by_id, store_set_result_by_id,
-};
+use crate::store::{store_increment_by_id, store_reset_failure_counters, store_set_result_by_id};
 use async_trait::async_trait;
 use dashmap::DashSet;
 use std::collections::HashMap;
@@ -262,12 +260,15 @@ pub(crate) async fn review_open_prs(
             match result {
                 Ok(Some(n)) => {
                     ready_tasks[task_idx].pr_number = Some(*n);
-                    store_set_by_id(
+                    if let Err(e) = store_set_result_by_id(
                         &Some(Arc::clone(store)),
                         ready_tasks[task_idx].store_id,
                         &[("pr_number", serde_json::json!(*n as i64))],
                     )
-                    .await;
+                    .await
+                    {
+                        tracing::warn!(task_id, err = %e, "failed to persist pr_number");
+                    }
                 }
                 Ok(None) => {
                     // No open PR — handled in phase 3.
@@ -479,12 +480,15 @@ pub(crate) async fn review_open_prs(
         };
 
         // Persist PR number (idempotent if already stored).
-        store_set_by_id(
+        if let Err(e) = store_set_result_by_id(
             &Some(Arc::clone(store)),
             task_info.store_id,
             &[("pr_number", serde_json::json!(pr_number as i64))],
         )
-        .await;
+        .await
+        {
+            tracing::warn!(task_id, err = %e, "failed to persist pr_number");
+        }
 
         let batch_data = match batch.get(&pr_number) {
             Some(d) => d,


### PR DESCRIPTION
## Summary

Replaced fire-and-forget `store_set`/`store_set_by_id` calls with error-propagating `store_set_result`/`store_set_result_by_id` in review.rs (push_failures reset) and review_poll.rs (pr_number persistence). Failures are now logged with tracing::warn! instead of silently swallowed.

### Files changed

- `src/engine/review.rs`
- `src/engine/review_poll.rs`


Closes #2384

---
*Task #2384 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*