### PR TITLE
bug: WeightSignal drain fires before signals arrive — router never learns from task outcomes

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1577,19 +1577,6 @@ pub async fn serve() -> anyhow::Result<()> {
         tokio::select! {
             _ = interval.tick() => {
                 let tick_start = std::time::Instant::now();
-                // Drain any pending weight signals from completed tasks
-                while let Ok(signal) = weight_rx.try_recv() {
-                    let mut rw = router.write().await;
-                    match signal {
-                        WeightSignal::RateLimited { ref agent } => {
-                            rw.record_rate_limit(agent);
-                        }
-                        WeightSignal::Success { ref agent } => {
-                            rw.record_success(agent);
-                        }
-                        WeightSignal::Blocked | WeightSignal::None => {}
-                    }
-                }
 
                 // Tick weight recovery for rate-limited agents
                 {
@@ -1638,6 +1625,21 @@ pub async fn serve() -> anyhow::Result<()> {
                         }).await;
                     }
                     drop(router_guard);
+
+                    // Drain pending weight signals after tick processing so the router
+                    // learns from outcomes produced by this iteration's task dispatches.
+                    while let Ok(signal) = weight_rx.try_recv() {
+                        let mut rw = router.write().await;
+                        match signal {
+                            WeightSignal::RateLimited { ref agent } => {
+                                rw.record_rate_limit(agent);
+                            }
+                            WeightSignal::Success { ref agent } => {
+                                rw.record_success(agent);
+                            }
+                            WeightSignal::Blocked | WeightSignal::None => {}
+                        }
+                    }
 
                     // Periodic sync (less frequent) — spawned as a background task so it
                     // cannot block the main tick loop. A stalled sync (hung HTTP call, slow
@@ -1797,6 +1799,20 @@ pub async fn serve() -> anyhow::Result<()> {
                         }).await;
                     }
                     drop(router_guard);
+
+                    // Drain pending weight signals after webhook-triggered tick processing.
+                    while let Ok(signal) = weight_rx.try_recv() {
+                        let mut rw = router.write().await;
+                        match signal {
+                            WeightSignal::RateLimited { ref agent } => {
+                                rw.record_rate_limit(agent);
+                            }
+                            WeightSignal::Success { ref agent } => {
+                                rw.record_success(agent);
+                            }
+                            WeightSignal::Blocked | WeightSignal::None => {}
+                        }
+                    }
                 }
 
                 // Also reset the interval so we don't get a redundant tick right after


### PR DESCRIPTION
## Summary

Moved weight-signal draining to run after tick execution so router weight updates are applied from completed task outcomes instead of draining pre-dispatch.

### What was done

- Updated `src/engine/mod.rs` to remove pre-tick drain from the interval branch.
- Added post-`tick::tick()` signal drain in the interval-driven tick path to apply `record_rate_limit`/`record_success` after task processing.
- Added the same post-tick signal drain in the webhook-triggered tick path for consistent behavior.
- Ran required checks successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (3179 passed, 19 skipped).
- Committed change as `f895d1f5` with message `fix(engine): drain weight signals after tick execution`.


### Files changed

- `src/engine/mod.rs`


Closes #2778

---
*Task #2778 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*