### PR TITLE
bug: needs_review_refires counter never increments when store_increment fails — escalation budget bypassed

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1156,9 +1156,9 @@ pub(crate) async fn sync_tick(
                     tracing::warn!(
                         task_id = task.task_id(),
                         err = %e,
-                        "failed to increment needs_review_refires — proceeding with re-fire anyway"
+                        "failed to increment needs_review_refires — deferring re-fire to next tick"
                     );
-                    new_refires
+                    continue;
                 }
             };
 


### PR DESCRIPTION
## Summary

Replaced the `new_refires` fallback with `continue` in the `store_increment` error arm at sync.rs:1155–1162. When the KV increment fails, the re-fire is now deferred to the next tick instead of proceeding with an unconfirmed counter — preventing the escalation budget bypass during KV store degradation. All 2963 tests pass.

### Files changed

- `src/engine/sync.rs`


Closes #2488

---
*Task #2488 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*