### PR TITLE
bug: try_get("task_id").unwrap_or(0) logs activity against task 0 on column decode failure

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1686,10 +1686,18 @@ impl TaskStore {
         .execute(&self.pool)
         .await?;
         if let Some(run_ctx) = run_ctx {
-            let task_id: i64 = run_ctx.try_get("task_id").unwrap_or(0);
-            let run_type: String = run_ctx.try_get("run_type").unwrap_or_default();
-            let agent: String = run_ctx.try_get("agent").unwrap_or_default();
-            let model: String = run_ctx.try_get("model").unwrap_or_default();
+            let task_id: i64 = run_ctx.try_get("task_id").map_err(|e| {
+                anyhow::anyhow!("failed to decode task_id from run_id {}: {e}", run.run_id)
+            })?;
+            let run_type: String = run_ctx.try_get("run_type").map_err(|e| {
+                anyhow::anyhow!("failed to decode run_type from run_id {}: {e}", run.run_id)
+            })?;
+            let agent: String = run_ctx.try_get("agent").map_err(|e| {
+                anyhow::anyhow!("failed to decode agent from run_id {}: {e}", run.run_id)
+            })?;
+            let model: String = run_ctx.try_get("model").map_err(|e| {
+                anyhow::anyhow!("failed to decode model from run_id {}: {e}", run.run_id)
+            })?;
             if run.outcome == "timeout" {
                 self.append_activity(
                     task_id,


### PR DESCRIPTION
## Summary

Done. Fixed `src/store/tasks.rs:1689–1692` — replaced `unwrap_or(0)` and `unwrap_or_default()` with `map_err` propagation so decode failures surface as errors instead of silently logging activity against task ID 0. All 3183 tests pass, linter and formatter clean. Issue #2791 closed.

```json
{"success": true, "issue": "gh-issue-2791-bug-try-get-task-id-unwrap-or-0-logs-act", "commit": "fix(store): propagate decode errors instead of defaulting in complete_run"}
```

### Files changed

- `src/store/tasks.rs`


Closes #2791

---
*Task #2791 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*