### PR TITLE
max_reroute_attempts = 0 causes immediate task blocking

### DIFF
--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -341,7 +341,8 @@ pub(crate) async fn review_open_prs(
                             .ok()
                             .and_then(|s| s.parse().ok())
                     })
-                    .unwrap_or(3);
+                    .unwrap_or(3)
+                    .max(1);
 
                 // Avoid incrementing persistent reroute counters when the last
                 // store error indicates a transient GitHub 5xx/transport failure.


### PR DESCRIPTION
## Summary

Fixed bug where max_reroute_attempts = 0 caused immediate task blocking. The fix ensures the minimum value is 1 by adding .max(1) to the config parsing.

Closes #2417

---
*Task #2417 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*