### PR TITLE
bug: estimate still not being synced to GitHub Projects

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -149,10 +149,44 @@ impl ExternalBackend for GitHubBackend {
             None => return Ok(()),
         };
 
-        // Only sync if the estimate field is configured.
-        if project.estimate_field_id().is_none() {
-            return Ok(());
-        }
+        // If the estimate field ID is missing from config, try to discover it
+        // automatically and persist it for future calls. This handles the case
+        // where the service was set up before the estimate sync feature existed.
+        let project = if project.estimate_field_id().is_none() {
+            match ProjectSync::discover_fields(project.project_id()).await {
+                Ok(discovered) => {
+                    if discovered.estimate_field_id().is_some() {
+                        if let Err(e) =
+                            crate::github::projects::write_project_config(&discovered).await
+                        {
+                            tracing::warn!(
+                                err = %e,
+                                "failed to persist discovered estimate field ID to config"
+                            );
+                        } else {
+                            tracing::info!(
+                                "auto-discovered and persisted project_estimate_field_id to config"
+                            );
+                        }
+                        discovered
+                    } else {
+                        tracing::debug!(
+                            "project has no 'Estimate' number field — skipping estimate sync"
+                        );
+                        return Ok(());
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        err = %e,
+                        "estimate field auto-discovery failed — skipping estimate sync"
+                    );
+                    return Ok(());
+                }
+            }
+        } else {
+            project
+        };
 
         // Fetch the issue to get its node_id.
         let issue = self.gh.get_issue(&self.repo, &id.0).await?;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -552,6 +552,62 @@ async fn reconcile_startup_worktrees(project_engines: &[ProjectEngine]) -> anyho
     Ok(())
 }
 
+/// Sync Fibonacci estimates stored in SQLite to the GitHub Projects board for
+/// all tasks that have a positive estimate.
+///
+/// Runs once on startup to catch tasks that were routed before the estimate
+/// sync feature was available or before `project_estimate_field_id` was
+/// configured. The underlying mutations are idempotent, so re-syncing an
+/// already-correct estimate is harmless.
+async fn reconcile_startup_estimates(project_engines: &[ProjectEngine]) {
+    use crate::backends::ExternalId;
+
+    for engine in project_engines {
+        let tasks = match engine.store.list_external_tasks_with_estimates().await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(repo = %engine.repo, err = %e, "startup estimate reconciliation: store query failed");
+                continue;
+            }
+        };
+
+        if tasks.is_empty() {
+            continue;
+        }
+
+        let mut synced: u32 = 0;
+        let mut failed: u32 = 0;
+        for (external_id, estimate) in &tasks {
+            match engine
+                .backend
+                .sync_estimate_to_project(&ExternalId(external_id.clone()), *estimate)
+                .await
+            {
+                Ok(()) => synced += 1,
+                Err(e) => {
+                    tracing::debug!(
+                        repo = %engine.repo,
+                        task_id = %external_id,
+                        estimate,
+                        err = %e,
+                        "startup estimate reconciliation: sync failed"
+                    );
+                    failed += 1;
+                }
+            }
+        }
+
+        if synced > 0 || failed > 0 {
+            tracing::info!(
+                repo = %engine.repo,
+                synced,
+                failed,
+                "startup estimate reconciliation complete"
+            );
+        }
+    }
+}
+
 /// Read per-project channel configuration from `.orch.yml`.
 fn read_project_channel_config(project_dir: &std::path::Path) -> ProjectChannelConfig {
     let config_path = project_dir.join(".orch.yml");
@@ -669,6 +725,7 @@ pub async fn serve() -> anyhow::Result<()> {
     if let Err(e) = reconcile_startup_worktrees(&project_engines).await {
         tracing::warn!(err = %e, "startup worktree reconciliation failed");
     }
+    reconcile_startup_estimates(&project_engines).await;
 
     // Build ChannelRouter from global config + per-project configs
     let global_channel_config = GlobalChannelConfig {

--- a/src/github/projects.rs
+++ b/src/github/projects.rs
@@ -299,6 +299,11 @@ impl ProjectSync {
         self.estimate_field_id.as_deref()
     }
 
+    /// Get the project ID.
+    pub fn project_id(&self) -> &str {
+        &self.project_id
+    }
+
     /// Update an item's Estimate number field on the project board.
     ///
     /// Returns the project item ID (either found or newly added).

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1230,6 +1230,32 @@ impl TaskStore {
         Ok(())
     }
 
+    /// Return `(external_id, estimate)` for all non-internal tasks that have a
+    /// positive Fibonacci estimate stored in the database.
+    ///
+    /// Used by startup estimate reconciliation to push orch-stored estimates to
+    /// the GitHub Projects board for tasks that were routed before the estimate
+    /// sync feature was available or before `project_estimate_field_id` was
+    /// configured.
+    pub async fn list_external_tasks_with_estimates(&self) -> anyhow::Result<Vec<(String, u8)>> {
+        let rows = sqlx::query(
+            "SELECT external_id, estimate FROM tasks \
+             WHERE estimate > 0 AND external_id NOT LIKE 'internal:%'",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut result = Vec::new();
+        for row in &rows {
+            let external_id: String = row.try_get("external_id")?;
+            let estimate_raw: i64 = row.try_get("estimate")?;
+            if (1..=255).contains(&estimate_raw) {
+                result.push((external_id, estimate_raw as u8));
+            }
+        }
+        Ok(result)
+    }
+
     /// Set the Fibonacci estimate for a task (only if currently 0).
     ///
     /// Used during ingestion to populate `tasks.estimate` from GitHub Projects


### PR DESCRIPTION
## Summary

Fixed two bugs causing estimates to not sync to GitHub Projects:

1. **Auto-discovery** (`src/backends/github.rs`): When `project_estimate_field_id` is missing from config (set up before the feature existed), `sync_estimate_to_project` now calls `discover_fields()` automatically, persists the discovered field ID to config, then proceeds with the sync instead of silently returning OK.

2. **Startup reconciliation** (`src/engine/mod.rs`): Added `reconcile_startup_estimates()` that runs once on startup and syncs estimates for ALL tasks with `estimate > 0` in the store. Tasks #2452 (estimate=3) and #2453 (estimate=5) will be synced when the service next restarts.

Supporting changes: added `project_id()` getter to `ProjectSync` (`src/github/projects.rs`) and `list_external_tasks_with_estimates()` query to `TaskStore` (`src/store/tasks.rs`).

All 2949 tests pass, fmt and clippy clean.

### Files changed

- `src/backends/github.rs`
- `src/engine/mod.rs`
- `src/github/projects.rs`
- `src/store/tasks.rs`


Closes #2457

---
*Task #2457 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*