### PR TITLE
bug: needs_review_refires counter pre-incremented before status update — premature Blocked escalation

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1274,8 +1274,22 @@ pub(crate) async fn sync_tick(
                 continue;
             }
 
-            // Fire: increment counter (this also updates updated_at, giving the task a fresh
-            // timestamp so subsequent ticks don't immediately re-fire it again).
+            // Fire: attempt the status update first. Only increment the counter on
+            // success so that transient DB failures don't artificially inflate
+            // needs_review_refires and cause premature Blocked escalation.
+            if let Err(e) = task_manager
+                .update_task_status(&task.external.id, Status::NeedsReview)
+                .await
+            {
+                tracing::warn!(
+                    task_id = task.task_id(),
+                    err = %e,
+                    "sync catch-up: failed to re-fire NeedsReview event — not incrementing counter"
+                );
+                continue;
+            }
+
+            // Increment only after the re-fire succeeds (mirrors the escalation path).
             let fired_refires = match crate::store::store_increment(
                 &Some(Arc::clone(store)),
                 repo,
@@ -1289,9 +1303,9 @@ pub(crate) async fn sync_tick(
                     tracing::warn!(
                         task_id = task.task_id(),
                         err = %e,
-                        "failed to increment needs_review_refires — deferring re-fire to next tick"
+                        "failed to increment needs_review_refires after re-fire"
                     );
-                    continue;
+                    current_refires + 1
                 }
             };
 
@@ -1302,17 +1316,6 @@ pub(crate) async fn sync_tick(
                 required_minutes,
                 "sync catch-up: re-firing NeedsReview event for stale task"
             );
-
-            if let Err(e) = task_manager
-                .update_task_status(&task.external.id, Status::NeedsReview)
-                .await
-            {
-                tracing::warn!(
-                    task_id = task.task_id(),
-                    err = %e,
-                    "sync catch-up: failed to re-fire NeedsReview event"
-                );
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixed premature Blocked escalation caused by pre-incrementing needs_review_refires before the status update. Now mirrors the escalation path: status update first, counter increment only on success.

### What was done

- Swapped order in src/engine/sync.rs lines 1277-1315: update_task_status(NeedsReview) is now called first; needs_review_refires is incremented only after a successful re-fire
- Added `continue` on status update failure so transient DB errors do not count as re-fire attempts
- Handled store_increment failure gracefully with a fallback to current_refires+1 (warning logged)
- All quality gates pass: cargo fmt, cargo clippy -D warnings, cargo nextest run (3211/3211 tests)


### Files changed

- `src/engine/sync.rs`


Closes #2811

---
*Task #2811 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*