### PR TITLE
bug: agent runner script path not quoted — spaces in ORCH_HOME path prevent agent session from starting

### DIFF
--- a/src/engine/runner/agent.rs
+++ b/src/engine/runner/agent.rs
@@ -190,7 +190,7 @@ exit $CMD_STATUS
         tokio::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).await?;
     }
 
-    let command = format!("bash {}", script_path.display());
+    let command = format!("bash \"{}\"", script_path.display());
 
     // Resolve GitHub token via the process-wide shared resolver (cached after first call)
     let github_token = match crate::github::token::shared().get_token().await {


### PR DESCRIPTION
## Summary

Fixed unquoted script path in tmux send-keys command (agent.rs:193). Changed `bash {}` to `bash "{}"` so paths with spaces in ORCH_HOME don't get word-split by the shell. All 2947 tests pass.

Closes #2430

---
*Task #2430 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*