### PR TITLE
bug: has_external_tasks() swallows DB errors and triggers wrong backend fallback

### DIFF
--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -98,7 +98,18 @@ pub fn spawn(
                     // Look up the task from the store to get an ExternalTask.
                     let task = {
                         if crate::engine::tasks::is_internal_id(task_id)
-                            || store.has_external_tasks(&repo).await
+                            || match store.has_external_tasks(&repo).await {
+                                Ok(has_external) => has_external,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        repo = %repo,
+                                        task_id,
+                                        error = %e,
+                                        "failed to check external task sentinel; keeping store-first review lookup"
+                                    );
+                                    true
+                                }
+                            }
                         {
                             // O(1) indexed lookup — resolve task_id to its SQLite row id,
                             // then fetch directly instead of scanning the whole needs_review set.

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -255,11 +255,31 @@ impl TaskManager {
             let store_tasks = if let Some(ref store) = self.store {
                 if is_all {
                     let tasks = store.list_all(&self.repo).await?;
-                    has_external_in_store = store.has_external_tasks(&self.repo).await;
+                    has_external_in_store = match store.has_external_tasks(&self.repo).await {
+                        Ok(has_external) => has_external,
+                        Err(e) => {
+                            tracing::warn!(
+                                repo = %self.repo,
+                                error = %e,
+                                "failed to check external task sentinel; using store-only list path"
+                            );
+                            true
+                        }
+                    };
                     tasks
                 } else {
                     let tasks = store.list_active(&self.repo).await?;
-                    has_external_in_store = store.has_external_tasks(&self.repo).await;
+                    has_external_in_store = match store.has_external_tasks(&self.repo).await {
+                        Ok(has_external) => has_external,
+                        Err(e) => {
+                            tracing::warn!(
+                                repo = %self.repo,
+                                error = %e,
+                                "failed to check external task sentinel; using store-only list path"
+                            );
+                            true
+                        }
+                    };
                     tasks
                 }
             } else {
@@ -309,7 +329,23 @@ impl TaskManager {
             let external = store.list_external_by_status(&self.repo, db_status).await?;
             // Use the fetched results when non-empty; only check the sentinel when empty
             // (empty could mean "no tasks with this status" OR "store not yet synced").
-            if !external.is_empty() || store.has_external_tasks(&self.repo).await {
+            let has_external_in_store = if external.is_empty() {
+                match store.has_external_tasks(&self.repo).await {
+                    Ok(has_external) => has_external,
+                    Err(e) => {
+                        tracing::warn!(
+                            repo = %self.repo,
+                            status = ?status,
+                            error = %e,
+                            "failed to check external task sentinel; skipping backend fallback"
+                        );
+                        true
+                    }
+                }
+            } else {
+                true
+            };
+            if has_external_in_store {
                 let external: Vec<ExternalTask> =
                     external.iter().map(store_task_to_external).collect();
                 return Ok(external);
@@ -331,7 +367,23 @@ impl TaskManager {
             let external = store.list_external_by_status(&self.repo, db_status).await?;
             // Use the fetched results when non-empty; only check the sentinel when empty
             // (empty could mean "no tasks with this status" OR "store not yet synced").
-            if !external.is_empty() || store.has_external_tasks(&self.repo).await {
+            let has_external_in_store = if external.is_empty() {
+                match store.has_external_tasks(&self.repo).await {
+                    Ok(has_external) => has_external,
+                    Err(e) => {
+                        tracing::warn!(
+                            repo = %self.repo,
+                            status = ?status,
+                            error = %e,
+                            "failed to check external task sentinel; skipping backend fallback"
+                        );
+                        true
+                    }
+                }
+            } else {
+                true
+            };
+            if has_external_in_store {
                 tasks.extend(external.into_iter().map(|t| store_task_to_external(&t)));
             } else {
                 // Store not synced yet — fall back to backend for external tasks
@@ -365,7 +417,22 @@ impl TaskManager {
             // the store has external tasks and we can skip the has_external_tasks query.
             let has_external_new = all_new.iter().any(|t| t.origin != "internal");
             let tasks: Vec<ExternalTask> = all_new.iter().map(store_task_to_external).collect();
-            if has_external_new || store.has_external_tasks(&self.repo).await {
+            let has_external_in_store = if has_external_new {
+                true
+            } else {
+                match store.has_external_tasks(&self.repo).await {
+                    Ok(has_external) => has_external,
+                    Err(e) => {
+                        tracing::warn!(
+                            repo = %self.repo,
+                            error = %e,
+                            "failed to check external task sentinel; skipping backend fallback"
+                        );
+                        true
+                    }
+                }
+            };
+            if has_external_in_store {
                 return Ok(tasks);
             }
         }

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -941,16 +941,15 @@ impl TaskStore {
     }
 
     /// Check whether the store has any external tasks for a repo.
-    pub async fn has_external_tasks(&self, repo: &str) -> bool {
-        sqlx::query_scalar::<_, i32>(
+    pub async fn has_external_tasks(&self, repo: &str) -> anyhow::Result<bool> {
+        let has_external = sqlx::query_scalar::<_, i32>(
             "SELECT 1 FROM tasks WHERE repo = ? AND origin != 'internal' LIMIT 1",
         )
         .bind(repo)
         .fetch_optional(&self.pool)
-        .await
-        .ok()
-        .flatten()
-        .is_some()
+        .await?
+        .is_some();
+        Ok(has_external)
     }
 
     /// Return a set of external IDs for all external tasks in a repo.

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -4480,7 +4480,7 @@ async fn cost_summary_returns_three_periods() {
 #[tokio::test]
 async fn has_external_tasks_returns_false_for_empty_repo() {
     let store = TaskStore::open_memory().await.unwrap();
-    assert!(!store.has_external_tasks("owner/repo").await);
+    assert!(!store.has_external_tasks("owner/repo").await.unwrap());
 }
 
 #[tokio::test]
@@ -4499,9 +4499,9 @@ async fn has_external_tasks_returns_true_after_external_insert() {
         })
         .await
         .unwrap();
-    assert!(store.has_external_tasks("owner/repo").await);
+    assert!(store.has_external_tasks("owner/repo").await.unwrap());
     // Different repo should still be false
-    assert!(!store.has_external_tasks("other/repo").await);
+    assert!(!store.has_external_tasks("other/repo").await.unwrap());
 }
 
 #[tokio::test]
@@ -4512,7 +4512,7 @@ async fn has_external_tasks_ignores_internal_rows() {
         .await
         .unwrap();
 
-    assert!(!store.has_external_tasks("owner/repo").await);
+    assert!(!store.has_external_tasks("owner/repo").await.unwrap());
 
     store
         .upsert_external(&UpsertExternal {
@@ -4528,7 +4528,7 @@ async fn has_external_tasks_ignores_internal_rows() {
         .await
         .unwrap();
 
-    assert!(store.has_external_tasks("owner/repo").await);
+    assert!(store.has_external_tasks("owner/repo").await.unwrap());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixed `has_external_tasks` error handling so DB failures are no longer treated as an empty external-task state, and updated callers to use explicit fallback behavior.

### What was done

- Changed `TaskStore::has_external_tasks` to return `anyhow::Result<bool>` and propagate SQL errors instead of converting them to `false`.
- Updated store-first control flow in `TaskManager` (`list_tasks`, `list_external_by_status`, `list_all_by_status`, `list_routable`) to handle sentinel query errors explicitly with warning logs and deterministic behavior (skip backend fallback on sentinel failure).
- Updated review subscriber lookup path to handle sentinel errors explicitly and keep store-first behavior with warning logs.
- Adjusted `has_external_tasks` unit tests to assert on `Result<bool>`.
- Ran required checks successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo nextest run`.


### Files changed

- `src/engine/subscribers/review.rs`
- `src/engine/tasks.rs`
- `src/store/tasks.rs`
- `src/store/tests.rs`


Closes #2738

---
*Task #2738 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*