### PR TITLE
bug: Redundant Arc::clone when passing store to store_set_by_id

### DIFF
--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -1429,7 +1429,7 @@ mod tests {
             .await
             .unwrap();
         crate::store::store_set_by_id(
-            &Some(Arc::clone(&store)),
+            &Some(&store),
             task_store_id,
             &[("branch", serde_json::json!("my-branch"))],
         )
@@ -1501,7 +1501,7 @@ mod tests {
             .await
             .unwrap();
         crate::store::store_set_by_id(
-            &Some(Arc::clone(&store)),
+            &Some(&store),
             task_id,
             &[("branch", serde_json::json!("feat-branch"))],
         )
@@ -1564,7 +1564,7 @@ mod tests {
             .await
             .unwrap();
         crate::store::store_set_by_id(
-            &Some(Arc::clone(&store)),
+            &Some(&store),
             task_id,
             &[("branch", serde_json::json!("feat-branch"))],
         )
@@ -1626,7 +1626,7 @@ mod tests {
             .await
             .unwrap();
         crate::store::store_set_by_id(
-            &Some(Arc::clone(&store)),
+            &Some(&store),
             task_id,
             &[("branch", serde_json::json!("feat-branch"))],
         )
@@ -1639,7 +1639,7 @@ mod tests {
         // Pre-set no_code_reroutes to a high value that exceeds any configured max after increment.
         // The default max is 3; use 99 to be robust against any real config on the test machine.
         crate::store::store_set_by_id(
-            &Some(Arc::clone(&store)),
+            &Some(&store),
             task_id,
             &[("no_code_reroutes", serde_json::json!(99i64))],
         )
@@ -1725,7 +1725,7 @@ mod tests {
             .await
             .unwrap();
         crate::store::store_set_by_id(
-            &Some(Arc::clone(&store)),
+            &Some(&store),
             task_id,
             &[("branch", serde_json::json!("feat-branch"))],
         )
@@ -1785,14 +1785,14 @@ mod tests {
             .await
             .unwrap();
         crate::store::store_set_by_id(
-            &Some(Arc::clone(&store)),
+            &Some(&store),
             task_id,
             &[("branch", serde_json::json!("feat-branch"))],
         )
         .await;
         // Set pr_number so task reaches Phase 4.
         crate::store::store_set_by_id(
-            &Some(Arc::clone(&store)),
+            &Some(&store),
             task_id,
             &[("pr_number", serde_json::json!(99i64))],
         )
@@ -1916,7 +1916,7 @@ mod tests {
         // Pre-set review_ts_map so the reviewer's review is already watermarked.
         let ts = "2026-01-05T00:00:00Z";
         crate::store::store_set_by_id(
-            &Some(Arc::clone(&store)),
+            &Some(&store),
             task_id,
             &[
                 ("branch", serde_json::json!("feat-branch")),
@@ -1994,13 +1994,13 @@ mod tests {
             .await
             .unwrap();
         crate::store::store_set_by_id(
-            &Some(Arc::clone(&store)),
+            &Some(&store),
             task_id,
             &[("branch", serde_json::json!("feat-branch"))],
         )
         .await;
         crate::store::store_set_by_id(
-            &Some(Arc::clone(&store)),
+            &Some(&store),
             task_id,
             &[("pr_number", serde_json::json!(20i64))],
         )
@@ -2008,7 +2008,7 @@ mod tests {
         // Set last_comment_review_ts to match the comment's created_at so it is deduplicated.
         let ts = "2026-01-05T00:00:00Z";
         crate::store::store_set_by_id(
-            &Some(Arc::clone(&store)),
+            &Some(&store),
             task_id,
             &[("last_comment_review_ts", serde_json::json!(ts))],
         )

--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -194,7 +194,7 @@ impl<'a> StoreCtx<'a> {
     /// Write fields, using the pre-resolved `store_id` when available.
     async fn set(&self, fields: &[(&str, serde_json::Value)]) {
         if let Some(store_id) = self.store_id_opt {
-            store::store_set_by_id(self.store, store_id, fields).await;
+            store::store_set_by_id(&self.store.as_ref(), store_id, fields).await;
         } else {
             store::store_set(self.store, self.repo, self.task_id, fields).await;
         }

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -381,7 +381,7 @@ pub(crate) async fn tick_detect_silent_agents(
                 // directly without an LLM re-routing cycle. Clearing model forces
                 // model_for_complexity to pick the best available model for the new agent.
                 store_set_by_id(
-                    &Some(Arc::clone(store)),
+                    &Some(store),
                     store_id,
                     &[
                         ("agent", serde_json::json!(fallback)),
@@ -398,7 +398,7 @@ pub(crate) async fn tick_detect_silent_agents(
                 .await;
             } else {
                 store_set_by_id(
-                    &Some(Arc::clone(store)),
+                    &Some(store),
                     store_id,
                     &[
                         ("agent", serde_json::Value::Null),
@@ -638,7 +638,7 @@ pub(crate) async fn tick_recover_stuck_tasks(
         };
         if let Some(store_id) = resolved_store_id {
             store_set_by_id(
-                &Some(Arc::clone(store)),
+                &Some(store),
                 store_id,
                 &[
                     ("agent", serde_json::Value::Null),
@@ -830,7 +830,7 @@ pub(crate) async fn tick_recover_stuck_tasks(
         };
         if let Some(store_id) = resolved_store_id {
             store_set_by_id(
-                &Some(Arc::clone(store)),
+                &Some(store),
                 store_id,
                 &[
                     ("agent", serde_json::Value::Null),

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -78,11 +78,11 @@ pub async fn opt_store_get_task(
 ///
 /// `store` may be None if the store isn't initialized yet.
 pub async fn store_set_by_id(
-    store: &Option<Arc<TaskStore>>,
+    store: &Option<&Arc<TaskStore>>,
     store_id: i64,
     store_fields: &[(&str, serde_json::Value)],
 ) {
-    if let Some(ref store) = store {
+    if let Some(store) = store {
         if let Err(e) = store.set_fields(store_id, store_fields).await {
             tracing::warn!(store_id, error = %e, "store set_fields failed");
         }

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -533,7 +533,7 @@ async fn helper_store_set_by_id_writes_fields() {
 
     let opt_store = Some(store.clone());
     store_set_by_id(
-        &opt_store,
+        &opt_store.as_ref(),
         id,
         &[
             ("branch", serde_json::json!("fix-bug-by-id")),


### PR DESCRIPTION
## Summary

All changes are clean. Here's a summary:

**What changed:**

1. **`src/store/helpers.rs`**: `store_set_by_id` parameter changed from `&Option<Arc<TaskStore>>` to `&Option<&Arc<TaskStore>>` — borrows the Arc reference instead of requiring an owned `Arc`.

2. **`src/engine/tick.rs`** (4 sites): `&Some(Arc::clone(store))` → `&Some(store)` where `store: &Arc<TaskStore>`. No Arc clone needed — just wraps the existing reference.

3. **`src/engine/runner/response_handler.rs`**: `self.store` → `

### Files changed

- `src/engine/review_poll.rs`
- `src/engine/runner/response_handler.rs`
- `src/engine/tick.rs`
- `src/store/helpers.rs`
- `src/store/tests.rs`


Closes #2779

---
*Task #2779 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*