### PR TITLE
fix: ReviewDecision::Rerouted stops no_code_reroutes counter reset — infinite retry loop

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -119,6 +119,8 @@ pub(crate) enum ReviewDecision {
     Blocked(String),
     /// No PR exists — nothing to review, task marked done directly.
     Skipped,
+    /// No PR and no commits — task re-routed for retry (no_code_reroutes counter must not be reset).
+    Rerouted,
 }
 
 /// Outcome of [`ensure_pr_exists`]: either a ready PR number or an early return decision.
@@ -663,6 +665,7 @@ fn review_decision_name(decision: &ReviewDecision) -> &'static str {
         ReviewDecision::Failed(_) => "failed",
         ReviewDecision::Blocked(_) => "blocked",
         ReviewDecision::Skipped => "skipped",
+        ReviewDecision::Rerouted => "rerouted",
     }
 }
 
@@ -949,7 +952,8 @@ async fn finalize_review_run(
     let outcome = match &parsed.decision {
         ReviewDecision::Approve
         | ReviewDecision::RequestChanges { .. }
-        | ReviewDecision::Skipped => "success",
+        | ReviewDecision::Skipped
+        | ReviewDecision::Rerouted => "success",
         ReviewDecision::Failed(_) | ReviewDecision::Blocked(_) => "failed",
     };
     let error = match &parsed.decision {
@@ -2036,7 +2040,7 @@ async fn ensure_pr_exists(
                         tracing::error!(task_id = task.id.0, err = %e, "update_task_status(New) failed — task may be stuck in InReview");
                     }
                 }
-                Ok(EnsurePrResult::EarlyReturn(ReviewDecision::Skipped))
+                Ok(EnsurePrResult::EarlyReturn(ReviewDecision::Rerouted))
             }
         }
         Err(e) => {

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -312,6 +312,12 @@ pub fn spawn(
                                 }
                                 ReviewOutcome::Ok
                             }
+                            Ok(ReviewDecision::Rerouted) => {
+                                // Task was re-routed because there was no PR and no commits.
+                                // Do NOT reset failure counters — no_code_reroutes must accumulate
+                                // so the max_reroute_attempts safety limit can be reached.
+                                ReviewOutcome::Ok
+                            }
                             Ok(ReviewDecision::Skipped) => {
                                 // Skipped indicates there's nothing to review (no PR etc.).
                                 // Clear transient failure counters but preserve review_cycles.

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -1548,6 +1548,88 @@ async fn reset_failure_counters_preserves_review_cycles() {
     assert_eq!(task.network_retries, 0);
 }
 
+/// Regression test for issue #2392.
+///
+/// `reset_failure_counters` zeros `no_code_reroutes`. This is why
+/// `ReviewDecision::Rerouted` must NOT call `reset_failure_counters` — the
+/// `Skipped` path did call it, causing the counter to reset to 0 on every cycle
+/// so the `max_reroute_attempts` limit was never reached.
+#[tokio::test]
+async fn reset_failure_counters_resets_no_code_reroutes() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let id = store
+        .create(&NewTask {
+            external_id: None,
+            repo: "owner/repo".to_string(),
+            origin: "internal".to_string(),
+            title: "no-code-reroute regression".to_string(),
+            body: "".to_string(),
+            source: "manual".to_string(),
+            source_id: "".to_string(),
+            author: "".to_string(),
+            url: "".to_string(),
+            labels: vec![],
+            parent_id: None,
+        })
+        .await
+        .unwrap();
+
+    store.increment(id, "no_code_reroutes").await.unwrap();
+    store.increment(id, "no_code_reroutes").await.unwrap();
+    let task = store.get(id).await.unwrap();
+    assert_eq!(task.no_code_reroutes, 2);
+
+    // Calling reset_failure_counters (the Skipped path) zeros the counter —
+    // this is the original bug: the counter could never reach max_reroute_attempts.
+    store.reset_failure_counters(id).await.unwrap();
+
+    let task = store.get(id).await.unwrap();
+    assert_eq!(
+        task.no_code_reroutes, 0,
+        "reset_failure_counters must zero no_code_reroutes (bug: Skipped path called this)"
+    );
+}
+
+/// Regression test for issue #2392.
+///
+/// When `ReviewDecision::Rerouted` is returned the subscriber must NOT call
+/// `reset_failure_counters`, so `no_code_reroutes` accumulates across cycles
+/// and the `max_reroute_attempts` safety limit is reachable.
+#[tokio::test]
+async fn no_code_reroutes_accumulates_when_reset_not_called() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let id = store
+        .create(&NewTask {
+            external_id: None,
+            repo: "owner/repo".to_string(),
+            origin: "internal".to_string(),
+            title: "no-code-reroute accumulation regression".to_string(),
+            body: "".to_string(),
+            source: "manual".to_string(),
+            source_id: "".to_string(),
+            author: "".to_string(),
+            url: "".to_string(),
+            labels: vec![],
+            parent_id: None,
+        })
+        .await
+        .unwrap();
+
+    // Simulate 3 consecutive Rerouted cycles: increment only, no reset.
+    for _ in 0..3 {
+        store.increment(id, "no_code_reroutes").await.unwrap();
+        // ReviewDecision::Rerouted path: reset_failure_counters is NOT called here.
+    }
+
+    let task = store.get(id).await.unwrap();
+    assert_eq!(
+        task.no_code_reroutes, 3,
+        "no_code_reroutes must accumulate across Rerouted cycles so max_reroute_attempts is enforced"
+    );
+}
+
 #[tokio::test]
 async fn status_lifecycle_full_flow() {
     let store = TaskStore::open_memory().await.unwrap();


### PR DESCRIPTION
## Summary

- Add `ReviewDecision::Rerouted` variant for the no-PR reroute path in `review.rs`
- Return `Rerouted` (instead of `Skipped`) when a task has no PR and no commits and is being re-routed for retry
- Handle `Rerouted` in the subscriber **without** calling `store_reset_failure_counters()`, so `no_code_reroutes` accumulates correctly
- `Skipped` semantics unchanged: PR already merged / nothing to review → reset counters

## Root cause

`review.rs` was returning `ReviewDecision::Skipped` from the no-PR reroute path. The subscriber reset `no_code_reroutes = 0` for every `Skipped` result. The counter oscillated 0 → 1 → 0 on every cycle and could never reach `max_reroute_attempts` (default 3), creating an infinite retry loop that consumed full agent runs and API credits.

Affected tasks in the last 12 h: 303, 2372, 286, 295, internal:102650, 104039, 103579.

## Changes

- `src/engine/review.rs` — add `Rerouted` variant; use it at line 2031; add to `review_decision_name()` and the `outcome` match
- `src/engine/subscribers/review.rs` — add `Rerouted` arm that returns `ReviewOutcome::Ok` without resetting counters

## Testing

- `cargo fmt -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo nextest run` — 2889 tests passed, 19 skipped ✅

Closes #2392

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task #2392 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*