### PR TITLE
fix: replace dispatch DashSet with DashMap to distinguish duplicate vs collision

### DIFF
--- a/src/engine/dispatch_guard.rs
+++ b/src/engine/dispatch_guard.rs
@@ -1,32 +1,62 @@
-//! RAII guard for the per-task dispatching [`DashSet`].
+//! RAII guard for the per-task dispatching [`DashMap`].
 //!
-//! [`DispatchGuard`] removes a key from the shared `dispatching` set when it is
+//! [`DispatchGuard`] removes a key from the shared `dispatching` map when it is
 //! dropped — whether the owning async task completes normally **or panics**.
 //!
 //! ## Problem it solves
 //!
-//! Without this guard, the cleanup code (`set.remove(&key)`) only runs when the
+//! Without this guard, the cleanup code (`map.remove(&key)`) only runs when the
 //! spawned async block reaches the end of its normal execution path.  If the block
 //! panics (e.g. from an `unwrap()` inside `review_and_merge`), Tokio catches the
 //! panic and terminates the task, but the manual remove never executes.  The key
-//! leaks in the set permanently: subsequent attempts to review the task are skipped
+//! leaks in the map permanently: subsequent attempts to review the task are skipped
 //! by the guard check, and stuck-task recovery keeps resetting the task to
 //! `NeedsReview` in an infinite loop until the service is restarted.
 //!
-//! ## Why DashSet instead of Mutex\<HashSet\>
+//! ## Why DashMap instead of Mutex\<HashMap\>
 //!
-//! The dispatching set is accessed from both async contexts (tick, sync, subscribers)
-//! and synchronous `Drop` implementations.  `DashSet` is a lock-free concurrent set
+//! The dispatching map is accessed from both async contexts (tick, sync, subscribers)
+//! and synchronous `Drop` implementations.  `DashMap` is a lock-free concurrent map
 //! that works in both contexts without risk of blocking Tokio worker threads — unlike
 //! `std::sync::Mutex` which blocks the OS thread, or `tokio::sync::Mutex` which
 //! cannot be used in `Drop`.
 //!
+//! ## Why DashMap instead of DashSet
+//!
+//! `DashSet::insert` returns `false` in two distinct cases:
+//! 1. The same task is already being dispatched (intended skip).
+//! 2. A different task happens to produce the same key (should never happen, but
+//!    silently skips a valid dispatch if it does).
+//!
+//! By storing the task-id as the map value, the caller can distinguish these cases:
+//! a matching task-id means an expected duplicate; a mismatched task-id is an
+//! unexpected collision that warrants a warning log.
+//!
 //! ## Usage
 //!
 //! ```rust,ignore
-//! // 1. Insert the key BEFORE the spawn.
-//! if !dispatching.insert(dispatch_key.clone()) {
-//!     continue; // already dispatching
+//! use dashmap::mapref::entry::Entry;
+//!
+//! // 1. Attempt to claim the dispatch slot atomically.
+//! match dispatching.entry(dispatch_key.clone()) {
+//!     Entry::Occupied(existing) => {
+//!         let existing_id = existing.get().clone();
+//!         drop(existing); // release shard lock before logging
+//!         if existing_id == task.id.0 {
+//!             tracing::debug!(task_id = %task.id.0, "task already dispatching, skipping duplicate");
+//!         } else {
+//!             tracing::warn!(
+//!                 task_id = %task.id.0,
+//!                 existing_task_id = %existing_id,
+//!                 dispatch_key,
+//!                 "dispatch key collision: unexpected task already holds this key"
+//!             );
+//!         }
+//!         continue;
+//!     }
+//!     Entry::Vacant(slot) => {
+//!         slot.insert(task.id.0.clone());
+//!     }
 //! }
 //!
 //! // 2. Create a guard that owns the removal obligation.
@@ -39,32 +69,32 @@
 //! });
 //! ```
 
-use dashmap::DashSet;
+use dashmap::DashMap;
 use std::sync::Arc;
 
-/// Removes a key from a shared [`DashSet<String>`] when dropped.
+/// Removes a key from a shared [`DashMap<String, String>`] when dropped.
 ///
 /// Create this guard (step 2) only after the key has already been inserted into
-/// the set (step 1) and before calling `tokio::spawn` (step 3).  Moving the guard
+/// the map (step 1) and before calling `tokio::spawn` (step 3).  Moving the guard
 /// into the spawned async block ensures the key is removed regardless of whether
 /// the block completes normally or unwinds via a panic.
 pub struct DispatchGuard {
-    set: Arc<DashSet<String>>,
+    map: Arc<DashMap<String, String>>,
     key: String,
 }
 
 impl DispatchGuard {
-    /// Creates a guard that will remove `key` from `set` on drop.
+    /// Creates a guard that will remove `key` from `map` on drop.
     ///
-    /// The caller must have already inserted `key` into `set`.
-    pub fn new(set: Arc<DashSet<String>>, key: String) -> Self {
-        Self { set, key }
+    /// The caller must have already inserted `key` into `map`.
+    pub fn new(map: Arc<DashMap<String, String>>, key: String) -> Self {
+        Self { map, key }
     }
 }
 
 impl Drop for DispatchGuard {
     fn drop(&mut self) {
-        self.set.remove(&self.key);
+        self.map.remove(&self.key);
     }
 }
 
@@ -73,37 +103,43 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
-    fn make_set(keys: &[&str]) -> Arc<DashSet<String>> {
-        let set = DashSet::new();
-        for key in keys {
-            set.insert(key.to_string());
+    fn make_map(entries: &[(&str, &str)]) -> Arc<DashMap<String, String>> {
+        let map = DashMap::new();
+        for (k, v) in entries {
+            map.insert(k.to_string(), v.to_string());
         }
-        Arc::new(set)
+        Arc::new(map)
     }
 
     #[test]
     fn drop_removes_key() {
-        let set = make_set(&["a", "b"]);
-        let guard = DispatchGuard::new(Arc::clone(&set), "a".to_string());
+        let map = make_map(&[("owner/repo/1", "1"), ("owner/repo/2", "2")]);
+        let guard = DispatchGuard::new(Arc::clone(&map), "owner/repo/1".to_string());
         drop(guard);
-        assert!(!set.contains("a"), "key must be removed on drop");
-        assert!(set.contains("b"), "unrelated key must be untouched");
+        assert!(
+            !map.contains_key("owner/repo/1"),
+            "key must be removed on drop"
+        );
+        assert!(
+            map.contains_key("owner/repo/2"),
+            "unrelated key must be untouched"
+        );
     }
 
     #[test]
     fn drop_is_idempotent_when_key_absent() {
-        let set = make_set(&[]);
+        let map = make_map(&[]);
         // Key not present — should not panic
-        let guard = DispatchGuard::new(Arc::clone(&set), "missing".to_string());
+        let guard = DispatchGuard::new(Arc::clone(&map), "missing".to_string());
         drop(guard);
-        assert!(set.is_empty());
+        assert!(map.is_empty());
     }
 
     #[tokio::test]
     async fn drop_runs_on_task_panic() {
-        let set = make_set(&["owner/repo/42"]);
+        let map = make_map(&[("owner/repo/42", "42")]);
         let key = "owner/repo/42".to_string();
-        let guard = DispatchGuard::new(Arc::clone(&set), key.clone());
+        let guard = DispatchGuard::new(Arc::clone(&map), key.clone());
 
         let handle = tokio::spawn(async move {
             let _guard = guard;
@@ -112,7 +148,7 @@ mod tests {
         let _ = handle.await; // absorb JoinError
 
         assert!(
-            !set.contains(&key),
+            !map.contains_key(&key),
             "key must be removed even when spawned task panics"
         );
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1349,7 +1349,7 @@ pub async fn serve() -> anyhow::Result<()> {
     // still returns the task (search index propagation delay). The tmux session does not
     // exist until the runner completes worktree setup (~10s later), so session_exists
     // alone is insufficient. Keyed by "{repo}/{task_id}".
-    let dispatching: Arc<dashmap::DashSet<String>> = Arc::new(dashmap::DashSet::new());
+    let dispatching: Arc<dashmap::DashMap<String, String>> = Arc::new(dashmap::DashMap::new());
 
     // In-memory guard to prevent double-spawn of auto-merge background tasks.
     // Since review_open_prs runs every sync_tick (~10s) but CI polling can take

--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -31,7 +31,7 @@ use crate::github::types::{GitHubComment, GitHubReviewComment, PullRequestReview
 use crate::store::TaskStore;
 use crate::store::{store_increment_by_id, store_reset_failure_counters, store_set_result_by_id};
 use async_trait::async_trait;
-use dashmap::DashSet;
+use dashmap::{DashMap, DashSet};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -158,7 +158,7 @@ pub(crate) async fn review_open_prs(
     config: &EngineConfig,
     task_manager: &Arc<TaskManager>,
     store: &Arc<TaskStore>,
-    dispatching: &Arc<DashSet<String>>,
+    dispatching: &Arc<DashMap<String, String>>,
     auto_merge_in_flight: &Arc<DashSet<String>>,
     in_review_tasks: &[ReviewTaskSnapshot],
     gh: &dyn GhReviewClient,
@@ -194,7 +194,7 @@ pub(crate) async fn review_open_prs(
 
         // Skip tasks currently being processed by the main tick.
         let dispatch_key = format!("{}/{}", repo, task_id);
-        if dispatching.contains(&dispatch_key) {
+        if dispatching.contains_key(&dispatch_key) {
             tracing::debug!(
                 task_id,
                 "task locked by dispatch flow, skipping review_open_prs"
@@ -973,7 +973,7 @@ mod tests {
     use crate::github::types::{GitHubComment, GitHubReview, GitHubUser};
     use crate::store::{NewTask, TaskStatus, TaskStore};
     use async_trait::async_trait;
-    use dashmap::DashSet;
+    use dashmap::{DashMap, DashSet};
     use std::collections::HashMap;
     use std::sync::Arc;
 
@@ -1256,7 +1256,7 @@ mod tests {
             Arc::clone(&store),
             "owner/repo".to_string(),
         ));
-        let dispatching = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let in_flight = Arc::new(DashSet::new());
         let gh = MockGh::default();
 
@@ -1315,8 +1315,11 @@ mod tests {
         };
 
         // Lock the task in the dispatching set.
-        let dispatching = Arc::new(DashSet::new());
-        dispatching.insert(format!("owner/repo/{}", snapshot.external.id.0));
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
+        dispatching.insert(
+            format!("owner/repo/{}", snapshot.external.id.0),
+            snapshot.external.id.0.clone(),
+        );
 
         // Mock returns pr_number = Some(42) so the task would normally proceed.
         let mut gh = MockGh::default();
@@ -1387,7 +1390,7 @@ mod tests {
         let mut gh = MockGh::default();
         gh.merged.insert("feat-branch".to_string(), true);
 
-        let dispatching = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let in_flight = Arc::new(DashSet::new());
         review_open_prs(
             &backend,
@@ -1447,7 +1450,7 @@ mod tests {
         // No PR, not merged.
         let gh = MockGh::default(); // merged defaults to false, pr_numbers empty
 
-        let dispatching = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let in_flight = Arc::new(DashSet::new());
         review_open_prs(
             &backend,
@@ -1516,7 +1519,7 @@ mod tests {
         };
 
         let gh = MockGh::default();
-        let dispatching = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let in_flight = Arc::new(DashSet::new());
         review_open_prs(
             &backend,
@@ -1603,7 +1606,7 @@ mod tests {
             stored,
         };
 
-        let dispatching = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let in_flight = Arc::new(DashSet::new());
         review_open_prs(
             &backend,
@@ -1673,7 +1676,7 @@ mod tests {
             batch_error: true,
             ..Default::default()
         };
-        let dispatching = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let in_flight = Arc::new(DashSet::new());
         let result = review_open_prs(
             &backend,
@@ -1753,7 +1756,7 @@ mod tests {
         let mut gh = MockGh::default();
         gh.batch_data.insert(10, batch_data);
 
-        let dispatching = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let in_flight = Arc::new(DashSet::new());
         review_open_prs(
             &backend,
@@ -1838,7 +1841,7 @@ mod tests {
         gh.batch_data.insert(20, batch_data);
         gh.collaborators.insert("bot".to_string(), true);
 
-        let dispatching = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let in_flight = Arc::new(DashSet::new());
         review_open_prs(
             &backend,

--- a/src/engine/subscribers/dispatch.rs
+++ b/src/engine/subscribers/dispatch.rs
@@ -8,7 +8,7 @@ use crate::engine::runner::{TaskRunner, WeightSignal};
 use crate::engine::tasks::TaskManager;
 use crate::store::TaskStore;
 use crate::tmux::TmuxManager;
-use dashmap::DashSet;
+use dashmap::DashMap;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use tokio::sync::{mpsc, RwLock, Semaphore};
@@ -29,7 +29,7 @@ pub fn spawn(
     task_manager: Arc<TaskManager>,
     weight_tx: mpsc::Sender<WeightSignal>,
     router_arc: Arc<RwLock<Router>>,
-    dispatching: Arc<DashSet<String>>,
+    dispatching: Arc<DashMap<String, String>>,
     store: Arc<TaskStore>,
     repo: String,
 ) {

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -11,7 +11,7 @@ use crate::github::http::GhHttp;
 use crate::repo_context::REPO_CONTEXT;
 use crate::store::{opt_store_get_task, TaskStore};
 use crate::tmux::TmuxManager;
-use dashmap::DashSet;
+use dashmap::DashMap;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use tokio::sync::{RwLock, Semaphore};
@@ -39,7 +39,7 @@ pub fn spawn(
     semaphore: Arc<Semaphore>,
     task_manager: Arc<TaskManager>,
     router: Arc<RwLock<Router>>,
-    dispatching: Arc<DashSet<String>>,
+    dispatching: Arc<DashMap<String, String>>,
     store: Arc<TaskStore>,
     repo: String,
 ) {
@@ -60,12 +60,33 @@ pub fn spawn(
 
                     // Atomically claim the task before any async work so concurrent
                     // review events cannot double-spawn the same review flow.
-                    if !dispatching.insert(dispatch_key.clone()) {
-                        tracing::debug!(
-                            task_id,
-                            "task locked by dispatch flow, skipping event-driven review"
-                        );
-                        continue;
+                    // Using DashMap lets us distinguish same-task duplicates (expected) from
+                    // key collisions involving a different task (should never happen).
+                    {
+                        use dashmap::mapref::entry::Entry;
+                        match dispatching.entry(dispatch_key.clone()) {
+                            Entry::Occupied(existing) => {
+                                let existing_id = existing.get().clone();
+                                drop(existing);
+                                if existing_id == *task_id {
+                                    tracing::debug!(
+                                        task_id,
+                                        "task locked by dispatch flow, skipping event-driven review"
+                                    );
+                                } else {
+                                    tracing::warn!(
+                                        task_id,
+                                        existing_task_id = existing_id,
+                                        dispatch_key,
+                                        "dispatch key collision: unexpected task already holds this key"
+                                    );
+                                }
+                                continue;
+                            }
+                            Entry::Vacant(slot) => {
+                                slot.insert(task_id.clone());
+                            }
+                        }
                     }
 
                     // Create guard IMMEDIATELY after inserting the key — owns removal for all subsequent exit paths

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -23,7 +23,7 @@ use crate::store;
 use crate::store::TaskStatus;
 use crate::store::TaskStore;
 use crate::tmux::TmuxManager;
-use dashmap::DashSet;
+use dashmap::{DashMap, DashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::process::Command;
@@ -581,7 +581,7 @@ async fn auto_unblock_blocked_tasks(
     repo: &str,
     task_manager: &Arc<TaskManager>,
     store: &Arc<TaskStore>,
-    dispatching: &Arc<DashSet<String>>,
+    dispatching: &Arc<DashMap<String, String>>,
 ) -> anyhow::Result<()> {
     let blocked = match store.list_by_status(repo, TaskStatus::Blocked).await {
         Ok(tasks) => tasks,
@@ -625,7 +625,7 @@ async fn auto_unblock_blocked_tasks(
             repo,
             task.external_id.as_deref().unwrap_or(&id_fallback)
         );
-        if dispatching.contains(&dispatch_key) {
+        if dispatching.contains_key(&dispatch_key) {
             continue;
         }
 
@@ -783,7 +783,7 @@ pub(crate) async fn sync_tick(
     router: &Arc<RwLock<Router>>,
     task_manager: &Arc<TaskManager>,
     store: &Arc<TaskStore>,
-    dispatching: &Arc<DashSet<String>>,
+    dispatching: &Arc<DashMap<String, String>>,
     auto_merge_in_flight: &Arc<DashSet<String>>,
 ) -> anyhow::Result<()> {
     tracing::debug!("sync tick");
@@ -940,7 +940,7 @@ pub(crate) async fn sync_tick(
             // Skip tasks currently being processed by the main tick (dispatch + review flow).
             let dispatch_key = format!("{}/{}", repo, task.task_id());
             {
-                if dispatching.contains(&dispatch_key) {
+                if dispatching.contains_key(&dispatch_key) {
                     tracing::debug!(
                         task_id = task.task_id(),
                         "task locked by dispatch flow, skipping stale check"
@@ -1072,7 +1072,7 @@ pub(crate) async fn sync_tick(
 
             // Skip tasks actively being dispatched (subscriber is working on them).
             let dispatch_key = format!("{}/{}", repo, task.task_id());
-            if dispatching.contains(&dispatch_key) {
+            if dispatching.contains_key(&dispatch_key) {
                 continue;
             }
             // Decide whether to re-fire now using exponential backoff based on a per-task counter.
@@ -2565,21 +2565,21 @@ mod tests {
 
     #[test]
     fn dispatching_set_blocks_duplicate_processing() {
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
 
         let repo = "owner/repo";
         let task_id = "42";
         let dispatch_key = format!("{}/{}", repo, task_id);
 
-        // Initially not in the set
-        assert!(!dispatching.contains(&dispatch_key));
+        // Initially not in the map
+        assert!(!dispatching.contains_key(&dispatch_key));
 
         // Insert — simulates dispatch starting
-        dispatching.insert(dispatch_key.clone());
+        dispatching.insert(dispatch_key.clone(), task_id.to_string());
 
         // Now should be blocked
         assert!(
-            dispatching.contains(&dispatch_key),
+            dispatching.contains_key(&dispatch_key),
             "task should be locked while dispatching"
         );
 
@@ -2588,26 +2588,29 @@ mod tests {
 
         // Now should be free again
         assert!(
-            !dispatching.contains(&dispatch_key),
+            !dispatching.contains_key(&dispatch_key),
             "task should be unlocked after review completes"
         );
     }
 
     #[test]
     fn dispatching_set_does_not_block_other_tasks() {
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
 
         let repo = "owner/repo";
 
         // Lock task 42
         let key_42 = format!("{}/42", repo);
-        dispatching.insert(key_42.clone());
+        dispatching.insert(key_42.clone(), "42".to_string());
 
         // Task 43 should NOT be blocked
         let key_43 = format!("{}/43", repo);
-        assert!(dispatching.contains(&key_42), "task 42 should be locked");
         assert!(
-            !dispatching.contains(&key_43),
+            dispatching.contains_key(&key_42),
+            "task 42 should be locked"
+        );
+        assert!(
+            !dispatching.contains_key(&key_43),
             "task 43 should not be locked"
         );
     }
@@ -2628,12 +2631,12 @@ mod tests {
     async fn dispatch_key_held_during_review_agent_execution() {
         use tokio::sync::oneshot;
 
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
 
         let dispatch_key = "owner/repo/42".to_string();
 
         // Step 1: insert before spawning — this is the invariant added by a6d8b9a.
-        dispatching.insert(dispatch_key.clone());
+        dispatching.insert(dispatch_key.clone(), "42".to_string());
 
         let (agent_started_tx, agent_started_rx) = oneshot::channel::<()>();
         let (check_done_tx, check_done_rx) = oneshot::channel::<()>();
@@ -2654,7 +2657,7 @@ mod tests {
         // sync_tick invocation running while the review agent is still active.
         agent_started_rx.await.unwrap();
         assert!(
-            dispatching.contains(&dispatch_key),
+            dispatching.contains_key(&dispatch_key),
             "dispatch_key must be visible in the dispatching set while the review \
              agent is running — without the a6d8b9a fix, review_open_prs would see \
              the key absent and re-dispatch the task, silently dropping \
@@ -2667,7 +2670,7 @@ mod tests {
 
         // Step 5: key released — review_open_prs can now act on the task if needed.
         assert!(
-            !dispatching.contains(&dispatch_key),
+            !dispatching.contains_key(&dispatch_key),
             "dispatch_key must be removed from the dispatching set after the \
              review agent completes so subsequent sync ticks can process the task"
         );
@@ -2689,13 +2692,13 @@ mod tests {
     async fn dispatch_guard_releases_key_on_panic() {
         use crate::engine::dispatch_guard::DispatchGuard;
 
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let key = "owner/repo/42".to_string();
 
         // Insert key before spawn — mirrors the production invariant established
         // by the a6d8b9a fix (key must be visible before the spawn so concurrent
         // review_open_prs callers see it and skip the task).
-        dispatching.insert(key.clone());
+        dispatching.insert(key.clone(), "42".to_string());
 
         // Create the guard (takes ownership of the removal obligation).
         let guard = DispatchGuard::new(Arc::clone(&dispatching), key.clone());
@@ -2711,7 +2714,7 @@ mod tests {
 
         // Key MUST be gone even though the task panicked.
         assert!(
-            !dispatching.contains(&key),
+            !dispatching.contains_key(&key),
             "dispatch key must be removed from the dispatching set even when the \
              spawned review task panics — without DispatchGuard the key leaks and \
              the task gets stuck in a permanent review loop"
@@ -2731,7 +2734,7 @@ mod tests {
         ));
         let tmux = Arc::new(TmuxManager::new());
         let router = Arc::new(RwLock::new(crate::engine::router::Router::from_config()));
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let auto_merge_in_flight: Arc<DashSet<String>> = Arc::new(DashSet::new());
 
         let id = store
@@ -2792,7 +2795,7 @@ mod tests {
         ));
         let tmux = Arc::new(TmuxManager::new());
         let router = Arc::new(RwLock::new(crate::engine::router::Router::from_config()));
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let auto_merge_in_flight: Arc<DashSet<String>> = Arc::new(DashSet::new());
 
         // Create external task and set to NeedsReview
@@ -2855,7 +2858,7 @@ mod tests {
         ));
         let tmux = Arc::new(TmuxManager::new());
         let router = Arc::new(RwLock::new(crate::engine::router::Router::from_config()));
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let auto_merge_in_flight: Arc<DashSet<String>> = Arc::new(DashSet::new());
 
         let id = store
@@ -2929,7 +2932,7 @@ mod tests {
         ));
         let tmux = Arc::new(TmuxManager::new());
         let router = Arc::new(RwLock::new(crate::engine::router::Router::from_config()));
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let auto_merge_in_flight: Arc<DashSet<String>> = Arc::new(DashSet::new());
 
         let id = store
@@ -2994,7 +2997,7 @@ mod tests {
         ));
         let tmux = Arc::new(TmuxManager::new());
         let router = Arc::new(RwLock::new(crate::engine::router::Router::from_config()));
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
         let auto_merge_in_flight: Arc<DashSet<String>> = Arc::new(DashSet::new());
 
         let id = store
@@ -3048,7 +3051,7 @@ mod tests {
             store.clone(),
             "owner/repo".to_string(),
         ));
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
 
         let id = store
             .upsert_external(&crate::store::UpsertExternal {
@@ -3126,7 +3129,7 @@ mod tests {
             store.clone(),
             "owner/repo".to_string(),
         ));
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
 
         let id = store
             .upsert_external(&crate::store::UpsertExternal {
@@ -3291,7 +3294,7 @@ mod tests {
             store.clone(),
             "owner/repo".to_string(),
         ));
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
 
         let id = store
             .upsert_external(&crate::store::UpsertExternal {
@@ -3365,7 +3368,7 @@ mod tests {
             store.clone(),
             "owner/repo".to_string(),
         ));
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
 
         let id = store
             .upsert_external(&crate::store::UpsertExternal {
@@ -3455,7 +3458,7 @@ mod tests {
             store.clone(),
             "owner/repo".to_string(),
         ));
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
 
         let id = store
             .upsert_external(&crate::store::UpsertExternal {
@@ -3543,17 +3546,17 @@ mod tests {
 
     #[test]
     fn dispatching_key_includes_repo_for_cross_project_isolation() {
-        let dispatching: Arc<DashSet<String>> = Arc::new(DashSet::new());
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
 
         // Lock task 42 in repo A
         let key_a = "owner/repo-a/42".to_string();
-        dispatching.insert(key_a.clone());
+        dispatching.insert(key_a.clone(), "42".to_string());
 
         // Same task ID in repo B should NOT be blocked
         let key_b = "owner/repo-b/42".to_string();
-        assert!(dispatching.contains(&key_a));
+        assert!(dispatching.contains_key(&key_a));
         assert!(
-            !dispatching.contains(&key_b),
+            !dispatching.contains_key(&key_b),
             "same task ID in different repo should not be blocked"
         );
     }

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -25,7 +25,7 @@ use crate::engine::tasks::{is_internal_id, TaskManager};
 use crate::repo_context::REPO_CONTEXT;
 use crate::store::TaskStore;
 use crate::tmux::TmuxManager;
-use dashmap::DashSet;
+use dashmap::DashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -1173,7 +1173,7 @@ pub(crate) async fn tick_dispatch_tasks(
     task_manager: &Arc<TaskManager>,
     weight_tx: &mpsc::Sender<WeightSignal>,
     router: &Router,
-    dispatching: &Arc<DashSet<String>>,
+    dispatching: &Arc<DashMap<String, String>>,
     store: &Arc<TaskStore>,
 ) -> anyhow::Result<()> {
     // Note: Routed tasks should never have no-agent (filtered during Phase 3a routing),
@@ -1240,12 +1240,35 @@ pub(crate) async fn tick_dispatch_tasks(
         // does not exist until the runner completes worktree setup (~10s later), so the
         // session_exists check alone is insufficient.
         let dispatch_key = format!("{}/{}", repo, task.id.0);
-        if !dispatching.insert(dispatch_key.clone()) {
-            tracing::debug!(
-                task_id = task.id.0,
-                "task already dispatching, skipping duplicate"
-            );
-            continue;
+        // Atomically claim the dispatch slot.  DashMap lets us distinguish:
+        //   - same task already in-flight (expected): log debug and skip.
+        //   - different task holds the same key (should never happen): log warning and skip.
+        // A plain DashSet::insert would return false for both cases without distinction.
+        {
+            use dashmap::mapref::entry::Entry;
+            match dispatching.entry(dispatch_key.clone()) {
+                Entry::Occupied(existing) => {
+                    let existing_id = existing.get().clone();
+                    drop(existing); // release shard lock before logging
+                    if existing_id == task.id.0 {
+                        tracing::debug!(
+                            task_id = task.id.0,
+                            "task already dispatching, skipping duplicate"
+                        );
+                    } else {
+                        tracing::warn!(
+                            task_id = task.id.0,
+                            existing_task_id = existing_id,
+                            dispatch_key,
+                            "dispatch key collision: unexpected task already holds this key"
+                        );
+                    }
+                    continue;
+                }
+                Entry::Vacant(slot) => {
+                    slot.insert(task.id.0.clone());
+                }
+            }
         }
         // RAII guard — removes dispatch_key on drop even if the spawned task panics.
         let dispatch_guard = DispatchGuard::new(dispatching.clone(), dispatch_key.clone());
@@ -1626,7 +1649,7 @@ pub(crate) async fn tick(
     router: &mut Router,
     task_manager: &Arc<TaskManager>,
     weight_tx: &mpsc::Sender<WeightSignal>,
-    dispatching: &Arc<DashSet<String>>,
+    dispatching: &Arc<DashMap<String, String>>,
     store: &Arc<TaskStore>,
     transport: Option<&Arc<crate::channels::transport::Transport>>,
 ) -> anyhow::Result<()> {
@@ -2483,7 +2506,7 @@ mod tests {
         let tmux = Arc::new(TmuxManager::new());
         let semaphore = Arc::new(Semaphore::new(4));
         let (weight_tx, _weight_rx) = mpsc::channel(16);
-        let dispatching = Arc::new(DashSet::new());
+        let dispatching = Arc::new(DashMap::new());
         let transport = Arc::new(Transport::new());
         let capture = Arc::new(CaptureService::new(transport));
 

--- a/tests/integration_subscribers.rs
+++ b/tests/integration_subscribers.rs
@@ -15,7 +15,7 @@
 //! ```
 
 use async_trait::async_trait;
-use dashmap::DashSet;
+use dashmap::DashMap;
 use orch::backends::{ExternalBackend, ExternalId, ExternalTask, Status};
 use orch::channels::capture::CaptureService;
 use orch::channels::transport::Transport;
@@ -308,7 +308,7 @@ async fn make_dispatch_harness(
     repo: &str,
 ) -> (
     broadcast::Sender<TaskEvent>,
-    Arc<DashSet<String>>,
+    Arc<DashMap<String, String>>,
     std::path::PathBuf,
 ) {
     let tmp = temp_db(&format!("dispatch-{}", repo.replace('/', "-")));
@@ -332,7 +332,7 @@ async fn make_dispatch_harness(
         ..RouterConfig::default()
     };
     let router = Arc::new(RwLock::new(Router::new(config)));
-    let dispatching = Arc::new(DashSet::<String>::new());
+    let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
 
     let (tx, rx) = broadcast::channel::<TaskEvent>(16);
     dispatch::spawn(
@@ -516,7 +516,7 @@ async fn make_review_harness(
     repo: &str,
 ) -> (
     broadcast::Sender<TaskEvent>,
-    Arc<DashSet<String>>,
+    Arc<DashMap<String, String>>,
     std::path::PathBuf,
 ) {
     let tmp = temp_db(&format!("review-{}", repo.replace('/', "-")));
@@ -536,7 +536,7 @@ async fn make_review_harness(
         ..RouterConfig::default()
     };
     let router = Arc::new(RwLock::new(Router::new(config)));
-    let dispatching = Arc::new(DashSet::<String>::new());
+    let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
 
     let (tx, rx) = broadcast::channel::<TaskEvent>(16);
     review::spawn(
@@ -590,7 +590,7 @@ async fn review_dispatching_guard_prevents_double_spawn() {
     // Pre-populate the key as if a review is already in flight.
     // This matches the format constructed in review::spawn:
     //   let dispatch_key = format!("{}/{}", repo, task_id);
-    dispatching.insert("owner/repo/42".to_string());
+    dispatching.insert("owner/repo/42".to_string(), "42".to_string());
 
     // The subscriber sees the key already present, logs, and continues
     // without launching a second review agent.
@@ -598,10 +598,10 @@ async fn review_dispatching_guard_prevents_double_spawn() {
         .unwrap();
 
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    // Dispatching set still contains the key (subscriber did not remove it
+    // Dispatching map still contains the key (subscriber did not remove it
     // since it never claimed ownership via DispatchGuard).
     assert!(
-        dispatching.contains("owner/repo/42"),
+        dispatching.contains_key("owner/repo/42"),
         "dispatching guard should have left the pre-existing key in place"
     );
     cleanup_db(&tmp);
@@ -663,8 +663,8 @@ async fn review_subscriber_only_handles_its_repo() {
     ));
     let router_a = Arc::new(RwLock::new(Router::new(config.clone())));
     let router_b = Arc::new(RwLock::new(Router::new(config)));
-    let dispatching_a = Arc::new(DashSet::<String>::new());
-    let dispatching_b = Arc::new(DashSet::<String>::new());
+    let dispatching_a: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
+    let dispatching_b: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
 
     let (tx, _) = broadcast::channel::<TaskEvent>(16);
     let rx_a = tx.subscribe();


### PR DESCRIPTION
## Summary

- Replaces `Arc<DashSet<String>>` with `Arc<DashMap<String, String>>` (key → task_id) for the dispatch guard across `tick.rs`, `sync.rs`, `review_poll.rs`, `subscribers/dispatch.rs`, `subscribers/review.rs`, and integration tests
- The `DashSet::insert` returning `false` was ambiguous: it could mean the same task is already dispatching (expected) or a different task holds the same key (unexpected collision). The new `DashMap` entry API distinguishes the two: same task → `debug` log, different task → `warn` log
- `DispatchGuard` updated to remove from `DashMap` instead of `DashSet`
- All 2996 tests pass, `cargo clippy --all-targets -- -D warnings` clean

## Test plan

- [x] `cargo nextest run` — 2996 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — no issues
- [x] `cargo fmt -- --check` — no issues

Closes #2606

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task #2606 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*