### PR TITLE
perf: batch_session_active() called twice per tick — duplicate tmux subprocess on every cycle

### DIFF
--- a/src/engine/subscribers/dispatch.rs
+++ b/src/engine/subscribers/dispatch.rs
@@ -42,6 +42,7 @@ pub fn spawn(
                     // The dispatching set guard inside tick_dispatch_tasks
                     // prevents double-dispatch if the tick loop also picks this up.
                     let router_guard = router_arc.read().await;
+                    let session_map = tmux.batch_session_active().await;
                     if let Err(e) = crate::engine::tick::tick_dispatch_tasks(
                         &backend,
                         &tmux,
@@ -54,6 +55,7 @@ pub fn spawn(
                         &router_guard,
                         &dispatching,
                         &store,
+                        &session_map,
                     )
                     .await
                     {

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -496,11 +496,9 @@ pub(crate) async fn tick_recover_stuck_tasks(
     task_manager: &Arc<TaskManager>,
     config: &EngineConfig,
     store: &Arc<TaskStore>,
+    session_map: &std::collections::HashMap<String, bool>,
 ) -> anyhow::Result<()> {
     let _span = tracing::info_span!("engine.tick.phase2.stuck_tasks").entered();
-    // Fetch all session statuses once (single `list-panes -a` call) and reuse
-    // throughout this function instead of spawning one subprocess per task.
-    let session_map = tmux.batch_session_active().await;
     let in_progress = match task_manager
         .list_external_by_status(Status::InProgress)
         .await
@@ -519,7 +517,7 @@ pub(crate) async fn tick_recover_stuck_tasks(
             &task.updated_at,
             config,
             "cannot parse updated_at, skipping stuck-task check",
-            &session_map,
+            session_map,
         ) else {
             continue;
         };
@@ -713,7 +711,7 @@ pub(crate) async fn tick_recover_stuck_tasks(
             &task.updated_at,
             config,
             "cannot parse updated_at, skipping stuck internal-task check",
-            &session_map,
+            session_map,
         ) else {
             continue;
         };
@@ -871,7 +869,7 @@ pub(crate) async fn tick_recover_stuck_tasks(
             &task.updated_at,
             &in_review_config,
             "cannot parse updated_at, skipping stuck in_review check",
-            &session_map,
+            session_map,
         ) else {
             continue;
         };
@@ -966,7 +964,7 @@ pub(crate) async fn tick_recover_stuck_tasks(
             &task.updated_at,
             config,
             "cannot parse updated_at, skipping stuck internal in_review check",
-            &session_map,
+            session_map,
         ) else {
             continue;
         };
@@ -1211,6 +1209,7 @@ pub(crate) async fn tick_dispatch_tasks(
     router: &Router,
     dispatching: &Arc<DashMap<String, String>>,
     store: &Arc<TaskStore>,
+    session_map: &std::collections::HashMap<String, bool>,
 ) -> anyhow::Result<()> {
     // Note: Routed tasks should never have no-agent (filtered during Phase 3a routing),
     // but we keep this filter as defense-in-depth.
@@ -1253,10 +1252,6 @@ pub(crate) async fn tick_dispatch_tasks(
     } else {
         0
     };
-
-    // Fetch all session pane-alive statuses once (single `list-panes -a` call) and
-    // reuse throughout the dispatch loop instead of spawning 2 subprocesses per task.
-    let dispatch_session_map = tmux.batch_session_active().await;
 
     for (idx, task) in dispatchable.into_iter().enumerate() {
         // In degraded mode, add delay between dispatches to pace the system
@@ -1312,7 +1307,7 @@ pub(crate) async fn tick_dispatch_tasks(
         // Check if already running (has active session)
         let session_name = tmux.session_name(repo, &task.id.0);
         if tmux
-            .session_blocks_dispatch_from_map(&session_name, &dispatch_session_map)
+            .session_blocks_dispatch_from_map(&session_name, session_map)
             .await
         {
             tracing::warn!(
@@ -1728,7 +1723,19 @@ pub(crate) async fn tick(
 
     tick_check_session_completions(tmux, repo, capture, store).await?;
     tick_detect_silent_agents(tmux, repo, capture, backend, task_manager, config, store).await?;
-    tick_recover_stuck_tasks(backend, tmux, repo, task_manager, config, store).await?;
+    // Fetch session map once and share between stuck-task recovery and dispatch to avoid
+    // spawning two `tmux list-panes -a` subprocesses per tick.
+    let session_map = tmux.batch_session_active().await;
+    tick_recover_stuck_tasks(
+        backend,
+        tmux,
+        repo,
+        task_manager,
+        config,
+        store,
+        &session_map,
+    )
+    .await?;
     tick_route_tasks(backend, task_manager, router, store, repo).await?;
     tick_dispatch_tasks(
         backend,
@@ -1742,6 +1749,7 @@ pub(crate) async fn tick(
         router,
         dispatching,
         store,
+        &session_map,
     )
     .await?;
     tick_unblock_parents(backend, task_manager, store, repo).await?;
@@ -2102,6 +2110,7 @@ mod tests {
             &task_manager,
             &config,
             &store,
+            &std::collections::HashMap::new(),
         )
         .await
         .unwrap();
@@ -2157,6 +2166,7 @@ mod tests {
             &task_manager,
             &config,
             &store,
+            &std::collections::HashMap::new(),
         )
         .await
         .unwrap();
@@ -2203,6 +2213,7 @@ mod tests {
             &task_manager,
             &config,
             &store,
+            &std::collections::HashMap::new(),
         )
         .await
         .unwrap();
@@ -2259,6 +2270,7 @@ mod tests {
             &task_manager,
             &config,
             &store,
+            &std::collections::HashMap::new(),
         )
         .await
         .unwrap();
@@ -2441,6 +2453,7 @@ mod tests {
             &task_manager,
             &config,
             &store,
+            &std::collections::HashMap::new(),
         )
         .await
         .unwrap();
@@ -2603,6 +2616,7 @@ mod tests {
                 &write_guard,
                 &dispatching,
                 &store,
+                &std::collections::HashMap::new(),
             ),
         )
         .await;
@@ -2740,6 +2754,7 @@ mod tests {
             &task_manager,
             &config,
             &store,
+            &std::collections::HashMap::new(),
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

Eliminated duplicate `tmux list-panes -a` subprocess per tick by hoisting `batch_session_active()` to `tick()` and passing the result as a `&HashMap<String, bool>` parameter to both `tick_recover_stuck_tasks` and `tick_dispatch_tasks`. Also updated the event-driven dispatch subscriber in `dispatch.rs` to fetch the map once before calling `tick_dispatch_tasks`. All 3036 tests pass, fmt/clippy clean.

### Files changed

- `src/engine/subscribers/dispatch.rs`
- `src/engine/tick.rs`


Closes #2647

---
*Task #2647 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*