### PR TITLE
bug: restore_stash_by_hash silently orphans stash entries when hash lookup fails or drop fails

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -307,11 +307,37 @@ async fn restore_stash_by_hash(dir: &Path, stash_hash: Option<&str>) {
             if list_out.status.success() {
                 let list_str = String::from_utf8_lossy(&list_out.stdout);
                 if let Some(stash_ref) = find_stash_ref_by_hash(&list_str, stash_hash) {
-                    let _ = Command::new("git")
+                    match Command::new("git")
                         .args(["stash", "drop", &stash_ref])
                         .current_dir(dir)
                         .output_with_context()
-                        .await;
+                        .await
+                    {
+                        Ok(drop_out) if !drop_out.status.success() => {
+                            let stderr = String::from_utf8_lossy(&drop_out.stderr);
+                            tracing::warn!(
+                                dir = %dir.display(),
+                                stash_ref = %stash_ref,
+                                err = %stderr,
+                                "stash drop failed after apply — entry may remain on stack"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                dir = %dir.display(),
+                                stash_ref = %stash_ref,
+                                error = %e,
+                                "stash drop command failed after apply — entry may remain on stack"
+                            );
+                        }
+                        _ => {}
+                    }
+                } else {
+                    tracing::warn!(
+                        dir = %dir.display(),
+                        stash = %stash_hash,
+                        "stash applied but could not find ref by hash — stash entry may be orphaned on stack"
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary

Added explicit warning logs in stash-restore cleanup paths so hash lookup misses and stash-drop failures are no longer silent.

### What was done

- Updated `restore_stash_by_hash()` in `src/engine/runner/git_ops.rs` to warn when `find_stash_ref_by_hash` returns `None` after a successful stash apply.
- Replaced the silent `let _ = git stash drop` path with explicit handling that logs warnings when `git stash drop` exits non-zero.
- Added warning logging for `git stash drop` command execution errors (`Err(e)`) with path and stash ref context.
- Ran `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings` successfully.
- Ran focused tests: `cargo test find_stash_ref_by_hash -- --nocapture` (passed).
- Committed the change in `53f61fcf` with message: `fix: warn when stash restore cannot clean up stash entry`.


### Remaining

- Investigate and resolve unrelated failing test in full suite: `engine::tests::configured_agents_fallback_returns_default_agents`.
- Re-run full `cargo nextest run` after that failure is addressed.


### Files changed

- `src/engine/runner/git_ops.rs`


Closes #2707

---
*Task #2707 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*