### PR TITLE
bug: non-canonical agent statuses become opaque failed runs ('no error info available')

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -102,7 +102,13 @@ fn classify_run_outcome(
         Ok(_)
             if matches!(
                 status,
-                "done" | "completed" | "in_progress" | "in_review" | "blocked" | "needs_review"
+                "done"
+                    | "completed"
+                    | "in_progress"
+                    | "in_review"
+                    | "blocked"
+                    | "needs_review"
+                    | "routed"
             ) =>
         {
             "success"
@@ -367,7 +373,25 @@ impl TaskRunner {
             };
 
             if error.is_empty() {
-                "no error info available".to_string()
+                if matches!(
+                    input.status,
+                    "done"
+                        | "completed"
+                        | "in_progress"
+                        | "in_review"
+                        | "blocked"
+                        | "needs_review"
+                        | "routed"
+                        | "new"
+                ) {
+                    // Canonical non-success statuses have no error message (e.g. "routed").
+                    String::new()
+                } else {
+                    // Non-canonical status with no error message — surface the status
+                    // explicitly so operators can identify which statuses need to be
+                    // added to the normalization map in parser.rs.
+                    format!("unrecognized status: {}", input.status)
+                }
             } else {
                 error
             }
@@ -1755,6 +1779,29 @@ mod tests {
         );
     }
 
+    #[test]
+    fn classify_run_outcome_routed_is_success() {
+        // "routed" is a canonical non-success status (task will be re-dispatched).
+        // It should be classified as "success" so the audit trail distinguishes it
+        // from genuine failures (#2801).
+        let parse_result = ok_parse_result("routed");
+        assert_eq!(
+            classify_run_outcome("routed", &parse_result, false, false),
+            "success"
+        );
+    }
+
+    #[test]
+    fn classify_run_outcome_non_canonical_is_failed() {
+        // Non-canonical statuses should be classified as "failed" in the audit.
+        // The explicit error message is provided by build_run_audit.
+        let parse_result = ok_parse_result("fix_deployed");
+        assert_eq!(
+            classify_run_outcome("fix_deployed", &parse_result, false, false),
+            "failed"
+        );
+    }
+
     #[tokio::test]
     async fn build_run_audit_success_ignores_stale_last_error() {
         let store = Arc::new(TaskStore::open_memory().await.unwrap());
@@ -1818,7 +1865,66 @@ mod tests {
             .await;
 
         assert_eq!(audit.outcome, "failed");
-        assert_eq!(audit.error, "no error info available");
+        // "new" is a canonical non-success status — no error message needed.
+        assert_eq!(audit.error, "");
+    }
+
+    #[tokio::test]
+    async fn build_run_audit_non_canonical_status_reports_explicit_error() {
+        // Non-canonical statuses (not in the allowlist) with no parse error
+        // should get an explicit "unrecognized status: X" message instead of
+        // the opaque "no error info available" placeholder (#2801).
+        let runner = TaskRunner::new("owner/repo".to_string());
+        let parse_result = ok_parse_result("fix_deployed");
+        let started_at = Utc::now();
+        let audit = runner
+            .build_run_audit(RunAuditInput {
+                task_id: "1",
+                status: "fix_deployed",
+                parse_result: &parse_result,
+                raw_stdout: "",
+                raw_stderr: "",
+                started_at: &started_at,
+                error_override: None,
+                elapsed_secs: Some(1),
+                push_failed: false,
+                budget_exceeded: false,
+            })
+            .await;
+
+        assert_eq!(audit.outcome, "failed");
+        assert_eq!(audit.error, "unrecognized status: fix_deployed");
+    }
+
+    #[tokio::test]
+    async fn build_run_audit_canonical_non_success_status_no_error_message() {
+        // Canonical non-success statuses (e.g. "routed") should not produce
+        // an error message — they're expected outcomes, not failures.
+        for status in &["routed", "blocked"] {
+            let runner = TaskRunner::new("owner/repo".to_string());
+            let parse_result = ok_parse_result(status);
+            let started_at = Utc::now();
+            let audit = runner
+                .build_run_audit(RunAuditInput {
+                    task_id: "1",
+                    status,
+                    parse_result: &parse_result,
+                    raw_stdout: "",
+                    raw_stderr: "",
+                    started_at: &started_at,
+                    error_override: None,
+                    elapsed_secs: Some(1),
+                    push_failed: false,
+                    budget_exceeded: false,
+                })
+                .await;
+
+            assert_eq!(audit.outcome, "success", "status={status}");
+            assert_eq!(
+                audit.error, "",
+                "status={status}: no error for canonical status"
+            );
+        }
     }
 
     // ── resolve_project_dir ──────────────────────────────────────────────────

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -73,7 +73,7 @@ pub fn parse(raw: &str) -> anyhow::Result<AgentResponse> {
     let mut saw_jsonish_candidate = false;
     for candidate in json_candidates(raw) {
         match parse_candidate(&candidate) {
-            Ok(resp) => return Ok(resp),
+            Ok(resp) => return Ok(normalize_status(resp)),
             Err(err) => {
                 if err.to_string() != "invalid agent response candidate" {
                     saw_jsonish_candidate = true;
@@ -97,6 +97,45 @@ pub fn parse(raw: &str) -> anyhow::Result<AgentResponse> {
         "agent output is not valid JSON or a supported JSON wrapper: {}",
         raw.trim()
     )
+}
+
+/// Map known non-canonical agent statuses to their canonical equivalents.
+///
+/// Agents sometimes return statuses like `"ok"`, `"success"`, or `"completed"`
+/// that are semantically equivalent to `"done"`. Normalizing them here ensures
+/// that `classify_run_outcome` correctly classifies the run as success and
+/// prevents opaque `"no error info available"` failures when an agent returns
+/// a valid but non-canonical status.
+///
+/// Unknown statuses are kept as-is so that downstream code can distinguish
+/// them from canonical ones (e.g. for debugging/metrics).
+fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
+    resp.status = match resp.status.as_str() {
+        // Canonical completion statuses.
+        "done" | "completed" | "ok" | "success" => "done".to_string(),
+        // Canonical progress statuses.
+        "in_progress" | "running" => "in_progress".to_string(),
+        "in_review" | "reviewing" => "in_review".to_string(),
+        "needs_review" | "pending_review" => "needs_review".to_string(),
+        // Canonical error statuses.
+        "blocked" | "error" | "failed" => "blocked".to_string(),
+        // Passthrough: known canonical statuses (already canonical, keep as-is).
+        s if s == "new"
+            || s == "routed"
+            || s == "in_progress"
+            || s == "done"
+            || s == "blocked"
+            || s == "in_review"
+            || s == "needs_review" =>
+        {
+            s.to_string()
+        }
+        // Unknown non-canonical status — keep as-is so the audit trail records
+        // exactly what the agent returned. This lets operators identify which
+        // statuses need to be added to the normalization map.
+        other => other.to_string(),
+    };
+    resp
 }
 
 /// Extract the first JSON code block from markdown.
@@ -775,5 +814,90 @@ Some output here.
         assert_eq!(resp.status, "needs_review");
         assert_eq!(resp.summary, "All tests pass");
         assert_eq!(resp.files, vec!["src/lib.rs"]);
+    }
+
+    // ── normalize_status tests ────────────────────────────────────────────────
+
+    #[test]
+    fn parse_normalizes_ok_alias_to_done() {
+        let input =
+            r#"{"status":"ok","summary":"all good","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "done");
+    }
+
+    #[test]
+    fn parse_normalizes_success_alias_to_done() {
+        let input = r#"{"status":"success","summary":"fixed it","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "done");
+    }
+
+    #[test]
+    fn parse_normalizes_completed_alias_to_done() {
+        let input = r#"{"status":"completed","summary":"done","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "done");
+    }
+
+    #[test]
+    fn parse_normalizes_running_alias_to_in_progress() {
+        let input = r#"{"status":"running","summary":"working","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "in_progress");
+    }
+
+    #[test]
+    fn parse_normalizes_reviewing_alias_to_in_review() {
+        let input = r#"{"status":"reviewing","summary":"reviewing","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "in_review");
+    }
+
+    #[test]
+    fn parse_normalizes_pending_review_alias_to_needs_review() {
+        let input = r#"{"status":"pending_review","summary":"ready","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "needs_review");
+    }
+
+    #[test]
+    fn parse_normalizes_error_alias_to_blocked() {
+        let input =
+            r#"{"status":"error","summary":"failed","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "blocked");
+    }
+
+    #[test]
+    fn parse_keeps_canonical_statuses_unchanged() {
+        for status in &[
+            "new",
+            "routed",
+            "in_progress",
+            "done",
+            "blocked",
+            "in_review",
+            "needs_review",
+        ] {
+            let input = format!(
+                r#"{{"status":"{status}","summary":"test","accomplished":[],"remaining":[],"files":[]}}"#
+            );
+            let resp = parse(&input).unwrap();
+            assert_eq!(
+                resp.status, *status,
+                "canonical status '{status}' should be unchanged"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_keeps_non_canonical_status_as_is_for_audit_trail() {
+        // Non-canonical statuses that are not in the alias map are kept as-is
+        // so operators can identify which statuses need to be added to normalize_status.
+        let input = r#"{"status":"fix_deployed","summary":"deployed","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        // Kept as-is (not normalized away) so build_run_audit can report it explicitly.
+        assert_eq!(resp.status, "fix_deployed");
     }
 }


### PR DESCRIPTION
## Summary

All 3209 tests pass. Here's a summary of the fix:

## Changes

### 1. `src/parser.rs` — Normalize non-canonical statuses at parse time

Added `normalize_status()` that maps common aliases to canonical task statuses:

| Agent returns | Normalized to |
|---|---|
| `ok`, `success`, `completed` | `done` |
| `running` | `in_progress` |
| `reviewing` | `in_review` |
| `pending_review` | `needs_review` |
| `error`, `failed` | `blocked` |
| canonical statuses (`done`, `in_progress`, etc.) | unchanged 

### What was done

- `classify_run_outcome`**: Added `"routed"` to the success allowlist (it's a canonical non-failure outcome).
- **Canonical non-success statuses** (`new`, `routed`, `blocked`): error = `""` (no message needed)
- **Non-canonical statuses** (e.g. `fix_deployed`): error = `"unrecognized status: fix_deployed"` — explicit and actionable
- Each alias mapping (`ok`→`done`, `success`→`done`, etc.)
- Canonical status passthrough
- Non-canonical status kept as-is for audit visibility
- `classify_run_outcome("routed")` = `"success"`
- `classify_run_outcome("fix_deployed")` = `"failed"`
- `build_run_audit` explicit error for unrecognized statuses
- `build_run_audit` no error for canonical non-success statuses


### Files changed

- `src/engine/runner/mod.rs`
- `src/parser.rs`


Closes #2801

---
*Task #2801 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*