### PR TITLE
bug: cleanup.rs silently swallows try_exists error on stored worktree path, masking filesystem errors

### DIFF
--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -355,7 +355,14 @@ pub(crate) async fn cleanup_task_worktree_with_opts(
     //   1. stored "worktree" path, if it exists on disk.
     //   2. Construct from worktrees_base + project name + branch, if it exists.
     let worktree_to_remove = if let Some(ref wt) = worktree_path {
-        if tokio::fs::try_exists(wt).await.unwrap_or(false) {
+        if match tokio::fs::try_exists(wt).await {
+            Ok(true) => true,
+            Ok(false) => false,
+            Err(e) => {
+                tracing::warn!(task_id, worktree = %wt.display(), err = %e, "try_exists failed on stored worktree path — trying branch-based fallback");
+                false
+            }
+        } {
             Some(wt.clone())
         } else {
             // The recorded worktree path doesn't exist — try reconstructing from branch.


### PR DESCRIPTION
## Summary

Replaced `unwrap_or(false)` on line 358 of `src/engine/cleanup.rs` with an explicit match that emits a `tracing::warn!` when `try_exists` errors on the stored worktree path. This matches the pattern already used in the branch-based fallback paths and ensures filesystem errors are observable in logs rather than silently swallowed. All 2996 tests pass.

### Files changed

- `src/engine/cleanup.rs`


Closes #2627

---
*Task #2627 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*