### PR TITLE
bug: find_existing_worktree stops scanning on first read_dir error

### DIFF
--- a/src/engine/runner/worktree.rs
+++ b/src/engine/runner/worktree.rs
@@ -706,15 +706,41 @@ async fn find_existing_worktree(worktrees_base: &Path, task_id: &str) -> Option<
 
     let mut entries = match tokio::fs::read_dir(worktrees_base).await {
         Ok(e) => e,
-        Err(_) => return None,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %worktrees_base.display(),
+                "failed to read worktrees directory while searching for existing worktree"
+            );
+            return None;
+        }
     };
-    while let Some(entry) = entries.next_entry().await.ok().flatten() {
-        let name = entry.file_name().to_string_lossy().to_string();
+    loop {
+        let next_entry = match entries.next_entry().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(e) => {
+                // Log the error but continue scanning - a single entry error shouldn't stop us
+                tracing::warn!(error = %e, "failed to read directory entry while searching for worktree");
+                continue;
+            }
+        };
+
+        let name = next_entry.file_name().to_string_lossy().to_string();
         let matches =
             name.starts_with(&prefix_new) || legacy_prefixes.iter().any(|p| name.starts_with(p));
-        // Use async metadata for is_dir check
-        if matches && entry.metadata().await.map(|m| m.is_dir()).unwrap_or(false) {
-            return Some(entry.path());
+        if matches {
+            match next_entry.metadata().await {
+                Ok(metadata) if metadata.is_dir() => return Some(next_entry.path()),
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        path = %next_entry.path().display(),
+                        "failed to read metadata for candidate worktree entry"
+                    );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixed `find_existing_worktree` to avoid aborting scan on `read_dir` iteration errors and added explicit warning logs for diagnosability; changes are committed.

### What was done

- Replaced `while let Some(entry) = entries.next_entry().await.ok().flatten()` with an explicit `loop`/`match` to handle `Ok(Some(_))`, `Ok(None)`, and `Err(_)` separately.
- Implemented warning logging for `tokio::fs::read_dir(worktrees_base)` failures before returning `None`.
- Implemented warning logging for per-entry `next_entry()` errors and continued scanning instead of terminating early.
- Implemented warning logging for `metadata()` failures on matching candidate entries, preserving scan continuity and diagnostics.
- Ran `cargo fmt -- --check` (pass).
- Ran `cargo clippy --all-targets -- -D warnings` (pass).
- Committed changes in `e3ccc846` with message `fix: keep worktree scan resilient to dir entry errors`.


### Remaining

- Investigate unrelated failing test in this environment and rerun full test gate.
- Re-run `cargo nextest run` to green once `engine::tests::configured_agents_fallback_returns_default_agents` is resolved/stabilized.


### Files changed

- `src/engine/runner/worktree.rs`


Closes #2733

---
*Task #2733 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*