### PR TITLE
bug: blocking std::fs in async contexts risks event loop starvation

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -25,7 +25,7 @@ async fn resolve_repo_root_for_orphaned_worktree(wt: &Path) -> anyhow::Result<St
     // not a directory)
     let git_file = wt.join(".git");
     if git_file.exists() {
-        if let Ok(content) = std::fs::read_to_string(&git_file) {
+        if let Ok(content) = tokio::fs::read_to_string(&git_file).await {
             // Parse the gitdir: line
             for line in content.lines() {
                 if let Some(gitdir) = line.strip_prefix("gitdir: ") {

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -1839,7 +1839,7 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap();
         let temp_home = TempDir::new().unwrap();
         let orch_home = temp_home.path().join(".orch");
-        std::fs::create_dir_all(&orch_home).unwrap();
+        tokio::fs::create_dir_all(&orch_home).await.unwrap();
         let old_orch_home = std::env::var("ORCH_HOME").ok();
         std::env::set_var("ORCH_HOME", &orch_home);
 
@@ -1919,7 +1919,7 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap();
         let temp_home = TempDir::new().unwrap();
         let orch_home = temp_home.path().join(".orch");
-        std::fs::create_dir_all(&orch_home).unwrap();
+        tokio::fs::create_dir_all(&orch_home).await.unwrap();
         let old_orch_home = std::env::var("ORCH_HOME").ok();
         std::env::set_var("ORCH_HOME", &orch_home);
 
@@ -2155,7 +2155,7 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap();
         let temp_home = TempDir::new().unwrap();
         let orch_home = temp_home.path().join(".orch");
-        std::fs::create_dir_all(&orch_home).unwrap();
+        tokio::fs::create_dir_all(&orch_home).await.unwrap();
         let old_orch_home = std::env::var("ORCH_HOME").ok();
         std::env::set_var("ORCH_HOME", &orch_home);
 


### PR DESCRIPTION
## Summary

Replaced blocking std::fs operations with tokio::fs equivalents in async contexts: tokio::fs::read_to_string in doctor.rs async fn, and tokio::fs::create_dir_all in three #[tokio::test] test setups in runner/mod.rs. src/home.rs was already correctly handled with block_in_place.

### Files changed

- `src/cli/doctor.rs`
- `src/engine/runner/mod.rs`


Closes #2498

---
*Task #2498 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*