### PR TITLE
fix: preserve attempts counter in reset_failure_counters to prevent audit trail overwrites

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1152,10 +1152,14 @@ impl TaskStore {
     /// undoing the review-cycle count that `handle_review_changes` just set.
     /// `ci_merge_failures` is preserved here because it must accumulate across attempts
     /// to enforce `MAX_CI_MERGE_FAILURES`, just like `review_cycles`.
+    ///
+    /// NOTE: `attempts` is intentionally NOT reset here. It must increase monotonically
+    /// across the task's lifetime so that `(task_id, attempt, run_type)` keys in
+    /// `task_runs` remain unique. Resetting it caused subsequent retries to overwrite
+    /// earlier audit trail records via the ON CONFLICT UPSERT in `start_run()`.
     pub async fn reset_failure_counters(&self, id: i64) -> anyhow::Result<()> {
         sqlx::query(
             "UPDATE tasks SET
-            attempts = 0,
             route_attempts = 0,
             review_agent_failures = 0,
             review_invocations = 0,
@@ -1453,7 +1457,6 @@ impl TaskStore {
             let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
             let sql = format!(
                 "UPDATE tasks SET
-            attempts = 0,
             route_attempts = 0,
             review_agent_failures = 0,
             review_invocations = 0,

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -569,7 +569,7 @@ async fn helper_store_reset_failure_counters_preserves_review_cycles() {
     let task = store.get(id).await.unwrap();
     assert_eq!(task.review_cycles, 1);
     assert_eq!(task.review_invocations, 0);
-    assert_eq!(task.attempts, 0);
+    assert_eq!(task.attempts, 1, "attempts must be preserved (monotonic)");
     assert_eq!(task.merge_conflict_retries, 0);
 }
 
@@ -1533,7 +1533,7 @@ async fn reset_failure_counters_preserves_review_cycles() {
     store.increment(id, "merge_conflict_retries").await.unwrap();
     store.increment(id, "network_retries").await.unwrap();
 
-    // reset_failure_counters must zero transient counters but preserve review_cycles and ci_merge_failures
+    // reset_failure_counters must zero transient counters but preserve review_cycles, ci_merge_failures, and attempts
     store.reset_failure_counters(id).await.unwrap();
 
     let task = store.get(id).await.unwrap();
@@ -1542,7 +1542,7 @@ async fn reset_failure_counters_preserves_review_cycles() {
         task.ci_merge_failures, 2,
         "ci_merge_failures must be preserved"
     );
-    assert_eq!(task.attempts, 0);
+    assert_eq!(task.attempts, 1, "attempts must be preserved (monotonic)");
     assert_eq!(task.review_agent_failures, 0);
     assert_eq!(task.merge_conflict_retries, 0);
     assert_eq!(task.network_retries, 0);
@@ -5597,7 +5597,7 @@ async fn batch_reset_failure_counters_preserves_review_cycles() {
 
     for id in [id1, id2] {
         let t = store.get(id).await.unwrap();
-        assert_eq!(t.attempts, 0);
+        assert_eq!(t.attempts, 1, "attempts must be preserved (monotonic)");
         assert_eq!(t.merge_conflict_retries, 0);
         assert_eq!(
             t.needs_review_refires, 0,


### PR DESCRIPTION
## Summary

- `reset_failure_counters()` was resetting `attempts = 0`, causing the next dispatch to use `attempt=1` again
- The `ON CONFLICT(task_id, attempt, run_type) DO UPDATE` in `start_run()` then silently overwrote the previous `attempt=1` record in `task_runs`
- Tasks that looped 6+ times via the "no PR and no commits" reroute showed only 1 run in the database — the last one

## Root cause

`attempts` must be monotonically increasing across the task's lifetime so `(task_id, attempt, run_type)` keys in `task_runs` remain unique. Resetting it to 0 between re-routes caused distinct runs to collide on the same key, destroying the audit trail and hiding cost/failure data for all retries.

## Fix

Removed `attempts = 0` from both `reset_failure_counters()` and `batch_reset_failure_counters()`. The counter now monotonically increases, ensuring every run produces a distinct `task_runs` record regardless of how many re-routes occur.

Updated all three tests that previously asserted `attempts == 0` after reset to assert `attempts` is preserved.

## Test plan

- [x] `cargo nextest run reset_failure_counters` — 8/8 pass
- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings` — clean

Closes #2394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task #2394 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*