### PR TITLE
fix: make set_model_cooldown and set_agent_cooldown async to guarantee KV persistence

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -411,10 +411,10 @@ pub async fn record_model_failure(agent_name: &str, model: &str) {
 ///
 /// Used by silence detection to cooldown the specific model that failed to
 /// produce any output, with a configurable duration.
-pub fn set_model_cooldown(agent_name: &str, model: &str, duration_secs: u64) {
+pub async fn set_model_cooldown(agent_name: &str, model: &str, duration_secs: u64) {
     let key = format!("{agent_name}:{model}");
     let cooldown_until = chrono::Utc::now().timestamp() + duration_secs as i64;
-    set_cooldown(&key, cooldown_until, "silence_detected");
+    set_cooldown_async(&key, cooldown_until, "silence_detected").await;
 }
 
 /// Set a short agent-level cooldown (in seconds).
@@ -423,9 +423,9 @@ pub fn set_model_cooldown(agent_name: &str, model: &str, duration_secs: u64) {
 /// router picks a different one on re-route. Unlike `record_agent_failure`
 /// (exponential backoff), this uses a short duration (typically 120s) —
 /// just enough to force one re-route cycle to a different agent.
-pub fn set_agent_cooldown(agent_name: &str, duration_secs: u64) {
+pub async fn set_agent_cooldown(agent_name: &str, duration_secs: u64) {
     let cooldown_until = chrono::Utc::now().timestamp() + duration_secs as i64;
-    set_cooldown(agent_name, cooldown_until, "silence_agent_cooldown");
+    set_cooldown_async(agent_name, cooldown_until, "silence_agent_cooldown").await;
 }
 
 /// Record a silence detection for an agent+model and apply extended cooldowns
@@ -477,7 +477,7 @@ pub async fn record_silence_detection(agent_name: &str, model: &str) -> Option<S
     let count = timestamps.len();
     let mut extended_cooldown_applied = false;
     if count >= SILENCE_COUNT_THRESHOLD {
-        set_model_cooldown(agent_name, model, SILENCE_EXTENDED_COOLDOWN_SECS);
+        set_model_cooldown(agent_name, model, SILENCE_EXTENDED_COOLDOWN_SECS).await;
         extended_cooldown_applied = true;
         timestamps.clear();
     }
@@ -683,38 +683,6 @@ async fn set_cooldown_async(key: &str, cooldown_until: i64, reason: &str) -> boo
     true
 }
 
-/// Set a cooldown with a specific expiry timestamp. Persists to KV.
-///
-/// Returns `true` if the cooldown was applied, `false` if an existing longer
-/// cooldown prevented the update (never-shorten rule).
-///
-/// For non-async callers (silence detection short cooldowns). The KV write is
-/// fire-and-forget — loss on crash is acceptable for these short-lived cooldowns.
-/// For critical cooldowns, use [`set_cooldown_async`] instead.
-fn set_cooldown(key: &str, cooldown_until: i64, reason: &str) -> bool {
-    if !set_cooldown_in_memory(key, cooldown_until, reason) {
-        return false;
-    }
-
-    // Persist to KV via a background task when we have a runtime.
-    // Unit tests call cooldown helpers without a Tokio runtime; avoid panicking.
-    let store_opt = cooldown_store().lock().ok().and_then(|g| g.clone());
-    if let Some(store) = store_opt {
-        let kv_key = format!("{KV_PREFIX}{key}");
-        let value = cooldown_until.to_string();
-        if tokio::runtime::Handle::try_current().is_ok() {
-            tokio::spawn(async move {
-                if let Err(e) = store.kv_set(&kv_key, &value).await {
-                    tracing::warn!(kv_key, err = %e, "failed to persist cooldown to KV store");
-                }
-            });
-        } else {
-            tracing::debug!(kv_key, "skipping KV cooldown persist (no Tokio runtime)");
-        }
-    }
-    true
-}
-
 /// Check if a key is currently in cooldown.
 fn is_in_cooldown(key: &str) -> bool {
     let map = cooldowns().lock().unwrap_or_else(|e| e.into_inner());
@@ -905,7 +873,7 @@ pub async fn record_github_5xx() {
             // Also set the generic cooldown so is_agent_in_cooldown("github:5xx")
             // returns true immediately, avoiding a race window where concurrent
             // requests bypass the circuit breaker.
-            set_agent_cooldown("github:5xx", GITHUB_5XX_COOLDOWN_SECS as u64);
+            set_agent_cooldown("github:5xx", GITHUB_5XX_COOLDOWN_SECS as u64).await;
         }
         // Clear the sliding window after tripping so we don't re-trip immediately
         let mut ts = github_5xx_timestamps()
@@ -1127,7 +1095,7 @@ mod tests {
 
         record_model_failure("testagent_persist", "testmodel_persist").await;
 
-        // set_cooldown persists via tokio::spawn — yield to let the task complete.
+        // Give the async KV write a moment to settle before querying.
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         let kv_key = format!("{KV_PREFIX}testagent_persist:testmodel_persist");
@@ -1189,7 +1157,7 @@ mod tests {
 
     #[tokio::test]
     async fn agent_cooldown_persists_to_kv() {
-        // Agent-level cooldowns should also go through set_cooldown which persists
+        // Agent-level cooldowns persist to KV via set_cooldown_async
         let agent = "test_agent_persist_check";
         record_agent_failure_with_message(agent, "").await;
         assert!(is_agent_in_cooldown(agent));
@@ -1198,7 +1166,7 @@ mod tests {
     #[tokio::test]
     async fn cooldown_never_shortens() {
         let agent = "test_agent_no_shorten";
-        set_agent_cooldown(agent, 24 * 60 * 60);
+        set_agent_cooldown(agent, 24 * 60 * 60).await;
         let initial = {
             let map = cooldowns().lock().unwrap();
             map.get(agent)
@@ -1220,12 +1188,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn silence_agent_cooldown_is_short_lived() {
+    #[tokio::test]
+    async fn silence_agent_cooldown_is_short_lived() {
         let agent = "test_silence_agent_cd";
         assert!(!is_agent_in_cooldown(agent));
 
-        set_agent_cooldown(agent, SILENCE_AGENT_COOLDOWN_SECS);
+        set_agent_cooldown(agent, SILENCE_AGENT_COOLDOWN_SECS).await;
         assert!(is_agent_in_cooldown(agent));
 
         // Verify it's a short cooldown (120s), not the exponential backoff one
@@ -1456,7 +1424,7 @@ mod tests {
             "first billing cycle cooldown should be ~24h, got {remaining_1}s"
         );
 
-        // Clear in-memory cooldown (but NOT failure count) to allow next set_cooldown
+        // Clear in-memory cooldown (but NOT failure count) to allow next set_cooldown_async
         {
             let mut map = cooldowns().lock().unwrap();
             map.remove(agent);
@@ -1707,7 +1675,7 @@ mod tests {
             "first failure should be ~5 min, got {remaining_1}s"
         );
 
-        // Clear the cooldown (but NOT failure count) to allow the next set_cooldown to apply
+        // Clear the cooldown (but NOT failure count) to allow the next set_cooldown_async to apply
         {
             let mut map = cooldowns().lock().unwrap();
             map.remove(agent);
@@ -1794,8 +1762,7 @@ mod tests {
             let _ = read_and_increment_failure_count(&Some(store.clone()), agent).await;
         }
         // Set a cooldown so clear_cooldown has something to clear
-        set_agent_cooldown(agent, 3600);
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        set_agent_cooldown(agent, 3600).await;
 
         // Verify failure count is 5
         let kv_key = format!("{FAILURE_COUNT_PREFIX}{agent}");
@@ -1842,9 +1809,8 @@ mod tests {
         let agents = ["test_clear_all_a", "test_clear_all_b"];
         for agent in &agents {
             let _ = read_and_increment_failure_count(&Some(store.clone()), agent).await;
-            set_agent_cooldown(agent, 3600);
+            set_agent_cooldown(agent, 3600).await;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         clear_cooldown("*", &store).await;
 

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -2809,8 +2809,8 @@ Hope that helps!"#;
             ..Default::default()
         };
         let router = Router::new(config);
-        set_model_cooldown("claude", "haiku-4-5-20251001", 300); // 5 min
-        set_model_cooldown("opencode", "haiku-4-5-20251001", 600); // 10 min
+        set_model_cooldown("claude", "haiku-4-5-20251001", 300).await; // 5 min
+        set_model_cooldown("opencode", "haiku-4-5-20251001", 600).await; // 10 min
 
         let earliest = router.earliest_pool_cooldown();
         assert!(earliest.is_some());
@@ -2820,8 +2820,8 @@ Hope that helps!"#;
         assert!((295..=300).contains(&remaining));
     }
 
-    #[test]
-    fn earliest_pool_cooldown_skips_non_pool_entries() {
+    #[tokio::test]
+    async fn earliest_pool_cooldown_skips_non_pool_entries() {
         // Use explicit pool so we can predict what entries exist.
         let config = RouterConfig {
             pool: vec![
@@ -2832,9 +2832,9 @@ Hope that helps!"#;
         };
         let router = Router::new(config);
         // Set cooldown on a non-pool model — should not affect earliest_pool_cooldown
-        set_model_cooldown("claude", "opus", 999);
+        set_model_cooldown("claude", "opus", 999).await;
         // Set cooldown on a pool entry (opencode:pool-model-b)
-        set_model_cooldown("opencode", "pool-model-b", 300);
+        set_model_cooldown("opencode", "pool-model-b", 300).await;
 
         let earliest = router.earliest_pool_cooldown();
         assert!(earliest.is_some());

--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -148,7 +148,8 @@ pub async fn handle_error(
                             agent_name,
                             model,
                             PROVIDER_RETURNED_ERROR_MODEL_COOLDOWN_SECS,
-                        );
+                        )
+                        .await;
                     } else {
                         response::record_model_failure(agent_name, model).await;
                     }
@@ -388,7 +389,7 @@ pub async fn handle_error(
                     // model cooldown.  These models (especially github-copilot/* in opencode)
                     // fail consistently across multiple hours; a 1-hour window means ~12
                     // wasted 2-minute attempts per day per model.  4 hours cuts that to ~3.
-                    crate::engine::cooldown::set_model_cooldown(agent_name, m, 4 * 3600);
+                    crate::engine::cooldown::set_model_cooldown(agent_name, m, 4 * 3600).await;
                 }
                 // Before falling through to handle_failover() (which tries claude/codex),
                 // check whether this agent has any free models that haven't been tried yet.

--- a/src/engine/runner/response.rs
+++ b/src/engine/runner/response.rs
@@ -431,7 +431,7 @@ pub async fn handle_failover(
         // Apply brief 120s cooldown on the failed agent so the router skips it
         // on the next routing attempt. This prevents the router from immediately
         // re-selecting the same agent after clearing both agent and model (#1492).
-        set_agent_cooldown(agent_name, 120);
+        set_agent_cooldown(agent_name, 120).await;
 
         let msg = format!("{error_message}, clearing agent/model for re-route");
         if let Err(e) = store::store_set_result(

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -3738,10 +3738,10 @@ mod tests {
             "test-agent-3d".to_string(),
         ];
 
-        // Place three agents into cooldown (in-memory only)
-        set_agent_cooldown("test-agent-3a", 3600);
-        set_agent_cooldown("test-agent-3b", 3600);
-        set_agent_cooldown("test-agent-3c", 3600);
+        // Place three agents into cooldown
+        set_agent_cooldown("test-agent-3a", 3600).await;
+        set_agent_cooldown("test-agent-3b", 3600).await;
+        set_agent_cooldown("test-agent-3c", 3600).await;
 
         // Call the helper and assert KV metrics written
         emit_degraded_agents_if_needed(&router.available_agents, &router.config, Some(&store))
@@ -3789,8 +3789,8 @@ mod tests {
         router.available_agents = vec!["test-agent-2a".to_string(), "test-agent-2b".to_string()];
 
         // Place only two agents into cooldown — below the threshold of 3
-        set_agent_cooldown("test-agent-2a", 3600);
-        set_agent_cooldown("test-agent-2b", 3600);
+        set_agent_cooldown("test-agent-2a", 3600).await;
+        set_agent_cooldown("test-agent-2b", 3600).await;
 
         emit_degraded_agents_if_needed(&router.available_agents, &router.config, Some(&store))
             .await;

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -285,7 +285,7 @@ pub(crate) async fn tick_detect_silent_agents(
 
         // 3. Cooldown the specific model (not the whole agent)
         if !agent_name.is_empty() && !model_name.is_empty() {
-            set_model_cooldown(&agent_name, &model_name, config.silence_cooldown);
+            set_model_cooldown(&agent_name, &model_name, config.silence_cooldown).await;
             if let Some(result) = record_silence_detection(&agent_name, &model_name).await {
                 if result.extended_cooldown_applied {
                     extended_note = format!(
@@ -300,7 +300,7 @@ pub(crate) async fn tick_detect_silent_agents(
         // Without this, the router picks the same agent with a different model,
         // looping through all models (~2 min each) before the long agent cooldown kicks in.
         if !agent_name.is_empty() {
-            set_agent_cooldown(&agent_name, SILENCE_AGENT_COOLDOWN_SECS);
+            set_agent_cooldown(&agent_name, SILENCE_AGENT_COOLDOWN_SECS).await;
         }
 
         // 4. Pick a fallback agent and set to Routed (not New) to preserve progress.
@@ -572,7 +572,7 @@ pub(crate) async fn tick_recover_stuck_tasks(
                 .unwrap_or_default();
 
             if !agent_name.is_empty() && !model_name.is_empty() {
-                set_model_cooldown(&agent_name, &model_name, config.silence_cooldown);
+                set_model_cooldown(&agent_name, &model_name, config.silence_cooldown).await;
                 record_agent_failure_with_message(
                     &agent_name,
                     &format!(
@@ -583,7 +583,7 @@ pub(crate) async fn tick_recover_stuck_tasks(
                 .await;
             }
             if !agent_name.is_empty() {
-                set_agent_cooldown(&agent_name, SILENCE_AGENT_COOLDOWN_SECS);
+                set_agent_cooldown(&agent_name, SILENCE_AGENT_COOLDOWN_SECS).await;
             }
             tracing::warn!(
                 task_id = task.id.0,
@@ -765,7 +765,7 @@ pub(crate) async fn tick_recover_stuck_tasks(
                 .unwrap_or_default();
 
             if !agent_name.is_empty() && !model_name.is_empty() {
-                set_model_cooldown(&agent_name, &model_name, config.silence_cooldown);
+                set_model_cooldown(&agent_name, &model_name, config.silence_cooldown).await;
                 record_agent_failure_with_message(
                     &agent_name,
                     &format!(
@@ -776,7 +776,7 @@ pub(crate) async fn tick_recover_stuck_tasks(
                 .await;
             }
             if !agent_name.is_empty() {
-                set_agent_cooldown(&agent_name, SILENCE_AGENT_COOLDOWN_SECS);
+                set_agent_cooldown(&agent_name, SILENCE_AGENT_COOLDOWN_SECS).await;
             }
             tracing::warn!(
                 task_id,

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -465,7 +465,8 @@ impl GhHttp {
                             attempts,
                             circuit_cooldown_secs
                         );
-                        engine_cooldown::set_agent_cooldown("github:5xx", circuit_cooldown_secs);
+                        engine_cooldown::set_agent_cooldown("github:5xx", circuit_cooldown_secs)
+                            .await;
                         break;
                     }
 
@@ -490,7 +491,7 @@ impl GhHttp {
                         "HTTP send failed after {} attempts — setting circuit-breaker",
                         attempts
                     );
-                    engine_cooldown::set_agent_cooldown("github:5xx", circuit_cooldown_secs);
+                    engine_cooldown::set_agent_cooldown("github:5xx", circuit_cooldown_secs).await;
                     break;
                 }
             }


### PR DESCRIPTION
## Summary

- `set_model_cooldown` and `set_agent_cooldown` previously used a fire-and-forget `tokio::spawn` for KV writes, so cooldowns could be silently lost if the runtime shut down before the spawned task completed
- On restart the in-memory cooldown map is empty, so a cooled-down agent would be retried immediately — defeating the backoff entirely
- Fix: make both functions `async` and delegate to the existing `set_cooldown_async` (which awaits the KV write inline before returning); remove the now-dead synchronous `set_cooldown` helper
- Update all call sites across `tick.rs`, `http.rs`, `runner/fallback.rs`, `runner/response.rs`, `sync.rs`, and `router/mod.rs` to `.await` the calls; convert two `#[test]` functions to `#[tokio::test]`

## Test plan

- [ ] `cargo nextest run` — all 3022 tests pass (verified locally)
- [ ] Silence detection cooldowns now persist through service restarts
- [ ] GitHub 5xx circuit-breaker cooldowns now persist through service restarts
- [ ] No regression in cooldown-never-shorten behaviour (existing test)

Fixes #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)