### PR TITLE
bug: store query error silently swallowed in route() — hides DB failures behind None fallback

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -583,7 +583,16 @@ impl Router {
                         None
                     }
                 }
-                _ => None,
+                Ok(None) => None,
+                Err(e) => {
+                    tracing::warn!(
+                        repo,
+                        task_id = %task.id.0,
+                        err = %e,
+                        "failed to fetch stored agent, falling back to label/LLM routing"
+                    );
+                    None
+                }
             };
 
             // 2. Fall back to explicit agent label


### PR DESCRIPTION
## Summary

bug: store query error silently swallowed in route() — hides DB failures behind None fallback

### Files changed

- `src/engine/router/mod.rs`


Closes #2450

---
*Task #2450 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*