### PR TITLE
bug: control_recent_summaries masks row decode failures as empty summaries

### DIFF
--- a/src/store/control.rs
+++ b/src/store/control.rs
@@ -218,10 +218,10 @@ impl TaskStore {
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;
-        Ok(rows
-            .iter()
-            .map(|r| r.try_get::<String, _>("summary").unwrap_or_default())
-            .collect())
+        rows.iter()
+            .map(|r| r.try_get::<String, _>("summary"))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
     }
 
     fn row_to_control_message(

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -5365,6 +5365,52 @@ async fn control_recent_summaries() {
 }
 
 #[tokio::test]
+async fn control_recent_summaries_propagates_decode_errors() {
+    // Regression: rows with non-string summary (BLOB) must not be silently
+    // defaulted to empty string — the error must propagate.
+    let store = TaskStore::open_memory().await.unwrap();
+
+    // Insert a valid summary row first.
+    store
+        .insert_control_message(
+            "default",
+            "assistant",
+            "cli",
+            None,
+            "valid",
+            Some("summary that is a real string"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Insert a row with a BLOB value in the summary column (not valid UTF-8).
+    // SQLite stores this as BLOB; reading it as String via try_get fails.
+    sqlx::query(
+        "INSERT INTO control_messages
+         (session_id, role, channel, content, summary, created_at)
+         VALUES ('default', 'assistant', 'cli', 'msg', X'01020304', datetime('now'))",
+    )
+    .execute(store.pool())
+    .await
+    .unwrap();
+
+    // The decode error on the BLOB row must propagate, NOT produce an
+    // empty-string entry or silently succeed.
+    let result = store.control_recent_summaries("default", 10).await;
+    assert!(
+        result.is_err(),
+        "expected decode error for BLOB summary row, got Ok: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
 async fn control_sessions_are_isolated() {
     let store = TaskStore::open_memory().await.unwrap();
     store


### PR DESCRIPTION
## Summary

Two changes made:

1. **`src/store/control.rs:221-224`** — Replaced `unwrap_or_default()` with proper error propagation. The return type changed from `anyhow::Result<Vec<String>>` to `anyhow::Result<Vec<String>>` (same signature, but now errors bubble up instead of being silenced). The `map_err(Into::into)` converts `sqlx::Error` → `anyhow::Error` via the standard `Into` impl.

2. **`src/store/tests.rs:5365-5410`** — Added `control_recent_summaries_propagates_decode_errors` regression test

### Files changed

- `src/store/control.rs`
- `src/store/tests.rs`


Closes #2766

---
*Task #2766 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*