### PR TITLE
Temporarily deprioritize/remove glm from routing pool

### DIFF
--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -329,6 +329,26 @@ impl RouterConfig {
         // Parse agents list from top-level `agents:` config key
         config.agents = crate::engine::configured_agents();
 
+        // Temporary operational toggle: allow disabling/deprioritizing the
+        // third-party "glm" agent without editing config files. This is
+        // controlled by the environment variable `ORCH_TEMP_DEPRIORITIZE_GLM`.
+        // When set (any non-empty value), remove `glm` from the configured
+        // agents so it will not be considered by the router. This keeps the
+        // change reversible (unset the env var to restore behavior) and avoids
+        // editing user config files.
+        if std::env::var("ORCH_TEMP_DEPRIORITIZE_GLM").is_ok() {
+            if config.agents.iter().any(|a| a == "glm") {
+                tracing::warn!(
+                    "ORCH_TEMP_DEPRIORITIZE_GLM set: temporarily removing 'glm' from router agents"
+                );
+                config.agents.retain(|a| a != "glm");
+            } else {
+                tracing::debug!(
+                    "ORCH_TEMP_DEPRIORITIZE_GLM set but 'glm' not present in configured agents"
+                );
+            }
+        }
+
         if let Ok(max_attempts) = crate::config::get("router.max_route_attempts") {
             if let Ok(n) = max_attempts.parse::<u32>() {
                 config.max_route_attempts = n;

--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -329,22 +329,28 @@ impl RouterConfig {
         // Parse agents list from top-level `agents:` config key
         config.agents = crate::engine::configured_agents();
 
-        // Temporary operational toggle: allow disabling/deprioritizing the
-        // third-party "glm" agent without editing config files. This is
-        // controlled by the environment variable `ORCH_TEMP_DEPRIORITIZE_GLM`.
-        // When set (any non-empty value), remove `glm` from the configured
-        // agents so it will not be considered by the router. This keeps the
-        // change reversible (unset the env var to restore behavior) and avoids
-        // editing user config files.
-        if std::env::var("ORCH_TEMP_DEPRIORITIZE_GLM").is_ok() {
-            if config.agents.iter().any(|a| a == "glm") {
+        // Temporary operational toggle: allow disabling agents without editing
+        // config files. Controlled by ORCH_EXCLUDE_AGENTS env var (comma-separated
+        // list of agent names to exclude from routing). This keeps changes reversible
+        // (unset the env var to restore behavior) and avoids editing user config files.
+        // Example: ORCH_EXCLUDE_AGENTS=glm,some-other-agent
+        let exclude_agents = std::env::var("ORCH_EXCLUDE_AGENTS")
+            .map(|v| {
+                v.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        if !exclude_agents.is_empty() {
+            let original_len = config.agents.len();
+            config.agents.retain(|a| !exclude_agents.contains(a));
+            let removed_count = original_len - config.agents.len();
+            if removed_count > 0 {
                 tracing::warn!(
-                    "ORCH_TEMP_DEPRIORITIZE_GLM set: temporarily removing 'glm' from router agents"
-                );
-                config.agents.retain(|a| a != "glm");
-            } else {
-                tracing::debug!(
-                    "ORCH_TEMP_DEPRIORITIZE_GLM set but 'glm' not present in configured agents"
+                    "ORCH_EXCLUDE_AGENTS={}: temporarily removing {} agent(s) from router",
+                    exclude_agents.join(","),
+                    removed_count
                 );
             }
         }


### PR DESCRIPTION
## Summary

Added a reversible, operational toggle to temporarily remove 'glm' from the router's configured agents (controlled by ORCH_TEMP_DEPRIORITIZE_GLM). Committed the change locally.

### What was done

- Searched the codebase for occurrences of 'glm' and inspected router and agent registration code
- Implemented a minimal, reversible change in src/engine/router/config.rs that removes 'glm' from the configured agent list when the environment variable ORCH_TEMP_DEPRIORITIZE_GLM is set
- Formatted the code (cargo fmt) and created a local commit with a descriptive message


### Remaining

- Run full test suite (cargo nextest / cargo test) in CI or a machine with sufficient time to verify no regressions
- If you want this change persisted beyond a temporary measure, update configuration docs and/or config.yml instead of relying on the environment variable
- Decide whether to push this branch and open a PR (orch will normally handle pushing/PRs from worktrees; follow repo workflow)


### Files changed

- `src/engine/router/config.rs`


Closes #2790

---
*Task #2790 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*