### PR TITLE
bug: tick_detect_silent_agents lacks error context in store lookups

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -221,13 +221,34 @@ pub(crate) async fn tick_detect_silent_agents(
             Ok(Some(store_id)) => match store.get(store_id).await {
                 Ok(task) => Some(task),
                 Err(e) => {
-                    tracing::warn!(task_id, error = %e, "failed to fetch task from store during silence detection");
+                    tracing::warn!(
+                        task_id,
+                        repo,
+                        store_id,
+                        operation = "store.get",
+                        error = %e,
+                        "silence detection: db error fetching task — agent/model cooldown will be skipped"
+                    );
                     None
                 }
             },
-            Ok(None) => None,
+            Ok(None) => {
+                tracing::debug!(
+                    task_id,
+                    repo,
+                    operation = "resolve_task_id",
+                    "silence detection: task not found in store (may have been cleaned up)"
+                );
+                None
+            }
             Err(e) => {
-                tracing::warn!(task_id, error = %e, "failed to resolve task id during silence detection");
+                tracing::warn!(
+                    task_id,
+                    repo,
+                    operation = "resolve_task_id",
+                    error = %e,
+                    "silence detection: db error resolving task id — agent/model cooldown will be skipped"
+                );
                 None
             }
         };


### PR DESCRIPTION
## Summary

Changes from previous attempts are already applied. The silence detection error logging in tick.rs (lines 220-254) has been enhanced with structured fields (repo, store_id, operation), distinguishes db errors from expected task-not-found cases with a debug log on Ok(None), and error messages explicitly state that agent/model cooldown will be skipped.

### Files changed

- `src/engine/tick.rs`


Closes #2497

---
*Task #2497 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*