### PR TITLE
bug: fire-and-forget record_rate_limit calls prevent router from detecting degraded agents

### DIFF
--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -428,9 +428,12 @@ pub async fn handle_error(
             _ => "error",
         };
         if let Some(ref s) = store {
-            let _ = s
+            if let Err(e) = s
                 .record_rate_limit(agent_name, error_type_str, Some(task_id))
-                .await;
+                .await
+            {
+                tracing::warn!(task_id, agent = %agent_name, err = %e, "failed to persist rate_limit event — router health check may miss this signal");
+            }
         }
     }
 

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -1045,9 +1045,12 @@ impl TaskRunner {
             if has_rate_limit_error {
                 // Record in the metrics store so the router's health check detects it.
                 if let Some(ref store) = self.store {
-                    let _ = store
+                    if let Err(e) = store
                         .record_rate_limit(&agent_name, "rate_limit", Some(task_id))
-                        .await;
+                        .await
+                    {
+                        tracing::warn!(task_id, agent = %agent_name, err = %e, "failed to persist rate_limit event — router health check may miss this signal");
+                    }
                 }
                 // Also record via the cooldown system so model_for_complexity() skips
                 // this model.  Use the stored last_error text as the message since


### PR DESCRIPTION
## Summary

Fixed fire-and-forget record_rate_limit calls in both locations to log warnings on failure instead of silently discarding rate limit events

### What was done

- Modified src/engine/runner/mod.rs:1045-1050 to log warning when store.record_rate_limit() fails
- Modified src/engine/runner/fallback.rs:428-433 to log warning when store.record_rate_limit() fails
- Committed changes with descriptive message


### Files changed

- `src/engine/runner/fallback.rs`
- `src/engine/runner/mod.rs`


Closes #2471

---
*Task #2471 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*