### PR TITLE
fix: propagate KV read errors in get_model/get_agent instead of silently defaulting

### DIFF
--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -7,8 +7,8 @@ use std::io::{self, BufRead, Write};
 /// Interactive REPL mode — reads from stdin, sends to control session.
 pub async fn interactive(session_id: &str) -> anyhow::Result<()> {
     let store = crate::cli::init_store().await?;
-    let model = control::get_model(&store).await;
-    let agent = control::get_agent(&store).await;
+    let model = control::get_model(&store).await?;
+    let agent = control::get_agent(&store).await?;
 
     let session_label = if session_id == TaskStore::DEFAULT_SESSION {
         String::new()
@@ -161,8 +161,8 @@ pub async fn stats(session_id: &str) -> anyhow::Result<()> {
     let store = crate::cli::init_store().await?;
 
     let summary = store.get_session_cost_summary(session_id).await?;
-    let fallback_model = control::get_model(&store).await;
-    let fallback_agent = control::get_agent(&store).await;
+    let fallback_model = control::get_model(&store).await?;
+    let fallback_agent = control::get_agent(&store).await?;
     let current_model = summary.primary_model.clone().unwrap_or(fallback_model);
     let current_agent = summary.primary_agent.clone().unwrap_or(fallback_agent);
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -319,32 +319,32 @@ pub async fn assemble_context(store: &TaskStore, session_id: &str) -> Result<Cha
     Ok(ChatContext { system, state })
 }
 
-/// Get the current model spec from KV, defaulting to `"sonnet"` on `"claude"`.
-pub async fn get_model(store: &TaskStore) -> String {
-    store
+/// Get the current model spec from KV, defaulting to `"sonnet"` when the key is absent.
+/// Returns an error if the store read fails.
+pub async fn get_model(store: &TaskStore) -> Result<String> {
+    Ok(store
         .kv_get("control:model")
         .await
-        .ok()
-        .flatten()
-        .unwrap_or_else(|| "sonnet".to_string())
+        .context("reading control:model from store")?
+        .unwrap_or_else(|| "sonnet".to_string()))
 }
 
-/// Get the current agent from KV, defaulting to `"claude"`.
-pub async fn get_agent(store: &TaskStore) -> String {
-    store
+/// Get the current agent from KV, defaulting to `"claude"` when the key is absent.
+/// Returns an error if the store read fails.
+pub async fn get_agent(store: &TaskStore) -> Result<String> {
+    Ok(store
         .kv_get("control:agent")
         .await
-        .ok()
-        .flatten()
-        .unwrap_or_else(|| "claude".to_string())
+        .context("reading control:agent from store")?
+        .unwrap_or_else(|| "claude".to_string()))
 }
 
 /// Get the current control session spec from KV.
-pub async fn get_current_spec(store: &TaskStore) -> ModelSpec {
-    ModelSpec {
-        agent: get_agent(store).await,
-        model: get_model(store).await,
-    }
+pub async fn get_current_spec(store: &TaskStore) -> Result<ModelSpec> {
+    Ok(ModelSpec {
+        agent: get_agent(store).await?,
+        model: get_model(store).await?,
+    })
 }
 
 /// Set the current model in KV.
@@ -396,7 +396,7 @@ async fn handle_control_command(
     command: ControlCommand,
 ) -> Result<String> {
     match command {
-        ControlCommand::Model(None) => Ok(format_current_spec(&get_current_spec(store).await)),
+        ControlCommand::Model(None) => Ok(format_current_spec(&get_current_spec(store).await?)),
         ControlCommand::Model(Some(new_spec)) => {
             let spec = parse_model_spec(&new_spec);
             validate_model(&spec).await?;
@@ -405,7 +405,7 @@ async fn handle_control_command(
             reset_session_uuid(store, session_id).await?;
             Ok(format_switched_spec(&spec))
         }
-        ControlCommand::Agent(None) => Ok(format_current_spec(&get_current_spec(store).await)),
+        ControlCommand::Agent(None) => Ok(format_current_spec(&get_current_spec(store).await?)),
         ControlCommand::Agent(Some(agent)) => {
             validate_agent(&agent)?;
             let spec = set_agent_spec(store, &agent).await?;
@@ -696,8 +696,8 @@ pub async fn send_message(
     let ctx = assemble_context(store, session_id).await?;
 
     // Resolve model and agent from KV
-    let model = get_model(store).await;
-    let agent = get_agent(store).await;
+    let model = get_model(store).await?;
+    let agent = get_agent(store).await?;
 
     // Prepend live state to user message so the LLM sees it directly
     let full_message = format!("{}\n\n---\n\n{}", ctx.state, message);
@@ -982,15 +982,15 @@ mod tests {
     #[tokio::test]
     async fn send_message_model_switch() {
         let store = TaskStore::open_memory().await.unwrap();
-        let model = get_model(&store).await;
+        let model = get_model(&store).await.unwrap();
         assert_eq!(model, "sonnet");
 
         // /model with explicit agent:model — will fail validation (no binary in test)
         // so test parse_model_spec + set_model_spec directly
         let spec = parse_model_spec("minimax:sonnet");
         set_model_spec(&store, &spec).await.unwrap();
-        assert_eq!(get_model(&store).await, "sonnet");
-        assert_eq!(get_agent(&store).await, "minimax");
+        assert_eq!(get_model(&store).await.unwrap(), "sonnet");
+        assert_eq!(get_agent(&store).await.unwrap(), "minimax");
     }
 
     #[tokio::test]
@@ -1020,8 +1020,8 @@ mod tests {
         let spec = set_agent_spec(&store, "codex").await.unwrap();
         assert_eq!(spec.agent, "codex");
         assert_eq!(spec.model, "gpt-4o");
-        assert_eq!(get_agent(&store).await, "codex");
-        assert_eq!(get_model(&store).await, "gpt-4o");
+        assert_eq!(get_agent(&store).await.unwrap(), "codex");
+        assert_eq!(get_model(&store).await.unwrap(), "gpt-4o");
     }
 
     #[test]
@@ -1070,8 +1070,8 @@ mod tests {
         let spec = set_agent_spec(&store, "codex").await.unwrap();
         assert_eq!(spec.agent, "codex");
         assert_eq!(spec.model, "gpt-4o");
-        assert_eq!(get_agent(&store).await, "codex");
-        assert_eq!(get_model(&store).await, "gpt-4o");
+        assert_eq!(get_agent(&store).await.unwrap(), "codex");
+        assert_eq!(get_model(&store).await.unwrap(), "gpt-4o");
     }
 
     #[tokio::test]
@@ -1126,7 +1126,7 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("unknown agent"));
 
         // Verify the original agent is still set (not overwritten)
-        assert_eq!(get_agent(&store).await, "claude");
+        assert_eq!(get_agent(&store).await.unwrap(), "claude");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2740.

## Summary

- `get_model()` and `get_agent()` now return `anyhow::Result<String>` instead of `String`
- Store errors are propagated with context instead of being swallowed by `.ok()`
- Default fallback (`claude:sonnet`) is preserved only for the `Ok(None)` case (key genuinely absent)
- All callers updated to propagate the error with `?`
- Tests updated to `.unwrap()` the result

## Before

```rust
store.kv_get("control:model").await.ok().flatten().unwrap_or_else(|| "sonnet".to_string())
```

Any DB error was treated identically to a missing key, silently switching the control session to `claude:sonnet`.

## After

```rust
store.kv_get("control:model").await.context("reading control:model from store")?.unwrap_or_else(|| "sonnet".to_string())
```

Store errors surface to the caller immediately, making DB faults visible at the call site rather than masking them as a model switch.

## Test plan

- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo nextest run` — 3101 passed, 19 skipped

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
*Task #2740 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*