### PR TITLE
bug: unreachable!() panic in parse_since_duration on malformed duration suffix

### DIFF
--- a/src/store/control.rs
+++ b/src/store/control.rs
@@ -386,7 +386,10 @@ pub fn parse_since_duration(s: &str) -> anyhow::Result<String> {
         'd' => n.checked_mul(86_400),
         'h' => n.checked_mul(3_600),
         'm' => n.checked_mul(60),
-        _ => unreachable!(),
+        _ => anyhow::bail!(
+            "unrecognized duration unit '{}' (expected d, h, or m)",
+            unit
+        ),
     }
     .ok_or_else(|| anyhow::anyhow!("--since value is too large"))?
     .try_into()


### PR DESCRIPTION
## Summary

Done. Fixed the bug in `src/store/control.rs:389` by replacing `unreachable!()` with a proper error return using `anyhow::bail!()`. This prevents a potential service panic if an unexpected duration unit somehow reaches that code path.

All checks passed:
- Formatting: ✓
- Clippy: ✓
- Tests: 2893 passed, 19 skipped

### What was done

- Formatting: ✓
- Clippy: ✓
- Tests: 2893 passed, 19 skipped


Closes #2399

---
*Task #2399 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*