### PR TITLE
fix: treat exit-0 empty-output as silent failure with model cooldown

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -1170,6 +1170,17 @@ pub(crate) mod patterns {
             };
         }
 
+        // Exit 0 with empty output is a silent failure (common with GitHub Copilot
+        // models in opencode). Return Unknown with a deterministic message so the
+        // caller (fallback.rs) detects it and applies model cooldown + free-model
+        // retry instead of treating it as a generic success.
+        if exit_code == 0 && text.trim().is_empty() {
+            return AgentError::Unknown {
+                exit_code,
+                message: "empty-output-exit0".to_string(),
+            };
+        }
+
         if let Some(e) = detect_missing_tool(text) {
             return e;
         }

--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -383,7 +383,13 @@ pub async fn handle_error(
             // Exit 0 with empty output is a silent failure (common with GitHub
             // Copilot models in opencode).  Record a model-specific cooldown so
             // the same model is not retried on every subsequent task.
-            if *exit_code == 0 && message.is_empty() {
+            // Also matches when message == "empty-output-exit0" (from classify_from_text
+            // or the direct empty-output branch in mod.rs).
+            if *exit_code == 0
+                && (message.is_empty()
+                    || message == "empty-output-exit0"
+                    || message.starts_with("empty-output-exit0:"))
+            {
                 if let Some(m) = model_name {
                     // Use a 4-hour cooldown for silent exits instead of the default 1-hour
                     // model cooldown.  These models (especially github-copilot/* in opencode)

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -628,12 +628,14 @@ impl TaskRunner {
                 session_output.elapsed_secs,
             ))
         } else {
-            // Exit 0 but empty output — check stderr for clues
-            let combined = format!("{}{}", session_output.raw_stdout, session_output.raw_stderr);
-            Err(agents::patterns::classify_from_text(
-                session_output.exit_code,
-                &combined,
-            ))
+            // Exit 0 but empty output — silent model failure. Use Unknown with a
+            // deterministic message matching what fallback.rs expects so the
+            // model gets a cooldown and free-model retry is attempted.
+            Err(agents::AgentError::Unknown {
+                exit_code: session_output.exit_code,
+                message: "empty-output-exit0: opencode returned exit 0 with empty stdout"
+                    .to_string(),
+            })
         };
 
         // Write structured result.json for deterministic testing and debugging


### PR DESCRIPTION
## Summary

OpenCode on github-copilot/gemini-3.1-pro-preview exits 0 with no stdout, leading to:
- Empty `task_runs.error` (hard to debug)
- Parse failures treated as generic failures instead of silent model failures
- Wasted retries against the same silent model

This fix ensures exit 0 + empty stdout is caught early, produces a deterministic `Unknown{exit_code:0}` error with message `"empty-output-exit0"`, and triggers the 4-hour model cooldown + free-model retry path in `fallback.rs` instead of generic failure handling.

## Test plan

- [x] `cargo fmt -- --check` — passes
- [x] `cargo clippy --all-targets -- -D warnings` — no issues
- [x] `cargo nextest run` — 3050 tests passed, 19 skipped
- [x] Existing `silent_exit0_*` fallback tests continue to pass

## Files changed

| File | Change |
|------|--------|
| `src/engine/runner/agents/mod.rs` | `classify_from_text()` returns `Unknown{exit_code:0, message:"empty-output-exit0"}` when exit 0 + empty text |
| `src/engine/runner/mod.rs` | Exit-0 empty-output branch produces descriptive `Unknown` error directly instead of calling classify_from_text on empty combined output |
| `src/engine/runner/fallback.rs` | `Unknown{exit_code:0}` detection now also matches `"empty-output-exit0"` and `"empty-output-exit0:*"` messages, ensuring model cooldown + free-model retry fires |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task #2675 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*