### PR TITLE
feat: coverage report should show per-file coverage breakdown

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,11 +89,9 @@ jobs:
         if: steps.find-pr.outputs.pr_number != ''
         run: |
           SUMMARY=$(lcov --summary lcov.info 2>&1 || echo "Coverage summary unavailable")
-          gh pr comment "$PR_NUMBER" --body "## Coverage Report
-
-          \`\`\`
-          ${SUMMARY}
-          \`\`\`"
+          LIST=$(lcov --list lcov.info 2>&1 || echo "Coverage list unavailable")
+          BODY=$(printf "## Coverage Report\n\nSummary:\n\n\`\`\`\n%s\n\`\`\`\n\nPer-file coverage:\n\n\`\`\`\n%s\n\`\`\`\n" "$SUMMARY" "$LIST")
+          gh pr comment "$PR_NUMBER" --body "$BODY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.find-pr.outputs.pr_number }}


### PR DESCRIPTION
## Summary

Added per-file coverage listing to the PR coverage report in the release workflow.

### What was done

- Inspected .github/workflows/release.yml to find the coverage reporting step
- Updated the 'Report coverage on PR' step to include both the overall lcov summary and a per-file listing (lcov --list)
- Verified the change via git diff and ensured only the intended workflow file was modified


### Remaining

- Run CI to verify the workflow produces the expected PR comment output (summary + per-file list) in practice
- Optionally format or truncate very large lcov outputs if the PR comment becomes too long (not implemented)


### Files changed

- `.github/workflows/release.yml`


Closes #2559

---
*Task #2559 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*