### PR TITLE
bug: no-code-reroute loop on external tasks — 5 tasks hit 20+ failures, agents keep completing without changes

### DIFF
--- a/migrations/025_no_code_last_agent.sql
+++ b/migrations/025_no_code_last_agent.sql
@@ -1,0 +1,5 @@
+-- Track which agent produced the last no-code failure for a task.
+-- Used to detect same-agent loops: if the router selects the same agent
+-- that just caused a no-code failure, the task is blocked immediately
+-- instead of re-running the same agent into the same worktree state.
+ALTER TABLE tasks ADD COLUMN no_code_last_agent TEXT NOT NULL DEFAULT '';

--- a/src/cli/events.rs
+++ b/src/cli/events.rs
@@ -363,6 +363,7 @@ mod tests {
             auto_unblock_last_reason: String::new(),
             ci_recovery_count: 0,
             no_code_reroutes: 0,
+            no_code_last_agent: String::new(),
             created_at: String::new(),
             updated_at: String::new(),
         };
@@ -431,6 +432,7 @@ mod tests {
             auto_unblock_last_reason: String::new(),
             ci_recovery_count: 0,
             no_code_reroutes: 0,
+            no_code_last_agent: String::new(),
             created_at: String::new(),
             updated_at: String::new(),
         };

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -37,7 +37,7 @@ use crate::engine::cooldown::{
     cooldown_until, is_agent_degraded, is_agent_in_cooldown, is_model_in_cooldown,
     refresh_degraded_agents,
 };
-use crate::store::{store_log_activity, TaskStore};
+use crate::store::{get_task_field_direct, store_log_activity, TaskStore};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -529,6 +529,44 @@ impl Router {
         Some(agent)
     }
 
+    /// If the selected agent matches `no_code_last_agent` for this task, filter it
+    /// out of the candidates and return the filtered list. Used to prevent the
+    /// same agent from being selected twice in a row after a no-code failure (#2410).
+    async fn skip_no_code_agent(
+        &self,
+        store: &std::sync::Arc<TaskStore>,
+        repo: &str,
+        task_id: &str,
+        candidates: &[String],
+    ) -> Option<Vec<String>> {
+        let no_code_agent = get_task_field_direct(store, repo, task_id, "no_code_last_agent")
+            .await
+            .unwrap_or_default();
+        if no_code_agent.is_empty() || !candidates.iter().any(|a| a == &no_code_agent) {
+            return None;
+        }
+        let filtered: Vec<String> = candidates
+            .iter()
+            .filter(|a| a.as_str() != no_code_agent)
+            .cloned()
+            .collect();
+        if filtered.is_empty() {
+            tracing::warn!(
+                task_id,
+                no_code_agent = %no_code_agent,
+                "all available agents are the no-code agent — cannot skip"
+            );
+            return None;
+        }
+        tracing::info!(
+            task_id,
+            skipped = %no_code_agent,
+            remaining = ?filtered,
+            "skipping no-code agent, routing to alternative"
+        );
+        Some(filtered)
+    }
+
     /// Route a task to the best agent.
     ///
     /// Routing logic (in priority order):
@@ -632,10 +670,21 @@ impl Router {
             let complexity = strategies::extract_complexity_from_labels(&task.labels);
 
             // Check if any agents have available models for this complexity
-            let candidates = self.available_agents_for_complexity(&complexity);
+            let mut candidates = self.available_agents_for_complexity(&complexity);
             if candidates.is_empty() {
                 self.wait_for_cooldown(Some(&complexity)).await?;
                 continue;
+            }
+
+            // Skip the no-code agent if one is recorded for this task (#2410).
+            // If all available agents are filtered out, we fall through to
+            // LLM routing with no constraints (LLM will pick the same agent but
+            // the response_handler will block it immediately via same-agent check).
+            if let Some(filtered) = self
+                .skip_no_code_agent(store, repo, &task.id.0, &candidates)
+                .await
+            {
+                candidates = filtered;
             }
 
             // 2. Weighted round-robin — capacity-based selection
@@ -703,6 +752,58 @@ impl Router {
                     if candidates.is_empty() {
                         self.wait_for_cooldown(Some(&result.complexity)).await?;
                         continue;
+                    }
+
+                    // If the LLM selected the no-code agent, filter it out and
+                    // pick an alternative (#2410). Re-use the existing fallback logic.
+                    let no_code_agent =
+                        get_task_field_direct(store, repo, &task.id.0, "no_code_last_agent")
+                            .await
+                            .unwrap_or_default();
+                    let use_fallback =
+                        !no_code_agent.is_empty() && candidates.iter().any(|a| a != &no_code_agent);
+                    if use_fallback || result.agent == no_code_agent {
+                        // Pick the first agent that isn't the no-code agent.
+                        let fallback_agent = candidates
+                            .iter()
+                            .find(|a| a.as_str() != no_code_agent)
+                            .cloned()
+                            .unwrap_or_else(|| candidates[0].clone());
+                        if fallback_agent != result.agent {
+                            tracing::info!(
+                                task_id = %task.id.0,
+                                llm_selected = %result.agent,
+                                skipped = %no_code_agent,
+                                fallback = %fallback_agent,
+                                "LLM selected the no-code agent — routing to alternative"
+                            );
+                        }
+                        let fallback_model = self.config.model_for_complexity(
+                            &fallback_agent,
+                            &result.complexity,
+                            &task.id.0,
+                        );
+
+                        self.set_route_attempts(&task.id.0, 0, store, repo).await;
+                        let result = RouteResult {
+                            agent: fallback_agent.clone(),
+                            model: fallback_model,
+                            complexity: result.complexity.clone(),
+                            estimate: result.estimate,
+                            reason: format!(
+                                "LLM selected no-code agent {}; routed to {}",
+                                result.agent, fallback_agent
+                            ),
+                            profile: result.profile.clone(),
+                            selected_skills: result.selected_skills.clone(),
+                            warning: Some(format!(
+                                "LLM selected no-code agent {}; used fallback {}",
+                                result.agent, fallback_agent
+                            )),
+                        };
+                        self.log_route_activity(store, repo, &task.id.0, &result, None)
+                            .await;
+                        return Ok(result);
                     }
 
                     let model_cooled = result

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -760,9 +760,7 @@ impl Router {
                         get_task_field_direct(store, repo, &task.id.0, "no_code_last_agent")
                             .await
                             .unwrap_or_default();
-                    let use_fallback =
-                        !no_code_agent.is_empty() && candidates.iter().any(|a| a != &no_code_agent);
-                    if use_fallback || result.agent == no_code_agent {
+                    if result.agent == no_code_agent {
                         // Pick the first agent that isn't the no-code agent.
                         let fallback_agent = candidates
                             .iter()

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -881,6 +881,7 @@ mod tests {
             auto_unblock_last_reason: String::new(),
             ci_recovery_count: 0,
             no_code_reroutes: 0,
+            no_code_last_agent: String::new(),
             created_at: String::new(),
             updated_at: String::new(),
         };

--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -794,6 +794,7 @@ async fn apply_post_decision_effects(
     is_external: bool,
     no_code_reroutes: u64,
     max_reroutes: u32,
+    agent_name: &str,
 ) {
     if push_state.is_workflow_scope_failure {
         // Non-retryable — block immediately with actionable guidance.
@@ -866,29 +867,70 @@ async fn apply_post_decision_effects(
             "agent done, commits pushed, but PR creation failed — re-dispatching as routed"
         );
     } else if is_no_code_reroute {
-        if final_status == "blocked" {
+        // Detect same-agent loop: if the router selects the same agent that just
+        // produced a no-code result, block immediately instead of letting it
+        // run again into the same unchanged worktree state (#2410).
+        let prev_no_code_agent = ctx
+            .get_task()
+            .await
+            .map(|t| t.no_code_last_agent.clone())
+            .unwrap_or_default();
+
+        let is_same_agent = !prev_no_code_agent.is_empty() && prev_no_code_agent == agent_name;
+
+        // Block if we've hit max reroutes OR if the same agent would be selected again.
+        let should_block = final_status == "blocked" || is_same_agent;
+
+        if should_block {
             tracing::error!(
                 task_id = ctx.task_id,
                 no_code_reroutes,
                 max_reroutes,
-                "reached max reroute attempts for no-code-result on external task — blocking for human review"
+                is_same_agent,
+                agent = %agent_name,
+                "blocking no-code reroute: {}",
+                if is_same_agent {
+                    format!(
+                        "same agent {} would be selected again (prev: {prev_no_code_agent})",
+                        agent_name
+                    )
+                } else {
+                    format!(
+                        "reached max reroute attempts ({}/{}) for no-code-result",
+                        no_code_reroutes, max_reroutes
+                    )
+                }
             );
         }
-        // Clear agent/model and record an explanatory last_error.
-        let msg = if final_status == "blocked" {
-            format!(
-                "agent completed without code changes after {}/{} reroute attempts on external task requiring PR",
-                no_code_reroutes, max_reroutes
-            )
+
+        let msg = if should_block {
+            if is_same_agent {
+                format!(
+                    "agent {} completed without code changes twice — same-agent loop detected, blocking for human review",
+                    agent_name
+                )
+            } else {
+                format!(
+                    "agent completed without code changes after {}/{} reroute attempts on external task requiring PR",
+                    no_code_reroutes, max_reroutes
+                )
+            }
         } else {
             "agent completed without code changes on external task requiring PR".to_string()
         };
-        ctx.set(&[
-            ("agent", serde_json::json!(null)),
-            ("model", serde_json::json!(null)),
-            ("last_error", serde_json::json!(msg)),
-        ])
-        .await;
+
+        let mut fields: Vec<(&str, serde_json::Value)> =
+            vec![("last_error", serde_json::json!(msg))];
+
+        // Always record which agent produced this no-code result so the router can
+        // skip it on the next attempt. Also clear agent/model to force re-routing
+        // (the router will pick a fresh agent, possibly the same one, which will be
+        // caught by the same-agent check on the next round).
+        fields.push(("no_code_last_agent", serde_json::json!(agent_name)));
+        fields.push(("agent", serde_json::json!(null)));
+        fields.push(("model", serde_json::json!(null)));
+
+        ctx.set(&fields).await;
     } else if resp_status == "done" && !has_pr && is_external {
         // External task with non-code labels (e.g. documentation, research) —
         // allowed to be marked done without a PR.
@@ -1173,6 +1215,7 @@ pub async fn handle_success(
         is_external,
         no_code_reroutes,
         max_reroutes,
+        agent_name,
     )
     .await;
 

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -704,6 +704,7 @@ async fn auto_unblock_blocked_tasks(
             fields.push(("route_attempts", serde_json::json!(0)));
         }
         fields.push(("no_code_reroutes", serde_json::json!(0)));
+        fields.push(("no_code_last_agent", serde_json::json!("")));
         if has_review_failure {
             fields.push(("review_agent_failures", serde_json::json!(0)));
             fields.push(("review_invocations", serde_json::json!(0)));

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -286,6 +286,34 @@ pub async fn store_increment(
     }
 }
 
+/// Read a specific string field from a task record.
+pub async fn get_task_field(
+    store: &Option<Arc<TaskStore>>,
+    repo: &str,
+    task_id: &str,
+    field: &str,
+) -> Option<String> {
+    let task = opt_store_get_task(store, repo, task_id).await?;
+    match field {
+        "no_code_last_agent" => Some(task.no_code_last_agent),
+        _ => {
+            tracing::warn!(task_id, field, "get_task_field: unknown field");
+            None
+        }
+    }
+}
+
+/// Read a specific string field from a task record (store always available).
+pub async fn get_task_field_direct(
+    store: &Arc<TaskStore>,
+    repo: &str,
+    task_id: &str,
+    field: &str,
+) -> Option<String> {
+    let store_opt: &Option<Arc<TaskStore>> = &Some(store.clone());
+    get_task_field(store_opt, repo, task_id, field).await
+}
+
 /// Reset all task counters in the task store.
 pub async fn store_reset_counters(store: &Option<Arc<TaskStore>>, repo: &str, task_id: &str) {
     if let Some(ref store) = store {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -39,11 +39,12 @@ mod tasks;
 pub use control::{parse_since_duration, ChatCostSummary, ControlMessage, MemoryEntry};
 #[allow(unused_imports)]
 pub use helpers::{
-    get_cost_estimate, get_recent_memory, get_token_summary, get_token_usage, get_total_tokens,
-    opt_store_get_task, opt_store_get_task_by_id, resolve_store_id, review_session_expected,
-    set_review_session_expected, store_increment, store_increment_by_id, store_log_activity,
-    store_reset_counters, store_reset_failure_counters, store_set, store_set_by_id,
-    store_set_result, store_set_result_by_id, store_touch_updated_at, store_touch_updated_at_by_id,
+    get_cost_estimate, get_recent_memory, get_task_field, get_task_field_direct, get_token_summary,
+    get_token_usage, get_total_tokens, opt_store_get_task, opt_store_get_task_by_id,
+    resolve_store_id, review_session_expected, set_review_session_expected, store_increment,
+    store_increment_by_id, store_log_activity, store_reset_counters, store_reset_failure_counters,
+    store_set, store_set_by_id, store_set_result, store_set_result_by_id, store_touch_updated_at,
+    store_touch_updated_at_by_id,
 };
 #[allow(unused_imports)]
 pub use jobs::JobState;

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1139,6 +1139,7 @@ impl TaskStore {
             auto_unblock_last_reason = '',
             ci_recovery_count = 0,
             no_code_reroutes = 0,
+            no_code_last_agent = '',
             needs_review_refires = 0,
             updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
          WHERE id = ?",
@@ -1176,6 +1177,7 @@ impl TaskStore {
             auto_unblock_last_reason = '',
             ci_recovery_count = 0,
             no_code_reroutes = 0,
+            no_code_last_agent = '',
             needs_review_refires = 0,
             updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
          WHERE id = ?",

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -20,10 +20,10 @@ pub(crate) const TASK_COLS: &str = "id, external_id, repo, origin, title, body, 
     model_reroute_chain, limit_reroute_chain, budget_warning, budget_exceeded, \
     memory, delegations, created_at, updated_at, review_session_expected, \
      review_invocations, needs_review_refires, push_failures, auto_unblock_count, auto_unblock_last_at, \
-     ci_recovery_count, auto_unblock_last_reason, no_code_reroutes, network_retries";
+     ci_recovery_count, auto_unblock_last_reason, no_code_reroutes, network_retries, no_code_last_agent";
 
 /// Number of columns in TASK_COLS (used for diagnostic verification).
-pub(crate) const TASK_COLS_COUNT: usize = 61;
+pub(crate) const TASK_COLS_COUNT: usize = 62;
 
 /// Explicit column list for `SELECT` queries on the `task_runs` table.
 const TASK_RUN_COLS: &str =
@@ -86,6 +86,7 @@ const ALLOWED_FIELDS: &[&str] = &[
     "ci_recovery_count",
     "no_code_reroutes",
     "network_retries",
+    "no_code_last_agent",
 ];
 
 /// Allowlist of fields that can be incremented via `increment` and `batch_increment`.
@@ -228,6 +229,8 @@ pub struct Task {
 
     // Done-without-PR circuit breaker
     pub no_code_reroutes: i32,
+    /// Which agent produced the last no-code failure (used to detect same-agent loops).
+    pub no_code_last_agent: String,
 
     // Timestamps
     pub created_at: String,
@@ -1964,6 +1967,9 @@ impl TaskStore {
                 .unwrap_or_default(),
             ci_recovery_count: row.try_get::<i32, _>("ci_recovery_count").unwrap_or(0),
             no_code_reroutes: row.try_get::<i32, _>("no_code_reroutes").unwrap_or(0),
+            no_code_last_agent: row
+                .try_get::<String, _>("no_code_last_agent")
+                .unwrap_or_default(),
             created_at: row.try_get::<String, _>("created_at").unwrap_or_default(),
             updated_at: row.try_get::<String, _>("updated_at").unwrap_or_default(),
         })


### PR DESCRIPTION
## Summary

The implementation is complete. Here's a summary of the fix for issue #2410:

## Summary of Changes

The fix prevents the "no-code reroute loop" where an agent completes without code changes, gets re-routed, and the same agent is selected again (running into the same unchanged worktree state).

### Key Changes:

1. **New Database Field** (`migrations/025_no_code_last_agent.sql`):
   - Added `no_code_last_agent` column to track which agent last produced a no-code failure

2. **Response Handler** 

### What was done

- Added `no_code_last_agent` column to track which agent last produced a no-code failure
- Lines 869-933: Added same-agent loop detection
- Records the failing agent in `no_code_last_agent` field
- Checks if the same agent would be selected again
- If same agent detected → blocks immediately instead of re-running
- Provides clear error messages explaining why
- Lines 532-568: Added `skip_no_code_agent()` helper that filters out the previously failing agent from candidates
- Lines 679-688: Applied filtering before weighted round-robin routing
- Lines 757-807: Added fallback logic for LLM routing - if LLM selects the same no-code agent, it picks an alternative
- `tasks.rs`: Added `no_code_last_agent` field to Task struct
- `helpers.rs`: Added `get_task_field_direct()` helper to efficiently read specific fields
- `sync.rs`: Clears `no_code_last_agent` on task reset
- Added `no_code_last_agent` field to test fixtures
- **First no-code failure**: Agent runs, produces no code changes → task set to `new` with `no_code_last_agent` recorded
- **Router skips that agent**: Next routing pass filters out the recorded agent from candidates
- **If LLM picks same agent anyway**: Fallback logic picks an alternative
- **If same agent would run again** (edge case): Response handler blocks immediately with clear error
- **If max reroutes exceeded**: Task blocked for human review


### Files changed

- `migrations/025_no_code_last_agent.sql`
- `src/cli/events.rs`
- `src/engine/router/mod.rs`
- `src/engine/runner/response.rs`
- `src/engine/runner/response_handler.rs`


Closes #2410

---
*Task #2410 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*