### PR TITLE
bug: kv_get_prefer_store silently swallows database errors

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -34,7 +34,17 @@ use tokio::sync::RwLock;
 /// the store query fails. Use [`try_kv_get_prefer_store`] if you need to
 /// distinguish between "key not found" and actual errors.
 async fn kv_get_prefer_store(store: &Option<&Arc<TaskStore>>, key: &str) -> Option<String> {
-    try_kv_get_prefer_store(store, key).await.ok().flatten()
+    match try_kv_get_prefer_store(store, key).await {
+        Ok(opt) => opt,
+        Err(e) => {
+            // Log errors so database/query failures are visible in logs.
+            // We still return None as a best-effort fallback when the store
+            // is unavailable to preserve existing behavior, but the error
+            // should be visible to operators and alerting systems.
+            tracing::error!(key, err = %e, "kv_get failed");
+            None
+        }
+    }
 }
 
 /// Try to read a KV value from the store, returning errors instead of


### PR DESCRIPTION
## Summary

Improve observability for KV reads by logging database errors in kv_get_prefer_store instead of silently swallowing them.

### What was done

- Changed kv_get_prefer_store to match on try_kv_get_prefer_store result and log Err cases with tracing::error!
- Kept existing return behavior (None on error) to preserve callers' expectations while making failures visible
- Ran test suite locally and committed the change


### Remaining

- Decide whether to further surface errors to callers (e.g., change return type to Result<Option<String>, Error>) in a follow-up
- Consider adding a health metric or incrementing a failure counter when DB queries fail (not implemented here)
- If desired, update any monitoring/alerting to react to the new error-level logs


### Files changed

- `src/engine/sync.rs`


Closes #2567

---
*Task #2567 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*