### PR TITLE
bug: sync_estimate_to_project blocks tick loop inline during routing

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -1080,18 +1080,25 @@ pub(crate) async fn tick_route_tasks(
                             );
                         }
                         // Sync the estimate to GitHub Projects if the router assigned one.
+                        // Fire-and-forget: do NOT await inline — GraphQL mutations can take
+                        // up to 30 s and would block the entire tick loop on every routed task.
                         if result.estimate > 0 {
-                            if let Err(e) = backend
-                                .sync_estimate_to_project(&task.id, result.estimate)
-                                .await
-                            {
-                                tracing::debug!(
-                                    task_id = task.id.0,
-                                    estimate = result.estimate,
-                                    err = %e,
-                                    "dual-write: estimate project sync failed"
-                                );
-                            }
+                            let backend_clone = Arc::clone(backend);
+                            let task_id = task.id.clone();
+                            let estimate = result.estimate;
+                            tokio::spawn(async move {
+                                if let Err(e) = backend_clone
+                                    .sync_estimate_to_project(&task_id, estimate)
+                                    .await
+                                {
+                                    tracing::debug!(
+                                        task_id = task_id.0,
+                                        estimate,
+                                        err = %e,
+                                        "dual-write: estimate project sync failed"
+                                    );
+                                }
+                            });
                         }
                     }
                     Err(e) => {


### PR DESCRIPTION
## Summary

Moved `sync_estimate_to_project` call in `tick_route_tasks` (tick.rs:1082) from inline `await` to `tokio::spawn` fire-and-forget. The tick loop no longer blocks on GraphQL mutations during routing. `Arc::clone(backend)` is passed into the spawned task. The startup reconciliation was already backgrounded by #2577, and the store query already filters terminal tasks.

### Files changed

- `src/engine/tick.rs`


Closes #2579

---
*Task #2579 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*