### PR TITLE
bug: flat 4h set_model_cooldown for exit-0-empty never escalates — persistently broken github-copilot/* models retried indefinitely

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -29,6 +29,12 @@ pub const BACKOFF_BASE_SECS: i64 = 5 * 60;
 /// Maximum backoff for generic agent/model failures: 4 hours.
 pub const BACKOFF_MAX_SECS: i64 = 4 * 60 * 60;
 
+/// Base backoff for persistent model failures (silent exit/provider errors): 4 hours.
+pub const PERSISTENT_MODEL_BACKOFF_BASE_SECS: i64 = 4 * 60 * 60;
+
+/// Maximum backoff for persistent model failures: 7 days.
+pub const PERSISTENT_MODEL_BACKOFF_MAX_SECS: i64 = 7 * 24 * 60 * 60;
+
 /// Base backoff for credit exhaustion (out_of_credits): 1 hour.
 pub const CREDIT_BACKOFF_BASE_SECS: i64 = 60 * 60;
 
@@ -414,6 +420,24 @@ pub async fn record_model_failure(agent_name: &str, model: &str) {
     let cooldown_until =
         chrono::Utc::now().timestamp() + compute_backoff(count, base, BACKOFF_MAX_SECS);
     set_cooldown_async(&key, cooldown_until, "model_error").await;
+}
+
+/// Record a persistent model-specific failure and apply longer exponential backoff.
+///
+/// Used for failure modes that are commonly broken for long periods (for example
+/// silent exit-0 or opaque provider errors). Starts at 4h and escalates with
+/// the generic backoff formula up to 7 days.
+pub async fn record_persistent_model_failure(agent_name: &str, model: &str) {
+    let key = format!("{agent_name}:{model}");
+    let store_opt = cooldown_store().lock().await.clone();
+    let count = read_and_increment_failure_count(&store_opt, &key).await;
+    let cooldown_secs = compute_backoff(
+        count,
+        PERSISTENT_MODEL_BACKOFF_BASE_SECS,
+        PERSISTENT_MODEL_BACKOFF_MAX_SECS,
+    );
+    let cooldown_until = chrono::Utc::now().timestamp() + cooldown_secs;
+    set_cooldown_async(&key, cooldown_until, "persistent_model_error").await;
 }
 
 /// Set a model cooldown with a custom duration (in seconds).
@@ -1156,6 +1180,44 @@ mod tests {
         let now = chrono::Utc::now().timestamp();
         // Should be in the future (cooldown_until, not failed_at)
         assert!(ts > now, "persisted timestamp should be in the future");
+    }
+
+    #[tokio::test]
+    async fn record_persistent_model_failure_escalates_and_increments_failure_count() {
+        let store = test_store().await;
+        *cooldown_store().lock().await = Some(store.clone());
+
+        let agent = "testagent_persistent";
+        let model = "testmodel_persistent";
+        let key = format!("{agent}:{model}");
+
+        // First failure -> base 4h.
+        record_persistent_model_failure(agent, model).await;
+        let now = chrono::Utc::now().timestamp();
+        let first_until = cooldown_until(&key).expect("first cooldown should exist");
+        let first_remaining = first_until.saturating_sub(now);
+        assert!(
+            first_remaining >= PERSISTENT_MODEL_BACKOFF_BASE_SECS - 5,
+            "first persistent model cooldown should be ~4h, got {first_remaining}s"
+        );
+
+        // Second failure -> 12h (3x growth).
+        record_persistent_model_failure(agent, model).await;
+        let now2 = chrono::Utc::now().timestamp();
+        let second_until = cooldown_until(&key).expect("second cooldown should exist");
+        let second_remaining = second_until.saturating_sub(now2);
+        assert!(
+            second_remaining >= (PERSISTENT_MODEL_BACKOFF_BASE_SECS * 3) - 5,
+            "second persistent model cooldown should be ~12h, got {second_remaining}s"
+        );
+
+        let count_key = format!("{FAILURE_COUNT_PREFIX}{agent}:{model}");
+        let stored_count = store
+            .kv_get(&count_key)
+            .await
+            .expect("kv read should succeed")
+            .expect("failure count should be written");
+        assert_eq!(stored_count, "2");
     }
 
     #[test]

--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -10,8 +10,6 @@ use std::sync::Arc;
 
 use super::{agents, response};
 
-const PROVIDER_RETURNED_ERROR_MODEL_COOLDOWN_SECS: u64 = 4 * 60 * 60;
-
 /// How `run()` should proceed after error handling.
 pub enum ErrorHandleResult {
     /// Task was rerouted — `run()` should record metrics then return early.
@@ -143,13 +141,9 @@ pub async fn handle_error(
                 if let Some(model) = model_name {
                     if is_provider_returned_error {
                         // Opaque provider failures can remain unstable for hours.
-                        // Keep this model out longer to avoid repeated wasted runs.
-                        crate::engine::cooldown::set_model_cooldown(
-                            agent_name,
-                            model,
-                            PROVIDER_RETURNED_ERROR_MODEL_COOLDOWN_SECS,
-                        )
-                        .await;
+                        // Use longer exponential model backoff to avoid repeated runs.
+                        crate::engine::cooldown::record_persistent_model_failure(agent_name, model)
+                            .await;
                     } else {
                         response::record_model_failure(agent_name, model).await;
                     }
@@ -391,11 +385,9 @@ pub async fn handle_error(
                     || message.starts_with("empty-output-exit0:"))
             {
                 if let Some(m) = model_name {
-                    // Use a 4-hour cooldown for silent exits instead of the default 1-hour
-                    // model cooldown.  These models (especially github-copilot/* in opencode)
-                    // fail consistently across multiple hours; a 1-hour window means ~12
-                    // wasted 2-minute attempts per day per model.  4 hours cuts that to ~3.
-                    crate::engine::cooldown::set_model_cooldown(agent_name, m, 4 * 3600).await;
+                    // Silent exits can remain broken for long periods. Start with 4h,
+                    // then escalate using exponential backoff for persistent failures.
+                    crate::engine::cooldown::record_persistent_model_failure(agent_name, m).await;
                 }
                 // Before falling through to handle_failover() (which tries claude/codex),
                 // check whether this agent has any free models that haven't been tried yet.
@@ -756,7 +748,7 @@ mod tests {
 
         // Allow a wider margin for scheduler/runtime jitter in concurrent test runs.
         assert!(
-            remaining >= PROVIDER_RETURNED_ERROR_MODEL_COOLDOWN_SECS as i64 - 30,
+            remaining >= crate::engine::cooldown::PERSISTENT_MODEL_BACKOFF_BASE_SECS - 30,
             "expected ~4h model cooldown, got {remaining}s"
         );
     }


### PR DESCRIPTION
## Summary

Replaced flat 4h model cooldown paths with persistent exponential model backoff so repeated exit-0-empty/provider errors now increment failure counts and escalate instead of retrying every 4h forever.

### What was done

- Added `record_persistent_model_failure(agent, model)` in `src/engine/cooldown.rs` with exponential backoff using a 4h base and 7d cap, backed by `failure_count:{agent}:{model}` increments.
- Added new cooldown constants `PERSISTENT_MODEL_BACKOFF_BASE_SECS` and `PERSISTENT_MODEL_BACKOFF_MAX_SECS`.
- Replaced both flat cooldown call sites in `src/engine/runner/fallback.rs` with `record_persistent_model_failure(...)`: the `Provider returned error` rate-limit path and the exit-0-empty silent failure path.
- Updated fallback test expectation to assert against the new persistent backoff base constant.
- Added test `record_persistent_model_failure_escalates_and_increments_failure_count` to verify 4h -> 12h escalation and persisted failure-count increment.
- Ran required checks successfully: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (3121 passed, 19 skipped).
- Committed as `72a16889` with message `fix(cooldown): escalate persistent model failure backoff`.


### Remaining

- Automated review pass and PR lifecycle handling by orch.


### Files changed

- `src/engine/cooldown.rs`
- `src/engine/runner/fallback.rs`


Closes #2749

---
*Task #2749 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*