### PR TITLE
fix(#2705): tasks marked done without PR — three root causes

### DIFF
--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -662,8 +662,11 @@ pub(crate) async fn review_open_prs(
             continue;
         }
 
-        // If the PR is fully approved but auto-close is disabled, advance the
-        // task state so it doesn't get repeatedly re-reviewed.
+        // If the PR is fully approved but auto-close is disabled, the task stays
+        // in_review waiting for a human to merge the PR.  We must NOT mark it Done
+        // here — the PR has not been merged, so the work is not complete.
+        // Once the human merges the PR, `already_merged` will be true on the next
+        // poll tick and the task will transition to Done correctly.
         if (all_approved || comment_approved)
             && !comment_changes_requested
             && !any_changes_requested
@@ -698,13 +701,15 @@ pub(crate) async fn review_open_prs(
                     }
                 }
 
-                tracing::info!(task_id, pr_number, comment_approved, "PR approved (auto_close disabled) — marking task done and leaving PR open for human merge");
-                if let Err(e) = task_manager
-                    .update_task_status(&task.id, Status::Done)
-                    .await
-                {
-                    tracing::warn!(task_id, err = %e, "failed to update task status to done");
-                }
+                // PR approved but not yet merged and auto_close is disabled —
+                // leave task in in_review so a human can merge it manually.
+                // Do NOT mark Done: the PR merge is the actual completion signal.
+                tracing::info!(
+                    task_id,
+                    pr_number,
+                    comment_approved,
+                    "PR approved (auto_close disabled) — leaving task in_review until PR is merged"
+                );
             }
             continue;
         }

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -557,6 +557,35 @@ pub fn synthesize_response_from_text(text: &str) -> Option<AgentResponse> {
                 break;
             }
         }
+
+        // Past-tense action verb at sentence start indicates a completed action
+        // (e.g. "Added detect_rate_limit patterns", "Fixed the nil-pointer bug").
+        // Accept only for short sentences without hedging language to avoid matching
+        // prose like "I added a note that this might fail later".
+        let past_tense_actions = [
+            "added ",
+            "fixed ",
+            "updated ",
+            "implemented ",
+            "created ",
+            "removed ",
+            "changed ",
+            "deleted ",
+            "applied ",
+            "resolved ",
+            "patched ",
+            "refactored ",
+            "merged ",
+            "pushed ",
+            "deployed ",
+        ];
+        if !contains_hedge
+            && word_count <= 12
+            && past_tense_actions.iter().any(|v| s_lower.starts_with(v))
+        {
+            done_confident = true;
+            break;
+        }
     }
 
     let looks_done = !looks_negative && (explicit_done || done_confident);
@@ -575,8 +604,16 @@ pub fn synthesize_response_from_text(text: &str) -> Option<AgentResponse> {
         "needs_review"
     } else if looks_done {
         "done"
-    } else {
+    } else if looks_negative {
+        // Agent explicitly stated the task is not complete — surface for human review.
         "needs_review"
+    } else {
+        // Text is ambiguous: no error signal, no completion signal, no explicit negation.
+        // This happens when agents emit exploratory or startup text (e.g. "Let's go!",
+        // "I need to find where...") and exit without producing structured JSON.
+        // Returning None causes callers to treat this as an invalid response and reroute
+        // the task rather than falsely advancing it to needs_review / in_review.
+        return None;
     };
 
     let summary_end = truncate_at_char_boundary(trimmed, 500);
@@ -1788,6 +1825,33 @@ mod tests {
         assert!(synthesize_response_from_text("   \n\t  ").is_none());
     }
 
+    // Regression: opencode/nemotron-3-super-free and similar models sometimes exit
+    // with code 0 after emitting only exploratory or startup text (e.g. "Let's go!",
+    // planning prose) without completing any work.  The synthesis must return None for
+    // such ambiguous text so the runner treats the run as an invalid response and
+    // reroutes the task instead of falsely advancing it to needs_review / in_review.
+    // (Issues #2404, #2653, #2666)
+    #[test]
+    fn synthesize_response_returns_none_for_ambiguous_startup_text() {
+        // Short greeting — not an error, not done, not an explicit negation.
+        assert!(
+            synthesize_response_from_text("Let's go!").is_none(),
+            "startup greeting must not synthesize as needs_review"
+        );
+        // Exploratory planning prose — agent is thinking out loud, not reporting completion.
+        assert!(
+            synthesize_response_from_text(
+                "I need to find where the stream command is implemented. \
+                 Looking at the CLI structure, it seems like the stream functionality \
+                 might be in the task module or another file. Let me check the CLI \
+                 command structure. First, let me look at the task module since stream \
+                 is related to tasks."
+            )
+            .is_none(),
+            "exploratory prose must not synthesize as needs_review"
+        );
+    }
+
     #[test]
     fn synthesize_response_does_not_mark_done_for_incomplete() {
         let response = synthesize_response_from_text("The task is incomplete").unwrap();
@@ -1861,16 +1925,21 @@ mod tests {
     fn synthesize_response_rejects_exploratory_prose() {
         // Regression test: ensure exploratory analysis that mentions "let me check"
         // or planning language is NOT synthesized into a "done" completion.
+        // With the ambiguous-text fix, this text correctly returns None (treated as
+        // an invalid response / reroute signal) rather than synthesizing needs_review.
+        // Crucially, it must NOT be marked "done".
         let exploratory = "I explored the codebase and found several .expect()/.unwrap() uses.\n\nLet me check each occurrence directly and run the tests to be sure. I may commit fixes afterwards.";
-        let response = synthesize_response_from_text(exploratory).unwrap();
-        assert_eq!(
-            response.status, "needs_review",
-            "Exploratory prose must not be auto-marked done"
-        );
-        assert!(
-            response.error.is_some(),
-            "Exploratory plain text should surface an error note"
-        );
+        match synthesize_response_from_text(exploratory) {
+            None => {
+                // Ambiguous exploratory prose correctly returns None — not marked done.
+            }
+            Some(resp) => {
+                assert_ne!(
+                    resp.status, "done",
+                    "Exploratory prose must not be auto-marked done"
+                );
+            }
+        }
     }
 
     #[test]
@@ -2531,13 +2600,19 @@ mod tests {
 
     #[test]
     fn synthesize_no_false_positive_file_paths() {
-        // URLs and version strings should not appear in files list
+        // URLs and version strings should not appear in files list.
+        // The text is ambiguous (no error, no done signal, no explicit negation) so
+        // synthesize_response_from_text returns None — no file extraction happens.
         let text = "See https://example.com/foo.rs for details. Version 1.2.3 is fine.";
-        let resp = synthesize_response_from_text(text).unwrap();
-        assert!(
-            resp.files.is_empty(),
-            "expected no file paths extracted from URL text, got: {:?}",
-            resp.files
-        );
+        match synthesize_response_from_text(text) {
+            None => {} // Ambiguous text correctly returns None — no files extracted.
+            Some(resp) => {
+                assert!(
+                    resp.files.is_empty(),
+                    "expected no file paths extracted from URL text, got: {:?}",
+                    resp.files
+                );
+            }
+        }
     }
 }

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -2126,14 +2126,15 @@ mod tests {
 
     #[test]
     fn parse_success_output_no_tokens_when_ndjson_has_none() {
-        // Plain text without token metadata
-        let text = "This is just a plain text response, not JSON at all.";
+        // Plain text with an explicit completion signal but no token metadata.
+        // Uses "No open positions" which is in the explicit_done list.
+        let text = "No open positions, no trade executions, no conditions change.";
 
         let runner = FailingMockRunner;
         let result = parse_success_output("1551", "opencode", &runner, text);
 
-        // Should still synthesize a response, but without tokens
-        let parsed = result.expect("should synthesize response from text");
+        // Should synthesize a "done" response, but without tokens (no NDJSON envelope).
+        let parsed = result.expect("should synthesize response from explicit-done text");
         assert_eq!(parsed.input_tokens, None);
         assert_eq!(parsed.output_tokens, None);
     }

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -311,26 +311,21 @@ pub fn spawn(
                                     tracing::warn!(task_id = %tid, err = %e, "failed to write needs_review_refires to store");
                                 }
 
-                                // Ensure approved PRs do not re-enter the review loop
-                                // when `auto_close_task_on_approval` is disabled.
-                                // The review gate normally marks Done when appropriate
-                                // but being defensive here prevents event-driven
-                                // re-dispatch races from leaving the task in InReview.
-                                let auto_close = crate::config::get("workflow.auto_close_task_on_approval")
-                                    .or_else(|_| crate::config::get("workflow.auto_close"))
-                                    .or_else(|_| crate::config::get("workflow.auto_merge"))
-                                    .map(|v| v.eq_ignore_ascii_case("true"))
-                                    .unwrap_or(false);
-
-                                if !auto_close {
-                                    tracing::info!(task_id = tid, "approval received (auto_close disabled) — marking task Done to avoid re-review");
-                                    if let Err(e) = task_manager_c
-                                        .update_task_status(&ExternalId(tid.clone()), Status::Done)
-                                        .await
-                                    {
-                                        tracing::warn!(task_id = %tid, err = %e, "failed to set Done after approval; task may still be InReview");
-                                    }
-                                }
+                                // When auto_close_task_on_approval is disabled the PR
+                                // merge is the actual completion signal — the review
+                                // agent approval only means the code looks good.  Marking
+                                // Done here (before the merge) causes tasks to appear
+                                // complete when no PR was ever merged (#2705).
+                                //
+                                // Leave the task in InReview.  The review_open_prs polling
+                                // loop detects `batch_data.merged == true` on the next tick
+                                // and transitions the task to Done correctly.  The review
+                                // agent will NOT be re-dispatched because the task never
+                                // returns to NeedsReview.
+                                tracing::info!(
+                                    task_id = tid,
+                                    "approval received (auto_close disabled) — leaving task in_review until PR is merged by a human"
+                                );
                                 ReviewOutcome::Ok
                             }
                             Ok(ReviewDecision::Rerouted) => {


### PR DESCRIPTION
## Summary

- **Bug 1** (`synthesize_response_from_text`): ambiguous plain text (startup messages like "Let's go!", planning prose from opencode/nemotron-3-super-free) defaulted to `needs_review`, advancing tasks through the review pipeline with no real work done. Fixed to return `None` so callers reroute instead.
- **Bug 2** (`review_poll.rs`): `review_open_prs` marked tasks `Done` when a PR was approved but not yet merged with `auto_close_task_on_approval=false`. Fixed to leave task `in_review` until actual merge.
- **Bug 3** (`subscribers/review.rs`): review subscriber marked tasks `Done` on approval when `auto_close=false`. Fixed to log and return `Ok`; the polling loop handles merge detection.

Also adds past-tense action verb detection ("Added X", "Fixed Y") so real completion summaries still parse correctly as done.

## Test plan

- [ ] `cargo nextest run` passes (3061 pass, 2 pre-existing env-specific failures unrelated to these changes)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt -- --check` clean
- [ ] Manually verify: tasks with ambiguous opencode output no longer advance to `needs_review`
- [ ] Manually verify: PR approval with `auto_close=false` leaves task `in_review`

## Affected issues

Re-created as new issues: #2712 (was #2653), #2713 (was #2404), #2714 (was #2666), #2715 (was #2622)

Closes #2705

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task #2705 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*