### PR TITLE
bug: fire-and-forget backend status updates in runner cause state divergence on failure

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -409,9 +409,12 @@ impl TaskRunner {
                 // Update GitHub status to NeedsReview so engine stops re-dispatching.
                 if let Some(b) = backend {
                     let id = crate::backends::ExternalId(task_id.to_string());
-                    let _ = b
+                    if let Err(e) = b
                         .update_status(&id, crate::backends::Status::NeedsReview)
-                        .await;
+                        .await
+                    {
+                        tracing::warn!(task_id, err = %e, "failed to update backend status to NeedsReview after max attempts");
+                    }
 
                     // If this was label-forced to a specific agent, remove the agent label
                     // so that /retry can route to a different agent instead of looping.
@@ -463,7 +466,9 @@ impl TaskRunner {
                 );
                 if let Some(b) = backend {
                     let id = crate::backends::ExternalId(task_id.to_string());
-                    let _ = b.update_status(&id, crate::backends::Status::Blocked).await;
+                    if let Err(e) = b.update_status(&id, crate::backends::Status::Blocked).await {
+                        tracing::warn!(task_id, err = %e, "failed to update backend status to Blocked after token budget exceeded");
+                    }
                 }
                 return Ok(Some(RunExecution {
                     status: "blocked".to_string(),


### PR DESCRIPTION
## Summary

Make backend status update failures visible by logging warnings and commit the change

### What was done

- Replaced fire-and-forget backend update calls with error-aware calls in src/engine/runner/mod.rs
- Logged a warning when updating backend status to NeedsReview fails after max attempts
- Logged a warning when updating backend status to Blocked fails after token budget exceeded
- Committed the change on the feature branch with message: "fix(runner): warn when backend status update fails to avoid silent state divergence"
- Ran rustfmt to ensure formatting


### Remaining

- Consider adding a retry or persisting desired backend status to the store for reconciliation (design decision required)
- Add tests or an integration scenario that simulates backend update failures to assert the warning and any retry behavior
- Decide whether to record desired external status in the task store so the sync tick can reconcile until backend update succeeds


### Files changed

- `src/engine/runner/mod.rs`


Closes #2470

---
*Task #2470 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*