### PR TITLE
bug: try_exists permission error treated as successful cleanup in remove_worktree_and_branch

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -366,14 +366,14 @@ pub(crate) async fn cleanup_task_worktree_with_opts(
                     .unwrap_or(repo)
                     .trim_end_matches(".git");
                 let candidate = worktrees_base.join(project).join(b);
-                match tokio::fs::try_exists(&candidate).await {
+                if match tokio::fs::try_exists(&candidate).await {
                     Ok(true) => true,
                     Ok(false) => false,
                     Err(e) => {
                         tracing::warn!(task_id, err = %e, "try_exists failed — assuming candidate does not exist");
                         false
                     }
-                }
+                } {
                     Some(candidate)
                 } else {
                     None
@@ -390,14 +390,14 @@ pub(crate) async fn cleanup_task_worktree_with_opts(
             .unwrap_or(repo)
             .trim_end_matches(".git");
         let candidate = worktrees_base.join(project).join(b);
-            match tokio::fs::try_exists(&candidate).await {
-                Ok(true) => true,
-                Ok(false) => false,
-                Err(e) => {
-                    tracing::warn!(task_id, err = %e, "try_exists failed — assuming candidate does not exist");
-                    false
-                }
+        if match tokio::fs::try_exists(&candidate).await {
+            Ok(true) => true,
+            Ok(false) => false,
+            Err(e) => {
+                tracing::warn!(task_id, err = %e, "try_exists failed — assuming candidate does not exist");
+                false
             }
+        } {
             Some(candidate)
         } else {
             None
@@ -667,14 +667,14 @@ pub(crate) async fn remove_worktree_and_branch(
                 );
                 if let Err(e) = tokio::fs::remove_dir_all(wt).await {
                     // Only warn if the directory actually still exists after removal attempt.
-        match tokio::fs::try_exists(wt).await {
-            Ok(true) => true,
-            Ok(false) => false,
-            Err(e) => {
-                tracing::warn!(task_id, err = %e, "try_exists failed — assuming worktree does not exist");
-                false
-            }
-        }
+                    if match tokio::fs::try_exists(wt).await {
+                        Ok(true) => true,
+                        Ok(false) => false,
+                        Err(e) => {
+                            tracing::warn!(task_id, err = %e, "try_exists failed — assuming worktree does not exist");
+                            false
+                        }
+                    } {
                         tracing::warn!(
                             task_id,
                             path = %wt.display(),

--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -366,7 +366,14 @@ pub(crate) async fn cleanup_task_worktree_with_opts(
                     .unwrap_or(repo)
                     .trim_end_matches(".git");
                 let candidate = worktrees_base.join(project).join(b);
-                if tokio::fs::try_exists(&candidate).await.unwrap_or(false) {
+                match tokio::fs::try_exists(&candidate).await {
+                    Ok(true) => true,
+                    Ok(false) => false,
+                    Err(e) => {
+                        tracing::warn!(task_id, err = %e, "try_exists failed — assuming candidate does not exist");
+                        false
+                    }
+                }
                     Some(candidate)
                 } else {
                     None
@@ -383,7 +390,14 @@ pub(crate) async fn cleanup_task_worktree_with_opts(
             .unwrap_or(repo)
             .trim_end_matches(".git");
         let candidate = worktrees_base.join(project).join(b);
-        if tokio::fs::try_exists(&candidate).await.unwrap_or(false) {
+            match tokio::fs::try_exists(&candidate).await {
+                Ok(true) => true,
+                Ok(false) => false,
+                Err(e) => {
+                    tracing::warn!(task_id, err = %e, "try_exists failed — assuming candidate does not exist");
+                    false
+                }
+            }
             Some(candidate)
         } else {
             None
@@ -653,7 +667,14 @@ pub(crate) async fn remove_worktree_and_branch(
                 );
                 if let Err(e) = tokio::fs::remove_dir_all(wt).await {
                     // Only warn if the directory actually still exists after removal attempt.
-                    if tokio::fs::try_exists(wt).await.unwrap_or(false) {
+        match tokio::fs::try_exists(wt).await {
+            Ok(true) => true,
+            Ok(false) => false,
+            Err(e) => {
+                tracing::warn!(task_id, err = %e, "try_exists failed — assuming worktree does not exist");
+                false
+            }
+        }
                         tracing::warn!(
                             task_id,
                             path = %wt.display(),
@@ -725,7 +746,14 @@ pub(crate) async fn remove_worktree_and_branch(
     }
 
     // Definitively check: is the worktree directory actually gone?
-    !tokio::fs::try_exists(wt).await.unwrap_or(false)
+    match tokio::fs::try_exists(wt).await {
+        Ok(false) => true, // confirmed gone
+        Ok(true) => false, // still there
+        Err(e) => {
+            tracing::warn!(task_id, err = %e, "try_exists failed — assuming worktree still present");
+            false // conservative: don't claim success
+        }
+    }
 }
 
 /// Delete local and remote branches for a task.


### PR DESCRIPTION
## Summary

Let me fix all remaining try_exists usages in the cleanup.rs file

### Files changed

- `src/engine/cleanup.rs`


Closes #2506

---
*Task #2506 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/nemotron-3-super-free`*