### PR TITLE
bug: webhook_status.save() calls std::fs::write on Tokio worker thread

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1190,7 +1190,7 @@ pub async fn serve() -> anyhow::Result<()> {
             s.port = Some(port);
             s.healthy = false;
             s.fallback_mode = false;
-            s.save();
+            s.save().await;
         }
 
         // Spawn the HTTP server with exponential-backoff retry on transient
@@ -1232,7 +1232,7 @@ pub async fn serve() -> anyhow::Result<()> {
                             s.healthy = false;
                             s.last_failure_reason = Some(reason);
                             s.startup_attempts = attempt;
-                            s.save();
+                            s.save().await;
                             break;
                         }
                         let delay = webhook_backoff_delay(attempt);
@@ -1246,7 +1246,7 @@ pub async fn serve() -> anyhow::Result<()> {
                             let mut s = status_for_spawn.lock().await;
                             s.startup_attempts = attempt;
                             s.last_failure_reason = Some(reason);
-                            s.save();
+                            s.save().await;
                         }
                         tokio::time::sleep(delay).await;
                     }
@@ -1286,7 +1286,7 @@ pub async fn serve() -> anyhow::Result<()> {
             let mut s = webhook_status.lock().await;
             s.configured = false;
             s.fallback_mode = true;
-            s.save();
+            s.save().await;
         }
         tracing::info!(
             orch_webhook_in_fallback = true,
@@ -1700,7 +1700,7 @@ pub async fn serve() -> anyhow::Result<()> {
                                 } else if failure_reason.is_some() {
                                     s.last_failure_reason = failure_reason;
                                 }
-                                s.save();
+                                s.save().await;
                             }
                         }
                         last_webhook_health_check = std::time::Instant::now();

--- a/src/webhook_status.rs
+++ b/src/webhook_status.rs
@@ -48,13 +48,17 @@ pub fn status_path() -> anyhow::Result<PathBuf> {
 
 impl WebhookStatus {
     /// Persist the status to disk. Non-fatal: logs a warning on write failure.
-    pub fn save(&self) {
+    pub async fn save(&self) {
         match status_path().and_then(|p| {
-            let json = serde_json::to_string_pretty(self)?;
-            std::fs::write(&p, json)?;
-            Ok(())
+            serde_json::to_string_pretty(self)
+                .map(|j| (p, j))
+                .map_err(anyhow::Error::from)
         }) {
-            Ok(()) => {}
+            Ok((p, json)) => {
+                if let Err(e) = tokio::fs::write(&p, json).await {
+                    tracing::warn!(error = ?e, "failed to persist webhook status");
+                }
+            }
             Err(e) => tracing::warn!(?e, "failed to persist webhook status"),
         }
     }


### PR DESCRIPTION
## Summary

Done. Here's a summary of the changes:

**`src/webhook_status.rs`** — `save()` is now `async`, using `tokio::fs::write` instead of `std::fs::write`. The error type mismatch between `serde_json::Error` and `anyhow::Error` is resolved with `.map_err(anyhow::Error::from)`.

**`src/engine/mod.rs`** — All 5 call sites (lines 1193, 1235, 1249, 1289, 1703) updated from `s.save()` to `s.save().await`.

All 2976 tests pass, clippy clean.

{"success":true,"branch":"gh-issue-2590-bug-webhook-status-sav

### What was done

- `src/webhook_status.rs`** — `save()` is now `async`, using `tokio::fs::write` instead of `std::fs::write`. The error type mismatch between `serde_json::Error` and `anyhow::Error` is resolved with `.map_err(anyhow::Error::from)`.
- `src/engine/mod.rs`** — All 5 call sites (lines 1193, 1235, 1249, 1289, 1703) updated from `s.save()` to `s.save().await`.


### Files changed

- `src/engine/mod.rs`
- `src/webhook_status.rs`


Closes #2590

---
*Task #2590 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*