### PR TITLE
bug: router LLM timeout of 90s delays fallback when fast agent is available

### DIFF
--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -57,6 +57,12 @@ pub fn retry_max_delay_ms() -> u64 {
         .unwrap_or(120_000)
 }
 
+/// Upper bound for router LLM timeout (seconds).
+///
+/// Routing is a short classification step and should fail fast so a single
+/// slow model does not stall fallback to other healthy agents.
+pub const MAX_ROUTER_TIMEOUT_SECS: u64 = 45;
+
 /// Return the configured base backoff (seconds) for an agent.
 ///
 /// Returns the value of `router.backoff_base.{agent}` if set, otherwise
@@ -240,7 +246,16 @@ impl RouterConfig {
 
         if let Ok(timeout) = crate::config::get("router.timeout_seconds") {
             if let Ok(secs) = timeout.parse::<u64>() {
-                config.timeout_seconds = secs;
+                let clamped = secs.min(MAX_ROUTER_TIMEOUT_SECS);
+                if clamped != secs {
+                    tracing::warn!(
+                        configured_secs = secs,
+                        applied_secs = clamped,
+                        max_secs = MAX_ROUTER_TIMEOUT_SECS,
+                        "router.timeout_seconds is too high; clamping to keep routing responsive"
+                    );
+                }
+                config.timeout_seconds = clamped;
             }
         }
 
@@ -533,7 +548,7 @@ impl RouterConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::RouterConfig;
+    use super::{RouterConfig, MAX_ROUTER_TIMEOUT_SECS};
     use std::sync::{Mutex, OnceLock};
 
     struct CurrentDirGuard {
@@ -728,6 +743,21 @@ mod tests {
                 "claude:haiku",
             ]
         );
+    }
+
+    #[test]
+    fn from_config_clamps_router_timeout_to_max() {
+        let _lock = cwd_mutex().lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".orch.yml"),
+            "router:\n  timeout_seconds: 90\n",
+        )
+        .unwrap();
+        let _guard = CurrentDirGuard::set(dir.path());
+
+        let config = RouterConfig::from_config();
+        assert_eq!(config.timeout_seconds, MAX_ROUTER_TIMEOUT_SECS);
     }
 
     #[test]

--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -180,7 +180,7 @@ impl Default for RouterConfig {
             mode: "llm".to_string(),
             router_agent: "claude".to_string(),
             router_model: "claude-haiku-4-5-20251001".to_string(),
-            timeout_seconds: 120,
+            timeout_seconds: 45,
             fallback_executor: "codex".to_string(),
             agents: DEFAULT_AGENTS.iter().map(|s| s.to_string()).collect(),
             max_route_attempts: 3,

--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -11,12 +11,18 @@
 //! - Sanity-checking the routing decision
 //! - Loading and caching the skills catalog from disk
 
+use super::{AgentProfile, RouteResult, RouterConfig};
 use crate::backends::ExternalTask;
 use crate::engine::runner::agents::{self, claude, opencode, AgentError};
 use std::path::PathBuf;
 use std::time::Duration;
 
-use super::{AgentProfile, RouteResult, RouterConfig};
+/// Prefix used to identify router LLM timeout errors in error messages.
+/// This lets callers (route_with_llm in mod.rs) distinguish timeouts from
+/// other failures without changing the error type hierarchy.
+/// Format: "router LLM timed out after {secs}s" — this prefix makes it easy
+/// to detect by string prefix without full pattern matching.
+pub(super) const TIMEOUT_PREFIX: &str = "router LLM timed out after ";
 use serde::Deserialize;
 
 /// Response from the LLM router.
@@ -775,7 +781,7 @@ impl LlmRouter {
                 anyhow::bail!("router LLM failed: {error_msg}");
             }
             Err(DirectCommandError::Timeout { secs }) => {
-                anyhow::bail!("router LLM timed out after {secs}s");
+                anyhow::bail!("{TIMEOUT_PREFIX}{secs}");
             }
             Err(DirectCommandError::EmptyResponse { stderr }) => {
                 tracing::warn!(stderr = %stderr, "router LLM returned empty stdout");

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -1115,7 +1115,7 @@ impl Router {
                 }
                 Err(e) => {
                     let err_msg = e.to_string();
-                    let is_timeout = err_msg.starts_with(TIMEOUT_PREFIX);
+                    let is_timeout = err_msg.contains(TIMEOUT_PREFIX);
                     if is_timeout {
                         tracing::warn!(
                             agent,
@@ -1199,7 +1199,7 @@ impl Router {
                 Ok(result) => return Ok(result),
                 Err(e) => {
                     let err_msg = e.to_string();
-                    let is_timeout = err_msg.starts_with(TIMEOUT_PREFIX);
+                    let is_timeout = err_msg.contains(TIMEOUT_PREFIX);
                     if is_timeout {
                         tracing::warn!(
                             agent = %fb_agent,

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -41,7 +41,7 @@ use crate::store::{get_task_field_direct, store_log_activity, TaskStore};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use llm::LlmRouter;
+use llm::{LlmRouter, TIMEOUT_PREFIX};
 
 /// Result of routing a task to an agent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1114,13 +1114,24 @@ impl Router {
                     return Ok(result);
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        agent,
-                        model = model_str,
-                        error = %e,
-                        "pool entry failed, recording cooldown and trying next"
-                    );
-                    crate::engine::runner::response::record_model_failure(agent, model_str).await;
+                    let err_msg = e.to_string();
+                    let is_timeout = err_msg.starts_with(TIMEOUT_PREFIX);
+                    if is_timeout {
+                        tracing::warn!(
+                            agent,
+                            model = model_str,
+                            "router LLM pool entry timed out — skipping cooldown, trying next entry"
+                        );
+                    } else {
+                        tracing::warn!(
+                            agent,
+                            model = model_str,
+                            error = %e,
+                            "pool entry failed, recording cooldown and trying next"
+                        );
+                        crate::engine::runner::response::record_model_failure(agent, model_str)
+                            .await;
+                    }
                     last_err = Some(e);
                     self.advance_pool_index_after_attempt(idx, n);
                 }
@@ -1187,14 +1198,27 @@ impl Router {
             {
                 Ok(result) => return Ok(result),
                 Err(e) => {
-                    tracing::warn!(
-                        agent = %fb_agent,
-                        model = %fb_model_str,
-                        error = %e,
-                        "fallback router LLM also failed"
-                    );
-                    crate::engine::runner::response::record_model_failure(&fb_agent, fb_model_str)
+                    let err_msg = e.to_string();
+                    let is_timeout = err_msg.starts_with(TIMEOUT_PREFIX);
+                    if is_timeout {
+                        tracing::warn!(
+                            agent = %fb_agent,
+                            model = %fb_model_str,
+                            "fallback router LLM timed out — skipping cooldown"
+                        );
+                    } else {
+                        tracing::warn!(
+                            agent = %fb_agent,
+                            model = %fb_model_str,
+                            error = %e,
+                            "fallback router LLM also failed"
+                        );
+                        crate::engine::runner::response::record_model_failure(
+                            &fb_agent,
+                            fb_model_str,
+                        )
                         .await;
+                    }
                     last_err = Some(e);
                 }
             }


### PR DESCRIPTION
## Summary

The rerun is blocked on a file lock, which confirms the first `nextest` process is still active; I’m waiting for that original run to finish and capture its result.

### Files changed

- `src/engine/router/config.rs`
- `src/engine/router/llm.rs`
- `src/engine/router/mod.rs`


Closes #2480

---
*Task #2480 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*