### PR TITLE
bug: PushResult::Failed used for no-commits case — semantic overload makes push path fragile

### DIFF
--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -319,12 +319,14 @@ async fn check_commits_and_clear_stale_errors(
 /// If rebase fails (conflicts), the task is blocked for human intervention.
 ///
 /// Returns `PushResult::Success` on success, `PushResult::Rebased` if rebase
-/// succeeded and the task should be re-routed, or `PushResult::Failed` if push
-/// failed and recovery was not possible.
+/// succeeded and the task should be re-routed, `PushResult::Failed` if push
+/// failed and recovery was not possible, or `PushResult::NoCommits` if the
+/// branch has no commits ahead of the default branch.
 enum PushResult {
     Success,
     Rebased,
     Failed,
+    NoCommits, // agent made no code changes
 }
 
 async fn push_branch_with_log(
@@ -622,7 +624,7 @@ async fn run_git_ops(
             })),
         )
         .await;
-        PushResult::Failed
+        PushResult::NoCommits
     } else {
         push_branch_with_log(
             ctx,
@@ -650,6 +652,11 @@ async fn run_git_ops(
         tracing::info!(
             task_id = ctx.task_id,
             "skipping PR creation after successful rebase — task will be re-routed"
+        );
+    } else if matches!(push_result, PushResult::NoCommits) {
+        tracing::info!(
+            task_id = ctx.task_id,
+            "no commits ahead of default branch, skipping push + PR"
         );
     } else if !has_pushed {
         // no commits — already logged "no commits ahead, skipping push + PR" at INFO level above


### PR DESCRIPTION
## Summary

Added PushResult::NoCommits variant to eliminate semantic overload

### What was done

- Added NoCommits variant to PushResult enum
- Updated no-commits branch to return PushResult::NoCommits instead of Failed
- Updated downstream match logic to explicitly handle PushResult::NoCommits
- Updated doc comment to document the new variant
- All tests pass (3036 passed)
- Formatting and clippy checks pass


### Files changed

- `src/engine/runner/response_handler.rs`


Closes #2646

---
*Task #2646 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*