### PR TITLE
bug: review subscriber blocks tasks during GitHub outages — circuit-breaker errors not recognized as transient

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -1333,6 +1333,11 @@ pub(crate) fn is_transient_github_error(err_str: &str) -> bool {
         return true;
     }
 
+    // Internal circuit-breaker state (orch's own GitHub 5xx protection)
+    if lower.contains("circuit-breaker") || lower.contains("circuit breaker") {
+        return true;
+    }
+
     // Rate limit errors (transient with cooldown/retry)
     if lower.contains("rate limit") || lower.contains("too many requests") {
         return true;


### PR DESCRIPTION
## Summary

Treat internal GitHub circuit-breaker errors as transient so review subscriber retries don't increment failure counters and block tasks during GitHub outages.

### What was done

- Updated src/engine/runner/git_ops.rs to recognize Orch's internal GitHub circuit-breaker messages as transient errors
- Added checks for "circuit-breaker" and "circuit breaker" (case-insensitive) inside is_transient_github_error
- Ran unit tests related to is_transient_github_error; all relevant tests passed


### Remaining

- Monitor CI after commit to ensure no unrelated tests fail in other environments
- Observe behavior during the next GitHub outage to confirm tasks remain in needs_review instead of becoming blocked


### Files changed

- `src/engine/runner/git_ops.rs`


Closes #2619

---
*Task #2619 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*