### PR TITLE
bug: update_status / update_status_if / reset_to_new silently default from_status on decode error — same missed fix as 4c02d7f3

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -675,7 +675,9 @@ impl TaskStore {
             .bind(id)
             .fetch_one(&self.pool)
             .await?;
-        let from_status: String = previous.try_get("status").unwrap_or_default();
+        let from_status: String = previous
+            .try_get("status")
+            .map_err(|e| anyhow::anyhow!("failed to read status column before update: {e}"))?;
         let agent: Option<String> = previous.try_get("agent").unwrap_or(None);
         let model: Option<String> = previous.try_get("model").unwrap_or(None);
         let sql = if status == TaskStatus::Blocked {
@@ -728,7 +730,9 @@ impl TaskStore {
             .bind(id)
             .fetch_one(&self.pool)
             .await?;
-        let from_status: String = previous.try_get("status").unwrap_or_default();
+        let from_status: String = previous
+            .try_get("status")
+            .map_err(|e| anyhow::anyhow!("failed to read status column before update: {e}"))?;
         let agent: Option<String> = previous.try_get("agent").unwrap_or(None);
         let model: Option<String> = previous.try_get("model").unwrap_or(None);
         let sql = if status == TaskStatus::Blocked {
@@ -781,7 +785,9 @@ impl TaskStore {
             .bind(id)
             .fetch_one(&self.pool)
             .await?;
-        let from_status: String = previous.try_get("status").unwrap_or_default();
+        let from_status: String = previous
+            .try_get("status")
+            .map_err(|e| anyhow::anyhow!("failed to read status column before update: {e}"))?;
         let agent: Option<String> = previous.try_get("agent").unwrap_or(None);
         let model: Option<String> = previous.try_get("model").unwrap_or(None);
         sqlx::query(


### PR DESCRIPTION
## Summary

Applied fix to all three functions in `src/store/tasks.rs`. All 3209 tests pass. Committed as `4b787c38`.

### Files changed

- `src/store/tasks.rs`


Closes #2806

---
*Task #2806 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*