### PR TITLE
bug: needs_review_refires counter increment silently dropped before escalation

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1059,13 +1059,20 @@ pub(crate) async fn sync_tick(
             // If we've exceeded max attempts, escalate the task to Blocked with a clear reason.
             if new_refires >= MAX_NEEDS_REVIEW_REFIRE_ATTEMPTS {
                 // Increment first so the escalation value is accurate.
-                let _ = crate::store::store_increment(
+                if let Err(e) = crate::store::store_increment(
                     &Some(Arc::clone(store)),
                     repo,
                     task.task_id(),
                     "needs_review_refires",
                 )
-                .await;
+                .await
+                {
+                    tracing::warn!(
+                        task_id = task.task_id(),
+                        err = %e,
+                        "failed to increment needs_review_refires before escalation"
+                    );
+                }
                 tracing::warn!(
                     task_id = task.task_id(),
                     new_refires,


### PR DESCRIPTION
## Summary

Fixed the silent error drop in needs_review_refires counter increment - now logs the error instead of discarding it with `let _ =`

### What was done

- Changed `let _ = store_increment(...)` to `if let Err(e) = store_increment(...)` with tracing::warn! on failure
- Added task_id and err context to the warning for observability


### Files changed

- `src/engine/sync.rs`


Closes #2463

---
*Task #2463 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*