### PR TITLE
feat: orch stream --formatted flag for human-readable NDJSON output

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -444,9 +444,9 @@ fn print_formatted(content: &str) {
 
 /// Stream live output from a running task.
 ///
-/// When `raw` is false (default), NDJSON lines are parsed and formatted into
-/// human-readable output. Pass `raw: true` to print unformatted NDJSON.
-pub async fn stream_task(task_id: &str, raw: bool) -> anyhow::Result<()> {
+/// When `formatted` is true (default), NDJSON lines are parsed and formatted
+/// into human-readable output. Pass `formatted: false` to print raw NDJSON.
+pub async fn stream_task(task_id: &str, formatted: bool) -> anyhow::Result<()> {
     let transport = Arc::new(Transport::new());
 
     let tmux = crate::tmux::TmuxManager::new();
@@ -485,10 +485,10 @@ pub async fn stream_task(task_id: &str, raw: bool) -> anyhow::Result<()> {
     loop {
         match rx.recv().await {
             Ok(chunk) => {
-                if raw {
-                    print!("{}", chunk.content);
-                } else {
+                if formatted {
                     print_formatted(&chunk.content);
+                } else {
+                    print!("{}", chunk.content);
                 }
                 std::io::Write::flush(&mut std::io::stdout())?;
 
@@ -520,9 +520,9 @@ pub async fn stream_task(task_id: &str, raw: bool) -> anyhow::Result<()> {
 /// new sessions that appear while streaming. Prefixes each line with the
 /// session name so interleaved output is distinguishable.
 ///
-/// When `raw` is false (default), NDJSON lines are formatted into human-readable
-/// output. Pass `raw: true` to print unformatted NDJSON.
-pub async fn stream_all(raw: bool) -> anyhow::Result<()> {
+/// When `formatted` is true (default), NDJSON lines are formatted into
+/// human-readable output. Pass `formatted: false` to print raw NDJSON.
+pub async fn stream_all(formatted: bool) -> anyhow::Result<()> {
     use std::collections::HashSet;
     use tokio::sync::broadcast;
 
@@ -655,17 +655,17 @@ pub async fn stream_all(raw: bool) -> anyhow::Result<()> {
         }
         // Prefix each line with the session name (strip the "orch-" prefix for brevity)
         let label = session.strip_prefix("orch-").unwrap_or(&session);
-        if raw {
-            for line in chunk.content.lines() {
-                println!("[{label}] {line}");
-            }
-        } else {
+        if formatted {
             for line in chunk.content.lines() {
                 if let Some(formatted) = ndjson::format_line(line) {
                     for fline in formatted.lines() {
                         println!("[{label}] {fline}");
                     }
                 }
+            }
+        } else {
+            for line in chunk.content.lines() {
+                println!("[{label}] {line}");
             }
         }
         // If content didn't end with newline, don't add extra one

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ mod template;
 mod tmux;
 mod webhook_status;
 
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{ArgAction, CommandFactory, Parser, Subcommand};
 use clap_complete::{generate, Shell};
 
 const MAX_SERVICE_LOG_BYTES: u64 = 2 * 1024 * 1024;
@@ -161,7 +161,8 @@ fn rotated_log_path(path: &std::path::Path, suffix: usize) -> std::path::PathBuf
 
 #[cfg(test)]
 mod tests {
-    use super::{rotate_log_if_needed, rotated_log_path, MAX_SERVICE_LOG_BYTES};
+    use super::{rotate_log_if_needed, rotated_log_path, Cli, Commands, MAX_SERVICE_LOG_BYTES};
+    use clap::Parser;
 
     #[test]
     fn rotated_log_path_appends_suffix() {
@@ -199,6 +200,42 @@ mod tests {
             std::fs::read(path.with_file_name("orch.log.3")).unwrap(),
             b"two"
         );
+    }
+
+    #[test]
+    fn stream_defaults_to_formatted_output() {
+        let cli = Cli::parse_from(["orch", "stream"]);
+        match cli.command {
+            Commands::Stream { formatted, raw, .. } => {
+                assert!(formatted);
+                assert!(!raw);
+            }
+            _ => panic!("expected stream command"),
+        }
+    }
+
+    #[test]
+    fn stream_allows_disabling_formatted_output() {
+        let cli = Cli::parse_from(["orch", "stream", "--formatted=false"]);
+        match cli.command {
+            Commands::Stream { formatted, raw, .. } => {
+                assert!(!formatted);
+                assert!(!raw);
+            }
+            _ => panic!("expected stream command"),
+        }
+    }
+
+    #[test]
+    fn stream_raw_flag_still_parses_for_backwards_compat() {
+        let cli = Cli::parse_from(["orch", "stream", "--raw"]);
+        match cli.command {
+            Commands::Stream { formatted, raw, .. } => {
+                assert!(formatted);
+                assert!(raw);
+            }
+            _ => panic!("expected stream command"),
+        }
     }
 }
 
@@ -251,8 +288,11 @@ enum Commands {
     Stream {
         /// Task ID to stream (omit to stream all running tasks)
         task_id: Option<String>,
-        /// Print raw NDJSON instead of human-readable output
-        #[arg(long)]
+        /// Format NDJSON into human-readable output (`--formatted=false` for raw)
+        #[arg(long, default_value_t = true, action = ArgAction::Set)]
+        formatted: bool,
+        /// Print raw NDJSON instead of human-readable output (deprecated: use `--formatted=false`)
+        #[arg(long, hide = true)]
         raw: bool,
     },
     /// Chat with the orch control session
@@ -758,10 +798,17 @@ async fn main() -> anyhow::Result<()> {
             let val = config::get(&key)?;
             println!("{val}");
         }
-        Commands::Stream { task_id, raw } => match task_id {
-            Some(id) => cli::stream_task(&id, raw).await?,
-            None => cli::stream_all(raw).await?,
-        },
+        Commands::Stream {
+            task_id,
+            formatted,
+            raw,
+        } => {
+            let formatted = if raw { false } else { formatted };
+            match task_id {
+                Some(id) => cli::stream_task(&id, formatted).await?,
+                None => cli::stream_all(formatted).await?,
+            }
+        }
         Commands::Chat {
             action,
             message,


### PR DESCRIPTION
## Summary

Added a `--formatted` stream flag (default `true`) with `--formatted=false` raw fallback, wired through both stream paths, and kept `--raw` as a hidden backward-compatible alias.

### What was done

- Updated `orch stream` CLI args to include `formatted: bool` with default `true` and explicit bool parsing via `ArgAction::Set`.
- Kept legacy `--raw` support as a hidden/deprecated flag and mapped it to force raw output behavior.
- Threaded the new `formatted` boolean through command dispatch into `cli::stream_task` and `cli::stream_all`.
- Updated streaming functions to use `formatted` semantics directly while preserving existing NDJSON formatting behavior.
- Added parser tests for `orch stream` defaults, `--formatted=false`, and `--raw` compatibility in `src/main.rs`.
- Ran required quality gates successfully: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (2947 passed, 19 skipped).
- Committed changes in `da236a08` with message `feat(cli): add --formatted toggle to stream output`.


Closes #2422

---
*Task #2422 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*