### PR TITLE
bug: non-atomic store_set + update_task_status in review.rs leaves task in inconsistent state on partial failure

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1990,7 +1990,9 @@ async fn ensure_pr_exists(
                 } else {
                     // Clear agent/model so router picks a different one and note the
                     // fact that this attempt produced no PR or code changes.
-                    store_set(
+                    // Use store_set_result so we only transition status when the
+                    // store write succeeds — partial failure would orphan the task.
+                    if let Err(e) = store_set_result(
                         &Some(Arc::clone(store)),
                         repo,
                         &task.id.0,
@@ -2003,8 +2005,13 @@ async fn ensure_pr_exists(
                             ),
                         ],
                     )
-                    .await;
-                    if let Err(e) = task_manager.update_task_status(&task.id, Status::New).await {
+                    .await
+                    {
+                        tracing::error!(task_id = task.id.0, err = %e, "failed to clear agent/model for reroute — skipping status transition");
+                        // Don't update status — task stays in InReview and will be retried next tick
+                    } else if let Err(e) =
+                        task_manager.update_task_status(&task.id, Status::New).await
+                    {
                         tracing::error!(task_id = task.id.0, err = %e, "update_task_status(New) failed — task may be stuck in InReview");
                     }
                 }


### PR DESCRIPTION
## Summary

Now I need to check the imports in review.rs to see if `store_set_result` is already imported:`store_set_result` is already imported. Now I can make the fix:Now let's verify the change looks correct and run the checks:There's a file lock conflict. Let me wait for it to clear:The build lock is stuck. Let me check if another cargo process is running:Multiple cargo processes are competing for the lock. Let me wait for my background process to complete:

### Files changed

- `src/engine/review.rs`


Closes #2472

---
*Task #2472 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*