### PR TITLE
perf: ingest_external_tasks fetches all open GitHub issues every sync tick without 'since' filtering

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -381,7 +381,7 @@ impl ExternalBackend for GitHubBackend {
 
     async fn list_reconciliation_candidates(&self) -> anyhow::Result<Vec<ExternalTask>> {
         let since = (Utc::now() - Duration::days(30)).to_rfc3339();
-        let open = self.gh.list_all_open_issues(&self.repo).await?;
+        let open = self.gh.list_all_open_issues(&self.repo, None).await?;
         let closed = self.gh.list_closed_issues_since(&self.repo, &since).await?;
         let issues = open.into_iter().chain(closed);
 
@@ -404,7 +404,7 @@ impl ExternalBackend for GitHubBackend {
 
     /// List open issues that have no `status:*` label (unprocessed) or have `status:new`.
     async fn list_routable(&self) -> anyhow::Result<Vec<ExternalTask>> {
-        let issues = self.gh.list_all_open_issues(&self.repo).await?;
+        let issues = self.gh.list_all_open_issues(&self.repo, None).await?;
         Ok(issues
             .into_iter()
             .filter(|issue| issue.pull_request.is_none()) // Exclude PRs
@@ -432,10 +432,12 @@ impl ExternalBackend for GitHubBackend {
     /// Single-call override: fetches all open issues once and partitions by status label locally,
     /// replacing the 1 (list_routable) + 5 (list_by_status per active status) fan-out with a
     /// single `list_all_open_issues` request.
+    /// When `since` is `Some(ts)`, uses GitHub's `?since` filter for efficiency.
     async fn list_active_open_issues(
         &self,
+        since: Option<&str>,
     ) -> anyhow::Result<Vec<(ExternalTask, Option<crate::backends::Status>)>> {
-        let issues = self.gh.list_all_open_issues(&self.repo).await?;
+        let issues = self.gh.list_all_open_issues(&self.repo, since).await?;
 
         let active_status_from_label = |label: &str| -> Option<crate::backends::Status> {
             match label {
@@ -549,7 +551,7 @@ impl ExternalBackend for GitHubBackend {
     async fn has_open_issue_with_title(&self, title: &str, label: &str) -> anyhow::Result<bool> {
         // Check open issues first
         let open_issues = if label.is_empty() {
-            self.gh.list_all_open_issues(&self.repo).await?
+            self.gh.list_all_open_issues(&self.repo, None).await?
         } else {
             self.gh.list_issues(&self.repo, label).await?
         };

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -220,11 +220,17 @@ pub trait ExternalBackend: Send + Sync {
     /// Fetch all open issues for ingest in a single logical call, returning each issue paired
     /// with its detected status (`None` = unlabeled/routable, `Some(s)` = has status label `s`).
     ///
+    /// When `since` is `Some(ts)`, only returns issues updated after that ISO 8601 timestamp.
+    /// This is more efficient for periodic syncs.  Use `None` for full sync.
+    ///
     /// The default implementation calls `list_routable()` followed by `list_by_status()` for
     /// each active non-new status, deduplicating by ID.  Backends that support bulk listing
     /// (e.g. GitHub) should override this to fetch all open issues in one API call and
     /// partition locally, eliminating the 1 + N fan-out.
-    async fn list_active_open_issues(&self) -> anyhow::Result<Vec<(ExternalTask, Option<Status>)>> {
+    async fn list_active_open_issues(
+        &self,
+        _since: Option<&str>,
+    ) -> anyhow::Result<Vec<(ExternalTask, Option<Status>)>> {
         let mut seen = std::collections::HashSet::new();
         let mut result = Vec::new();
 

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1735,20 +1735,37 @@ pub(crate) async fn ingest_external_tasks(
         }
     }
 
+    // Track last ingest time for incremental fetches (same pattern as mentions_last_checked).
+    // Use 24h fallback on first run or if the key is missing.
+    let kv_key = format!("issues_last_ingested:{repo}");
+    let fallback = (chrono::Utc::now() - chrono::Duration::hours(24))
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+    let since = store
+        .kv_get(&kv_key)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or(fallback);
+    let since_for_fetch = since.clone();
+
     // Fetch all open issues in a single backend call and partition by status label locally.
     // The GitHub backend overrides list_active_open_issues() to use one list_all_open_issues()
     // request instead of a routable call + N per-status calls.
-    let all_tasks: Vec<(crate::backends::ExternalTask, Option<Status>)> =
-        match backend.list_active_open_issues().await {
-            Ok(tasks) => tasks,
-            Err(e) => {
-                tracing::debug!(
-                    ?e,
-                    "ingest: failed to list active open issues — skipping this cycle"
-                );
-                return Ok(());
-            }
-        };
+    // Pass `since` to filter issues updated since last ingest for efficiency.
+    let all_tasks: Vec<(crate::backends::ExternalTask, Option<Status>)> = match backend
+        .list_active_open_issues(Some(&since_for_fetch))
+        .await
+    {
+        Ok(tasks) => tasks,
+        Err(e) => {
+            tracing::debug!(
+                ?e,
+                "ingest: failed to list active open issues — skipping this cycle"
+            );
+            return Ok(());
+        }
+    };
 
     // Upsert into the store, collecting store IDs for batch status check.
     // Also acknowledge newly detected issues (eyes reaction).
@@ -1938,6 +1955,12 @@ pub(crate) async fn ingest_external_tasks(
         }
     }
 
+    // Record last ingest time for next incremental fetch.
+    let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    if let Err(e) = store.kv_set(&kv_key, &now).await {
+        tracing::warn!(key = kv_key, err = %e, "ingest: failed to record last ingest time");
+    }
+
     Ok(())
 }
 
@@ -2015,6 +2038,7 @@ mod tests {
         }
         async fn list_active_open_issues(
             &self,
+            _: Option<&str>,
         ) -> anyhow::Result<Vec<(ExternalTask, Option<Status>)>> {
             let mut result = Vec::new();
             for (label, tasks) in &self.tasks {
@@ -2339,6 +2363,7 @@ mod tests {
             /// Return a mix: one unlabeled (no status) + one labeled in_progress.
             async fn list_active_open_issues(
                 &self,
+                _: Option<&str>,
             ) -> anyhow::Result<Vec<(ExternalTask, Option<Status>)>> {
                 Ok(vec![
                     (make_ext_task("100", "Unlabeled routable"), None),

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -1084,11 +1084,20 @@ impl GhHttp {
     }
 
     /// List all open issues (no label filter, paginated).
-    pub async fn list_all_open_issues(&self, repo: &str) -> anyhow::Result<Vec<GitHubIssue>> {
+    ///
+    /// When `since` is `Some(ts)`, only returns issues updated after that ISO 8601 timestamp.
+    /// This is more efficient for periodic syncs — GitHub filters server-side.
+    pub async fn list_all_open_issues(
+        &self,
+        repo: &str,
+        since: Option<&str>,
+    ) -> anyhow::Result<Vec<GitHubIssue>> {
         let url = format!("{GITHUB_API}/repos/{repo}/issues");
-        let all: Vec<GitHubIssue> = self
-            .get_all_pages(&url, &[("state", "open"), ("per_page", "100")])
-            .await?;
+        let params = match since {
+            Some(ts) => vec![("state", "open"), ("since", ts), ("per_page", "100")],
+            None => vec![("state", "open"), ("per_page", "100")],
+        };
+        let all: Vec<GitHubIssue> = self.get_all_pages(&url, &params).await?;
         // GitHub /issues API returns PRs too — filter them out
         Ok(all
             .into_iter()


### PR DESCRIPTION
## Summary

Let me read the relevant sections of the code:

Let me check how `mentions_last_checked` KV key is used:


Let me look at the backends/github.rs to see how it overrides list_active_open_issues:

Now I understand the structure. Let me implement the fix:

1. First, update the trait and HTTP client
2. Then update the backend implementation
3. Finally update `ingest_external_tasks` to use the `since` filter

Let me update the remaining calls to use `None` for the `since` parameter:


Let me check wh

### What was done

- First, update the trait and HTTP client
- Then update the backend implementation
- Finally update `ingest_external_tasks` to use the `since` filter


### Files changed

- `backends/github.rs`
- `src/github/http.rs`


Closes #2493

---
*Task #2493 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*