### PR TITLE
bug: review_poll batch failure counter uses unwrap_or(1) — error escalation never fires when KV store is degraded

### DIFF
--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -433,7 +433,18 @@ pub(crate) async fn review_open_prs(
             data
         }
         Err(e) => {
-            let fails = store.kv_increment(&batch_fail_key).await.unwrap_or(1);
+            // Track consecutive batch fetch failures in the KV store. If the
+            // KV increment itself fails (e.g. transient DB error), treat the
+            // situation as immediately degraded so operators receive an error
+            // level signal instead of silently staying at warn level.
+            let fails = match store.kv_increment(&batch_fail_key).await {
+                Ok(n) => n,
+                Err(kv_err) => {
+                    tracing::warn!(kv_err = %kv_err, err = %e, "failed to track batch_fail counter — treating as degraded");
+                    // Use a sentinel high value so the escalation path fires.
+                    u32::MAX
+                }
+            };
             if fails >= 10 {
                 tracing::error!(
                     err = %e,


### PR DESCRIPTION
## Summary

Fix review polling batch-failure counter handling so escalation fires when KV increment fails.

### What was done

- Updated src/engine/review_poll.rs to stop using unwrap_or(1) when kv_increment fails.
- When kv_increment errors, log a warning with both the KV error and original batch error and treat the failure count as a sentinel (u32::MAX) so the escalation path (error-level logging) immediately fires.
- Added a brief comment explaining the rationale to ensure maintainers understand why a sentinel value is used.


### Remaining

- Optional: run full test suite / cargo check in CI to verify no regressions (local cargo check/build timed out here due to project size).
- Optional: consider adding a unit/integration test that simulates kv_increment failure to assert the error-level escalation behavior (not added because this is a minimal fix).


### Files changed

- `src/engine/review_poll.rs`


Closes #2476

---
*Task #2476 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*