### PR TITLE
bug: weighted_select fallback returns "unknown" string instead of last agent

### DIFF
--- a/src/engine/router/weights.rs
+++ b/src/engine/router/weights.rs
@@ -228,12 +228,7 @@ impl AgentWeights {
 
         // Rounding edge case — return last agent (agents is guaranteed non-empty by caller)
         debug_assert!(!agents.is_empty(), "agents must not be empty");
-        Some(
-            agents
-                .last()
-                .cloned()
-                .unwrap_or_else(|| String::from("unknown")),
-        )
+        Some(agents[agents.len() - 1].clone())
     }
 
     /// Get the current weight for an agent.


### PR DESCRIPTION
## Summary

Fixed bug in AgentWeights::weighted_select where fallback returned 'unknown' string instead of last agent. Removed dead unwrap_or_else branch and replaced with direct indexing since agents is guaranteed non-empty.

### What was done

- Edited src/engine/router/weights.rs to fix the weighted_select fallback


### Files changed

- `src/engine/router/weights.rs`


Closes #2462

---
*Task #2462 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/nemotron-3-super-free`*