### PR TITLE
bug: blocking Path::exists() calls in async fn resolve_repo_root_for_orphaned_worktree (cleanup.rs)

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -877,7 +877,7 @@ pub(crate) async fn resolve_repo_root_for_orphaned_worktree(
     wt: &std::path::Path,
 ) -> anyhow::Result<String> {
     let git_file = wt.join(".git");
-    if git_file.exists() {
+    if tokio::fs::try_exists(&git_file).await.unwrap_or(false) {
         if let Ok(content) = tokio::fs::read_to_string(&git_file).await {
             for line in content.lines() {
                 if let Some(gitdir) = line.strip_prefix("gitdir: ") {
@@ -925,7 +925,7 @@ pub(crate) async fn resolve_repo_root_for_orphaned_worktree(
                     })
                     .unwrap_or_default()
             };
-            if bare.exists() {
+            if tokio::fs::try_exists(&bare).await.unwrap_or(false) {
                 return Ok(bare.display().to_string());
             }
         }


### PR DESCRIPTION
## Summary

Both blocking `Path::exists()` calls in `resolve_repo_root_for_orphaned_worktree` (cleanup.rs:880 and cleanup.rs:928) have been replaced with `tokio::fs::try_exists().await.unwrap_or(false)`. All 2975 tests pass, clippy reports no issues, and formatting is clean.

### Files changed

- `src/engine/cleanup.rs`


Closes #2520

---
*Task #2520 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*