### PR TITLE
bug: read_dir().into_iter().flatten() silently swallows IO errors in output recovery fallback

### DIFF
--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -179,12 +179,18 @@ pub async fn read_output_file(task_id: &str, primary_path: &Path, repo: &str) ->
             let mut attempt_nums: Vec<u32> = tokio::task::spawn_blocking({
                 let a = attempts_dir.clone();
                 move || {
-                    std::fs::read_dir(&a)
-                        .into_iter()
-                        .flatten()
-                        .filter_map(|e| e.ok())
-                        .filter_map(|e| e.file_name().to_str().and_then(|n| n.parse().ok()))
-                        .collect::<Vec<u32>>()
+                    match std::fs::read_dir(&a) {
+                        Ok(entries) => entries
+                            .filter_map(|e| e.ok())
+                            .filter_map(|e| {
+                                e.file_name().to_str().and_then(|n| n.parse().ok())
+                            })
+                            .collect::<Vec<u32>>(),
+                        Err(e) => {
+                            tracing::warn!(path = %a.display(), err = %e, "failed to read attempts dir in output fallback");
+                            Vec::new()
+                        }
+                    }
                 }
             })
             .await


### PR DESCRIPTION
## Summary

Fixed `src/engine/runner/response.rs:182-188`: replaced `.into_iter().flatten()` error-swallowing pattern with an explicit `match` that logs a `tracing::warn!` when `read_dir` fails. All 2975 tests pass, clippy clean.

### Files changed

- `src/engine/runner/response.rs`


Closes #2538

---
*Task #2538 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*