### PR TITLE
bug: empty task_runs.error persists despite #2527 fix

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -344,14 +344,18 @@ impl TaskRunner {
             .get_field(input.task_id, "last_error")
             .await
             .filter(|s| !s.is_empty());
-        let error =
-            input
-                .error_override
-                .or(last_error)
-                .unwrap_or_else(|| match input.parse_result {
-                    Ok(parsed) => parsed.response.error.clone().unwrap_or_default(),
-                    Err(err) => err.to_string(),
-                });
+        let error = match input.error_override.clone().or_else(|| last_error.clone()) {
+            Some(e) if !e.is_empty() => e,
+            _ => match input.parse_result {
+                Ok(parsed) => parsed.response.error.clone().unwrap_or_default(),
+                Err(err) => err.to_string(),
+            },
+        };
+        let error = if error.is_empty() {
+            "no error info available".to_string()
+        } else {
+            error
+        };
 
         let total_cost_usd = match &self.store {
             Some(_) => {


### PR DESCRIPTION
## Summary

Fixed empty task_runs.error bug in build_run_audit by adding fallback message when all error sources are empty. When parse_result was Ok with no agent error, last_error was empty, and error_override was None, the error field was being set to empty string. Added final fallback to 'no error info available' to ensure diagnostic data is always present.

### What was done

- Fixed error chain in build_run_audit to never produce empty error strings
- Added fallback message 'no error info available' when all error sources (error_override, last_error, parse_result.error) are empty
- Verified fix with cargo fmt, clippy, and nextest (3040 tests passed)


### Files changed

- `src/engine/runner/mod.rs`


Closes #2651

---
*Task #2651 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*