### PR TITLE
fix: detect and recover from corrupted worktree index in setup_worktree

### DIFF
--- a/src/engine/runner/worktree.rs
+++ b/src/engine/runner/worktree.rs
@@ -429,6 +429,57 @@ pub async fn setup_worktree(
             .current_dir(&worktree_dir)
             .output_with_context()
             .await;
+
+        // Check for a corrupted git index (e.g. "error: could not write index").
+        // `git status` reads the index; a non-zero exit with index-related stderr
+        // indicates corruption that will cause every subsequent git operation to
+        // fail, leading to an infinite stuck-recovery loop.  When detected, nuke
+        // the worktree and recreate it from scratch below.
+        let index_ok = Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(&worktree_dir)
+            .output_with_context()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+
+        if !index_ok {
+            let stderr_hint = Command::new("git")
+                .args(["status", "--porcelain"])
+                .current_dir(&worktree_dir)
+                .output_with_context()
+                .await
+                .map(|o| String::from_utf8_lossy(&o.stderr).trim().to_string())
+                .unwrap_or_default();
+            tracing::warn!(
+                task_id,
+                worktree = %worktree_dir.display(),
+                stderr = %stderr_hint,
+                "corrupted worktree index detected — removing and recreating worktree"
+            );
+            // Remove git worktree reference first, then delete the directory.
+            let _ = Command::new("git")
+                .args([
+                    "-C",
+                    &main_dir.to_string_lossy(),
+                    "worktree",
+                    "remove",
+                    "--force",
+                    &worktree_dir.to_string_lossy(),
+                ])
+                .output_with_context()
+                .await;
+            // If the directory still exists (e.g. worktree remove failed), remove it
+            // manually so the worktree-creation block below re-creates it cleanly.
+            if tokio::fs::metadata(&worktree_dir).await.is_ok() {
+                let _ = tokio::fs::remove_dir_all(&worktree_dir).await;
+            }
+            // Prune stale worktree metadata so git won't complain on re-add.
+            let _ = Command::new("git")
+                .args(["-C", &main_dir.to_string_lossy(), "worktree", "prune"])
+                .output_with_context()
+                .await;
+        }
     }
 
     // Create worktree if it doesn't exist


### PR DESCRIPTION
## Summary

- After `git rebase --abort`, run `git status --porcelain` as a lightweight index health check in `setup_worktree`
- On failure (corrupted index), remove the worktree via `git worktree remove --force`, delete the directory, and prune stale metadata
- The existing worktree-creation path then rebuilds it cleanly from scratch, turning the infinite 30-minute stuck-recovery loop into a one-time self-healing recovery

## Test plan

- [ ] All 3000 unit tests pass (`cargo nextest run`)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Manually verify: corrupt `.git/index` in a worktree, confirm next dispatch recreates it instead of looping

Fixes #2635

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task #2635 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*