### PR TITLE
bug: OutputBuffer::diff_and_update sends duplicate content when UTF-8 boundary falls mid-char

### DIFF
--- a/src/channels/capture.rs
+++ b/src/channels/capture.rs
@@ -337,9 +337,9 @@ impl OutputBuffer {
             // Same-length overwrite (e.g. spinner/progress refresh) — resync with full content.
             current_content.to_string()
         } else {
-            let mut offset = self.last_len.min(current_len);
-            while offset > 0 && !current_content.is_char_boundary(offset) {
-                offset -= 1;
+            let mut offset = self.last_len;
+            while offset < current_len && !current_content.is_char_boundary(offset) {
+                offset += 1;
             }
             String::from_utf8_lossy(&current_bytes[offset..]).to_string()
         };


### PR DESCRIPTION
## Summary

Fixed duplicate-content bug in `OutputBuffer::diff_and_update` (`src/channels/capture.rs:340-342`). Changed the UTF-8 boundary adjustment from decrementing backward (which re-included already-broadcast bytes) to incrementing forward, ensuring only bytes at or after `last_len` are sent. All 3058 tests pass.

### Files changed

- `src/channels/capture.rs`


Closes #2694

---
*Task #2694 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*