### PR TITLE
bug: discord gateway has no timeout on WebSocket connect or initial Hello frame

### DIFF
--- a/src/channels/discord_ws.rs
+++ b/src/channels/discord_ws.rs
@@ -274,8 +274,8 @@ async fn run_gateway(
         let ws_url = state.ws_url();
         tracing::debug!(url = %ws_url, "connecting to discord gateway");
 
-        match connect_async(&ws_url).await {
-            Ok((ws, _)) => {
+        match tokio::time::timeout(Duration::from_secs(30), connect_async(&ws_url)).await {
+            Ok(Ok((ws, _))) => {
                 backoff = Duration::from_secs(1); // reset on success
 
                 let result =
@@ -297,11 +297,17 @@ async fn run_gateway(
                     }
                 }
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 tracing::warn!(
                     ?e,
                     backoff_secs = backoff.as_secs(),
                     "discord gateway: connect failed"
+                );
+            }
+            Err(_) => {
+                tracing::warn!(
+                    backoff_secs = backoff.as_secs(),
+                    "discord gateway: connect timed out"
                 );
             }
         }
@@ -334,7 +340,9 @@ async fn handle_connection(
     let (mut write, mut read) = ws.split();
 
     // ── Step 1: Hello ────────────────────────────────────────────────────────
-    let text = next_text_message(&mut read).await?;
+    let text = tokio::time::timeout(Duration::from_secs(15), next_text_message(&mut read))
+        .await
+        .map_err(|_| anyhow::anyhow!("discord gateway: Hello timed out"))??;
     let hello: GatewayPayload = serde_json::from_str(&text)?;
     anyhow::ensure!(
         hello.op == OP_HELLO,


### PR DESCRIPTION
## Summary

Added 30s timeout on `connect_async` and 15s timeout on the Hello frame read in `src/channels/discord_ws.rs`. Both timeout paths log a warning and fall through to the existing backoff/reconnect loop. All 2975 tests pass.

### Files changed

- `src/channels/discord_ws.rs`


Closes #2548

---
*Task #2548 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*