### PR TITLE
bug: GitHub label remove/add operations awaited inline in tick_route_tasks() — adds 3-5s per routed task, causing 17-42s slow tick warnings

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -1010,29 +1010,46 @@ pub(crate) async fn tick_route_tasks(
                         );
                     }
                 } else {
-                    // Remove old agent/complexity/model labels to avoid duplicates on re-route
-                    for label in &task.labels {
-                        if label.starts_with("agent:")
-                            || label.starts_with("complexity:")
-                            || label.starts_with("model:")
-                        {
-                            if let Err(e) = backend.remove_label(&task.id, label).await {
-                                tracing::warn!(task_id = task.id.0, label, error = %e, "failed to remove stale routing label during re-route");
+                    // Fire-and-forget: label operations are cosmetic (routing already
+                    // persisted in DB). Spawning them prevents blocking the tick loop
+                    // on 6-9 sequential HTTP calls (~3-9s overhead per routed task).
+                    let backend_clone = Arc::clone(backend);
+                    let task_id_clone = task.id.clone();
+                    let task_labels: Vec<String> = task.labels.clone();
+                    let new_labels = {
+                        let mut labels = vec![
+                            format!("agent:{}", result.agent),
+                            format!("complexity:{}", result.complexity),
+                        ];
+                        if let Some(ref model) = result.model {
+                            labels.push(format!("model:{model}"));
+                        }
+                        labels
+                    };
+                    tokio::spawn(async move {
+                        // Remove old agent/complexity/model labels
+                        for label in &task_labels {
+                            if label.starts_with("agent:")
+                                || label.starts_with("complexity:")
+                                || label.starts_with("model:")
+                            {
+                                if let Err(e) =
+                                    backend_clone.remove_label(&task_id_clone, label).await
+                                {
+                                    tracing::warn!(task_id = task_id_clone.0, label, error = %e, "failed to remove stale routing label during re-route");
+                                }
                             }
                         }
-                    }
-
-                    // Add agent, complexity, and model labels
-                    let mut labels = vec![
-                        format!("agent:{}", result.agent),
-                        format!("complexity:{}", result.complexity),
-                    ];
-                    if let Some(ref model) = result.model {
-                        labels.push(format!("model:{model}"));
-                    }
-                    if let Err(e) = backend.set_labels(&task.id, &labels).await {
-                        tracing::warn!(task_id = task.id.0, ?e, "failed to set routing labels");
-                    }
+                        // Add new labels
+                        if let Err(e) = backend_clone.set_labels(&task_id_clone, &new_labels).await
+                        {
+                            tracing::warn!(
+                                task_id = task_id_clone.0,
+                                ?e,
+                                "failed to set routing labels"
+                            );
+                        }
+                    });
 
                     // Transition to routed
                     if let Err(e) = task_manager


### PR DESCRIPTION
## Summary

Fixed slow tick warnings by spawning GitHub label operations as background tasks instead of awaiting them inline in tick_route_tasks(). This removes 3-9s of blocking HTTP calls per routed task.

### What was done

- Identified blocking label operations in tick_route_tasks() at src/engine/tick.rs:1012-1035
- Changed from 6-9 sequential awaited HTTP calls to fire-and-forget tokio::spawn
- Preserved all error handling behavior (tracing::warn only)
- All CI checks pass: cargo fmt, clippy, nextest (2976 tests)


### Files changed

- `src/engine/tick.rs`


Closes #2596

---
*Task #2596 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*