### PR TITLE
bug: task_runs.error is polluted with 'no error info available' even when outcome=success

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -344,17 +344,33 @@ impl TaskRunner {
             .get_field(input.task_id, "last_error")
             .await
             .filter(|s| !s.is_empty());
-        let error = match input.error_override.clone().or_else(|| last_error.clone()) {
-            Some(e) if !e.is_empty() => e,
-            _ => match input.parse_result {
-                Ok(parsed) => parsed.response.error.clone().unwrap_or_default(),
-                Err(err) => err.to_string(),
-            },
-        };
-        let error = if error.is_empty() {
-            "no error info available".to_string()
+        let outcome = classify_run_outcome(
+            input.status,
+            input.parse_result,
+            input.push_failed,
+            input.budget_exceeded,
+        )
+        .to_string();
+
+        let error = if outcome == "success" {
+            String::new()
         } else {
-            error
+            let error = match input.error_override.as_deref().filter(|s| !s.is_empty()) {
+                Some(error_override) => error_override.to_string(),
+                None => match last_error {
+                    Some(last_error) => last_error,
+                    None => match input.parse_result {
+                        Ok(parsed) => parsed.response.error.clone().unwrap_or_default(),
+                        Err(err) => err.to_string(),
+                    },
+                },
+            };
+
+            if error.is_empty() {
+                "no error info available".to_string()
+            } else {
+                error
+            }
         };
 
         let total_cost_usd = match &self.store {
@@ -377,13 +393,7 @@ impl TaskRunner {
             stdout: input.raw_stdout.to_string(),
             stderr: input.raw_stderr.to_string(),
             parsed_response: serialize_parsed_response(input.parse_result, input.raw_stdout),
-            outcome: classify_run_outcome(
-                input.status,
-                input.parse_result,
-                input.push_failed,
-                input.budget_exceeded,
-            )
-            .to_string(),
+            outcome,
             error,
             input_tokens,
             output_tokens,
@@ -1464,12 +1474,35 @@ mod tests {
     use super::*;
     use crate::backends::{ExternalId, ExternalTask, Mention, Status};
     use crate::engine::runner::agents::patterns::safe_tail as safe_utf8_tail;
+    use crate::parser::AgentResponse;
+    use crate::store::{NewTask, TaskStore};
     use async_trait::async_trait;
+    use chrono::Utc;
     use once_cell::sync::Lazy;
     use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
 
     static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    fn ok_parse_result(status: &str) -> Result<agents::ParsedResponse, agents::AgentError> {
+        Ok(agents::ParsedResponse {
+            response: AgentResponse {
+                status: status.to_string(),
+                summary: String::new(),
+                accomplished: vec![],
+                remaining: vec![],
+                files: vec![],
+                error: None,
+                input_tokens: None,
+                output_tokens: None,
+                learnings: vec![],
+                delegations: vec![],
+            },
+            input_tokens: None,
+            output_tokens: None,
+            duration_ms: None,
+        })
+    }
 
     // ── safe_utf8_tail ───────────────────────────────────────────────────────
 
@@ -1693,6 +1726,72 @@ mod tests {
             classify_run_error_type("billing account suspended"),
             "failed"
         );
+    }
+
+    #[tokio::test]
+    async fn build_run_audit_success_ignores_stale_last_error() {
+        let store = Arc::new(TaskStore::open_memory().await.unwrap());
+        let task_id = store
+            .create(&NewTask {
+                repo: "owner/repo".to_string(),
+                origin: "internal".to_string(),
+                title: "Test".to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        store
+            .set_fields(
+                task_id,
+                &[("last_error", serde_json::json!("no error info available"))],
+            )
+            .await
+            .unwrap();
+
+        let runner = TaskRunner::new("owner/repo".to_string()).with_store(store);
+        let parse_result = ok_parse_result("done");
+        let started_at = Utc::now();
+        let audit = runner
+            .build_run_audit(RunAuditInput {
+                task_id: &task_id.to_string(),
+                status: "done",
+                parse_result: &parse_result,
+                raw_stdout: "",
+                raw_stderr: "",
+                started_at: &started_at,
+                error_override: None,
+                elapsed_secs: Some(1),
+                push_failed: false,
+                budget_exceeded: false,
+            })
+            .await;
+
+        assert_eq!(audit.outcome, "success");
+        assert!(audit.error.is_empty());
+    }
+
+    #[tokio::test]
+    async fn build_run_audit_non_success_uses_fallback_error_when_empty() {
+        let runner = TaskRunner::new("owner/repo".to_string());
+        let parse_result = ok_parse_result("new");
+        let started_at = Utc::now();
+        let audit = runner
+            .build_run_audit(RunAuditInput {
+                task_id: "1",
+                status: "new",
+                parse_result: &parse_result,
+                raw_stdout: "",
+                raw_stderr: "",
+                started_at: &started_at,
+                error_override: None,
+                elapsed_secs: Some(1),
+                push_failed: false,
+                budget_exceeded: false,
+            })
+            .await;
+
+        assert_eq!(audit.outcome, "failed");
+        assert_eq!(audit.error, "no error info available");
     }
 
     // ── resolve_project_dir ──────────────────────────────────────────────────

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1667,7 +1667,7 @@ impl TaskStore {
         sqlx::query(
             "UPDATE task_runs SET
             exit_code = ?, stdout = ?, stderr = ?, parsed_response = ?,
-            outcome = ?, error = ?,
+            outcome = ?, error = NULLIF(?, ''),
             input_tokens = ?, output_tokens = ?, total_cost_usd = ?,
             duration_secs = ?,
             completed_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -759,6 +759,56 @@ async fn task_runs_lifecycle() {
 }
 
 #[tokio::test]
+async fn complete_run_stores_null_error_for_empty_string() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let task_id = store
+        .create(&NewTask {
+            repo: "owner/repo".to_string(),
+            origin: "internal".to_string(),
+            title: "Test".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let run_id = store
+        .start_run(&StartRun {
+            task_id,
+            attempt: 1,
+            run_type: "agent",
+            agent: "claude",
+            model: "sonnet",
+            command: "claude -p ...",
+            prompt: "system prompt",
+        })
+        .await
+        .unwrap();
+
+    store
+        .complete_run(&CompleteRun {
+            run_id,
+            exit_code: Some(0),
+            stdout: "",
+            stderr: "",
+            parsed: "{}",
+            outcome: "success",
+            error: "",
+            tokens: RunTokenUsage::default(),
+        })
+        .await
+        .unwrap();
+
+    let stored_error: Option<String> =
+        sqlx::query_scalar("SELECT error FROM task_runs WHERE id = ?")
+            .bind(run_id)
+            .fetch_one(&store.pool)
+            .await
+            .unwrap();
+    assert_eq!(stored_error, None);
+}
+
+#[tokio::test]
 async fn set_fields_updates_task() {
     let store = TaskStore::open_memory().await.unwrap();
 


### PR DESCRIPTION
## Summary

Fixed run-audit error handling so successful task runs no longer persist synthetic error text, and added regressions to lock behavior at runner and store layers.

### What was done

- Updated `TaskRunner::build_run_audit` in `src/engine/runner/mod.rs` to compute `outcome` first and force empty error for `outcome == "success"`.
- Restricted placeholder injection (`"no error info available"`) to non-success outcomes only, preserving diagnostic fallback for failed/non-success runs with empty extracted errors.
- Added runner regression tests in `src/engine/runner/mod.rs` for: success run ignores stale `last_error`, and non-success run with empty extracted detail gets fallback placeholder.
- Updated `TaskStore::complete_run` in `src/store/tasks.rs` to store `task_runs.error` as SQL `NULL` when the provided error string is empty via `NULLIF(?, '')`.
- Added store regression test `complete_run_stores_null_error_for_empty_string` in `src/store/tests.rs` to verify DB-level `NULL` persistence for empty error strings.
- Ran targeted tests for the new cases; all passed.
- Ran `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings`; both passed.
- Committed changes in `4671315d` with message: `fix: stop polluting successful task_runs with placeholder error`.


### Remaining

- Full `cargo nextest run` currently fails on unrelated existing test `engine::tests::configured_agents_fallback_returns_default_agents` (also fails in isolated run), so full green test suite was not achieved in this attempt.


### Files changed

- `src/engine/runner/mod.rs`
- `src/store/tasks.rs`
- `src/store/tests.rs`


Closes #2718

---
*Task #2718 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*