### PR TITLE
bug: rate_limits join in get_metrics_summary_by_repo can double-count events (missing NOT EXISTS guard)

### DIFF
--- a/src/store/metrics.rs
+++ b/src/store/metrics.rs
@@ -442,7 +442,10 @@ impl TaskStore {
         let rate_limits: (i64,) = sqlx::query_as(
             "SELECT COUNT(*)
              FROM rate_limits r
-             INNER JOIN tasks t ON r.task_id = CAST(t.id AS TEXT) OR r.task_id = t.external_id
+             LEFT JOIN tasks t ON r.task_id = CAST(t.id AS TEXT)
+                 OR (r.task_id = t.external_id AND NOT EXISTS (
+                     SELECT 1 FROM tasks t2 WHERE t2.id = CAST(r.task_id AS INTEGER)
+                 ))
              WHERE r.occurred_at >= datetime('now', ?)
              AND t.repo = ?",
         )

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -5110,6 +5110,42 @@ async fn metrics_summary_rate_limits_are_repo_scoped() {
 }
 
 #[tokio::test]
+async fn metrics_summary_rate_limits_no_duplication_on_id_external_id_collision() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let id1 = store
+        .create_internal("owner/orch", "Task A", "", "test", "", None)
+        .await
+        .unwrap();
+    let id2 = store
+        .create_internal("owner/orch", "Task B", "", "test", "", None)
+        .await
+        .unwrap();
+
+    // Force an id/external_id collision across two different tasks.
+    store
+        .update_external_id(id2, &id1.to_string())
+        .await
+        .unwrap();
+
+    // This event references task A by numeric id; without the NOT EXISTS guard
+    // it would fan out to task A (id match) and task B (external_id match).
+    store
+        .record_rate_limit("claude", "rate_limit", Some(&id1.to_string()))
+        .await
+        .unwrap();
+
+    let orch_summary = store
+        .get_metrics_summary_by_repo("owner/orch", 24)
+        .await
+        .unwrap();
+    assert_eq!(
+        orch_summary.rate_limits_24h, 1,
+        "rate limit event must not be double-counted on id/external_id collision"
+    );
+}
+
+#[tokio::test]
 async fn subscription_round_trip_with_multiple_channels() {
     let store = TaskStore::open_memory().await.unwrap();
 


### PR DESCRIPTION
## Summary

Fixed repo-scoped rate-limit counting to avoid duplicate joins on task id/external_id collisions, and added a regression test.

### What was done

- Updated `get_metrics_summary_by_repo` in `src/store/metrics.rs` to replace the plain OR join with the guarded `NOT EXISTS` fallback pattern used by task_metrics queries.
- Added `metrics_summary_rate_limits_no_duplication_on_id_external_id_collision` in `src/store/tests.rs` to verify a rate-limit event is counted once when one task id collides with another task external_id.
- Ran required checks successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run`.
- Committed changes in `5f837543` with message `fix(metrics): prevent rate-limit double count on task id collision`.
- Verified clean working tree and commit presence via `git status --short` and `git log --oneline main..HEAD`.


### Files changed

- `src/store/metrics.rs`
- `src/store/tests.rs`


Closes #2815

---
*Task #2815 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*