### PR TITLE
bug: git rebase --abort failures silently discarded in stash_rebase_restore — broken worktrees undetectable

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -261,22 +261,38 @@ pub(crate) async fn stash_rebase_restore(
             let stderr = String::from_utf8_lossy(&o.stderr).to_string();
             tracing::warn!(dir = %dir.display(), target_ref, err = %stderr, "rebase failed");
             if opts.abort_on_failure {
-                let _ = Command::new("git")
+                let abort = Command::new("git")
                     .args(["rebase", "--abort"])
                     .current_dir(dir)
                     .output_with_context()
                     .await;
+                match abort {
+                    Err(e) => tracing::warn!(dir = %dir.display(), error = %e, "git rebase --abort failed — worktree may be in inconsistent state"),
+                    Ok(o) if !o.status.success() => {
+                        let stderr = String::from_utf8_lossy(&o.stderr);
+                        tracing::warn!(dir = %dir.display(), stderr = %stderr, "git rebase --abort returned non-zero — worktree may be in inconsistent state");
+                    }
+                    _ => {}
+                }
             }
             restore_stash_by_hash(dir, stash_ref.as_deref()).await;
             Ok(RebaseOutcome::Failed(stderr))
         }
         Err(e) => {
             if opts.abort_on_failure {
-                let _ = Command::new("git")
+                let abort = Command::new("git")
                     .args(["rebase", "--abort"])
                     .current_dir(dir)
                     .output_with_context()
                     .await;
+                match abort {
+                    Err(e) => tracing::warn!(dir = %dir.display(), error = %e, "git rebase --abort failed — worktree may be in inconsistent state"),
+                    Ok(o) if !o.status.success() => {
+                        let stderr = String::from_utf8_lossy(&o.stderr);
+                        tracing::warn!(dir = %dir.display(), stderr = %stderr, "git rebase --abort returned non-zero — worktree may be in inconsistent state");
+                    }
+                    _ => {}
+                }
             }
             restore_stash_by_hash(dir, stash_ref.as_deref()).await;
             Err(e)

--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -267,7 +267,9 @@ pub(crate) async fn stash_rebase_restore(
                     .output_with_context()
                     .await;
                 match abort {
-                    Err(e) => tracing::warn!(dir = %dir.display(), error = %e, "git rebase --abort failed — worktree may be in inconsistent state"),
+                    Err(e) => {
+                        tracing::warn!(dir = %dir.display(), error = %e, "git rebase --abort failed — worktree may be in inconsistent state")
+                    }
                     Ok(o) if !o.status.success() => {
                         let stderr = String::from_utf8_lossy(&o.stderr);
                         tracing::warn!(dir = %dir.display(), stderr = %stderr, "git rebase --abort returned non-zero — worktree may be in inconsistent state");
@@ -286,7 +288,9 @@ pub(crate) async fn stash_rebase_restore(
                     .output_with_context()
                     .await;
                 match abort {
-                    Err(e) => tracing::warn!(dir = %dir.display(), error = %e, "git rebase --abort failed — worktree may be in inconsistent state"),
+                    Err(e) => {
+                        tracing::warn!(dir = %dir.display(), error = %e, "git rebase --abort failed — worktree may be in inconsistent state")
+                    }
                     Ok(o) if !o.status.success() => {
                         let stderr = String::from_utf8_lossy(&o.stderr);
                         tracing::warn!(dir = %dir.display(), stderr = %stderr, "git rebase --abort returned non-zero — worktree may be in inconsistent state");


### PR DESCRIPTION
## Summary

Log git rebase --abort failures in stash_rebase_restore to avoid silent discard and detect inconsistent worktrees.

### What was done

- Inspected src/engine/runner/git_ops.rs and located stash_rebase_restore()
- Replaced silent `let _ = Command::new("git") ... rebase --abort` calls with logic that logs failures and non-zero exit statuses
- Ensured both call sites (rebase failure branch and rebase execution error branch) now warn on abort failures
- Searched repository for remaining occurrences of 'rebase --abort' to confirm updates


### Remaining

- Run full test suite / cargo nextest locally as part of CI to validate behavior under all rebase failure scenarios (not executed here)
- Optionally add unit/integration tests that simulate git failure cases to assert the warning behavior (would require git sandboxing in tests)


### Files changed

- `src/engine/runner/git_ops.rs`


Closes #2706

---
*Task #2706 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*