### PR TITLE
bug: list_all_by_status missing backend fallback for external tasks before first sync

### DIFF
--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -328,6 +328,9 @@ impl TaskManager {
             // (empty could mean "no tasks with this status" OR "store not yet synced").
             if !external.is_empty() || store.has_external_tasks(&self.repo).await {
                 tasks.extend(external.into_iter().map(|t| store_task_to_external(&t)));
+            } else {
+                // Store not synced yet — fall back to backend for external tasks
+                tasks.extend(self.backend.list_by_status(status).await?);
             }
         } else {
             // No store - get from backend


### PR DESCRIPTION
## Summary

Added backend fallback in list_all_by_status for the case where the store exists but has no external tasks yet (pre-first-sync). This mirrors the existing fallback logic in list_external_by_status and ensures cleanup.rs can find Done external tasks before the first sync completes.

### What was done

- Added else branch after has_external_tasks check in list_all_by_status (src/engine/tasks.rs:331-333) to fall back to backend.list_by_status when the store is not yet synced
- Verified cargo fmt, cargo clippy (0 warnings), and cargo nextest run (3058/3058 passed)
- Committed the fix


### Files changed

- `src/engine/tasks.rs`


Closes #2695

---
*Task #2695 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*