### PR TITLE
bug: token accounting still uses unchecked signed/unsigned casts in control/store helpers

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -498,6 +498,27 @@ pub struct InvokeResult {
     pub output_tokens: Option<u64>,
 }
 
+fn token_u64_to_i64_saturating(tokens: u64) -> i64 {
+    i64::try_from(tokens).unwrap_or(i64::MAX)
+}
+
+fn opt_token_u64_to_i64_saturating(tokens: Option<u64>) -> Option<i64> {
+    tokens.map(token_u64_to_i64_saturating)
+}
+
+fn total_tokens_u64_to_i64_saturating(
+    input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+) -> Option<i64> {
+    match (input_tokens, output_tokens) {
+        (Some(input), Some(output)) => {
+            Some(token_u64_to_i64_saturating(input.saturating_add(output)))
+        }
+        (Some(tokens), None) | (None, Some(tokens)) => Some(token_u64_to_i64_saturating(tokens)),
+        _ => None,
+    }
+}
+
 /// Prepare temp directory for agent invocation files.
 ///
 /// Uses `~/.orch/state/control/{pid}/` for isolation between concurrent processes.
@@ -753,16 +774,10 @@ pub async fn send_message(
     persist_memories(store, session_id, &parsed.memories).await?;
 
     // Store assistant message with token usage
-    let total_tokens = match (result.input_tokens, result.output_tokens) {
-        // Use saturating_add + try_from to avoid u64 overflow and prevent
-        // casting a large u64 into a negative i64. If the sum doesn't fit
-        // into i64, cap to i64::MAX (matches store/tasks.rs pattern).
-        (Some(i), Some(o)) => Some(i64::try_from(i.saturating_add(o)).unwrap_or(i64::MAX)),
-        (Some(t), None) | (None, Some(t)) => Some(t as i64),
-        _ => None,
-    };
-    let input_tokens = result.input_tokens.map(|t| t as i64);
-    let output_tokens = result.output_tokens.map(|t| t as i64);
+    let total_tokens =
+        total_tokens_u64_to_i64_saturating(result.input_tokens, result.output_tokens);
+    let input_tokens = opt_token_u64_to_i64_saturating(result.input_tokens);
+    let output_tokens = opt_token_u64_to_i64_saturating(result.output_tokens);
     let cost_usd = match (result.input_tokens, result.output_tokens) {
         (Some(input), Some(output)) => {
             let pricing = crate::store::pricing_for_model(&model);
@@ -1136,6 +1151,27 @@ mod tests {
         );
     }
 
+    #[test]
+    fn token_u64_to_i64_saturating_caps_large_values() {
+        assert_eq!(token_u64_to_i64_saturating(u64::MAX), i64::MAX);
+    }
+
+    #[test]
+    fn total_tokens_u64_to_i64_saturating_caps_single_large_value() {
+        assert_eq!(
+            total_tokens_u64_to_i64_saturating(Some(u64::MAX), None),
+            Some(i64::MAX)
+        );
+    }
+
+    #[test]
+    fn total_tokens_u64_to_i64_saturating_caps_large_sum() {
+        assert_eq!(
+            total_tokens_u64_to_i64_saturating(Some(u64::MAX), Some(1)),
+            Some(i64::MAX)
+        );
+    }
+
     #[tokio::test]
     async fn insert_control_message_stores_cost_usd() {
         use crate::store::{pricing_for_model, TokenUsage};
@@ -1161,9 +1197,9 @@ mod tests {
                 Some("greeted"),
                 Some("sonnet"),
                 Some("claude"),
-                Some(input_tokens as i64),
-                Some(output_tokens as i64),
-                Some((input_tokens + output_tokens) as i64),
+                opt_token_u64_to_i64_saturating(Some(input_tokens)),
+                opt_token_u64_to_i64_saturating(Some(output_tokens)),
+                total_tokens_u64_to_i64_saturating(Some(input_tokens), Some(output_tokens)),
                 cost_usd,
             )
             .await

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -8,6 +8,10 @@ use crate::store::{CostEstimate, MemoryEntry, Task, TaskStore, TokenUsage};
 use anyhow::anyhow;
 use std::sync::Arc;
 
+fn token_i64_to_u64_non_negative(tokens: i64) -> u64 {
+    u64::try_from(tokens.max(0)).unwrap_or(0)
+}
+
 /// Resolve a task's numeric store ID from its external identifier.
 ///
 /// Returns `None` if the store is unavailable, the task is not found, or the
@@ -365,8 +369,8 @@ pub async fn get_token_usage(
         if let Ok(Some(store_id)) = s.resolve_task_id(repo, task_id).await {
             if let Ok(task) = s.get(store_id).await {
                 return TokenUsage {
-                    input_tokens: task.input_tokens as u64,
-                    output_tokens: task.output_tokens as u64,
+                    input_tokens: token_i64_to_u64_non_negative(task.input_tokens),
+                    output_tokens: token_i64_to_u64_non_negative(task.output_tokens),
                 };
             }
         }
@@ -409,8 +413,8 @@ pub async fn get_token_summary(
         if let Ok(Some(store_id)) = s.resolve_task_id(repo, task_id).await {
             if let Ok(task) = s.get(store_id).await {
                 let usage = TokenUsage {
-                    input_tokens: task.input_tokens as u64,
-                    output_tokens: task.output_tokens as u64,
+                    input_tokens: token_i64_to_u64_non_negative(task.input_tokens),
+                    output_tokens: token_i64_to_u64_non_negative(task.output_tokens),
                 };
                 let total = usage.total_tokens();
                 let cost = CostEstimate {

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -288,6 +288,72 @@ async fn helper_get_token_usage_from_store() {
 }
 
 #[tokio::test]
+async fn helper_get_token_usage_negative_tokens_clamp_to_zero() {
+    let store = Arc::new(TaskStore::open_memory().await.unwrap());
+    let id = store
+        .create(&NewTask {
+            external_id: Some("701".to_string()),
+            repo: "owner/repo".to_string(),
+            origin: "github".to_string(),
+            title: "Negative token test".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    store
+        .set_fields(
+            id,
+            &[
+                ("input_tokens", serde_json::json!(-42)),
+                ("output_tokens", serde_json::json!(8)),
+            ],
+        )
+        .await
+        .unwrap();
+
+    let opt_store = Some(store);
+    let usage = get_token_usage(&opt_store, "owner/repo", "701").await;
+    assert_eq!(usage.input_tokens, 0);
+    assert_eq!(usage.output_tokens, 8);
+    assert_eq!(usage.total_tokens(), 8);
+}
+
+#[tokio::test]
+async fn helper_get_token_summary_negative_tokens_clamp_to_zero() {
+    let store = Arc::new(TaskStore::open_memory().await.unwrap());
+    let id = store
+        .create(&NewTask {
+            external_id: Some("702".to_string()),
+            repo: "owner/repo".to_string(),
+            origin: "github".to_string(),
+            title: "Negative summary token test".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    store
+        .set_fields(
+            id,
+            &[
+                ("input_tokens", serde_json::json!(-5)),
+                ("output_tokens", serde_json::json!(10)),
+                ("input_cost_usd", serde_json::json!(0.05)),
+                ("output_cost_usd", serde_json::json!(0.15)),
+                ("total_cost_usd", serde_json::json!(0.20)),
+            ],
+        )
+        .await
+        .unwrap();
+
+    let opt_store = Some(store);
+    let (total_tokens, cost) = get_token_summary(&opt_store, "owner/repo", "702").await;
+    assert_eq!(total_tokens, 10);
+    assert!((cost.total_cost_usd - 0.20).abs() < f64::EPSILON);
+}
+
+#[tokio::test]
 async fn helper_get_cost_estimate_from_store() {
     let store = Arc::new(TaskStore::open_memory().await.unwrap());
     let id = store


### PR DESCRIPTION
## Summary

Replaced unchecked token casts with saturating/checked conversions in control and store helper paths, and added regression tests for oversized/negative token cases.

### What was done

- Updated control token accounting to use centralized saturating helpers instead of unchecked `u64 -> i64` casts in assistant message persistence.
- Updated store token readers to clamp negative persisted token counters to zero before converting to `u64` in `get_token_usage` and `get_token_summary`.
- Added control regression tests covering `u64::MAX` single-value and summed token conversion behavior.
- Added store regression tests verifying negative stored token values do not wrap to huge `u64` totals.
- Ran `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings` successfully.
- Ran targeted tests successfully: `cargo test token_u64_to_i64_saturating_caps_large_values`, `cargo test helper_get_token_usage_negative_tokens_clamp_to_zero`, `cargo test helper_get_token_summary_negative_tokens_clamp_to_zero`.
- Committed changes as `0f10dcf8` with message `fix: harden token accounting casts in control and store helpers`.


### Remaining

- Investigate/resolve unrelated full-suite failure in `cargo nextest run`: `engine::tests::configured_agents_fallback_returns_default_agents` (assertion on default agents).


### Files changed

- `src/control.rs`
- `src/store/helpers.rs`
- `src/store/tests.rs`


Closes #2727

---
*Task #2727 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*