### PR TITLE
bug: busy-loop when agents degraded without cooldown timestamp

### DIFF
--- a/gh-issue-2604-bug-busy-loop-when-agents-degraded-witho.json
+++ b/gh-issue-2604-bug-busy-loop-when-agents-degraded-witho.json
@@ -1,0 +1,21 @@
+{
+  "status": "done",
+  "summary": "Fixed busy-loop issue when agents are degraded without cooldown timestamps by making wait_for_cooldown return an error instead of Ok(()).",
+  "accomplished": [
+    "Modified src/engine/router/mod.rs to return Err(AllCooledError) instead of Ok(()) when all agents are degraded but none have timed cooldown entries",
+    "This prevents the tight busy-loop by ensuring degraded agents trigger the same backoff behavior as agents with actual cooldown timestamps",
+    "Verified the fix compiles successfully with cargo check"
+  ],
+  "remaining": [],
+  "files_changed": [
+    "src/engine/router/mod.rs"
+  ],
+  "blockers": [],
+  "reason": "",
+  "learnings": [
+    "The wait_for_cooldown function was returning Ok(()) in degraded agent scenarios, causing immediate retries",
+    "Returning an error instead allows the existing tick loop backoff mechanism to prevent busy-loops",
+    "Consistency with how actual cooldowns are handled is important for predictable behavior"
+  ],
+  "delegations": []
+}

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -460,19 +460,20 @@ impl Router {
         // retries every `tick_interval` (default 10s), so allow the tick loop
         // to drive retries instead of sleeping here.
         let now = chrono::Utc::now().timestamp();
-let Some(earliest) = self.earliest_cooldown_until(complexity) else {
-    // All agents are degraded but none have a timed cooldown entry
-    // (e.g. over-threshold rate limiting without explicit cooldown duration).
-    // Log at warn and return an error so the tick skips this task and retries after backoff.
-    tracing::warn!(
+        let Some(earliest) = self.earliest_cooldown_until(complexity) else {
+            // All agents are degraded but none have a timed cooldown entry
+            // (e.g. over-threshold rate limiting without explicit cooldown duration).
+            // Log at warn and return an error so the tick skips this task and retries after backoff.
+            tracing::warn!(
         scope = complexity.unwrap_or("all agents"),
         "all agents degraded (no cooldown timestamp available) — skipping task, will retry after backoff"
     );
-    // Return an error similar to the cooldown case to trigger backoff in the tick loop
-    return Err(AllCooledError { 
-        scope: complexity.unwrap_or("all agents").to_string() 
-    }.into());
-};
+            // Return an error similar to the cooldown case to trigger backoff in the tick loop
+            return Err(AllCooledError {
+                scope: complexity.unwrap_or("all agents").to_string(),
+            }
+            .into());
+        };
 
         let remaining = earliest.saturating_sub(now);
         if remaining > 0 {

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -460,16 +460,19 @@ impl Router {
         // retries every `tick_interval` (default 10s), so allow the tick loop
         // to drive retries instead of sleeping here.
         let now = chrono::Utc::now().timestamp();
-        let Some(earliest) = self.earliest_cooldown_until(complexity) else {
-            // All agents are degraded but none have a timed cooldown entry
-            // (e.g. over-threshold rate limiting without explicit cooldown duration).
-            // Log at warn and return Ok so the tick skips this task cleanly and retries.
-            tracing::warn!(
-                scope = complexity.unwrap_or("all agents"),
-                "all agents degraded (no cooldown timestamp available) — skipping task, tick will retry"
-            );
-            return Ok(());
-        };
+let Some(earliest) = self.earliest_cooldown_until(complexity) else {
+    // All agents are degraded but none have a timed cooldown entry
+    // (e.g. over-threshold rate limiting without explicit cooldown duration).
+    // Log at warn and return an error so the tick skips this task and retries after backoff.
+    tracing::warn!(
+        scope = complexity.unwrap_or("all agents"),
+        "all agents degraded (no cooldown timestamp available) — skipping task, will retry after backoff"
+    );
+    // Return an error similar to the cooldown case to trigger backoff in the tick loop
+    return Err(AllCooledError { 
+        scope: complexity.unwrap_or("all agents").to_string() 
+    }.into());
+};
 
         let remaining = earliest.saturating_sub(now);
         if remaining > 0 {


### PR DESCRIPTION
## Summary

Fixed busy-loop issue when agents are degraded without cooldown timestamps by making wait_for_cooldown return an error instead of Ok(()).

### What was done

- Modified src/engine/router/mod.rs to return Err(AllCooledError) instead of Ok(()) when all agents are degraded but none have timed cooldown entries
- This prevents the tight busy-loop by ensuring degraded agents trigger the same backoff behavior as agents with actual cooldown timestamps
- Verified the fix compiles successfully with cargo check


### Files changed

- `gh-issue-2604-bug-busy-loop-when-agents-degraded-witho.json`
- `src/engine/router/mod.rs`


Closes #2604

---
*Task #2604 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/nemotron-3-super-free`*