### PR TITLE
bug: stash failure guard missing in rebase_on_branch and rebase_on_default_branch — rebase attempted with uncommitted changes

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -887,6 +887,18 @@ pub(crate) async fn auto_merge_pr(
                                     None
                                 };
 
+                            // Guard: if has_changes was true but stash failed, skip the rebase
+                            // to avoid "cannot rebase: You have unstaged changes" error.
+                            let has_uncommitted_changes =
+                                crate::engine::runner::git_ops::has_changes(&wt_path).await;
+                            if has_uncommitted_changes && stash_ref.is_none() {
+                                tracing::warn!(
+                                    task_id = task.id.0,
+                                    "git stash failed during conflict-resolution rebase — skipping rebase"
+                                );
+                                return Ok(());
+                            }
+
                             let rebase_out = tokio::process::Command::new("git")
                                 .args([
                                     "-c",

--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -281,6 +281,18 @@ pub async fn rebase_on_branch(dir: &Path, branch: &str) -> anyhow::Result<bool> 
         None
     };
 
+    // Guard: if has_changes was true but stash failed, skip the rebase to avoid
+    // "cannot rebase: You have unstaged changes" error. The worktree remains dirty
+    // and the next tick will retry.
+    let has_uncommitted_changes = has_changes(dir).await;
+    if has_uncommitted_changes && stash_ref.is_none() {
+        tracing::warn!(
+            branch = branch,
+            "git stash failed during rebase_on_branch — skipping rebase to avoid worktree loss"
+        );
+        return Ok(false);
+    }
+
     // Perform the rebase.
     let output = Command::new("git")
         .args(["rebase", &origin_branch])
@@ -434,6 +446,18 @@ pub async fn rebase_on_default(dir: &Path, default_branch: &str) {
     } else {
         None
     };
+
+    // Guard: if has_changes was true but stash failed, skip the rebase to avoid
+    // "cannot rebase: You have unstaged changes" error. The worktree remains dirty
+    // and the next tick will retry.
+    let has_uncommitted_changes = has_changes(dir).await;
+    if has_uncommitted_changes && stash_ref.is_none() {
+        tracing::warn!(
+            default_branch,
+            "git stash failed during rebase_on_default — skipping rebase to avoid worktree loss"
+        );
+        return;
+    }
 
     let output = Command::new("git")
         .args(["rebase", &format!("origin/{default_branch}")])


### PR DESCRIPTION
## Summary

Fixed stash failure guard missing in three rebase paths — added guards that skip rebase when stash fails

### What was done

- Added stash failure guard in rebase_on_branch() in git_ops.rs
- Added stash failure guard in rebase_on_default() in git_ops.rs
- Added stash failure guard in auto_merge.rs conflict-resolution rebase path
- All tests pass (2975 tests)
- cargo fmt and clippy pass


### Files changed

- `src/engine/auto_merge.rs`
- `src/engine/runner/git_ops.rs`


Closes #2534

---
*Task #2534 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*