### PR TITLE
bug: review result discarded after stuck-task recovery races with review completion — 13-minute review wasted

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -159,6 +159,13 @@ pub struct EngineConfig {
     /// Stuck task timeout for tasks with no active tmux session (seconds).
     /// Shorter than `stuck_timeout` because no session means the agent has already exited.
     pub no_session_stuck_timeout: u64,
+    /// Stuck task timeout for in_review tasks with no active tmux session (seconds).
+    /// Longer than `no_session_stuck_timeout` because review agents exit their tmux session
+    /// on normal completion before the result is delivered to the engine. Using a short
+    /// no-session timeout for in_review tasks causes a race where a completed review result
+    /// arrives after the stuck recovery has already reset the task to needs_review, discarding
+    /// the review work.
+    pub in_review_no_session_stuck_timeout: u64,
     /// Auto-create follow-up tasks when PR reviews request changes
     pub auto_create_followup_on_changes: bool,
     /// Auto-close task (mark Done) when all PR reviews are approved.
@@ -182,6 +189,7 @@ impl Default for EngineConfig {
             max_parallel: 4,
             stuck_timeout: 1800,
             no_session_stuck_timeout: 600,
+            in_review_no_session_stuck_timeout: 1800,
             auto_create_followup_on_changes: true,
             auto_close_task_on_approval: false,
             graceful_shutdown_timeout: std::time::Duration::from_secs(600),
@@ -233,6 +241,14 @@ impl EngineConfig {
                 config.no_session_stuck_timeout = secs;
             } else {
                 tracing::warn!(key = "engine.no_session_stuck_timeout", value = %val, default_secs = config.no_session_stuck_timeout, "invalid value for engine.no_session_stuck_timeout, using default");
+            }
+        }
+
+        if let Ok(val) = crate::config::get("engine.in_review_no_session_stuck_timeout") {
+            if let Ok(secs) = val.parse::<u64>() {
+                config.in_review_no_session_stuck_timeout = secs;
+            } else {
+                tracing::warn!(key = "engine.in_review_no_session_stuck_timeout", value = %val, default_secs = config.in_review_no_session_stuck_timeout, "invalid value for engine.in_review_no_session_stuck_timeout, using default");
             }
         }
 

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -817,12 +817,23 @@ pub(crate) async fn tick_recover_stuck_tasks(
         }
 
         let review_task_id = format!("{}-review", task.id.0);
+        // Use in_review_no_session_stuck_timeout instead of the standard
+        // no_session_stuck_timeout. Review agents exit their tmux session on
+        // normal completion before delivering the result to the engine, so a
+        // short no-session timeout causes a race: the stuck recovery fires,
+        // resets the task to needs_review, and the completed result arriving
+        // moments later is discarded as stale. A longer threshold gives the
+        // result delivery enough time to complete.
+        let in_review_config = crate::engine::EngineConfig {
+            no_session_stuck_timeout: config.in_review_no_session_stuck_timeout,
+            ..config.clone()
+        };
         let Some(timing) = stuck_task_timing_from_map(
             tmux,
             repo,
             &review_task_id,
             &task.updated_at,
-            config,
+            &in_review_config,
             "cannot parse updated_at, skipping stuck in_review check",
             &session_map,
         ) else {


### PR DESCRIPTION
## Summary

Added `in_review_no_session_stuck_timeout` (default 1800s) to EngineConfig and used it in the in_review stuck recovery loop instead of the standard `no_session_stuck_timeout` (600s). Review agents exit their tmux session on normal completion before delivering results, so the 10-minute threshold was too short for reviews taking 13+ minutes. The fix raises the effective threshold for in_review no-session recovery to 30 minutes, matching the existing with-session timeout, while leaving the 10-minute threshold for in_progress tasks unchanged.

### Files changed

- `src/engine/mod.rs`
- `src/engine/tick.rs`


Closes #2597

---
*Task #2597 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*