### PR TITLE
bug: set_fields has dead code from duplicate ALLOWED_FIELDS check

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1074,10 +1074,6 @@ impl TaskStore {
         let mut values: Vec<Option<String>> = Vec::new();
 
         for (col, val) in updates {
-            anyhow::ensure!(
-                ALLOWED_FIELDS.contains(col),
-                "column {col} is not in the update allowlist"
-            );
             set_parts.push(format!("{col} = ?"));
             match val {
                 serde_json::Value::String(s) => values.push(Some(s.clone())),
@@ -1427,10 +1423,6 @@ impl TaskStore {
             let mut set_parts = Vec::new();
             let mut values: Vec<Option<String>> = Vec::new();
             for (col, val) in *entry_updates {
-                anyhow::ensure!(
-                    ALLOWED_FIELDS.contains(col),
-                    "column {col} is not in the update allowlist"
-                );
                 set_parts.push(format!("{col} = ?"));
                 match val {
                     serde_json::Value::String(s) => values.push(Some(s.clone())),


### PR DESCRIPTION
## Summary

Removed duplicate ALLOWED_FIELDS checks in set_fields and batch_set_fields functions to eliminate dead code.

### What was done

- Deleted redundant inner ALLOWED_FIELDS containment check in set_fields (lines 1077-1080)
- Deleted redundant inner ALLOWED_FIELDS containment check in batch_set_fields (lines 1430-1433)


### Files changed

- `src/store/tasks.rs`


Closes #2655

---
*Task #2655 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/nemotron-3-super-free`*