### PR TITLE
bug: PR body omits 'Files changed' section when agent uses text synthesis fallback

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -981,7 +981,7 @@ fn push_needs_rebase(stderr: &str) -> bool {
 /// - `Err(PrCreateError)` - API error or other failure
 #[allow(clippy::too_many_arguments)]
 pub async fn create_pr_if_needed(
-    _dir: &Path,
+    dir: &Path,
     branch: &str,
     title: &str,
     summary: &str,
@@ -1041,9 +1041,36 @@ pub async fn create_pr_if_needed(
         }
     }
 
-    if !files.is_empty() {
+    // When the agent didn't self-report files, derive them from git.
+    let git_files: Vec<String>;
+    let effective_files: &[String] = if files.is_empty() {
+        match tokio::process::Command::new("git")
+            .args([
+                "diff",
+                &format!("origin/{base_branch}...HEAD"),
+                "--name-only",
+            ])
+            .current_dir(dir)
+            .output()
+            .await
+        {
+            Ok(output) if output.status.success() => {
+                git_files = String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .filter(|l| !l.is_empty())
+                    .map(|l| l.to_string())
+                    .collect();
+                &git_files
+            }
+            _ => files,
+        }
+    } else {
+        files
+    };
+
+    if !effective_files.is_empty() {
         body.push_str("\n\n### Files changed\n\n");
-        for file in files {
+        for file in effective_files {
             body.push_str(&format!("- `{file}`\n"));
         }
     }


### PR DESCRIPTION
## Summary

Fixed PR body missing 'Files changed' section by deriving the file list from git when the agent's self-reported files list is empty. Renamed `_dir` to `dir` in `create_pr_if_needed` and added a `git diff origin/{base_branch}...HEAD --name-only` fallback that populates `effective_files` when `files` is empty. All checks pass (fmt, clippy, tests). The one failing test (`tmux::tests::session_blocks_dispatch_cleans_dead_session`) is pre-existing and unrelated to these changes.

### Files changed

- `src/engine/runner/git_ops.rs`


Closes #2446

---
*Task #2446 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*