### PR TITLE
bug: scan_skills_directory in router/llm.rs uses entries.flatten() silently swallowing DirEntry IO errors

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -788,7 +788,14 @@ async fn check_orphaned_worktrees(all_tasks: &[Task], findings: &mut Vec<Finding
         .map(|t| (t.worktree.as_str(), t))
         .collect();
 
-    for project_entry in project_dirs.flatten() {
+    for project_entry in project_dirs {
+        let project_entry = match project_entry {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!(err = %e, "error reading worktrees directory entry");
+                continue;
+            }
+        };
         if !project_entry
             .file_type()
             .map(|t| t.is_dir())
@@ -800,7 +807,14 @@ async fn check_orphaned_worktrees(all_tasks: &[Task], findings: &mut Vec<Finding
             Ok(d) => d,
             Err(_) => continue,
         };
-        for branch_entry in branch_dirs.flatten() {
+        for branch_entry in branch_dirs {
+            let branch_entry = match branch_entry {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!(err = %e, "error reading project directory entry");
+                    continue;
+                }
+            };
             if !branch_entry
                 .file_type()
                 .map(|t| t.is_dir())

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -32,7 +32,14 @@ pub async fn run(dry_run: bool) -> anyhow::Result<()> {
         }
     };
 
-    for project_entry in project_dirs.flatten() {
+    for project_entry in project_dirs {
+        let project_entry = match project_entry {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("error reading worktrees directory entry: {e}");
+                continue;
+            }
+        };
         if !project_entry
             .file_type()
             .map(|t| t.is_dir())
@@ -44,7 +51,14 @@ pub async fn run(dry_run: bool) -> anyhow::Result<()> {
             Ok(d) => d,
             Err(_) => continue,
         };
-        for branch_entry in branch_dirs.flatten() {
+        for branch_entry in branch_dirs {
+            let branch_entry = match branch_entry {
+                Ok(e) => e,
+                Err(e) => {
+                    eprintln!("error reading project directory entry: {e}");
+                    continue;
+                }
+            };
             if !branch_entry
                 .file_type()
                 .map(|t| t.is_dir())

--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -392,7 +392,14 @@ fn scan_skills_directory(skills_dir: &std::path::Path) -> Option<String> {
 
     let mut skills = Vec::new();
     if let Ok(entries) = std::fs::read_dir(skills_dir) {
-        for entry in entries.flatten() {
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!(path = %skills_dir.display(), err = %e, "error reading skills directory entry");
+                    continue;
+                }
+            };
             let path = entry.path();
             if !path.is_dir() {
                 continue;


### PR DESCRIPTION
## Summary

bug: scan_skills_directory in router/llm.rs uses entries.flatten() silently swallowing DirEntry IO errors

### Files changed

- `src/cli/doctor.rs`
- `src/cli/prune.rs`
- `src/engine/router/llm.rs`


Closes #2545

---
*Task #2545 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*