### PR TITLE
bug: claude agent task_runs.error field empty on failure — impossible to diagnose 30+ failures per 12h window

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -1334,12 +1334,21 @@ pub async fn get_route_result(
         valid
     });
 
-    // If a stale model was discarded, update the database to clear it.
-    // This prevents repeated warnings on subsequent dispatches (#1907).
+    // If a stale model was discarded, update the database to clear the model
+    // and record a diagnostic last_error so task_runs.error is populated if
+    // the subsequent run fails (fixes issue #2527).
     let original_model = task.model.clone().filter(|m| !m.is_empty());
     if original_model.is_some() && model.is_none() {
+        let stale_model = original_model.as_deref().unwrap_or("unknown");
+        let stale_err = format!("stale model discarded: {stale_model} not in {agent} model pools");
         if let Err(e) = store
-            .set_fields(store_id, &[("model", serde_json::json!(""))])
+            .set_fields(
+                store_id,
+                &[
+                    ("model", serde_json::json!("")),
+                    ("last_error", serde_json::json!(stale_err)),
+                ],
+            )
             .await
         {
             // Log the error so transient DB failures are visible and diagnosable.

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -335,7 +335,15 @@ impl TaskRunner {
     }
 
     async fn build_run_audit(&self, input: RunAuditInput<'_>) -> RunAudit {
-        let last_error = self.get_field(input.task_id, "last_error").await;
+        // Filter empty strings so that a blank last_error does not shadow the
+        // actual parse_result error.  Without this, `Option::or(Some(""))` would
+        // return `Some("")` and prevent the `unwrap_or_else` fallback from ever
+        // running, causing task_runs.error to be written as "" even when the
+        // agent returned a classifiable error (fixes issue #2527).
+        let last_error = self
+            .get_field(input.task_id, "last_error")
+            .await
+            .filter(|s| !s.is_empty());
         let error =
             input
                 .error_override


### PR DESCRIPTION
## Summary

Fixed empty task_runs.error field on failure (issue #2527). Two changes: (1) filter empty last_error in build_run_audit() so parse_result errors are used as fallback instead of being silently shadowed by Some(""); (2) write last_error when stale model is discarded during routing so the event is captured in task_runs.error. All 2975 tests pass.

### Files changed

- `src/engine/router/mod.rs`
- `src/engine/runner/mod.rs`


Closes #2527

---
*Task #2527 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*