### PR TITLE
bug: GitHub Actions billing failure indistinguishable from code failure — triggers CI retry loop, blocks 19+ tasks

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -164,6 +164,56 @@ pub(crate) fn any_changes_requested_in_reviews(reviews: &[GitHubReview]) -> bool
         .any(|r| r.state == "CHANGES_REQUESTED")
 }
 
+/// Returns `true` if any failed check run for `sha` carries a GitHub Actions
+/// billing failure annotation.
+///
+/// When an account has unpaid invoices or has hit a spending limit, GitHub
+/// refuses to start jobs and records the reason ("The job was not started
+/// because recent account payments have failed …") as a check-run annotation.
+/// The CI state still comes back as `"failure"`, which would normally trigger
+/// the agent retry loop — but no code change can fix a billing problem.
+/// This function lets the caller short-circuit that loop and block the task
+/// immediately with a human-readable billing message instead.
+async fn is_billing_failure(gh: &GhHttp, repo: &str, sha: &str) -> bool {
+    let check_runs = match gh.get_check_runs(repo, sha).await {
+        Ok(runs) => runs,
+        Err(e) => {
+            tracing::debug!(err = %e, "failed to fetch check runs for billing failure check");
+            return false;
+        }
+    };
+
+    for run in check_runs
+        .iter()
+        .filter(|r| r.conclusion.as_deref() == Some("failure"))
+    {
+        match gh.get_check_run_annotations(repo, run.id).await {
+            Ok(annotations) => {
+                for annotation in &annotations {
+                    let msg = annotation.message.as_deref().unwrap_or("");
+                    let title = annotation.title.as_deref().unwrap_or("");
+                    if msg.contains("account payments have failed")
+                        || msg.contains("spending limit")
+                        || title.contains("account payments have failed")
+                        || title.contains("spending limit")
+                    {
+                        return true;
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    check_run_id = run.id,
+                    err = %e,
+                    "failed to fetch check run annotations"
+                );
+            }
+        }
+    }
+
+    false
+}
+
 /// Auto-merge a PR after review approval.
 ///
 /// Checks that the automated review comment says "approve" and that CI checks
@@ -436,6 +486,32 @@ pub(crate) async fn auto_merge_pr(
         match state.as_str() {
             "success" => break,
             "failure" => {
+                // Check for billing failures before incrementing the code-quality
+                // failure counter.  Billing failures are infrastructure problems —
+                // no agent can fix them — so we block the task immediately and skip
+                // the re-route loop entirely.
+                if is_billing_failure(&gh, repo, &head_sha).await {
+                    tracing::error!(
+                        task_id = task.id.0,
+                        pr_number,
+                        "GitHub Actions billing failure detected — blocking for human intervention"
+                    );
+                    let fields = [(
+                        "block_reason",
+                        serde_json::json!(
+                            "GitHub Actions billing failure — check Billing & plans settings \
+                             (jobs are not starting due to payment failure or spending limit)"
+                        ),
+                    )];
+                    if let Err(e) = task_manager
+                        .update_task_status_and_result(&task.id, Status::Blocked, &fields)
+                        .await
+                    {
+                        tracing::error!(task_id = task.id.0, err = %e, "failed to write billing block_reason and set Blocked");
+                    }
+                    return Ok(());
+                }
+
                 let ci_failures = match store_increment(
                     &Some(Arc::clone(store)),
                     repo,

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -11,7 +11,7 @@
 
 use super::token;
 use super::types::{
-    GitHubCheckRun, GitHubComment, GitHubIssue, GitHubPullRequest, GitHubReview,
+    GitHubAnnotation, GitHubCheckRun, GitHubComment, GitHubIssue, GitHubPullRequest, GitHubReview,
     GitHubReviewComment,
 };
 use crate::engine::cooldown as engine_cooldown;
@@ -1816,6 +1816,21 @@ impl GhHttp {
             "{GITHUB_API}/repos/{repo}/commits/{sha}/check-runs?filter=latest&per_page=100"
         );
         self.get_all_pages_from_wrapper(&url, "check_runs").await
+    }
+
+    /// Get annotations for a specific check run.
+    ///
+    /// Returns the list of annotations attached to the check run, including
+    /// billing failure messages ("The job was not started because recent account
+    /// payments have failed …") that GitHub surfaces as annotations rather than
+    /// as a distinct CI conclusion value.
+    pub async fn get_check_run_annotations(
+        &self,
+        repo: &str,
+        check_run_id: u64,
+    ) -> anyhow::Result<Vec<GitHubAnnotation>> {
+        let url = format!("{GITHUB_API}/repos/{repo}/check-runs/{check_run_id}/annotations");
+        self.get_all_pages(&url, &[("per_page", "100")]).await
     }
 
     /// Get reviews for a PR.

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -54,9 +54,22 @@ pub struct GitHubPullRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitHubCheckRun {
+    pub id: u64,
     pub name: String,
     pub status: String,
     pub conclusion: Option<String>,
+}
+
+/// A check run annotation returned by the GitHub Checks API.
+///
+/// Annotations appear on the "Annotations" tab of a check run in the GitHub UI.
+/// GitHub uses annotations for job-level messages, including billing failures
+/// ("The job was not started because recent account payments have failed …").
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubAnnotation {
+    pub annotation_level: Option<String>,
+    pub message: Option<String>,
+    pub title: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Implemented billing failure detection in auto_merge.rs to distinguish GitHub Actions billing failures from code failures. Added GitHubAnnotation type, get_check_run_annotations API method, and is_billing_failure helper that checks check run annotations for billing error messages. Modified the CI failure handler to detect billing failures before incrementing the retry counter, blocking immediately with a human-readable billing message instead of re-routing tasks to agents.

### Files changed

- `src/github/types.rs`
- `src/github/http.rs`
- `src/engine/auto_merge.rs`


Closes #2526

---
*Task #2526 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*