### PR TITLE
bug: kv_increment returns u32 but casts unchecked from i64, silently truncating large counters

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -188,11 +188,12 @@ pub async fn init_cooldown_store(store: Arc<crate::store::TaskStore>) {
 /// | 2     | 300       | 900    |
 /// | 3     | 300       | 2700   |
 /// | 4     | 300       | 8100 → capped |
-pub fn compute_backoff(count: u32, base: i64, max: i64) -> i64 {
+pub fn compute_backoff(count: u64, base: i64, max: i64) -> i64 {
     if count <= 1 {
         return base;
     }
-    let factor = 3_i64.saturating_pow(count.saturating_sub(1));
+    let exp = count.saturating_sub(1).min(u32::MAX as u64) as u32;
+    let factor = 3_i64.saturating_pow(exp);
     base.saturating_mul(factor).min(max)
 }
 
@@ -202,12 +203,12 @@ pub fn compute_backoff(count: u32, base: i64, max: i64) -> i64 {
 /// cooldown duration from growing beyond the cap, so unbounded counts are safe.
 ///
 /// Returns 1 when no store is configured (unit-test contexts without a store).
-/// Returns `u32::MAX` on store errors (e.g. lock contention) so backoff applies the cap duration
+/// Returns `u64::MAX` on store errors (e.g. lock contention) so backoff applies the cap duration
 /// instead of resetting to the base, preventing rapid re-dispatch during store outages.
 async fn read_and_increment_failure_count(
     store_opt: &Option<Arc<crate::store::TaskStore>>,
     key: &str,
-) -> u32 {
+) -> u64 {
     read_and_increment_failure_count_with_prefix(store_opt, FAILURE_COUNT_PREFIX, key).await
 }
 
@@ -219,14 +220,14 @@ async fn read_and_increment_failure_count_with_prefix(
     store_opt: &Option<Arc<crate::store::TaskStore>>,
     prefix: &str,
     key: &str,
-) -> u32 {
+) -> u64 {
     let kv_key = format!("{prefix}{key}");
     if let Some(store) = store_opt {
         match store.kv_increment(&kv_key).await {
             Ok(n) => n,
             Err(e) => {
                 tracing::warn!(key = %kv_key, err = %e, "failed to increment failure count — treating as high count for safe backoff");
-                u32::MAX
+                u64::MAX
             }
         }
     } else {
@@ -1871,7 +1872,8 @@ mod tests {
             compute_backoff(100, BACKOFF_BASE_SECS, BACKOFF_MAX_SECS),
             BACKOFF_MAX_SECS
         );
-        assert_eq!(compute_backoff(u32::MAX, 300, 14400), 14400);
+        assert_eq!(compute_backoff(u32::MAX as u64, 300, 14400), 14400);
+        assert_eq!(compute_backoff(u64::MAX, 300, 14400), 14400);
     }
 
     #[test]

--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -442,7 +442,7 @@ pub(crate) async fn review_open_prs(
                 Err(kv_err) => {
                     tracing::warn!(kv_err = %kv_err, err = %e, "failed to track batch_fail counter — treating as degraded");
                     // Use a sentinel high value so the escalation path fires.
-                    u32::MAX
+                    u64::MAX
                 }
             };
             if fails >= 10 {

--- a/src/store/kv.rs
+++ b/src/store/kv.rs
@@ -27,7 +27,7 @@ impl TaskStore {
     /// Executes a single SQL statement (`INSERT … ON CONFLICT … DO UPDATE`) so concurrent
     /// callers cannot race — SQLite's serialised write lock ensures the read-modify-write is
     /// indivisible.  Returns the new value after the increment.
-    pub async fn kv_increment(&self, key: &str) -> anyhow::Result<u32> {
+    pub async fn kv_increment(&self, key: &str) -> anyhow::Result<u64> {
         let row: (i64,) = sqlx::query_as(
             "INSERT INTO kv (key, value, updated_at) VALUES (?1, '1', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
              ON CONFLICT(key) DO UPDATE
@@ -38,7 +38,7 @@ impl TaskStore {
         .bind(key)
         .fetch_one(&self.pool)
         .await?;
-        Ok(row.0.max(1) as u32)
+        Ok(row.0.max(1) as u64)
     }
 
     /// Delete a key from the KV store.


### PR DESCRIPTION
## Summary

Fixed kv_increment to return u64 and updated callers to use u64 to avoid silent truncation; adjusted backoff functions and tests accordingly.

### What was done

- Changed TaskStore::kv_increment signature and implementation to return anyhow::Result<u64> and return row.0.max(1) as u64
- Updated engine cooldown logic to use u64 for failure counters and compute_backoff's count parameter
- Updated review polling path to treat store increment errors as u64::MAX sentinel
- Updated unit tests and helpers that rely on kv_increment/store increment return types (kept numeric expectations unchanged as they work with u64)
- Committed the changes on branch gh-issue-2509-bug-kv-increment-returns-u32-but-casts-u


### Remaining

- Run full test suite (cargo nextest run / cargo test) locally to be safe — I did not run tests in this environment
- If CI surfaces any type mismatches in other modules that expect u32, address them (search shows adjusting callers already performed for the main hotspots)


### Files changed

- `src/engine/cooldown.rs`
- `src/engine/review_poll.rs`
- `src/store/kv.rs`


Closes #2509

---
*Task #2509 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*