### PR TITLE
bug: scan() skips comment lines but has_leaks() doesn't — 'N secrets detected' warning shows 0 when secret is in a comment line

### DIFF
--- a/src/security.rs
+++ b/src/security.rs
@@ -123,9 +123,11 @@ static LEAK_PATTERNS: LazyLock<Vec<(&str, Regex, bool)>> =
 /// - `//` (C-style comments)
 /// - `#` (shell/Python comments)
 /// - `<!--` (HTML comments)
-fn is_comment_line(trimmed: &str) -> bool {
-    trimmed.starts_with("//") || trimmed.starts_with('#') || trimmed.starts_with("<!--")
-}
+// Previously we skipped lines that looked like code comments which could
+// hide real secrets (eg. `# GITHUB_TOKEN=ghp_...`). That produced a confusing
+// situation where `has_leaks()` returned true but `scan()` returned 0 matches.
+// Align behavior: do not skip comment-like lines in `scan()` — check every
+// line so `scan()` and `has_leaks()` are consistent.
 
 /// Scan text for potential leaked secrets.
 ///
@@ -135,11 +137,7 @@ pub fn scan(text: &str) -> Vec<LeakMatch> {
     let mut matches = Vec::new();
 
     for (line_num, line) in text.lines().enumerate() {
-        let trimmed = line.trim();
-        // Skip lines that look like code comments explaining patterns
-        if is_comment_line(trimmed) {
-            continue;
-        }
+        let _trimmed = line.trim();
 
         for (rule, pattern, _high_conf) in LEAK_PATTERNS.iter() {
             if let Some(m) = pattern.find(line) {
@@ -234,8 +232,11 @@ mod tests {
     #[test]
     fn ignores_comments() {
         let text = "// Example: OPENAI_API_KEY=sk-proj-1234567890abcdefghijklmn";
+        // We no longer skip comment-like lines in `scan()`; secrets in comments
+        // should be detected just like in normal text so `has_leaks()` and
+        // `scan()` remain consistent.
         let matches = scan(text);
-        assert!(matches.is_empty());
+        assert!(!matches.is_empty());
     }
 
     #[test]

--- a/src/security.rs
+++ b/src/security.rs
@@ -117,12 +117,6 @@ fn build_leak_patterns(specs: &[LeakPatternSpec]) -> Vec<(&'static str, Regex, b
 static LEAK_PATTERNS: LazyLock<Vec<(&str, Regex, bool)>> =
     LazyLock::new(|| build_leak_patterns(LEAK_PATTERN_SPECS));
 
-/// Check if a trimmed line is a comment that should be skipped.
-///
-/// Skips lines that look like code comments explaining patterns:
-/// - `//` (C-style comments)
-/// - `#` (shell/Python comments)
-/// - `<!--` (HTML comments)
 // Previously we skipped lines that looked like code comments which could
 // hide real secrets (eg. `# GITHUB_TOKEN=ghp_...`). That produced a confusing
 // situation where `has_leaks()` returned true but `scan()` returned 0 matches.
@@ -137,8 +131,6 @@ pub fn scan(text: &str) -> Vec<LeakMatch> {
     let mut matches = Vec::new();
 
     for (line_num, line) in text.lines().enumerate() {
-        let _trimmed = line.trim();
-
         for (rule, pattern, _high_conf) in LEAK_PATTERNS.iter() {
             if let Some(m) = pattern.find(line) {
                 let matched = m.as_str();


### PR DESCRIPTION
## Summary

Fix inconsistent comment-line handling in security scanning: scan() no longer skips comment-like lines and tests updated to reflect that secrets in comment lines are detected.

### What was done

- Removed logic that skipped lines starting with //, #, or <!-- in scan() so it inspects all lines consistently with has_leaks()
- Added explanatory comment in src/security.rs explaining the rationale
- Updated the unit test that previously expected comment lines to be ignored so it now expects secrets in comment-like lines to be detected
- Ran rust unit tests (cargo test --lib) locally and committed the change


### Remaining

- Monitor CI; a few unrelated tests in unrelated modules were previously failing in the local run (appear pre-existing) — CI will validate full test matrix
- If desired, consider adding a targeted heuristic later (e.g. skip only when 'example'/'placeholder' present) — currently intentionally conservative to avoid silent misses


### Files changed

- `src/security.rs`


Closes #2805

---
*Task #2805 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*