### PR TITLE
bug: event-driven dispatch holds router RwLock read guard across awaits

### DIFF
--- a/src/engine/subscribers/dispatch.rs
+++ b/src/engine/subscribers/dispatch.rs
@@ -13,6 +13,25 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tokio::sync::{mpsc, RwLock, Semaphore};
 
+type SessionMap = std::collections::HashMap<String, bool>;
+
+async fn prepare_dispatch_context<F>(
+    router_arc: &Arc<RwLock<Router>>,
+    session_map_fut: F,
+) -> (crate::engine::tick::DispatchMode, SessionMap)
+where
+    F: std::future::Future<Output = SessionMap>,
+{
+    // Keep lock scope minimal: snapshot router state, then drop the guard
+    // before awaiting session/dispatch work.
+    let dispatch_mode = {
+        let router_guard = router_arc.read().await;
+        crate::engine::tick::dispatch_mode_from_router(&router_guard)
+    };
+    let session_map = session_map_fut.await;
+    (dispatch_mode, session_map)
+}
+
 /// Spawn a task that listens for Routed events and dispatches agents.
 ///
 /// This mirrors the logic in `tick_dispatch_tasks` but triggers instantly
@@ -41,8 +60,8 @@ pub fn spawn(
                     // Delegate to existing dispatch logic.
                     // The dispatching set guard inside tick_dispatch_tasks
                     // prevents double-dispatch if the tick loop also picks this up.
-                    let router_guard = router_arc.read().await;
-                    let session_map = tmux.batch_session_active().await;
+                    let (dispatch_mode, session_map) =
+                        prepare_dispatch_context(&router_arc, tmux.batch_session_active()).await;
                     if let Err(e) = crate::engine::tick::tick_dispatch_tasks(
                         &backend,
                         &tmux,
@@ -52,7 +71,7 @@ pub fn spawn(
                         &semaphore,
                         &task_manager,
                         &weight_tx,
-                        &router_guard,
+                        dispatch_mode,
                         &dispatching,
                         &store,
                         &session_map,
@@ -70,4 +89,41 @@ pub fn spawn(
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::router::{Router, RouterConfig};
+    use std::time::Duration;
+    use tokio::sync::{oneshot, Notify};
+
+    #[tokio::test]
+    async fn prepare_dispatch_context_drops_read_lock_before_awaiting_session_map() {
+        let router_arc = Arc::new(RwLock::new(Router::new(RouterConfig::default())));
+        let (tx, rx) = oneshot::channel::<SessionMap>();
+        let waiting = Arc::new(Notify::new());
+        let waiting_for_task = Arc::clone(&waiting);
+        let router_for_task = Arc::clone(&router_arc);
+
+        let task = tokio::spawn(async move {
+            prepare_dispatch_context(&router_for_task, async move {
+                waiting_for_task.notify_one();
+                rx.await.unwrap_or_default()
+            })
+            .await
+        });
+
+        // Wait until the function has entered its awaited session-map future.
+        waiting.notified().await;
+
+        // If the read guard leaked across the await above, this write lock would block.
+        let write_guard = tokio::time::timeout(Duration::from_secs(2), router_arc.write())
+            .await
+            .expect("router write lock blocked while dispatch subscriber awaited session map");
+        drop(write_guard);
+
+        let _ = tx.send(SessionMap::new());
+        let _ = task.await.expect("prepare_dispatch_context task panicked");
+    }
 }

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -1202,6 +1202,24 @@ pub(crate) async fn tick_route_tasks(
 }
 
 /// Phase 3b of tick: spawn agents for all status:routed tasks up to the parallel limit.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DispatchMode {
+    pub(crate) is_degraded: bool,
+    pub(crate) healthy_agents: usize,
+    pub(crate) threshold: usize,
+}
+
+pub(crate) fn dispatch_mode_from_router(router: &Router) -> DispatchMode {
+    let threshold = crate::engine::router::config::min_healthy_agents_threshold();
+    let healthy_agents = router.healthy_agent_count("simple");
+    DispatchMode {
+        is_degraded: healthy_agents < threshold,
+        healthy_agents,
+        threshold,
+    }
+}
+
+/// Phase 3b of tick: spawn agents for all status:routed tasks up to the parallel limit.
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all, name = "engine.tick.phase3b.dispatch")]
 pub(crate) async fn tick_dispatch_tasks(
@@ -1213,7 +1231,7 @@ pub(crate) async fn tick_dispatch_tasks(
     semaphore: &Arc<Semaphore>,
     task_manager: &Arc<TaskManager>,
     weight_tx: &mpsc::Sender<WeightSignal>,
-    router: &Router,
+    dispatch_mode: DispatchMode,
     dispatching: &Arc<DashMap<String, String>>,
     store: &Arc<TaskStore>,
     session_map: &std::collections::HashMap<String, bool>,
@@ -1235,26 +1253,21 @@ pub(crate) async fn tick_dispatch_tasks(
         .filter(|t| !t.labels.iter().any(|l| l == "no-agent"))
         .collect();
 
-    // Check if we are in degraded mode (fewer than threshold healthy agents)
-    let threshold = crate::engine::router::config::min_healthy_agents_threshold();
-    let healthy_count = router.healthy_agent_count("simple");
-    let is_degraded = healthy_count < threshold;
-
     if dispatchable.is_empty() {
         tracing::debug!(count = 0, "dispatchable tasks found");
         return Ok(());
     }
 
     tracing::info!(count = dispatchable.len(), "dispatchable tasks found");
-    if is_degraded {
+    if dispatch_mode.is_degraded {
         tracing::warn!(
-            healthy_agents = healthy_count,
-            threshold = threshold,
+            healthy_agents = dispatch_mode.healthy_agents,
+            threshold = dispatch_mode.threshold,
             "degraded mode: using sequential dispatch"
         );
     }
 
-    let sequential_delay = if is_degraded {
+    let sequential_delay = if dispatch_mode.is_degraded {
         crate::engine::router::config::sequential_dispatch_delay_ms()
     } else {
         0
@@ -1262,7 +1275,7 @@ pub(crate) async fn tick_dispatch_tasks(
 
     for (idx, task) in dispatchable.into_iter().enumerate() {
         // In degraded mode, add delay between dispatches to pace the system
-        if idx > 0 && is_degraded {
+        if idx > 0 && dispatch_mode.is_degraded {
             let delay_ms = sequential_delay;
             tracing::debug!(
                 task_id = task.id.0,
@@ -1744,6 +1757,7 @@ pub(crate) async fn tick(
     )
     .await?;
     tick_route_tasks(backend, task_manager, router, store, repo).await?;
+    let dispatch_mode = dispatch_mode_from_router(router);
     tick_dispatch_tasks(
         backend,
         tmux,
@@ -1753,7 +1767,7 @@ pub(crate) async fn tick(
         semaphore,
         task_manager,
         weight_tx,
-        router,
+        dispatch_mode,
         dispatching,
         store,
         &session_map,
@@ -2602,10 +2616,11 @@ mod tests {
         let router = Router::new(router_config);
         let router_arc = Arc::new(RwLock::new(router));
 
-        // Simulate what the main loop does: hold a write lock, then call
-        // tick_dispatch_tasks. The function now takes &Router (dereferenced
-        // from the guard), so no lock re-acquisition occurs.
+        // Simulate what the main loop does: hold a write lock, snapshot
+        // dispatch mode, then call tick_dispatch_tasks without passing any
+        // lock guard into async dispatch work.
         let write_guard = router_arc.write().await;
+        let dispatch_mode = dispatch_mode_from_router(&write_guard);
 
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(2),
@@ -2620,7 +2635,7 @@ mod tests {
                 &semaphore,
                 &task_manager,
                 &weight_tx,
-                &write_guard,
+                dispatch_mode,
                 &dispatching,
                 &store,
                 &std::collections::HashMap::new(),


### PR DESCRIPTION
## Summary

Refactored event-driven dispatch to snapshot router dispatch health without holding a router RwLock read guard across awaits, and added a regression test for lock-scope behavior; changes are committed.

### What was done

- Introduced `DispatchMode` snapshotting in `src/engine/tick.rs` via `dispatch_mode_from_router(&Router)` and updated `tick_dispatch_tasks` to consume this plain value instead of `&Router`.
- Updated tick call sites to compute dispatch mode before async dispatch work and pass the snapshot into `tick_dispatch_tasks`.
- Refactored `src/engine/subscribers/dispatch.rs` to use `prepare_dispatch_context(...)`, which acquires router read lock only for snapshotting and drops it before awaiting session-map/dispatch async operations.
- Added regression test `prepare_dispatch_context_drops_read_lock_before_awaiting_session_map` to ensure router write lock remains acquirable while subscriber path is awaiting.
- Updated existing dispatch deadlock regression test to match the new dispatch-mode snapshot API.
- Committed as `99cd7a16` with message: `fix: avoid holding router read lock across dispatch awaits`.


### Remaining

- Investigate/fix unrelated baseline test failure in `engine::tests::configured_agents_fallback_returns_default_agents` (fails in this worktree before/after the lock-scope fix).
- Re-run full `cargo nextest run` after that baseline failure is addressed.


### Files changed

- `src/engine/subscribers/dispatch.rs`
- `src/engine/tick.rs`


Closes #2725

---
*Task #2725 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*