### PR TITLE
perf: missing (repo, pr_number) index causes full table scan in resolve_id_by_pr_number

### DIFF
--- a/migrations/026_repo_pr_number_index.sql
+++ b/migrations/026_repo_pr_number_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_tasks_repo_pr_number ON tasks(repo, pr_number);


### PR DESCRIPTION
Resolves #2435

Auto-created by orch review gate (agent forgot to open PR)