### PR TITLE
bug: is_degraded() is defined but never called — operators have no visibility when all agents are on cooldown

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -444,7 +444,6 @@ impl Router {
 
     /// Check if the system is in degraded mode (fewer than threshold healthy agents).
     /// Uses "simple" complexity as the baseline since it has the widest model support.
-    #[allow(dead_code)]
     pub fn is_degraded(&self, threshold: usize) -> bool {
         self.healthy_agent_count("simple") < threshold
     }

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -1250,8 +1250,9 @@ pub(crate) struct DispatchMode {
 pub(crate) fn dispatch_mode_from_router(router: &Router) -> DispatchMode {
     let threshold = crate::engine::router::config::min_healthy_agents_threshold();
     let healthy_agents = router.healthy_agent_count("simple");
+    let is_degraded = router.is_degraded(threshold);
     DispatchMode {
-        is_degraded: healthy_agents < threshold,
+        is_degraded,
         healthy_agents,
         threshold,
     }


### PR DESCRIPTION
## Summary

All 3179 tests pass. Here's a summary of the fix:

**Changes made:**

1. **`src/engine/router/mod.rs:445-450`** — Removed `#[allow(dead_code)]` from `is_degraded()`. The method was defined but never called, so Rust flagged it as dead code. The attribute suppressed the warning but hid the bug.

2. **`src/engine/tick.rs:1250-1258`** — `dispatch_mode_from_router()` now calls `router.is_degraded(threshold)` instead of duplicating the logic inline. This wires the existing `is_degraded()` method i

### What was done

- Changes made:**
- **`src/engine/router/mod.rs:445-450`** — Removed `#[allow(dead_code)]` from `is_degraded()`. The method was defined but never called, so Rust flagged it as dead code. The attribute suppressed the warning but hid the bug.
- **`src/engine/tick.rs:1250-1258`** — `dispatch_mode_from_router()` now calls `router.is_degraded(threshold)` instead of duplicating the logic inline. This wires the existing `is_degraded()` method into the routing path.
- How degraded state visibility already worked (before this fix):**
- `tick.rs:1300-1305` logs `"degraded mode: using sequential dispatch"` when `DispatchMode.is_degraded` is true
- `sync.rs:emit_degraded_agents_if_needed()` writes `metrics:orch.agents_degraded.count` and `metrics:orch.agents_degraded.alert` metrics, and logs a warning when 3+ agents are degraded
- What this fix adds:**
- `Router::is_degraded()` is now called by the tick loop rather than sitting unused, eliminating the dead-code smell and making the routing health check explicit at the call site.


### Files changed

- `src/engine/router/mod.rs`
- `src/engine/tick.rs`


Closes #2780

---
*Task #2780 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*