### PR TITLE
bug: blocking Path::exists/is_dir calls in async code should use tokio::fs or spawn_blocking

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -1394,7 +1394,13 @@ impl TaskRunner {
                 let path = PathBuf::from(path_str);
                 // Check if this project's .orch.yml has matching repo
                 if let Ok(repo) = config::get_repo_for_project(&path) {
-                    if repo == self.repo && path.exists() {
+                    // Use thread spawn for path.exists() to avoid blocking async runtime
+                    let path_for_check = path.clone();
+                    if repo == self.repo
+                        && std::thread::spawn(move || path_for_check.exists())
+                            .join()
+                            .unwrap_or(false)
+                    {
                         return Ok(path);
                     }
                 }
@@ -1405,7 +1411,11 @@ impl TaskRunner {
         if let Ok(dir) = config::get("project_dir") {
             if !dir.is_empty() {
                 let path = PathBuf::from(&dir);
-                if path.exists() {
+                let path_for_check = path.clone();
+                if std::thread::spawn(move || path_for_check.exists())
+                    .join()
+                    .unwrap_or(false)
+                {
                     return Ok(path);
                 }
             }
@@ -1419,7 +1429,11 @@ impl TaskRunner {
                 .join("projects")
                 .join(parts[0])
                 .join(format!("{}.git", parts[1]));
-            if bare.exists() {
+            let bare_for_check = bare.clone();
+            if std::thread::spawn(move || bare_for_check.exists())
+                .join()
+                .unwrap_or(false)
+            {
                 return Ok(bare);
             }
         }

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -1438,7 +1438,8 @@ impl TaskRunner {
             }
         }
 
-        anyhow::bail!("no project directory found for {}", self.repo)
+        // Fall back to current directory
+        Ok(std::env::current_dir()?)
     }
 }
 

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -484,7 +484,7 @@ impl TaskRunner {
         }
 
         // Resolve project directory
-        let project_dir = self.resolve_project_dir()?;
+        let project_dir = self.resolve_project_dir().await?;
 
         // Prepare task: worktree, context, prompts, and agent invocation
         let init = task_init::prepare_task(
@@ -1380,7 +1380,7 @@ impl TaskRunner {
     }
 
     /// Resolve the project directory for this repo.
-    fn resolve_project_dir(&self) -> anyhow::Result<PathBuf> {
+    async fn resolve_project_dir(&self) -> anyhow::Result<PathBuf> {
         // Explicit env var always wins
         if let Ok(dir) = std::env::var("PROJECT_DIR") {
             if !dir.is_empty() {
@@ -1394,11 +1394,11 @@ impl TaskRunner {
                 let path = PathBuf::from(path_str);
                 // Check if this project's .orch.yml has matching repo
                 if let Ok(repo) = config::get_repo_for_project(&path) {
-                    // Use thread spawn for path.exists() to avoid blocking async runtime
+                    // Use spawn_blocking for path.exists() from async context
                     let path_for_check = path.clone();
                     if repo == self.repo
-                        && std::thread::spawn(move || path_for_check.exists())
-                            .join()
+                        && tokio::task::spawn_blocking(move || path_for_check.exists())
+                            .await
                             .unwrap_or(false)
                     {
                         return Ok(path);
@@ -1412,8 +1412,8 @@ impl TaskRunner {
             if !dir.is_empty() {
                 let path = PathBuf::from(&dir);
                 let path_for_check = path.clone();
-                if std::thread::spawn(move || path_for_check.exists())
-                    .join()
+                if tokio::task::spawn_blocking(move || path_for_check.exists())
+                    .await
                     .unwrap_or(false)
                 {
                     return Ok(path);
@@ -1430,16 +1430,15 @@ impl TaskRunner {
                 .join(parts[0])
                 .join(format!("{}.git", parts[1]));
             let bare_for_check = bare.clone();
-            if std::thread::spawn(move || bare_for_check.exists())
-                .join()
+            if tokio::task::spawn_blocking(move || bare_for_check.exists())
+                .await
                 .unwrap_or(false)
             {
                 return Ok(bare);
             }
         }
 
-        // Fall back to current directory
-        Ok(std::env::current_dir()?)
+        anyhow::bail!("no project directory found for {}", self.repo)
     }
 }
 
@@ -1681,8 +1680,8 @@ mod tests {
 
     // ── resolve_project_dir ──────────────────────────────────────────────────
 
-    #[test]
-    fn resolve_project_dir_uses_project_dir_env() {
+    #[tokio::test]
+    async fn resolve_project_dir_uses_project_dir_env() {
         // When PROJECT_DIR env var is set, it should always win.
         let runner = TaskRunner::new("owner/repo".to_string());
 
@@ -1695,7 +1694,7 @@ mod tests {
         // thread-safe in general, but the subsequent call is synchronous and
         // isolated to the temp dir created above.
         std::env::set_var("PROJECT_DIR", &dir_str);
-        let result = runner.resolve_project_dir();
+        let result = runner.resolve_project_dir().await;
         std::env::remove_var("PROJECT_DIR");
 
         assert!(
@@ -1705,12 +1704,12 @@ mod tests {
         assert_eq!(result.unwrap(), dir.path());
     }
 
-    #[test]
-    fn resolve_project_dir_empty_project_dir_env_falls_through() {
+    #[tokio::test]
+    async fn resolve_project_dir_empty_project_dir_env_falls_through() {
         // An empty PROJECT_DIR should be ignored and fall through to other logic.
         let runner = TaskRunner::new("owner/testrepo-nonexistent".to_string());
         std::env::set_var("PROJECT_DIR", "");
-        let result = runner.resolve_project_dir();
+        let result = runner.resolve_project_dir().await;
         std::env::remove_var("PROJECT_DIR");
 
         // Should succeed (falls back to current dir) without panicking.

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -1394,13 +1394,9 @@ impl TaskRunner {
                 let path = PathBuf::from(path_str);
                 // Check if this project's .orch.yml has matching repo
                 if let Ok(repo) = config::get_repo_for_project(&path) {
-                    // Use spawn_blocking for path.exists() from async context
+                    // Use tokio::fs::metadata for async-safe existence check
                     let path_for_check = path.clone();
-                    if repo == self.repo
-                        && tokio::task::spawn_blocking(move || path_for_check.exists())
-                            .await
-                            .unwrap_or(false)
-                    {
+                    if repo == self.repo && tokio::fs::metadata(&path_for_check).await.is_ok() {
                         return Ok(path);
                     }
                 }
@@ -1412,10 +1408,7 @@ impl TaskRunner {
             if !dir.is_empty() {
                 let path = PathBuf::from(&dir);
                 let path_for_check = path.clone();
-                if tokio::task::spawn_blocking(move || path_for_check.exists())
-                    .await
-                    .unwrap_or(false)
-                {
+                if tokio::fs::metadata(&path_for_check).await.is_ok() {
                     return Ok(path);
                 }
             }

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -170,12 +170,12 @@ pub async fn read_output_file(task_id: &str, primary_path: &Path, repo: &str) ->
     // Fallback: check all attempt dirs for this task (newest first)
     if let Ok(task_dir) = crate::home::task_dir_async(repo, task_id).await {
         let attempts_dir = task_dir.join("attempts");
-        // Use async metadata to avoid blocking the reactor thread.
-        let attempts_is_dir = tokio::fs::metadata(&attempts_dir)
+        // Use async metadata for is_dir check
+        if tokio::fs::metadata(&attempts_dir)
             .await
             .map(|m| m.is_dir())
-            .unwrap_or(false);
-        if attempts_is_dir {
+            .unwrap_or(false)
+        {
             let mut attempt_nums: Vec<u32> = tokio::task::spawn_blocking({
                 let a = attempts_dir.clone();
                 move || {

--- a/src/engine/runner/worktree.rs
+++ b/src/engine/runner/worktree.rs
@@ -44,22 +44,13 @@ pub async fn list_project_worktrees(project_dir: &Path) -> anyhow::Result<Vec<Pa
     let base = project_worktrees_dir(project_dir);
     let mut worktrees = Vec::new();
 
-    // Use async metadata to avoid blocking the reactor thread.
-    let base_is_dir = tokio::fs::metadata(&base)
-        .await
-        .map(|m| m.is_dir())
-        .unwrap_or(false);
-    if !base_is_dir {
+    if !tokio::fs::metadata(&base).await.is_ok() {
         return Ok(worktrees);
     }
 
     let mut entries = tokio::fs::read_dir(&base).await?;
     while let Some(entry) = entries.next_entry().await? {
-        let entry_is_dir = tokio::fs::metadata(entry.path())
-            .await
-            .map(|m| m.is_dir())
-            .unwrap_or(false);
-        if entry_is_dir {
+        if entry.metadata().await.map(|m| m.is_dir()).unwrap_or(false) {
             worktrees.push(entry.path());
         }
     }
@@ -338,15 +329,16 @@ async fn resolve_branch_start_point(repo_root: &str, branch: &str, default_branc
 /// indicating the worktree metadata is broken and the directory should be cleaned up.
 pub async fn validate_worktree_gitdir(worktree_dir: &Path) -> bool {
     let git_file = worktree_dir.join(".git");
-
-    // Use async metadata to avoid blocking the reactor thread.
-    let git_file_meta = match tokio::fs::metadata(&git_file).await {
-        Ok(m) => m,
-        Err(_) => return false,
-    };
-
+    // Use tokio::fs::metadata for async-safe existence check
+    if !tokio::fs::metadata(&git_file).await.is_ok() {
+        return false;
+    }
     // In a linked worktree .git is a file; in the main repo it's a directory (always valid).
-    if git_file_meta.is_dir() {
+    if tokio::fs::metadata(&git_file)
+        .await
+        .map(|m| m.is_dir())
+        .unwrap_or(false)
+    {
         return true;
     }
 
@@ -355,6 +347,7 @@ pub async fn validate_worktree_gitdir(worktree_dir: &Path) -> bool {
         Err(_) => return false,
     };
     // Expected format: "gitdir: /absolute/path/to/.git/worktrees/<name>\n"
+    // Use spawn_blocking for the final exists check on the resolved path
     if let Some(gitdir_path) = content
         .lines()
         .next()
@@ -454,20 +447,20 @@ pub async fn setup_worktree(
 
     let (branch_name_str, worktree_dir) = if let Some(ref saved) = saved_branch {
         if !saved.is_empty() {
-            // Use spawn_blocking to avoid blocking the reactor thread on a stat call.
-            let wt_exists = match &saved_worktree {
+            // Use spawn_blocking for blocking Path::exists call in async context
+            let wt = match &saved_worktree {
                 Some(wt) if !wt.is_empty() => {
                     let wt_str = wt.clone();
-                    tokio::task::spawn_blocking(move || Path::new(&wt_str).exists())
+                    let exists = tokio::task::spawn_blocking(move || Path::new(&wt_str).exists())
                         .await
-                        .unwrap_or(false)
+                        .unwrap_or(false);
+                    if exists {
+                        PathBuf::from(wt)
+                    } else {
+                        worktrees_base.join(saved)
+                    }
                 }
-                _ => false,
-            };
-            let wt = if wt_exists {
-                PathBuf::from(saved_worktree.as_ref().unwrap())
-            } else {
-                worktrees_base.join(saved)
+                _ => worktrees_base.join(saved),
             };
             (saved.clone(), wt)
         } else if let Some((parent_branch, parent_wt)) =
@@ -514,13 +507,8 @@ pub async fn setup_worktree(
     // inherit that broken state, causing all subsequent git operations to
     // fail.  Aborting here is safe: if no rebase is in progress git exits
     // with a non-zero code which we silently ignore.
-    let wt_exists_for_rebase = {
-        let wt = worktree_dir.clone();
-        tokio::task::spawn_blocking(move || wt.exists())
-            .await
-            .unwrap_or(false)
-    };
-    if wt_exists_for_rebase {
+    // Use tokio::fs for async-safe existence check
+    if tokio::fs::metadata(&worktree_dir).await.is_ok() {
         let _ = Command::new("git")
             .args(["rebase", "--abort"])
             .current_dir(&worktree_dir)
@@ -529,13 +517,7 @@ pub async fn setup_worktree(
     }
 
     // Create worktree if it doesn't exist
-    let wt_exists_for_create = {
-        let wt = worktree_dir.clone();
-        tokio::task::spawn_blocking(move || wt.exists())
-            .await
-            .unwrap_or(false)
-    };
-    if !wt_exists_for_create {
+    if tokio::fs::metadata(&worktree_dir).await.is_err() {
         tracing::info!(task_id, worktree = %worktree_dir.display(), "creating worktree");
 
         // Pull/fetch latest so the new branch starts from up-to-date main.
@@ -595,13 +577,7 @@ pub async fn setup_worktree(
             .output_with_context()
             .await?;
 
-        let worktree_created = {
-            let wt = worktree_dir.clone();
-            tokio::task::spawn_blocking(move || wt.exists())
-                .await
-                .unwrap_or(false)
-        };
-        if !output.status.success() && !worktree_created {
+        if !output.status.success() && tokio::fs::metadata(&worktree_dir).await.is_err() {
             let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
             // Retry: prune and recreate
@@ -675,13 +651,7 @@ pub async fn setup_worktree(
                 }
             }
 
-            let worktree_created_final = {
-                let wt = worktree_dir.clone();
-                tokio::task::spawn_blocking(move || wt.exists())
-                    .await
-                    .unwrap_or(false)
-            };
-            if !worktree_created_final {
+            if tokio::fs::metadata(&worktree_dir).await.is_err() {
                 anyhow::bail!(
                     "failed to create worktree at {} for task {} (stdout: {}, stderr: {}, retry stdout: {}, retry stderr: {}, retry error: {})",
                     worktree_dir.display(),
@@ -776,12 +746,8 @@ async fn find_existing_worktree(worktrees_base: &Path, task_id: &str) -> Option<
         let name = entry.file_name().to_string_lossy().to_string();
         let matches =
             name.starts_with(&prefix_new) || legacy_prefixes.iter().any(|p| name.starts_with(p));
-        // Use async metadata to avoid blocking the reactor thread.
-        let entry_is_dir = tokio::fs::metadata(entry.path())
-            .await
-            .map(|m| m.is_dir())
-            .unwrap_or(false);
-        if matches && entry_is_dir {
+        // Use async metadata for is_dir check
+        if matches && entry.metadata().await.map(|m| m.is_dir()).unwrap_or(false) {
             return Some(entry.path());
         }
     }

--- a/src/engine/runner/worktree.rs
+++ b/src/engine/runner/worktree.rs
@@ -44,7 +44,7 @@ pub async fn list_project_worktrees(project_dir: &Path) -> anyhow::Result<Vec<Pa
     let base = project_worktrees_dir(project_dir);
     let mut worktrees = Vec::new();
 
-    if !tokio::fs::metadata(&base).await.is_ok() {
+    if tokio::fs::metadata(&base).await.is_err() {
         return Ok(worktrees);
     }
 
@@ -330,7 +330,7 @@ async fn resolve_branch_start_point(repo_root: &str, branch: &str, default_branc
 pub async fn validate_worktree_gitdir(worktree_dir: &Path) -> bool {
     let git_file = worktree_dir.join(".git");
     // Use tokio::fs::metadata for async-safe existence check
-    if !tokio::fs::metadata(&git_file).await.is_ok() {
+    if tokio::fs::metadata(&git_file).await.is_err() {
         return false;
     }
     // In a linked worktree .git is a file; in the main repo it's a directory (always valid).
@@ -1163,5 +1163,58 @@ mod tests {
         let (branch, wt) = result.expect("should return parent branch");
         assert_eq!(branch, "gh-issue-99-parent-task");
         assert_eq!(wt, parent_wt_dir);
+    }
+
+    /// Regression test: concurrent calls to list_project_worktrees and
+    /// validate_worktree_gitdir should not starve the Tokio worker thread
+    /// pool. This was broken by blocking Path::exists/is_dir calls in async
+    /// functions (issue #2467).
+    #[tokio::test]
+    async fn concurrent_worktree_checks_no_starvation() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let worktrees_base = temp_dir.path().join("worktrees");
+        tokio::fs::create_dir_all(&worktrees_base).await.unwrap();
+
+        // Create a fake worktree with valid gitdir
+        let wt_dir = worktrees_base.join("gh-issue-123-test");
+        tokio::fs::create_dir_all(&wt_dir).await.unwrap();
+        // Create .git as a file pointing to a real directory (worktree link)
+        let gitdir_target = temp_dir
+            .path()
+            .join(".git")
+            .join("worktrees")
+            .join("gh-issue-123-test");
+        tokio::fs::create_dir_all(&gitdir_target).await.unwrap();
+        let git_file = wt_dir.join(".git");
+        tokio::fs::write(&git_file, format!("gitdir: {}\n", gitdir_target.display()))
+            .await
+            .unwrap();
+
+        // Spawn many concurrent tasks - if any use blocking calls, they'll
+        // block the worker thread and cause timeout or deadlock.
+        let handles: Vec<_> = (0..20)
+            .map(|i| {
+                let wb = worktrees_base.clone();
+                let wd = wt_dir.clone();
+                tokio::spawn(async move {
+                    if i % 2 == 0 {
+                        list_project_worktrees(&wb).await.ok();
+                    } else {
+                        validate_worktree_gitdir(&wd).await;
+                    }
+                })
+            })
+            .collect();
+
+        // Wait with timeout to detect starvation
+        let results = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            futures::future::join_all(handles).await
+        })
+        .await;
+
+        assert!(
+            results.is_ok(),
+            "concurrent worktree checks timed out (starvation?)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Now I'll fix the blocking filesystem calls in async functions. Let me start with the worktree.rs file:

Looking at line 487, `resolve_project_dir()` is called inside the async function `run_task`. The function itself is not async but it's being called from async code. Let me convert it to an async function and use tokio for the exists checks.

### Files changed

- `src/engine/runner/mod.rs`
- `src/engine/runner/response.rs`
- `src/engine/runner/worktree.rs`


Closes #2467

---
*Task #2467 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*