### PR TITLE
bug: auto_commit silently discards git restore --staged failure — staged files leak across retries

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -379,11 +379,28 @@ pub async fn auto_commit(
         tracing::warn!(task_id, err = %stderr, "git commit failed");
         // Unstage files so has_changes() sees them as unstaged on the next
         // check and the workflow can retry the commit cleanly.
-        let _ = Command::new("git")
+        let restore = Command::new("git")
             .args(["restore", "--staged", "."])
             .current_dir(dir)
             .output_with_context()
             .await;
+        match restore {
+            Ok(o) if !o.status.success() => {
+                tracing::warn!(
+                    task_id,
+                    stderr = %String::from_utf8_lossy(&o.stderr),
+                    "git restore --staged failed after commit failure — files remain staged"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    task_id,
+                    error = %e,
+                    "git restore --staged command failed after commit failure — files remain staged"
+                );
+            }
+            _ => {}
+        }
         return Ok(false);
     }
 


### PR DESCRIPTION
## Summary

Fixed silent discarding of git restore --staged failure in auto_commit() — now logs warning when cleanup fails after commit failure

### What was done

- Added proper error handling for git restore --staged . after commit failure with warning logs
- Handles both non-success exit status and command execution errors
- Makes root cause visible in logs when files remain staged across retries


### Files changed

- `src/engine/runner/git_ops.rs`


Closes #2708

---
*Task #2708 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*