### PR TITLE
bug: parse_link_next panics if Link header has '>' before '<' in rel=next part

### DIFF
--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -2770,6 +2770,9 @@ fn parse_link_next(headers: &header::HeaderMap) -> Option<String> {
             // Extract URL between < and >
             let start = part.find('<')? + 1;
             let end = part.find('>')?;
+            if start >= end {
+                return None;
+            }
             return Some(part[start..end].to_string());
         }
     }
@@ -3191,6 +3194,20 @@ mod tests {
         let mut headers = header::HeaderMap::new();
         // Malformed: no angle-bracket URL, just garbage
         headers.insert("link", "garbage; rel=\"next\"".parse().unwrap());
+        assert_eq!(parse_link_next(&headers), None);
+    }
+
+    #[test]
+    fn parse_link_next_none_when_gt_before_lt() {
+        let mut headers = header::HeaderMap::new();
+        headers.insert("link", ">junk; rel=\"next\"; <url>".parse().unwrap());
+        assert_eq!(parse_link_next(&headers), None); // should not panic
+    }
+
+    #[test]
+    fn parse_link_next_none_when_empty_url() {
+        let mut headers = header::HeaderMap::new();
+        headers.insert("link", "<>; rel=\"next\"".parse().unwrap());
         assert_eq!(parse_link_next(&headers), None);
     }
 


### PR DESCRIPTION
## Summary

Fixed `parse_link_next` in `src/github/http.rs` to return `None` when `end <= start` (preventing a panic on malformed Link headers with `>` before `<`, or empty `<>` URLs). Added two new unit tests covering both cases. All 12 `parse_link_next` tests pass; `cargo fmt` and `cargo clippy` are clean.

### Files changed

- `src/github/http.rs`


Closes #2692

---
*Task #2692 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*