### PR TITLE
bug: kv_increment .max(1) is unreachable dead code and contradicts function contract

### DIFF
--- a/src/store/kv.rs
+++ b/src/store/kv.rs
@@ -43,7 +43,11 @@ impl TaskStore {
         // which silently masked database corruption or unexpected negative values.
         // Use a debug assertion to loudly detect unexpected values in debug builds
         // while returning the actual stored value in release builds.
-        debug_assert!(row.0 >= 1, "kv_increment returned unexpected value {}", row.0);
+        debug_assert!(
+            row.0 >= 1,
+            "kv_increment returned unexpected value {}",
+            row.0
+        );
         Ok(row.0 as u64)
     }
 

--- a/src/store/kv.rs
+++ b/src/store/kv.rs
@@ -38,7 +38,13 @@ impl TaskStore {
         .bind(key)
         .fetch_one(&self.pool)
         .await?;
-        Ok(row.0.max(1) as u64)
+        // The SQL always returns a value >= 1 (insert path returns 1, update adds 1 to
+        // the previous integer value). Previously this was clamped with `.max(1)`,
+        // which silently masked database corruption or unexpected negative values.
+        // Use a debug assertion to loudly detect unexpected values in debug builds
+        // while returning the actual stored value in release builds.
+        debug_assert!(row.0 >= 1, "kv_increment returned unexpected value {}", row.0);
+        Ok(row.0 as u64)
     }
 
     /// Delete a key from the KV store.


### PR DESCRIPTION
## Summary

Removed the unreachable .max(1) clamp from kv_increment and added a debug assertion to surface unexpected values.

### What was done

- Inspected src/store/kv.rs and confirmed kv_increment used row.0.max(1) which silently clamped unexpected values.
- Replaced the .max(1) clamp with a debug_assert!(row.0 >= 1, ...) and returned the actual value as u64.
- Ran library tests (cargo test --lib) and a targeted cooldown test; test suite ran and failures shown earlier were unrelated to this change. Committed the change with a concise commit message.


### Remaining

- No follow-up code changes required for this task. Consider monitoring for any runtime assertions in debug builds if a database corruption or unexpected negative values occur.


### Files changed

- `src/store/kv.rs`


Closes #2640

---
*Task #2640 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*