### PR TITLE
router: LLM pool pre-cooling blocks fallback from being attempted

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -1038,25 +1038,25 @@ impl Router {
         // If every pool entry was pre-cooled (nothing was attempted), do not
         // immediately exhaust the pool again — fail fast and let the tick loop
         // retry on the next cycle instead of cascading failures.
+        // However, we should still try the fallback if configured.
         if !attempted_any {
             let now = chrono::Utc::now().timestamp();
             let earliest = self.earliest_pool_cooldown();
             if let Some(until) = earliest {
+                // Pool entries exist but are all cooled - we'll try fallback below
                 let remaining = until.saturating_sub(now);
                 tracing::warn!(
                     remaining_secs = remaining,
                     pool = ?pool,
-                    "all router LLM pool entries on cooldown — failing fast to let tick retry"
+                    "all router LLM pool entries on cooldown — will try fallback"
                 );
-                return Err(AllCooledError {
-                    scope: "router pool".to_string(),
-                }
-                .into());
+                // Continue to fallback logic instead of returning early
+            } else {
+                // No pool cooldowns found either — this means the pool was empty
+                // or every entry was filtered out for some other reason.
+                return Err(last_err
+                    .unwrap_or_else(|| anyhow::anyhow!("all router LLM pool entries exhausted")));
             }
-            // No pool cooldowns found either — this means the pool was empty
-            // or every entry was filtered out for some other reason.
-            return Err(last_err
-                .unwrap_or_else(|| anyhow::anyhow!("all router LLM pool entries exhausted")));
         }
 
         // All pool entries failed or were cooled — try the configured fallback


### PR DESCRIPTION
## Summary

Fix committed and pushed. Here's the summary:

**Bug:** When all router LLM pool entries were pre-cooled (rate-limited), the code returned `AllCooledError` immediately at `mod.rs:1044-1054`, never reaching the configured fallback (`claude:haiku`). This caused tasks to fail entirely instead of falling back.

**Fix:** When all pool entries are pre-cooled (`!attempted_any && earliest.is_some()`), the code now logs a warning and falls through to the fallback logic instead of returning early. The onl

### What was done

- Bug:** When all router LLM pool entries were pre-cooled (rate-limited), the code returned `AllCooledError` immediately at `mod.rs:1044-1054`, never reaching the configured fallback (`claude:haiku`). This caused tasks to fail entirely instead of falling back.
- Fix:** When all pool entries are pre-cooled (`!attempted_any && earliest.is_some()`), the code now logs a warning and falls through to the fallback logic instead of returning early. The only case that returns early is when the pool was empty (`earliest.is_none()`), meaning no entries were configured at all.
- Quality gates:** `cargo fmt`, `cargo clippy`, and 142 router tests all pass.


Closes #2403

---
*Task #2403 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*