### PR TITLE
feat: opencode silent exit-0 should retry with free models before failing over to claude/codex

### DIFF
--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -374,29 +374,24 @@ pub async fn handle_error(
                 }
                 // Before falling through to handle_failover() (which tries claude/codex),
                 // check whether this agent has any free models that haven't been tried yet.
-                // Only do this for simple-complexity tasks: free models are the right tier
-                // for simple tasks.  For medium/complex tasks, fall through to
-                // handle_failover() so the next agent is chosen at the same complexity
-                // level (e.g. claude/sonnet or codex/gpt-5.2) instead of a weaker model.
-                let is_simple = matches!(complexity, None | Some("simple"));
+                // Silent exit-0 is usually model/provider-specific; retrying other free
+                // models first avoids wasting paid claude/codex failovers.
                 let current = model_name.unwrap_or("");
-                if is_simple {
-                    if let Some(result) = try_free_model_reroute(
-                        task_id,
-                        agent_name,
-                        agent_runner,
-                        &[current],
-                        true,
-                        Some("opencode"),
-                        true,
-                        "silent exit 0, retrying with free model",
-                        store,
-                        repo,
-                    )
-                    .await
-                    {
-                        return Ok(result);
-                    }
+                if let Some(result) = try_free_model_reroute(
+                    task_id,
+                    agent_name,
+                    agent_runner,
+                    &[current],
+                    true,
+                    Some("opencode"),
+                    true,
+                    "silent exit 0, retrying with free model",
+                    store,
+                    repo,
+                )
+                .await
+                {
+                    return Ok(result);
                 }
             }
             (
@@ -764,7 +759,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn silent_exit0_skips_free_model_for_medium_complexity() {
+    async fn silent_exit0_retries_free_model_for_medium_complexity() {
         let runner = MockRunner {
             free: vec!["opencode/mimo-v2-omni-free".to_string()],
         };
@@ -773,7 +768,7 @@ mod tests {
             message: String::new(),
         };
 
-        // complexity=medium → skip free model retry, fall through to agent failover
+        // complexity=medium → still retry free model before cross-agent failover
         let result = handle_error(
             "test-1195-medium",
             &err,
@@ -789,13 +784,13 @@ mod tests {
         .unwrap();
 
         assert!(
-            matches!(result, ErrorHandleResult::Continue { .. }),
-            "expected Continue for medium complexity — should fall through to agent failover, not retry with free model"
+            matches!(result, ErrorHandleResult::EarlyReturn { ref status } if status == "routed"),
+            "expected EarlyReturn{{status: routed}} for medium complexity — free model should be tried before failover"
         );
     }
 
     #[tokio::test]
-    async fn silent_exit0_skips_free_model_for_complex_complexity() {
+    async fn silent_exit0_retries_free_model_for_complex_complexity() {
         let runner = MockRunner {
             free: vec!["opencode/mimo-v2-omni-free".to_string()],
         };
@@ -804,7 +799,7 @@ mod tests {
             message: String::new(),
         };
 
-        // complexity=complex → skip free model retry, fall through to agent failover
+        // complexity=complex → still retry free model before cross-agent failover
         let result = handle_error(
             "test-1195-complex",
             &err,
@@ -820,8 +815,8 @@ mod tests {
         .unwrap();
 
         assert!(
-            matches!(result, ErrorHandleResult::Continue { .. }),
-            "expected Continue for complex complexity — should fall through to agent failover, not retry with free model"
+            matches!(result, ErrorHandleResult::EarlyReturn { ref status } if status == "routed"),
+            "expected EarlyReturn{{status: routed}} for complex complexity — free model should be tried before failover"
         );
     }
 


### PR DESCRIPTION
## Summary

Updated silent exit-0 handling so opencode retries available free models before falling through to cross-agent failover, and aligned tests with the new behavior.

### What was done

- Removed the complexity gate in `AgentError::Unknown { exit_code: 0, message: "" }` handling so free-model reroute is attempted for silent exit-0 regardless of complexity.
- Kept model cooldown recording for silent exit-0 and preserved existing fallback path when no eligible free model remains.
- Updated and renamed medium/complex silent-exit tests to assert reroute (`EarlyReturn { status: "routed" }`) instead of immediate failover.
- Ran validation checks successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, targeted `cargo test -q silent_exit0_`, and full `cargo nextest run` (2944 passed).
- Committed changes with message: `fix(runner): retry free opencode models on silent exit-0 before failover`.


Closes #2424

---
*Task #2424 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*