### PR TITLE
bug: git push/fetch in auto_merge rebase recovery has no timeout — auto_merge_in_flight held indefinitely

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -856,11 +856,24 @@ pub(crate) async fn auto_merge_pr(
                         "attempting rebase to resolve merge conflict"
                     );
                     let default_branch = worktree::detect_default_branch(&wt_path).await;
-                    let fetch_result = tokio::process::Command::new("git")
-                        .args(["fetch", "origin"])
-                        .current_dir(&wt_path)
-                        .output()
-                        .await;
+                    let git_timeout = std::time::Duration::from_secs(120);
+                    let fetch_result = tokio::time::timeout(
+                        git_timeout,
+                        tokio::process::Command::new("git")
+                            .args(["fetch", "origin"])
+                            .current_dir(&wt_path)
+                            .kill_on_drop(true)
+                            .output(),
+                    )
+                    .await
+                    .unwrap_or_else(|_| {
+                        tracing::warn!(
+                            task_id = task.id.0,
+                            "git fetch timed out in rebase recovery after {}s",
+                            git_timeout.as_secs()
+                        );
+                        Err(std::io::Error::other("git fetch timed out"))
+                    });
 
                     let rebase_result = match fetch_result {
                         Ok(out) if out.status.success() => {
@@ -891,11 +904,23 @@ pub(crate) async fn auto_merge_pr(
 
                     match rebase_result {
                         Ok(git_ops::RebaseOutcome::Succeeded) => {
-                            let push_result = tokio::process::Command::new("git")
-                                .args(["push", "--force-with-lease"])
-                                .current_dir(&wt_path)
-                                .output()
-                                .await;
+                            let push_result = tokio::time::timeout(
+                                git_timeout,
+                                tokio::process::Command::new("git")
+                                    .args(["push", "--force-with-lease"])
+                                    .current_dir(&wt_path)
+                                    .kill_on_drop(true)
+                                    .output(),
+                            )
+                            .await
+                            .unwrap_or_else(|_| {
+                                tracing::warn!(
+                                    task_id = task.id.0,
+                                    "git push timed out in rebase recovery after {}s",
+                                    git_timeout.as_secs()
+                                );
+                                Err(std::io::Error::other("git push timed out"))
+                            });
 
                             match push_result {
                                 Ok(push_out) if push_out.status.success() => {


### PR DESCRIPTION
## Summary

Added 120s timeouts with kill_on_drop(true) to both git fetch and git push in auto_merge rebase recovery (auto_merge.rs:859-876 and 907-923). Uses tokio::time::timeout wrapping the process commands — same pattern as sync.rs. On timeout, emits a warn log and returns an Err so the task stays in InReview for retry rather than holding auto_merge_in_flight indefinitely.

### Files changed

- `src/engine/auto_merge.rs`


Closes #2585

---
*Task #2585 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*