### PR TITLE
bug: router RwLock read guard held across three async awaits in sync spawned task — write lock starvation

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1666,9 +1666,19 @@ pub async fn serve() -> anyhow::Result<()> {
                                     }).await;
                                 }
                                 // Emit degraded-agents metric/log once per sync cycle.
+                                // Clone the needed data before releasing the read guard so
+                                // the lock is not held across the async store writes.
                                 if let Some((_, _, _, store)) = sync_engines.first() {
-                                    let r = sync_router.read().await;
-                                    sync::emit_degraded_agents_if_needed(&r, Some(store)).await;
+                                    let (available_agents, config) = {
+                                        let r = sync_router.read().await;
+                                        (r.available_agents.clone(), r.config.clone())
+                                    };
+                                    sync::emit_degraded_agents_if_needed(
+                                        &available_agents,
+                                        &config,
+                                        Some(store),
+                                    )
+                                    .await;
                                 }
                                 let elapsed = sync_start.elapsed();
                                 tracing::info!(elapsed_ms = elapsed.as_millis() as u64, "sync tick complete");

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -115,6 +115,21 @@ impl RouteResult {
     }
 }
 
+/// An opaque, cheaply-cloneable handle to the LLM routing subsystem.
+///
+/// Obtain one via [`Router::llm_router_handle`].  Holding this handle does
+/// **not** require holding the router's `RwLock`, so async operations can
+/// safely be called without starving write-lock waiters.
+pub struct LlmRouterHandle(std::sync::Arc<LlmRouter>);
+
+impl LlmRouterHandle {
+    /// Invalidate the skills catalog cache so the next routing call reloads
+    /// from disk.  Safe to await without holding any `RwLock` on `Router`.
+    pub async fn invalidate_skills_catalog(&self) {
+        self.0.invalidate_skills_catalog().await;
+    }
+}
+
 /// The agent router.
 pub struct Router {
     /// Router configuration
@@ -123,8 +138,9 @@ pub struct Router {
     pub available_agents: Vec<String>,
     /// Per-agent rate limit weights (used when weighted_round_robin is enabled)
     pub weights: AgentWeights,
-    /// LLM routing subsystem
-    llm_router: LlmRouter,
+    /// LLM routing subsystem (wrapped in Arc so callers can clone a handle
+    /// without holding the router RwLock across async operations)
+    llm_router: std::sync::Arc<LlmRouter>,
     /// Round-robin index for task routing
     pub(crate) rr_index: usize,
     /// Last agent routed to (for distribution tracking)
@@ -180,7 +196,7 @@ impl Router {
             config,
             available_agents,
             weights,
-            llm_router: LlmRouter::new(),
+            llm_router: std::sync::Arc::new(LlmRouter::new()),
             rr_index: 0,
             last_agent: None,
             review_rr_index: 0,
@@ -194,11 +210,15 @@ impl Router {
         Self::new(RouterConfig::from_config())
     }
 
-    /// Invalidate the skills catalog cache so the next routing call reloads from disk.
+    /// Return a cloned handle to the LLM router subsystem.
     ///
-    /// Call this after `skills_sync()` writes new/updated skill files.
-    pub async fn invalidate_skills_catalog(&self) {
-        self.llm_router.invalidate_skills_catalog().await;
+    /// Callers that need to invoke async methods on the underlying `LlmRouter`
+    /// should clone this handle *before* releasing any `RwLock` read guard on
+    /// `Router`, then call the async method after the guard is dropped.  This
+    /// prevents holding the read lock across await points (which starves
+    /// write-lock waiters due to Tokio's write-preferring `RwLock`).
+    pub fn llm_router_handle(&self) -> LlmRouterHandle {
+        LlmRouterHandle(self.llm_router.clone())
     }
 
     fn advance_pool_index_after_attempt(&mut self, idx: usize, pool_len: usize) {
@@ -1876,7 +1896,7 @@ Hope that helps!"#;
             config,
             available_agents: agents,
             weights,
-            llm_router: LlmRouter::new(),
+            llm_router: std::sync::Arc::new(LlmRouter::new()),
             rr_index: 0,
             last_agent: None,
             review_rr_index: 0,
@@ -1911,7 +1931,7 @@ Hope that helps!"#;
             config,
             available_agents: agents,
             weights,
-            llm_router: LlmRouter::new(),
+            llm_router: std::sync::Arc::new(LlmRouter::new()),
             rr_index: 0,
             last_agent: None,
             review_rr_index: 0,
@@ -1967,7 +1987,7 @@ Hope that helps!"#;
             config,
             available_agents: agents,
             weights,
-            llm_router: LlmRouter::new(),
+            llm_router: std::sync::Arc::new(LlmRouter::new()),
             rr_index: 0,
             last_agent: None,
             review_rr_index: 0,
@@ -2257,7 +2277,7 @@ Hope that helps!"#;
             config,
             available_agents: agents,
             weights,
-            llm_router: LlmRouter::new(),
+            llm_router: std::sync::Arc::new(LlmRouter::new()),
             rr_index: 0,
             last_agent: None,
             review_rr_index: 0,
@@ -2298,7 +2318,7 @@ Hope that helps!"#;
             config,
             available_agents: agents,
             weights,
-            llm_router: LlmRouter::new(),
+            llm_router: std::sync::Arc::new(LlmRouter::new()),
             rr_index: 0,
             last_agent: None,
             review_rr_index: 0,
@@ -2364,7 +2384,7 @@ Hope that helps!"#;
             config,
             available_agents: agents,
             weights,
-            llm_router: LlmRouter::new(),
+            llm_router: std::sync::Arc::new(LlmRouter::new()),
             rr_index: 0,
             last_agent: None,
             review_rr_index: 0,
@@ -2404,7 +2424,7 @@ Hope that helps!"#;
             config,
             available_agents: agents,
             weights,
-            llm_router: LlmRouter::new(),
+            llm_router: std::sync::Arc::new(LlmRouter::new()),
             rr_index: 0,
             last_agent: None,
             // Start index at 2, which is >= candidates.len() (2), triggering the bug
@@ -2448,7 +2468,7 @@ Hope that helps!"#;
             config,
             available_agents: agents,
             weights,
-            llm_router: LlmRouter::new(),
+            llm_router: std::sync::Arc::new(LlmRouter::new()),
             rr_index: 0,
             last_agent: None,
             review_rr_index: 0,
@@ -2510,7 +2530,7 @@ Hope that helps!"#;
             config,
             available_agents: agents,
             weights,
-            llm_router: LlmRouter::new(),
+            llm_router: std::sync::Arc::new(LlmRouter::new()),
             rr_index: 0,
             last_agent: None,
             review_rr_index: 0,

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -14,7 +14,7 @@ use crate::cmd::CommandErrorContext;
 use crate::config;
 use crate::engine::cooldown::{
     cooldown_reason, github_circuit_remaining_secs, is_agent_in_cooldown, is_github_circuit_open,
-    is_model_in_cooldown,
+    is_model_in_cooldown, refresh_degraded_agents,
 };
 use crate::engine::router::Router;
 use crate::engine::runner::agents::patterns;
@@ -1203,7 +1203,10 @@ pub(crate) async fn sync_tick(
         Ok(()) => {
             // Invalidate the LLM router's skills catalog cache so new/updated
             // skill files are picked up on the next routing call.
-            router.read().await.invalidate_skills_catalog().await;
+            // Clone the Arc handle *before* releasing the read guard so the
+            // read lock is not held across the async invalidation call.
+            let llm = router.read().await.llm_router_handle();
+            llm.invalidate_skills_catalog().await;
         }
         Err(e) => {
             tracing::warn!(err = %e, "skills sync failed");
@@ -1211,9 +1214,30 @@ pub(crate) async fn sync_tick(
     }
 
     // Pre-emptive health check: refresh degraded-agent flags from rate_limits table.
+    // Clone the required data out of the router while holding the read guard,
+    // then release the guard before the async DB query so the write lock is
+    // not starved for the duration of the I/O operation.
     {
-        let r = router.read().await;
-        r.refresh_health(store).await;
+        let (available_agents, config) = {
+            let r = router.read().await;
+            (r.available_agents.clone(), r.config.clone())
+        };
+        let model_checker = |agent: &str| -> bool {
+            for comp in &["simple", "medium", "complex", "review"] {
+                if config.has_available_model_for_complexity(agent, comp) {
+                    return true;
+                }
+            }
+            false
+        };
+        refresh_degraded_agents(
+            store,
+            &available_agents,
+            &model_checker,
+            crate::engine::router::config::health_check_window_hours(),
+            crate::engine::router::config::degraded_rate_limit_threshold(),
+        )
+        .await;
     }
 
     Ok(())
@@ -1588,7 +1612,8 @@ struct DegradedAgentDetail {
 ///   `metrics:orch.agents_degraded.alert` is set to `"1"`. The alert is
 ///   cleared to `"0"` when the count drops below the threshold.
 pub(crate) async fn emit_degraded_agents_if_needed(
-    router: &crate::engine::router::Router,
+    available_agents: &[String],
+    config: &crate::engine::router::RouterConfig,
     store: Option<&Arc<TaskStore>>,
 ) {
     // Complexity tiers to check for configured models.
@@ -1596,14 +1621,14 @@ pub(crate) async fn emit_degraded_agents_if_needed(
 
     let mut details: Vec<DegradedAgentDetail> = Vec::new();
 
-    for agent in &router.available_agents {
+    for agent in available_agents {
         let agent_in_cd = is_agent_in_cooldown(agent);
 
         // Collect individually cooled models across all complexity tiers (deduped).
         let mut cooled_models: Vec<String> = Vec::new();
         let mut seen_models = std::collections::HashSet::new();
         for comp in COMPLEXITIES {
-            if let Some(pool) = router.config.model_pool_for_complexity(agent, comp) {
+            if let Some(pool) = config.model_pool_for_complexity(agent, comp) {
                 for model in pool {
                     if seen_models.insert(model.clone()) && is_model_in_cooldown(agent, &model) {
                         cooled_models.push(model);
@@ -1614,11 +1639,9 @@ pub(crate) async fn emit_degraded_agents_if_needed(
 
         // An agent is degraded if it is in agent-level cooldown OR has no
         // available (non-cooled) model across any complexity tier.
-        let has_model = COMPLEXITIES.iter().any(|comp| {
-            router
-                .config
-                .has_available_model_for_complexity(agent, comp)
-        });
+        let has_model = COMPLEXITIES
+            .iter()
+            .any(|comp| config.has_available_model_for_complexity(agent, comp));
 
         if agent_in_cd || !has_model {
             let reason = if agent_in_cd {
@@ -3615,7 +3638,8 @@ mod tests {
         set_agent_cooldown("test-agent-3c", 3600);
 
         // Call the helper and assert KV metrics written
-        emit_degraded_agents_if_needed(&router, Some(&store)).await;
+        emit_degraded_agents_if_needed(&router.available_agents, &router.config, Some(&store))
+            .await;
 
         // Count metric always written
         let count_val = store
@@ -3662,7 +3686,8 @@ mod tests {
         set_agent_cooldown("test-agent-2a", 3600);
         set_agent_cooldown("test-agent-2b", 3600);
 
-        emit_degraded_agents_if_needed(&router, Some(&store)).await;
+        emit_degraded_agents_if_needed(&router.available_agents, &router.config, Some(&store))
+            .await;
 
         // Count metric still written (always-emit)
         let count_val = store


### PR DESCRIPTION
## Summary

All done. Here's a summary of what was fixed:

**Three read guard hold-across-await sites eliminated:**

1. **`sync.rs` (skills sync path)** — Introduced `LlmRouterHandle`, a public `Arc<LlmRouter>` newtype. The call site now clones the handle while holding the read guard, then calls `invalidate_skills_catalog()` after the guard drops.

2. **`sync.rs` (health check path)** — Clones `available_agents` and `config` out of the read guard in a scoped block, then calls `refresh_degraded_agents` d

### What was done

- Three read guard hold-across-await sites eliminated:**
- **`sync.rs` (skills sync path)** — Introduced `LlmRouterHandle`, a public `Arc<LlmRouter>` newtype. The call site now clones the handle while holding the read guard, then calls `invalidate_skills_catalog()` after the guard drops.
- **`sync.rs` (health check path)** — Clones `available_agents` and `config` out of the read guard in a scoped block, then calls `refresh_degraded_agents` directly without holding the guard across the DB query.
- **`mod.rs` (degraded-agents metric path)** — Same pattern: clone `available_agents` + `config` before the guard drops, pass them to `emit_degraded_agents_if_needed` (signature changed from `&Router` to `(&[String], &RouterConfig)`).
- Supporting change:** `Router.llm_router` is now `Arc<LlmRouter>` (was `LlmRouter`) so cloning the handle is a cheap pointer bump with no allocation.


### Files changed

- `src/engine/mod.rs`
- `src/engine/router/mod.rs`
- `src/engine/sync.rs`


Closes #2614

---
*Task #2614 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*