### PR TITLE
bug: u64 token sum cast to i64 without saturation in control.rs

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -750,7 +750,10 @@ pub async fn send_message(
 
     // Store assistant message with token usage
     let total_tokens = match (result.input_tokens, result.output_tokens) {
-        (Some(i), Some(o)) => Some((i + o) as i64),
+        // Use saturating_add + try_from to avoid u64 overflow and prevent
+        // casting a large u64 into a negative i64. If the sum doesn't fit
+        // into i64, cap to i64::MAX (matches store/tasks.rs pattern).
+        (Some(i), Some(o)) => Some(i64::try_from(i.saturating_add(o)).unwrap_or(i64::MAX)),
         (Some(t), None) | (None, Some(t)) => Some(t as i64),
         _ => None,
     };


### PR DESCRIPTION
## Summary

Fix unsafe cast when summing u64 token counts in control session; use saturating add and cap to i64::MAX.

### What was done

- Updated src/control.rs to prevent negative total_tokens from arising when summing input/output u64 token counts.
- Replaced direct (i + o) as i64 cast with saturating_add and i64::try_from(...).unwrap_or(i64::MAX) to match existing store pattern.
- Ran quick checks (git diff shown, cargo clippy finished) to validate the change compiles locally.


### Remaining

- Run full test suite (cargo nextest run / cargo test) in CI or locally if desired.
- Optionally audit other locations for similar unsafe casts (search for 'as i64' on aggregated u64 sums).


### Files changed

- `src/control.rs`


Closes #2540

---
*Task #2540 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*