### PR TITLE
feat: implement local model routing via Ollama

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -59,27 +59,17 @@ engine:
 
 router:
   mode: "llm"              # "llm" (default), "local", or "round_robin"
-  agent: "claude"           # Which agent performs routing
-  model: "haiku"            # Model for routing (fast/cheap)
+  agent: "claude"          # Which agent performs routing
+  model: "haiku"           # Model for routing (fast/cheap)
   timeout_seconds: 60
   fallback_executor: "codex"
-  max_route_attempts: 3     # After N LLM routing failures, fall back to round-robin
-  # weighted_round_robin: false  # Deprioritize agents hitting rate limits
-  # weights:                 # Per-agent routing weights
-  # pool:                    # Router LLM pool: "claude:haiku", "opencode:free", etc.
-  # fallback:                 # Fallback when pool exhausted
-
-  # Local Ollama routing (when mode: "local")
-  # ollama_url: "http://localhost:11434"           # Ollama API endpoint (default)
-  # ollama_model: "qwen2.5-coder:3b-instruct"  # Model to use (default)
-  # ollama_timeout_seconds: 30                         # Timeout for Ollama calls (default)
-  agent: "claude"           # Which agent performs routing
-  model: "haiku"            # Model for routing (fast/cheap)
-  timeout_seconds: 60
-  fallback_executor: "codex"
-  max_route_attempts: 3     # After N LLM routing failures, fall back to round-robin
+  max_route_attempts: 3    # After N LLM routing failures, fall back to round-robin
   # Enable weighted round-robin: deprioritize agents hitting rate limits.
   # weighted_round_robin: false
+  # Local Ollama routing (when mode: "local")
+  # ollama_url: "http://localhost:11434"        # Ollama API endpoint (default)
+  # ollama_model: "qwen2.5-coder:3b-instruct"  # Model to use (default)
+  # ollama_timeout_seconds: 30                  # Timeout for Ollama calls (default)
   # Routing weights (higher = more tasks routed to this agent)
   # weights:
   #   claude: 0.25

--- a/config.example.yml
+++ b/config.example.yml
@@ -58,7 +58,21 @@ engine:
   # silence_cooldown: 3600
 
 router:
-  mode: "llm"              # "llm" (default) or "round_robin"
+  mode: "llm"              # "llm" (default), "local", or "round_robin"
+  agent: "claude"           # Which agent performs routing
+  model: "haiku"            # Model for routing (fast/cheap)
+  timeout_seconds: 60
+  fallback_executor: "codex"
+  max_route_attempts: 3     # After N LLM routing failures, fall back to round-robin
+  # weighted_round_robin: false  # Deprioritize agents hitting rate limits
+  # weights:                 # Per-agent routing weights
+  # pool:                    # Router LLM pool: "claude:haiku", "opencode:free", etc.
+  # fallback:                 # Fallback when pool exhausted
+
+  # Local Ollama routing (when mode: "local")
+  # ollama_url: "http://localhost:11434"           # Ollama API endpoint (default)
+  # ollama_model: "qwen2.5-coder:3b-instruct"  # Model to use (default)
+  # ollama_timeout_seconds: 30                         # Timeout for Ollama calls (default)
   agent: "claude"           # Which agent performs routing
   model: "haiku"            # Model for routing (fast/cheap)
   timeout_seconds: 60

--- a/src/channels/transport.rs
+++ b/src/channels/transport.rs
@@ -241,10 +241,9 @@ impl Transport {
 
     /// Unbind a task session, removing all associated entries.
     ///
-    /// Removes the entry from `bindings`, all reverse-lookup entries from
-    /// `thread_to_task` whose value matches the session key, and clears any
-    /// cached output for the session.  Call this when a task session ends so
-    /// memory does not grow indefinitely.
+    /// Removes the entry from `bindings` and all reverse-lookup entries from
+    /// `thread_to_task` whose value matches the session key. Call this when a
+    /// task session ends so memory does not grow indefinitely.
     pub async fn unbind(&self, repo: &str, task_id: &str) {
         let skey = session_key(repo, task_id);
 

--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -275,7 +275,7 @@ impl RouterConfig {
 
         // Try to load from config
         if let Ok(mode) = crate::config::get("router.mode") {
-            if mode == "round_robin" || mode == "llm" {
+            if mode == "round_robin" || mode == "llm" || mode == "local" {
                 config.mode = mode;
             }
         }

--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -103,7 +103,11 @@ pub const DEFAULT_AGENTS: &[&str] = &["claude", "codex", "opencode", "kimi", "mi
 /// Router configuration.
 #[derive(Debug, Clone)]
 pub struct RouterConfig {
-    /// Routing mode: "llm" or "round_robin"
+    /// Routing mode: "llm", "local", or "round_robin"
+    ///
+    /// - "llm": Use cloud LLMs for routing (default, supports pool-based routing)
+    /// - "local": Use local Ollama model for routing
+    /// - "round_robin": Distribute tasks evenly across available agents
     pub mode: String,
     /// Which agent performs routing (default: "claude")
     pub router_agent: String,
@@ -180,6 +184,12 @@ pub struct RouterConfig {
     ///
     /// Configurable via `router.max_tasks_per_tick` (default: 1).
     pub max_tasks_per_tick: usize,
+    /// Ollama base URL for local routing (default: "http://localhost:11434").
+    pub ollama_url: String,
+    /// Ollama model name for routing (default: "qwen2.5-coder:3b-instruct").
+    pub ollama_model: String,
+    /// Timeout for Ollama HTTP call in seconds (default: 30).
+    pub ollama_timeout_seconds: u64,
     /// Total time budget (seconds) for the entire LLM routing cascade (all pool
     /// entries + fallback combined). When exceeded, routing immediately falls back
     /// to round-robin without waiting for the remaining pool entries to time out
@@ -250,6 +260,9 @@ impl Default for RouterConfig {
             skip_limited_threshold: 0.3,
             agent_backoff_bases: HashMap::new(),
             max_tasks_per_tick: 1,
+            ollama_url: "http://localhost:11434".to_string(),
+            ollama_model: "qwen2.5-coder:3b-instruct".to_string(),
+            ollama_timeout_seconds: 30,
             llm_budget_secs: 45,
         }
     }
@@ -458,6 +471,25 @@ impl RouterConfig {
                         .map(|s| s.trim().to_string())
                         .filter(|s| !s.is_empty())
                         .collect();
+                }
+            }
+        }
+
+        // Parse Ollama-specific config for local routing mode
+        if let Ok(url) = crate::config::get("router.ollama_url") {
+            if !url.is_empty() {
+                config.ollama_url = url;
+            }
+        }
+        if let Ok(model) = crate::config::get("router.ollama_model") {
+            if !model.is_empty() {
+                config.ollama_model = model;
+            }
+        }
+        if let Ok(timeout) = crate::config::get("router.ollama_timeout_seconds") {
+            if let Ok(secs) = timeout.parse::<u64>() {
+                if secs > 0 {
+                    config.ollama_timeout_seconds = secs;
                 }
             }
         }

--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -475,6 +475,18 @@ impl RouterConfig {
             }
         }
 
+        // Parse llm_budget_secs — total time cap for the entire pool cascade.
+        // Defaults to timeout_seconds (already resolved above) so the cascade
+        // can't exceed what a single pool entry would normally take.
+        config.llm_budget_secs = config.timeout_seconds;
+        if let Ok(val) = crate::config::get("router.llm_budget_secs") {
+            if let Ok(secs) = val.parse::<u64>() {
+                if secs > 0 {
+                    config.llm_budget_secs = secs;
+                }
+            }
+        }
+
         // Parse Ollama-specific config for local routing mode
         if let Ok(url) = crate::config::get("router.ollama_url") {
             if !url.is_empty() {

--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -1127,12 +1127,6 @@ impl LlmRouter {
         }
 
         None
-
-}
-
-
-/// Parse response from Ollama or other local LLMs.
-///
     }
 }
 

--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -1127,6 +1127,12 @@ impl LlmRouter {
         }
 
         None
+
+}
+
+
+/// Parse response from Ollama or other local LLMs.
+///
     }
 }
 

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod config;
 mod llm;
+mod ollama;
 mod selection;
 mod strategies;
 pub mod weights;
@@ -733,7 +734,37 @@ impl Router {
                 return Ok(result);
             }
 
-            // 3. LLM-based routing with retry tracking
+            // 4. Local Ollama routing
+            if self.config.mode == "local" {
+                tracing::debug!(task_id = %task.id.0, ollama_url = %self.config.ollama_url, "routing via local Ollama");
+                let ollama_router = ollama::OllamaRouter::new(&self.config);
+                match ollama_router.route(task, &self.config).await {
+                    Ok(result) => {
+                        self.log_route_activity(store, repo, &task.id.0, &result, None)
+                            .await;
+                        return Ok(result);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            task_id = %task.id.0,
+                            error = %e,
+                            "Ollama routing failed, falling back to round-robin"
+                        );
+                        let result = strategies::route_via_round_robin_stateful(
+                            &candidates,
+                            &self.config,
+                            task,
+                            &mut self.rr_index,
+                            &mut self.last_agent,
+                        )?;
+                        self.log_route_activity(store, repo, &task.id.0, &result, None)
+                            .await;
+                        return Ok(result);
+                    }
+                }
+            }
+
+            // 5. LLM-based routing with retry tracking
             let route_attempts = self.get_route_attempts(&task.id.0, store, repo).await;
 
             if route_attempts >= self.config.max_route_attempts {
@@ -2029,10 +2060,12 @@ Hope that helps!"#;
         // Reload — should re-read config and remain valid
         router.reload_async().await;
 
-        // After reload, mode should be a valid value (llm or round_robin)
+        // After reload, mode should be a valid value (llm, local, or round_robin)
         assert!(
-            router.config.mode == "llm" || router.config.mode == "round_robin",
-            "mode should be 'llm' or 'round_robin', got '{}'",
+            router.config.mode == "llm"
+                || router.config.mode == "round_robin"
+                || router.config.mode == "local",
+            "mode should be 'llm', 'local', or 'round_robin', got '{}'",
             router.config.mode
         );
         // Fallback executor should always be set

--- a/src/engine/router/ollama.rs
+++ b/src/engine/router/ollama.rs
@@ -219,3 +219,165 @@ impl OllamaRouter {
         Ok(prompt)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backends::{ExternalId, ExternalTask};
+
+    fn make_router() -> OllamaRouter {
+        OllamaRouter::new(&RouterConfig::default())
+    }
+
+    fn make_task(title: &str, body: &str, labels: Vec<&str>) -> ExternalTask {
+        ExternalTask {
+            id: ExternalId("42".to_string()),
+            title: title.to_string(),
+            body: body.to_string(),
+            state: "open".to_string(),
+            labels: labels.iter().map(|s| s.to_string()).collect(),
+            author: "testuser".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            url: "https://github.com/test/test/issues/42".to_string(),
+        }
+    }
+
+    // ── OllamaResponse JSON parsing ────────────────────────────────────────────
+
+    #[test]
+    fn ollama_response_parses_clean_json() {
+        let json = r#"{"response":"Here is my routing: {\"executor\":\"claude\",\"complexity\":\"medium\",\"reason\":\"good fit\"}"}"#;
+        let resp: OllamaResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.response.contains("executor"));
+        assert!(resp.response.contains("claude"));
+    }
+
+    #[test]
+    fn ollama_response_with_empty_response() {
+        let json = r#"{"response":""}"#;
+        let resp: OllamaResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.response, "");
+    }
+
+    #[test]
+    fn ollama_response_with_unicode() {
+        let json =
+            r#"{"response":"{\n  \"executor\": \"codex\",\n  \"complexity\": \"simple\"\n}"}"#;
+        let resp: OllamaResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.response.contains("executor"));
+        assert!(resp.response.contains("codex"));
+    }
+
+    // ── OllamaResponse JSON parse failure → plain text fallback ───────────────
+    // When Ollama returns plain text (no JSON wrapper), the caller falls back to
+    // treating the raw body as the response text. We test that the raw body
+    // is accessible for this fallback path.
+
+    #[test]
+    fn ollama_response_raw_body_used_on_json_failure() {
+        // Simulate the fallback: JSON parse fails → body becomes the response
+        let raw_body = r#"Here's my routing decision: use claude for this task."#;
+        let result: OllamaResponse = match serde_json::from_str::<OllamaResponse>(raw_body) {
+            Ok(r) => r,
+            Err(_) => OllamaResponse {
+                response: raw_body.to_string(),
+            },
+        };
+        assert_eq!(result.response, raw_body);
+        // The fallback text is then trimmed and passed to parse_llm_response
+        assert!(!result.response.trim().is_empty());
+    }
+
+    #[test]
+    fn ollama_response_trim_works() {
+        let json = r#"{"response":"  {\"executor\":\"claude\"}  "}"#;
+        let resp: OllamaResponse = serde_json::from_str(json).unwrap();
+        let trimmed = resp.response.trim();
+        assert!(trimmed.starts_with('{'));
+        assert!(trimmed.ends_with('}'));
+    }
+
+    // ── build_routing_prompt ───────────────────────────────────────────────────
+
+    #[test]
+    fn build_routing_prompt_substitutes_task_fields() {
+        let router = make_router();
+        let task = make_task(
+            "Fix bug in auth",
+            "The login flow is broken",
+            vec!["backend", "bug"],
+        );
+        let config = RouterConfig::default();
+        let prompt = router.build_routing_prompt(&task, &config).unwrap();
+
+        // Task fields substituted
+        assert!(prompt.contains("Fix bug in auth"));
+        assert!(prompt.contains("The login flow is broken"));
+        assert!(prompt.contains("backend, bug"));
+        // Router agent substituted
+        assert!(prompt.contains("ollama"));
+        // Default agents present
+        assert!(prompt.contains("claude"));
+    }
+
+    #[test]
+    fn build_routing_prompt_includes_labels() {
+        let router = make_router();
+        let task = make_task("Title", "Body", vec!["priority:high", "good-first-issue"]);
+        let config = RouterConfig::default();
+        let prompt = router.build_routing_prompt(&task, &config).unwrap();
+        assert!(prompt.contains("priority:high"));
+        assert!(prompt.contains("good-first-issue"));
+    }
+
+    #[test]
+    fn build_routing_prompt_skills_catalog_replaced_with_empty() {
+        let router = make_router();
+        let task = make_task("Title", "Body", vec![]);
+        let config = RouterConfig::default();
+        let prompt = router.build_routing_prompt(&task, &config).unwrap();
+        // Ollama uses "[]" for skills catalog since it doesn't support dynamic skills
+        // The template placeholder {{SKILLS_CATALOG}} should be replaced with "[]"
+        assert!(
+            !prompt.contains("{{SKILLS_CATALOG}}"),
+            "SKILLS_CATALOG placeholder should be substituted"
+        );
+    }
+
+    #[test]
+    fn build_routing_prompt_includes_weights() {
+        let router = make_router();
+        let task = make_task("Title", "Body", vec![]);
+        let mut config = RouterConfig::default();
+        config.weights.insert("claude".to_string(), 0.5);
+        config.weights.insert("codex".to_string(), 0.3);
+        let prompt = router.build_routing_prompt(&task, &config).unwrap();
+        // Weights string should be formatted
+        assert!(prompt.contains("claude") || prompt.contains("codex"));
+    }
+
+    // ── OllamaRouter construction ───────────────────────────────────────────────
+
+    #[test]
+    fn ollama_router_uses_config_values() {
+        let config = RouterConfig {
+            ollama_url: "http://localhost:11434".to_string(),
+            ollama_model: "qwen2.5-coder:3b-instruct".to_string(),
+            ollama_timeout_seconds: 30,
+            ..RouterConfig::default()
+        };
+        let router = OllamaRouter::new(&config);
+        assert_eq!(router.url, "http://localhost:11434");
+        assert_eq!(router.model, "qwen2.5-coder:3b-instruct");
+        assert_eq!(router.timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn ollama_router_default_values() {
+        let router = make_router();
+        assert_eq!(router.url, "http://localhost:11434");
+        assert_eq!(router.model, "qwen2.5-coder:3b-instruct");
+        assert_eq!(router.timeout, Duration::from_secs(30));
+    }
+}

--- a/src/engine/router/ollama.rs
+++ b/src/engine/router/ollama.rs
@@ -4,9 +4,9 @@
 //! When router.mode is "local", tasks are routed using a local model
 //! instead of cloud LLMs, reducing latency and cost.
 
-use super::RouteResult;
-use crate::backends::ExternalTask;
 use super::config::RouterConfig;
+use super::{AgentProfile, RouteResult};
+use crate::backends::ExternalTask;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -28,10 +28,7 @@ struct OllamaOptions {
 /// Response from Ollama /api/generate endpoint.
 #[derive(Debug, Deserialize)]
 struct OllamaResponse {
-    model: String,
     response: String,
-    #[serde(default)]
-    done: bool,
 }
 
 /// LLM router adapter for Ollama.
@@ -60,7 +57,11 @@ impl OllamaRouter {
     ///
     /// Builds a routing prompt, calls Ollama, parses the JSON response,
     /// and returns a RouteResult.
-    pub async fn route(&self, task: &ExternalTask, config: &RouterConfig) -> anyhow::Result<RouteResult> {
+    pub async fn route(
+        &self,
+        task: &ExternalTask,
+        config: &RouterConfig,
+    ) -> anyhow::Result<RouteResult> {
         // Build routing prompt
         let prompt = self.build_routing_prompt(task, config)?;
 
@@ -74,9 +75,7 @@ impl OllamaRouter {
             }),
         };
 
-        let client = reqwest::Client::builder()
-            .timeout(self.timeout)
-            .build()?;
+        let client = reqwest::Client::builder().timeout(self.timeout).build()?;
 
         let url = format!("{}/api/generate", self.url);
 
@@ -87,11 +86,7 @@ impl OllamaRouter {
             "calling Ollama for routing"
         );
 
-        let response = client
-            .post(&url)
-            .json(&request)
-            .send()
-            .await?;
+        let response = client.post(&url).json(&request).send().await?;
 
         if !response.status().is_success() {
             let status = response.status();
@@ -108,37 +103,10 @@ impl OllamaRouter {
         let ollama_resp: OllamaResponse = match serde_json::from_str(&body) {
             Ok(r) => r,
             Err(e) => {
-                // Ollama might return plain text without JSON structure
+                // Ollama might return plain text without JSON wrapper — treat body as response text
                 tracing::debug!(error = %e, raw_body = %body, "Ollama response parse failed, treating as plain text");
-
-                // Try to extract JSON from plain text response
-                if let Some(json_start) = body.find('{') {
-                    if let Some(json_end) = body.rfind('}') {
-                        let json_str = &body[json_start..=json_end + 1];
-                        match serde_json::from_str::<OllamaResponse>(json_str) {
-                            Ok(r) => r,
-                            Err(_) => {
-                                // Last resort: treat plain text as response
-                                OllamaResponse {
-                                    model: self.model.clone(),
-                                    response: body.clone(),
-                                    done: true,
-                                }
-                            }
-                        }
-                    } else {
-                        OllamaResponse {
-                            model: self.model.clone(),
-                            response: body.clone(),
-                            done: true,
-                        }
-                    }
-                } else {
-                    OllamaResponse {
-                        model: self.model.clone(),
-                        response: body.clone(),
-                        done: true,
-                    }
+                OllamaResponse {
+                    response: body.clone(),
                 }
             }
         };
@@ -152,15 +120,68 @@ impl OllamaRouter {
         );
 
         // Use the same parsing logic as LlmRouter for compatibility
-        super::llm::LlmRouter::new().parse_ollama_response(
-            task,
-            llm_text,
-            &self.model,
-        )
+        let llm_router = super::llm::LlmRouter::new();
+        let llm_response = llm_router.parse_llm_response("ollama", llm_text)?;
+
+        // Validate executor against configured agents
+        let mut agent = llm_response.executor.to_lowercase();
+        if !config.agents.contains(&agent) {
+            agent = if !config.fallback_executor.is_empty() {
+                config.fallback_executor.clone()
+            } else {
+                config.agents.first().cloned().unwrap_or_default()
+            };
+        }
+
+        let complexity = if llm_response.complexity.is_empty() {
+            "medium".to_string()
+        } else {
+            llm_response.complexity.to_lowercase()
+        };
+
+        let model = config.model_for_complexity(&agent, &complexity, &task.id.0);
+
+        let mut profile = AgentProfile {
+            role: llm_response.profile.role,
+            skills: llm_response.profile.skills,
+            tools: if llm_response.profile.tools.is_empty() {
+                config.allowed_tools.clone()
+            } else {
+                llm_response.profile.tools
+            },
+            constraints: llm_response.profile.constraints,
+        };
+        for tool in &config.allowed_tools {
+            if !profile.tools.contains(tool) {
+                profile.tools.push(tool.clone());
+            }
+        }
+
+        let mut selected_skills = llm_response.selected_skills;
+        for skill in &config.default_skills {
+            if !selected_skills.contains(skill) {
+                selected_skills.push(skill.clone());
+            }
+        }
+
+        Ok(RouteResult {
+            agent,
+            model,
+            complexity,
+            estimate: llm_response.estimate,
+            reason: llm_response.reason,
+            profile,
+            selected_skills,
+            warning: None,
+        })
     }
 
     /// Build routing prompt from template.
-    fn build_routing_prompt(&self, task: &ExternalTask, config: &RouterConfig) -> anyhow::Result<String> {
+    fn build_routing_prompt(
+        &self,
+        task: &ExternalTask,
+        config: &RouterConfig,
+    ) -> anyhow::Result<String> {
         let template = include_str!("../../../prompts/route.md");
 
         // Build available agents string

--- a/src/engine/router/ollama.rs
+++ b/src/engine/router/ollama.rs
@@ -1,0 +1,200 @@
+//! Local routing via Ollama.
+//!
+//! This module provides routing using locally-hosted models via Ollama's HTTP API.
+//! When router.mode is "local", tasks are routed using a local model
+//! instead of cloud LLMs, reducing latency and cost.
+
+use super::RouteResult;
+use crate::backends::ExternalTask;
+use super::config::RouterConfig;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Request body for Ollama /api/generate endpoint.
+#[derive(Debug, Clone, Serialize)]
+struct OllamaRequest {
+    model: String,
+    prompt: String,
+    stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    options: Option<OllamaOptions>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct OllamaOptions {
+    temperature: f32,
+}
+
+/// Response from Ollama /api/generate endpoint.
+#[derive(Debug, Deserialize)]
+struct OllamaResponse {
+    model: String,
+    response: String,
+    #[serde(default)]
+    done: bool,
+}
+
+/// LLM router adapter for Ollama.
+///
+/// Handles HTTP requests to localhost:11434 and parses responses
+/// using the same format as cloud LLMs.
+pub struct OllamaRouter {
+    /// Base URL for Ollama API.
+    url: String,
+    /// Model name to use for routing.
+    model: String,
+    /// Timeout for HTTP requests.
+    timeout: Duration,
+}
+
+impl OllamaRouter {
+    pub fn new(config: &RouterConfig) -> Self {
+        Self {
+            url: config.ollama_url.clone(),
+            model: config.ollama_model.clone(),
+            timeout: Duration::from_secs(config.ollama_timeout_seconds),
+        }
+    }
+
+    /// Route using Ollama HTTP API.
+    ///
+    /// Builds a routing prompt, calls Ollama, parses the JSON response,
+    /// and returns a RouteResult.
+    pub async fn route(&self, task: &ExternalTask, config: &RouterConfig) -> anyhow::Result<RouteResult> {
+        // Build routing prompt
+        let prompt = self.build_routing_prompt(task, config)?;
+
+        // Build HTTP request
+        let request = OllamaRequest {
+            model: self.model.clone(),
+            prompt: prompt.clone(),
+            stream: false,
+            options: Some(OllamaOptions {
+                temperature: 0.1, // Low temperature for consistent routing
+            }),
+        };
+
+        let client = reqwest::Client::builder()
+            .timeout(self.timeout)
+            .build()?;
+
+        let url = format!("{}/api/generate", self.url);
+
+        tracing::debug!(
+            task_id = %task.id.0,
+            url = %self.url,
+            model = %self.model,
+            "calling Ollama for routing"
+        );
+
+        let response = client
+            .post(&url)
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            anyhow::bail!(
+                "Ollama request failed with status {}: {}",
+                status,
+                response.text().await.unwrap_or_default()
+            );
+        }
+
+        let body = response.text().await?;
+
+        // Parse Ollama response
+        let ollama_resp: OllamaResponse = match serde_json::from_str(&body) {
+            Ok(r) => r,
+            Err(e) => {
+                // Ollama might return plain text without JSON structure
+                tracing::debug!(error = %e, raw_body = %body, "Ollama response parse failed, treating as plain text");
+
+                // Try to extract JSON from plain text response
+                if let Some(json_start) = body.find('{') {
+                    if let Some(json_end) = body.rfind('}') {
+                        let json_str = &body[json_start..=json_end + 1];
+                        match serde_json::from_str::<OllamaResponse>(json_str) {
+                            Ok(r) => r,
+                            Err(_) => {
+                                // Last resort: treat plain text as response
+                                OllamaResponse {
+                                    model: self.model.clone(),
+                                    response: body.clone(),
+                                    done: true,
+                                }
+                            }
+                        }
+                    } else {
+                        OllamaResponse {
+                            model: self.model.clone(),
+                            response: body.clone(),
+                            done: true,
+                        }
+                    }
+                } else {
+                    OllamaResponse {
+                        model: self.model.clone(),
+                        response: body.clone(),
+                        done: true,
+                    }
+                }
+            }
+        };
+
+        // Parse the LLM response using the same format as cloud routers
+        let llm_text = ollama_resp.response.trim();
+        tracing::debug!(
+            task_id = %task.id.0,
+            response_len = llm_text.len(),
+            "Ollama routing response received"
+        );
+
+        // Use the same parsing logic as LlmRouter for compatibility
+        super::llm::LlmRouter::new().parse_ollama_response(
+            task,
+            llm_text,
+            &self.model,
+        )
+    }
+
+    /// Build routing prompt from template.
+    fn build_routing_prompt(&self, task: &ExternalTask, config: &RouterConfig) -> anyhow::Result<String> {
+        let template = include_str!("../../../prompts/route.md");
+
+        // Build available agents string
+        let available_agents_str = config.agents.join(", ");
+
+        // Build weights string for the prompt
+        let weights_str = if config.weights.is_empty() {
+            "No weights configured — distribute evenly.".to_string()
+        } else {
+            config
+                .agents
+                .iter()
+                .map(|a| {
+                    let w = config.weights.get(a).copied().unwrap_or(1.0);
+                    format!("{a}: {w}")
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+
+        // Build labels string
+        let labels = task.labels.join(", ");
+
+        // Simple template substitution
+        let prompt = template
+            .replace("{{ROUTER_AGENT}}", "ollama")
+            .replace("{{AVAILABLE_AGENTS}}", &available_agents_str)
+            .replace("{{AGENT_WEIGHTS}}", &weights_str)
+            .replace("{{SKILLS_CATALOG}}", "[]") // Ollama doesn't support dynamic skills catalog
+            .replace("{{TASK_ID}}", &task.id.0)
+            .replace("{{TASK_TITLE}}", &task.title)
+            .replace("{{TASK_LABELS}}", &labels)
+            .replace("{{TASK_BODY}}", &task.body);
+
+        Ok(prompt)
+    }
+}


### PR DESCRIPTION
## Summary

Let me look at the LLM module to understand how routing calls are made:Now let me add the `local` mode to the router config:Now let me add Ollama-specific configuration fields to `RouterConfig`:Let me check the full file structure around the RouterConfig struct:The file appears to be in a corrupted state. Let me restore it:Now let me make a proper edit to add Ollama fields to RouterConfig:Now let me update the `Default` implementation to include the new fields:Now let me update the `from_config`

### Files changed

- `config.example.yml`
- `src/engine/router/config.rs`
- `src/engine/router/llm.rs`
- `src/engine/router/ollama.rs`


Closes #2623

---
*Task #2623 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gemini-3.1-pro-preview`*