### PR TITLE
bug: get_metrics_summary_by_repo counts global rate_limits instead of repo-scoped events

### DIFF
--- a/src/store/metrics.rs
+++ b/src/store/metrics.rs
@@ -434,9 +434,14 @@ impl TaskStore {
             .collect();
 
         let rate_limits: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM rate_limits WHERE occurred_at >= datetime('now', ?)",
+            "SELECT COUNT(*)
+             FROM rate_limits r
+             INNER JOIN tasks t ON r.task_id = CAST(t.id AS TEXT) OR r.task_id = t.external_id
+             WHERE r.occurred_at >= datetime('now', ?)
+             AND t.repo = ?",
         )
         .bind(&interval)
+        .bind(repo)
         .fetch_one(&self.pool)
         .await?;
 

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -4938,6 +4938,57 @@ async fn metrics_summary_by_repo_filters_correctly() {
 }
 
 #[tokio::test]
+async fn metrics_summary_rate_limits_are_repo_scoped() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let id1 = store
+        .create_internal("owner/orch", "Task A", "", "test", "", None)
+        .await
+        .unwrap();
+    let id2 = store
+        .create_internal("owner/bean", "Task B", "", "test", "", None)
+        .await
+        .unwrap();
+
+    store
+        .record_rate_limit("claude", "rate_limit", Some(&id1.to_string()))
+        .await
+        .unwrap();
+    store
+        .record_rate_limit("claude", "rate_limit", Some(&id1.to_string()))
+        .await
+        .unwrap();
+    store
+        .record_rate_limit("codex", "rate_limit", Some(&id2.to_string()))
+        .await
+        .unwrap();
+
+    let orch_summary = store
+        .get_metrics_summary_by_repo("owner/orch", 24)
+        .await
+        .unwrap();
+    assert_eq!(
+        orch_summary.rate_limits_24h, 2,
+        "orch should only see its own 2 rate limits"
+    );
+
+    let bean_summary = store
+        .get_metrics_summary_by_repo("owner/bean", 24)
+        .await
+        .unwrap();
+    assert_eq!(
+        bean_summary.rate_limits_24h, 1,
+        "bean should only see its own 1 rate limit"
+    );
+
+    let all_summary = store.get_metrics_summary_24h().await.unwrap();
+    assert_eq!(
+        all_summary.rate_limits_24h, 3,
+        "global should see all 3 rate limits"
+    );
+}
+
+#[tokio::test]
 async fn subscription_round_trip_with_multiple_channels() {
     let store = TaskStore::open_memory().await.unwrap();
 


### PR DESCRIPTION
## Summary

Fixed rate_limits_24h to be repo-scoped by joining rate_limits.task_id to tasks and filtering by repo, matching the pattern used for task_metrics. Added regression test.

### What was done

- Fixed get_metrics_summary_by_repo to filter rate_limits by repo
- Added metrics_summary_rate_limits_are_repo_scoped test with two repos


### Files changed

- `src/store/metrics.rs`
- `src/store/tests.rs`


Closes #2784

---
*Task #2784 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*