### PR TITLE
bug: unreachable!() panic in record_mention_task on network failures

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -523,9 +523,9 @@ async fn handle_slash_command(
                     mention.author, mention.body
                 ),
             ),
-            // Already handled above
             CommandOutcome::FetchFailed | CommandOutcome::CollaboratorCheckFailed => {
-                unreachable!()
+                tracing::debug!("skipping mention task record due to earlier command failure");
+                return;
             }
         };
 


### PR DESCRIPTION
## Summary

Fix is already in place and passes all quality gates. The change replaces `unreachable!()` with graceful handling:

```rust
CommandOutcome::FetchFailed | CommandOutcome::CollaboratorCheckFailed => {
    tracing::debug!("skipping mention task record due to earlier command failure");
    return;
}
```

This prevents the engine from crashing when network failures occur during mention processing.

Closes #2400

---
*Task #2400 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*