### PR TITLE
bug: i32-as-u64 casts missing .max(0) guard cause shift overflow / wrong comparison in several places

### DIFF
--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -366,7 +366,7 @@ pub(crate) async fn review_open_prs(
                     }
                 };
 
-                if reroutes as u32 >= max_reroutes {
+                if reroutes >= max_reroutes as u64 {
                     tracing::error!(
                         task_id,
                         reroutes,
@@ -579,7 +579,7 @@ pub(crate) async fn review_open_prs(
                 let is_conflicting = batch_data.mergeable == Some(false);
 
                 if is_conflicting {
-                    let retries = stored_task.merge_conflict_retries as u64;
+                    let retries = stored_task.merge_conflict_retries.max(0) as u64;
                     match handle_merge_conflict(
                         &task.id,
                         pr_number,
@@ -681,7 +681,7 @@ pub(crate) async fn review_open_prs(
                 let is_conflicting = batch_data.mergeable == Some(false);
 
                 if is_conflicting {
-                    let retries = stored_task.merge_conflict_retries as u64;
+                    let retries = stored_task.merge_conflict_retries.max(0) as u64;
                     match handle_merge_conflict(
                         &task.id,
                         pr_number,

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1053,7 +1053,7 @@ pub(crate) async fn sync_tick(
                 continue;
             }
             // Decide whether to re-fire now using exponential backoff based on a per-task counter.
-            let current_refires = task.stored.needs_review_refires as u64;
+            let current_refires = task.stored.needs_review_refires.max(0) as u64;
             let new_refires = current_refires + 1;
 
             // If we've exceeded max attempts, escalate the task to Blocked with a clear reason.


### PR DESCRIPTION
## Summary

Applied .max(0) guards to all four i32-as-u64 cast sites: sync.rs:1056 (shift-amount overflow fix), review_poll.rs:582 and 684 (merge_conflict_retries spurious block fix), and review_poll.rs:369 (widen comparison to u64 instead of narrowing). All 2975 tests pass.

### Files changed

- `src/engine/review_poll.rs`
- `src/engine/sync.rs`


Closes #2539

---
*Task #2539 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*