### PR TITLE
bug: merge_conflict_retries as u64 missing .max(0) guard in auto_merge.rs — same class as PR #2542

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -763,7 +763,7 @@ pub(crate) async fn auto_merge_pr(
         if is_conflict {
             let retries = opt_store_get_task(&Some(Arc::clone(store)), repo, &task.id.0)
                 .await
-                .map(|t| t.merge_conflict_retries as u64)
+                .map(|t| t.merge_conflict_retries.max(0) as u64)
                 .unwrap_or(0);
             if retries >= MAX_MERGE_CONFLICT_RETRIES {
                 tracing::error!(

--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -727,7 +727,7 @@ async fn detect_push_failure_state(
                 // On DB error, read current value to ensure blocking threshold is still reachable
                 ctx.get_task()
                     .await
-                    .map(|t| (t.push_failures as u64) + 1)
+                    .map(|t| (t.push_failures.max(0) as u64) + 1)
                     .unwrap_or(1) // assume at least 1 if we can't read either
             }
         }
@@ -772,7 +772,7 @@ async fn detect_no_code_reroutes(
             // On DB error, read current value to ensure blocking threshold is still reachable
             ctx.get_task()
                 .await
-                .map(|t| (t.no_code_reroutes as u64) + 1)
+                .map(|t| (t.no_code_reroutes.max(0) as u64) + 1)
                 .unwrap_or(1) // assume at least 1 if we can't read either
         }
     }


### PR DESCRIPTION
## Summary

Applied `.max(0)` guards to three i32-as-u64 casts: `merge_conflict_retries` in `auto_merge.rs:766`, `push_failures` in `response_handler.rs:730`, and `no_code_reroutes` in `response_handler.rs:775`. All 2975 tests pass.

### Files changed

- `src/engine/auto_merge.rs`
- `src/engine/runner/response_handler.rs`


Closes #2544

---
*Task #2544 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*