### PR TITLE
bug: LLM routing silently falls back to no-code agent when it is the only available candidate

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -863,15 +863,23 @@ impl Router {
                             .find(|a| a.as_str() != no_code_agent)
                             .cloned()
                             .unwrap_or_else(|| candidates[0].clone());
-                        if fallback_agent != result.agent {
-                            tracing::info!(
+                        if fallback_agent.as_str() == no_code_agent {
+                            tracing::warn!(
                                 task_id = %task.id.0,
-                                llm_selected = %result.agent,
-                                skipped = %no_code_agent,
-                                fallback = %fallback_agent,
-                                "LLM selected the no-code agent — routing to alternative"
+                                no_code_agent = %no_code_agent,
+                                complexity = %result.complexity,
+                                "all available agents are the no-code agent — waiting for another agent"
                             );
+                            self.wait_for_cooldown(Some(&result.complexity)).await?;
+                            continue;
                         }
+                        tracing::info!(
+                            task_id = %task.id.0,
+                            llm_selected = %result.agent,
+                            skipped = %no_code_agent,
+                            fallback = %fallback_agent,
+                            "LLM selected the no-code agent — routing to alternative"
+                        );
                         let fallback_model = self.config.model_for_complexity(
                             &fallback_agent,
                             &result.complexity,


### PR DESCRIPTION
## Summary

Fixed LLM routing so tasks no longer silently reroute back to the same no-code agent when that agent is the only available candidate.

### What was done

- Patched `src/engine/router/mod.rs` in the LLM routing no-code fallback path to detect when the computed fallback is still `no_code_last_agent`.
- Added an explicit guard that logs a warning, calls `wait_for_cooldown(Some(&result.complexity)).await?`, and `continue`s instead of returning an invalid `RouteResult`.
- Kept the existing successful alternative-agent reroute behavior intact and preserved route-attempt reset behavior for valid fallback cases.
- Ran required checks successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (3177 passed, 19 skipped).
- Committed the fix with conventional commit message: `fix(router): wait when no-code agent is sole LLM fallback candidate`.


### Files changed

- `src/engine/router/mod.rs`


Closes #2771

---
*Task #2771 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*