### PR TITLE
bug: AgentError::InvalidResponse skips model-level cooldown — parse-error models retried without backoff

### DIFF
--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -292,10 +292,17 @@ pub async fn handle_error(
             response::RetryableError::Failed,
             format!("permission denied: {message}"),
         ),
-        agents::AgentError::InvalidResponse { .. } => (
-            response::RetryableError::Failed,
-            format!("{agent_name} invalid response"),
-        ),
+        agents::AgentError::InvalidResponse { .. } => {
+            // Record model-specific cooldown so the same model that produced an
+            // unparseable response isn't immediately retried on the next task.
+            if let Some(model) = model_name {
+                response::record_model_failure(agent_name, model).await;
+            }
+            (
+                response::RetryableError::Failed,
+                format!("{agent_name} invalid response"),
+            )
+        }
         agents::AgentError::AgentFailed { message } => {
             // "Provider returned error" (opencode) and similar upstream failures.
             // Record model+agent cooldowns so the router skips this model on retry,
@@ -972,6 +979,48 @@ mod tests {
         assert!(
             matches!(result, ErrorHandleResult::Continue { .. }),
             "expected Continue (fallthrough to failover) when no free models available"
+        );
+    }
+
+    /// Verify that InvalidResponse applies model-level cooldown.
+    ///
+    /// This fixes issue #2750: InvalidResponse used to skip model-level cooldown,
+    /// allowing models that produced unparseable responses to be immediately
+    /// retried on the next task without any backoff.
+    #[tokio::test]
+    async fn invalid_response_sets_model_cooldown() {
+        let runner = MockRunner { free: vec![] };
+        let agent = "opencode";
+        let model = "opencode/nemotron-3-super-free";
+
+        // Confirm no model cooldown before the error.
+        assert!(
+            !crate::engine::cooldown::is_model_in_cooldown(agent, model),
+            "model should not be in cooldown before handle_error"
+        );
+
+        let err = AgentError::InvalidResponse {
+            raw: "invalid json output".to_string(),
+        };
+
+        let _result = handle_error(
+            "test-2750-invalid-response",
+            &err,
+            agent,
+            &runner,
+            Some(model),
+            Some("simple"),
+            1,
+            &None,
+            "owner/repo",
+        )
+        .await
+        .unwrap();
+
+        // Model-level cooldown must be set after InvalidResponse.
+        assert!(
+            crate::engine::cooldown::is_model_in_cooldown(agent, model),
+            "model should be in cooldown after InvalidResponse (fixes issue #2750)"
         );
     }
 }


### PR DESCRIPTION
## Summary

## Summary

I've successfully fixed bug #2750 where `AgentError::InvalidResponse` was skipping model-level cooldown. Here's what was done:

### The Problem
Models that produced unparseable responses (InvalidResponse errors) were not being subject to model-specific cooldowns. This meant models with high parse error rates (like opencode/nemotron-3-super-free with 9 parse errors in 36 hours) would be immediately retried on the next task without any exponential backoff.

### The Solution
Modified `s

### What was done

- Call `response::record_model_failure(agent_name, model)` when a model is provided
- This applies exponential backoff based on the model's failure count, just like `AgentFailed` and `Auth` errors do
- **File**: `src/engine/runner/fallback.rs`
- **Lines 295-305**: Added model-level cooldown recording to the `InvalidResponse` match arm
- **New test**: Added `invalid_response_sets_model_cooldown()` test to verify the fix works correctly
- ✅ All 1514 unit tests pass
- ✅ New test confirms model cooldown is applied for InvalidResponse errors
- ✅ Code formatting and linting checks pass
- ✅ Fix aligns InvalidResponse handling with existing AgentFailed and Auth error patterns


### Files changed

- `src/engine/runner/fallback.rs`


Closes #2750

---
*Task #2750 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*