### PR TITLE
bug: handle_review_changes dispatches task with stale model when store_set_result fails

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -1501,7 +1501,8 @@ pub(crate) async fn handle_review_changes(
             )
             .await
             {
-                tracing::warn!(task_id = task.id.0, err = %e, "store write failed");
+                tracing::warn!(task_id = task.id.0, err = %e, "model update failed — will retry on next tick");
+                return Ok(());
             }
 
             let fields = [


### PR DESCRIPTION
## Summary

Fixed handle_review_changes to return early when the model store write fails, preventing dispatch with a stale/invalid agent:model combination. Added `return Ok(())` after the warning at auto_merge.rs:1504, matching the pattern already used for the Routed transition failure.

Closes #2437

---
*Task #2437 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*