### PR TITLE
bug: network_retries defaults to 1 on store failure, bypassing MAX_NETWORK_RETRIES guard

### DIFF
--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -318,9 +318,12 @@ pub async fn handle_error(
                     tracing::warn!(
                         task_id,
                         error = %e,
-                        "failed to increment network_retries — assuming 1 to prevent infinite loop"
+                        "failed to increment network_retries — escalating to needs_review"
                     );
-                    1
+                    return Ok(ErrorHandleResult::Continue {
+                        status: "needs_review".to_string(),
+                        error: format!("{agent_name} network error (store unavailable): {message}"),
+                    });
                 }
             };
             if let Err(e) = store::store_set_result(


### PR DESCRIPTION
## Summary

Fix applied and committed. The change in `fallback.rs:317-327` replaces the `1` fallback with an immediate `needs_review` escalation — same pattern as the `MAX_NETWORK_RETRIES` exhaustion path above it. The pre-existing `tmux::tests::session_blocks_dispatch_cleans_dead_session` failure is unrelated to this change (confirmed by reproducing it on the stashed baseline).

```json
{"success": true, "changes": ["src/engine/runner/fallback.rs"], "commit": "d44f2283", "pre_existing_failures": ["tmux::

### Files changed

- `src/engine/runner/fallback.rs`


Closes #2507

---
*Task #2507 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*