### PR TITLE
feat: auto-clean worktrees of CI-blocked tasks when blocking threshold is hit

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -639,6 +639,12 @@ pub(crate) async fn auto_merge_pr(
                         tracing::error!(task_id = task.id.0, err = %e, "failed to write block_reason and set Blocked");
                         return Ok(());
                     }
+                    // Immediately attempt to clean up the task's worktree when blocking
+                    // due to CI failures to avoid orphaned worktrees that will never be
+                    // re-used until human intervention.
+                    if let Err(e) = cleanup_task_worktree(&task.id.0, repo, store).await {
+                        tracing::warn!(task_id = task.id.0, err = %e, "cleanup after CI-failure block failed");
+                    }
                 } else {
                     tracing::warn!(
                         task_id = task.id.0,
@@ -693,6 +699,10 @@ pub(crate) async fn auto_merge_pr(
                         {
                             tracing::error!(task_id = task.id.0, err = %e, "failed to write block_reason and set Blocked");
                             return Ok(());
+                        }
+                        // Attempt cleanup for CI-timeout based blocks as well.
+                        if let Err(e) = cleanup_task_worktree(&task.id.0, repo, store).await {
+                            tracing::warn!(task_id = task.id.0, err = %e, "cleanup after CI-timeout block failed");
                         }
                     } else {
                         tracing::warn!(


### PR DESCRIPTION
## Summary

Add immediate worktree cleanup when tasks are blocked due to CI failure/timeouts

### What was done

- Inspected code paths where tasks are marked Blocked for CI failures/timeouts (src/engine/auto_merge.rs)
- Confirmed existing cleanup utilities exist (cleanup_task_worktree in src/engine/cleanup.rs) and are already imported in auto_merge.rs
- Added calls to cleanup_task_worktree(...) immediately after persisting a Blocked status for CI failure and CI-timeout paths to prevent orphaned worktrees accumulating


### Remaining

- Run full CI checks locally (cargo fmt, cargo clippy, cargo nextest) and fix any issues
- Create and sign a commit with the change (user must request commit/push per workflow rules)
- Run integration tests / targeted unit tests related to auto-merge and cleanup to ensure no regressions
- Optionally add unit tests that exercise blocking-to-cleanup behaviour (if desired)


### Files changed

- `src/engine/auto_merge.rs`


Closes #2555

---
*Task #2555 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*