### PR TITLE
bug: response.rs output recovery uses filter_map(|e| e.ok()) to silently swallow read_dir entry IO errors

### DIFF
--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -180,12 +180,26 @@ pub async fn read_output_file(task_id: &str, primary_path: &Path, repo: &str) ->
                 let a = attempts_dir.clone();
                 move || {
                     match std::fs::read_dir(&a) {
-                        Ok(entries) => entries
-                            .filter_map(|e| e.ok())
-                            .filter_map(|e| {
-                                e.file_name().to_str().and_then(|n| n.parse().ok())
-                            })
-                            .collect::<Vec<u32>>(),
+                        Ok(entries) => {
+                            let mut nums = Vec::new();
+                            for entry in entries {
+                                match entry {
+                                    Ok(e) => {
+                                        if let Some(n) =
+                                            e.file_name().to_str().and_then(|n| n.parse().ok())
+                                        {
+                                            nums.push(n);
+                                        }
+                                    }
+                                    Err(e) => tracing::warn!(
+                                        path = %a.display(),
+                                        err = %e,
+                                        "error reading attempt dir entry in output fallback"
+                                    ),
+                                }
+                            }
+                            nums
+                        }
                         Err(e) => {
                             tracing::warn!(path = %a.display(), err = %e, "failed to read attempts dir in output fallback");
                             Vec::new()


### PR DESCRIPTION
## Summary

Replaced `filter_map(|e| e.ok())` with explicit per-entry error logging in `src/engine/runner/response.rs:182-193`. IO errors on individual attempt directory entries are now logged as warnings (consistent with #2547) rather than silently discarded. All 2975 tests pass.

### Files changed

- `src/engine/runner/response.rs`


Closes #2549

---
*Task #2549 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*