### PR TITLE
router: holding skills_catalog Mutex across spawn_blocking await

### DIFF
--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -685,15 +685,16 @@ impl LlmRouter {
     /// Load skills catalog from skills.yml or skills directory.
     /// Cached after first load to avoid blocking I/O in async context.
     async fn load_skills_catalog(&self) -> anyhow::Result<String> {
-        let mut cache = self.skills_catalog.lock().await;
-        if let Some(ref catalog) = *cache {
-            return Ok(catalog.clone());
-        }
+        // First, check the cache with a short-lived lock
+        {
+            let cache = self.skills_catalog.lock().await;
+            if let Some(ref catalog) = *cache {
+                return Ok(catalog.clone());
+            }
+        } // Lock is dropped here
 
-        // Offload uncached loading to blocking thread pool to avoid blocking the Tokio reactor.
-        // Clone any data we need to avoid capturing &self across thread boundary.
-        // Holding the tokio::sync::Mutex across .await is safe — it doesn't block a worker thread,
-        // it just suspends the task. This ensures only one caller does the I/O work.
+        // Cache miss — offload loading to blocking thread pool.
+        // Capture only what we need to avoid holding any locks across the await.
         let skills_dir_opt: Option<PathBuf> = match std::env::var("ORCH_HOME") {
             Ok(orch_home) => Some(PathBuf::from(orch_home).join("skills")),
             Err(_) => None,
@@ -730,6 +731,8 @@ impl LlmRouter {
         .await
         .map_err(|e| anyhow::anyhow!("spawn_blocking failed: {e}"))?;
 
+        // Update the cache with a second short-lived lock
+        let mut cache = self.skills_catalog.lock().await;
         *cache = Some(catalog.clone());
 
         Ok(catalog)


### PR DESCRIPTION
## Summary

The fix is complete. Here's a summary:

## Fix Applied: Router Skills Catalog Mutex Scope Limitation

**Problem**: `load_skills_catalog()` was holding the `skills_catalog` Mutex across the `spawn_blocking().await` call, serializing all router calls when the catalog needed to be loaded from disk.

**Solution**: Limited the MutexGuard scope by:
1. Acquiring lock only briefly to check the cache (drops immediately)
2. If cache miss, performing blocking I/O WITHOUT holding any lock
3. Re-acquiring lo

### What was done

- Problem**: `load_skills_catalog()` was holding the `skills_catalog` Mutex across the `spawn_blocking().await` call, serializing all router calls when the catalog needed to be loaded from disk.
- Acquiring lock only briefly to check the cache (drops immediately)
- If cache miss, performing blocking I/O WITHOUT holding any lock
- Re-acquiring lock only to update the cache after I/O completes
- Changes**: `src/engine/router/llm.rs` - 11 insertions, 8 deletions
- ✅ `cargo fmt -- --check` passes
- ✅ `cargo clippy --all-targets -- -D warnings` passes
- ✅ All 112 llm-specific tests pass
- ✅ All 144 router tests pass
- Note**: The failing test `engine::tests::configured_agents_fallback_returns_default_agents` is a pre-existing issue (fails before my changes too) and unrelated to this fix. It should be addressed in a separate issue.


### Files changed

- `src/engine/router/llm.rs`


Closes #2714

---
*Task #2714 · Created by glm[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*