### PR TITLE
bug: update_task_status(Routed) failure swallowed in tick — causes infinite LLM re-routing loop

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -1100,6 +1100,7 @@ pub(crate) async fn tick_route_tasks(
                             ?e,
                             "failed to set internal status:routed"
                         );
+                        continue;
                     }
                 } else {
                     // Fire-and-forget: label operations are cosmetic (routing already
@@ -1149,6 +1150,7 @@ pub(crate) async fn tick_route_tasks(
                         .await
                     {
                         tracing::warn!(task_id = task.id.0, ?e, "failed to set status:routed");
+                        continue;
                     }
                 }
 


### PR DESCRIPTION
## Summary

Fixed the routed-status failure handling in tick routing so tasks stop processing when `update_task_status(..., Routed)` fails, preventing continued routing flow on inconsistent state.

### What was done

- Updated `src/engine/tick.rs` internal-task branch to `continue` after `update_task_status(&task.id, Status::Routed)` failure.
- Updated `src/engine/tick.rs` external-task branch to `continue` after `update_task_status(&task.id, Status::Routed)` failure.
- Ran required checks successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (3183 passed, 19 skipped).
- Committed changes with conventional commit: `fix: skip routing continuation when routed status update fails` (ad4893c3).


### Files changed

- `src/engine/tick.rs`


Closes #2793

---
*Task #2793 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*