### PR TITLE
perf: add  to auto-clean orphaned worktrees from CLI

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1,7 +1,9 @@
 use crate::backends::github::GitHubBackend;
 use crate::backends::{ExternalBackend, ExternalId};
 use crate::config;
-use crate::engine::cleanup::{remove_worktree_and_branch, resolve_repo_root};
+use crate::engine::cleanup::{
+    cleanup_orphaned_worktree, remove_worktree_and_branch, resolve_repo_root,
+};
 use crate::github::http::GhHttp;
 use crate::store::{Task, TaskStatus, TaskStore};
 use crate::tmux::TmuxManager;
@@ -10,81 +12,6 @@ use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-
-/// Resolve the main git repository root for an orphaned worktree.
-///
-/// For orphaned worktrees, we cannot use `resolve_repo_root` because the worktree
-/// may belong to a different project than the current repo context. Instead, we
-/// derive the repo root from the worktree's `.git` file/directory.
-///
-/// A worktree's `.git` file contains a `gitdir:` pointer to the main repo's
-/// git directory (e.g., `/path/to/repo/.git/worktrees/<name>`). We extract this
-/// path and derive the repo root from it.
-async fn resolve_repo_root_for_orphaned_worktree(wt: &Path) -> anyhow::Result<String> {
-    // First, try to read the .git file in the worktree (it's a file for worktrees,
-    // not a directory)
-    let git_file = wt.join(".git");
-    if git_file.exists() {
-        if let Ok(content) = tokio::fs::read_to_string(&git_file).await {
-            // Parse the gitdir: line
-            for line in content.lines() {
-                if let Some(gitdir) = line.strip_prefix("gitdir: ") {
-                    // gitdir points to something like /path/to/repo/.git/worktrees/<name>
-                    // The repo root is two levels up from here
-                    let gitdir_path = std::path::PathBuf::from(gitdir);
-                    if let Some(repo_root) = gitdir_path.parent().and_then(|p| p.parent()) {
-                        return Ok(repo_root.display().to_string());
-                    }
-                }
-            }
-        }
-    }
-
-    // Fallback: try to find the repo by looking at registered projects
-    // Extract the project name from the worktree path
-    // Worktree path format: ~/.orch/worktrees/<project>/<branch-name>
-    let worktrees_dir = crate::home::worktrees_dir()?;
-    if let Ok(relative) = wt.strip_prefix(&worktrees_dir) {
-        if let Some(project_name) = relative.components().next() {
-            let project_name = project_name.as_os_str().to_string_lossy();
-
-            // Look for a registered project with this name
-            if let Ok(paths) = config::get_project_paths() {
-                for path_str in &paths {
-                    let path = std::path::Path::new(path_str);
-                    if let Some(name) = path.file_name() {
-                        if name.to_string_lossy() == project_name {
-                            return Ok(path_str.clone());
-                        }
-                    }
-                }
-            }
-
-            // Try bare clone at ~/.orch/projects/<owner>/<project>.git
-            let parts: Vec<&str> = project_name.split('/').collect();
-            let bare = if parts.len() == 2 {
-                crate::home::projects_dir()
-                    .map(|d| d.join(parts[0]).join(format!("{}.git", parts[1])))
-                    .unwrap_or_default()
-            } else {
-                crate::home::projects_dir()
-                    .map(|d| {
-                        d.join("gabrielkoerich")
-                            .join(format!("{}.git", project_name))
-                    })
-                    .unwrap_or_default()
-            };
-            if bare.exists() {
-                return Ok(bare.display().to_string());
-            }
-        }
-    }
-
-    anyhow::bail!(
-        "cannot resolve repo root for orphaned worktree at {} - tried .git file parsing and project lookup",
-        wt.display()
-    )
-}
 
 /// What kind of automatic repair can be applied to a finding.
 enum FixAction {
@@ -1571,37 +1498,13 @@ async fn apply_fixes(
                     continue;
                 }
 
-                // For orphaned worktrees, derive the repo root from the worktree path
-                // by examining the .git file/directory, since the worktree may belong to
-                // a different project than the current repo context.
-                let wt = Path::new(path);
-                let repo_root = resolve_repo_root_for_orphaned_worktree(wt).await;
-
-                match repo_root {
-                    Ok(root) => {
-                        let removed = remove_worktree_and_branch(
-                            &f.task_id,
-                            wt,
-                            None,
-                            Path::new(&root),
-                            false,
-                        )
-                        .await;
-                        if removed {
-                            println!("  fixed: removed orphaned worktree {}", path);
-                            fixed += 1;
-                        } else {
-                            eprintln!("  fix failed: could not remove orphaned worktree {}", path);
-                            skipped += 1;
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!(
-                            "  fix failed: cannot resolve repo root for orphan cleanup: {}",
-                            e
-                        );
-                        skipped += 1;
-                    }
+                let removed = cleanup_orphaned_worktree(&f.task_id, Path::new(path)).await;
+                if removed {
+                    println!("  fixed: removed orphaned worktree {}", path);
+                    fixed += 1;
+                } else {
+                    eprintln!("  fix failed: could not remove orphaned worktree {}", path);
+                    skipped += 1;
                 }
             }
             FixAction::MarkDoneFromMergedPr { store_id } => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@ pub mod events;
 pub mod job;
 pub mod ndjson;
 pub mod notify;
+pub mod prune;
 pub mod service;
 pub mod session;
 pub mod stats;

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -1,0 +1,100 @@
+use crate::engine::cleanup::cleanup_orphaned_worktree;
+use std::path::Path;
+use std::sync::Arc;
+
+/// Remove orphaned worktrees — directories under `~/.orch/worktrees/` that are
+/// not referenced by any task in the store.
+///
+/// Unlike `orch doctor --fix`, this command does not require `--fix` to be
+/// specified and does not prompt for confirmation. Orphaned worktrees are
+/// unreferenced by definition and safe to remove automatically.
+pub async fn run(dry_run: bool) -> anyhow::Result<()> {
+    let store = Arc::new(crate::cli::init_store().await?);
+    let all_tasks = store.list_all_global().await?;
+
+    let worktrees_dir = crate::home::worktrees_dir()?;
+
+    // Build a set of owned worktree paths for O(1) lookup.
+    let owned: std::collections::HashSet<String> = all_tasks
+        .iter()
+        .filter(|t| !t.worktree.is_empty())
+        .map(|t| t.worktree.clone())
+        .collect();
+
+    let mut removed = 0usize;
+    let mut failed = 0usize;
+
+    let project_dirs = match std::fs::read_dir(&worktrees_dir) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("cannot read worktrees directory: {e}");
+            return Ok(());
+        }
+    };
+
+    for project_entry in project_dirs.flatten() {
+        if !project_entry
+            .file_type()
+            .map(|t| t.is_dir())
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        let branch_dirs = match std::fs::read_dir(project_entry.path()) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+        for branch_entry in branch_dirs.flatten() {
+            if !branch_entry
+                .file_type()
+                .map(|t| t.is_dir())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let wt_path = branch_entry.path().to_string_lossy().to_string();
+            if owned.contains(&wt_path) {
+                continue;
+            }
+
+            if dry_run {
+                println!("would remove: {}", wt_path);
+                removed += 1;
+                continue;
+            }
+
+            let ok = cleanup_orphaned_worktree("prune", Path::new(&wt_path)).await;
+            if ok {
+                println!("removed: {}", wt_path);
+                removed += 1;
+            } else {
+                eprintln!("failed to remove: {}", wt_path);
+                failed += 1;
+            }
+        }
+    }
+
+    if removed == 0 && failed == 0 {
+        println!("No orphaned worktrees found.");
+        return Ok(());
+    }
+
+    if dry_run {
+        println!(
+            "\n{} orphaned worktree(s) would be removed (dry run)",
+            removed
+        );
+    } else {
+        println!(
+            "\nRemoved {} orphaned worktree(s){}",
+            removed,
+            if failed > 0 {
+                format!(", {} failed", failed)
+            } else {
+                String::new()
+            }
+        );
+    }
+
+    Ok(())
+}

--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -847,6 +847,96 @@ async fn worktree_age_hours(worktree: &std::path::Path) -> Option<u64> {
     Some(age.as_secs() / 3600)
 }
 
+/// Resolve the repo root for an orphaned worktree and remove it.
+///
+/// Used by `orch doctor --fix` and `orch prune` to clean up worktrees that are
+/// no longer owned by any task. Returns `true` if the worktree directory is gone
+/// after the call.
+pub(crate) async fn cleanup_orphaned_worktree(task_id: &str, wt: &std::path::Path) -> bool {
+    let repo_root = match resolve_repo_root_for_orphaned_worktree(wt).await {
+        Ok(root) => root,
+        Err(e) => {
+            tracing::warn!(
+                worktree = %wt.display(),
+                error = %e,
+                "cannot resolve repo root for orphaned worktree"
+            );
+            return false;
+        }
+    };
+    remove_worktree_and_branch(task_id, wt, None, std::path::Path::new(&repo_root), false).await
+}
+
+/// Resolve the main git repository root for an orphaned worktree.
+///
+/// First tries to parse the `.git` file's `gitdir:` pointer (two levels up from
+/// the pointer gives the bare repo root, which is the orch convention). Falls back
+/// to looking up registered projects by directory name when the `.git` file is
+/// absent or unparseable.
+pub(crate) async fn resolve_repo_root_for_orphaned_worktree(
+    wt: &std::path::Path,
+) -> anyhow::Result<String> {
+    let git_file = wt.join(".git");
+    if git_file.exists() {
+        if let Ok(content) = tokio::fs::read_to_string(&git_file).await {
+            for line in content.lines() {
+                if let Some(gitdir) = line.strip_prefix("gitdir: ") {
+                    // gitdir points to: <repo>/.git/worktrees/<name> (non-bare)
+                    //                or <repo>.git/worktrees/<name>   (bare)
+                    // Two levels up reaches the .git dir / bare repo root.
+                    let gitdir_path = std::path::PathBuf::from(gitdir);
+                    if let Some(repo_root) = gitdir_path.parent().and_then(|p| p.parent()) {
+                        return Ok(repo_root.display().to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback: look up registered projects by the project-name component of the
+    // worktree path (format: ~/.orch/worktrees/<project>/<branch>).
+    let worktrees_dir = crate::home::worktrees_dir()?;
+    if let Ok(relative) = wt.strip_prefix(&worktrees_dir) {
+        if let Some(project_name) = relative.components().next() {
+            let project_name = project_name.as_os_str().to_string_lossy();
+
+            if let Ok(paths) = crate::config::get_project_paths() {
+                for path_str in &paths {
+                    let path = std::path::Path::new(path_str);
+                    if let Some(name) = path.file_name() {
+                        if name.to_string_lossy() == project_name {
+                            return Ok(path_str.clone());
+                        }
+                    }
+                }
+            }
+
+            // Try bare clone at ~/.orch/projects/<owner>/<project>.git
+            let parts: Vec<&str> = project_name.split('/').collect();
+            let bare = if parts.len() == 2 {
+                crate::home::projects_dir()
+                    .map(|d| d.join(parts[0]).join(format!("{}.git", parts[1])))
+                    .unwrap_or_default()
+            } else {
+                crate::home::projects_dir()
+                    .map(|d| {
+                        d.join("gabrielkoerich")
+                            .join(format!("{}.git", project_name))
+                    })
+                    .unwrap_or_default()
+            };
+            if bare.exists() {
+                return Ok(bare.display().to_string());
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "cannot resolve repo root for orphaned worktree at {} — tried .git parsing and project lookup",
+        wt.display()
+    )
+}
+
 /// Resolve the main git repository root from a worktree's .git file.
 ///
 /// For cross-project worktree cleanup, we cannot rely on `resolve_repo_root` because

--- a/src/main.rs
+++ b/src/main.rs
@@ -418,6 +418,12 @@ enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Remove orphaned worktrees not owned by any task
+    Prune {
+        /// Show what would be removed without making changes
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Export task session output in human-readable format
     Session {
         #[command(subcommand)]
@@ -1052,6 +1058,9 @@ async fn main() -> anyhow::Result<()> {
         },
         Commands::Doctor { full, fix, dry_run } => {
             cli::doctor::run(full, fix, dry_run).await?;
+        }
+        Commands::Prune { dry_run } => {
+            cli::prune::run(dry_run).await?;
         }
         Commands::Session { action } => match action {
             SessionAction::Export {


### PR DESCRIPTION
## Summary

Added `orch prune [--dry-run]` command that automatically removes orphaned worktrees without confirmation. Extracted the shared resolution+removal logic (`resolve_repo_root_for_orphaned_worktree` + `cleanup_orphaned_worktree`) into `src/engine/cleanup.rs` so both `doctor --fix` and `prune` reuse it. All tests pass.

### Files changed

- `src/cli/doctor.rs`
- `src/cli/mod.rs`
- `src/cli/prune.rs`
- `src/engine/cleanup.rs`
- `src/main.rs`


Closes #2515

---
*Task #2515 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*