### PR TITLE
bug: dedup continue skips task ingest even when update_status fails, accumulating duplicate comments

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1813,20 +1813,23 @@ pub(crate) async fn ingest_external_tasks(
                                 "ingest: failed to comment on duplicate issue"
                             );
                         }
-                        if let Err(e) = backend.update_status(&task.id, Status::Done).await {
-                            tracing::warn!(
-                                task_id = task.id.0,
-                                err = %e,
-                                "ingest: failed to close duplicate issue"
-                            );
-                        } else {
-                            tracing::info!(
-                                task_id = task.id.0,
-                                duplicate_of = target.id,
-                                "ingest: closed duplicate issue"
-                            );
+                        match backend.update_status(&task.id, Status::Done).await {
+                            Ok(()) => {
+                                tracing::info!(
+                                    task_id = task.id.0,
+                                    duplicate_of = target.id,
+                                    "ingest: closed duplicate issue"
+                                );
+                                continue;
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    task_id = task.id.0,
+                                    err = %e,
+                                    "ingest: failed to close duplicate issue — falling through to ingest normally"
+                                );
+                            }
                         }
-                        continue;
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Fixed the dedup `continue` bug in `src/engine/sync.rs` at line 1816–1832. Changed the unconditional `continue` after `update_status` to only execute `continue` on `Ok(())`. On `Err`, the code now falls through to `ensure_external_task` so the task is ingested into SQLite normally, preventing the infinite duplicate-comment loop on transient GitHub API failures.

### Files changed

- `src/engine/sync.rs`


Closes #2561

---
*Task #2561 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*