### PR TITLE
bug: increment_task_tokens and update_task_run silently clamp to i64::MAX on token overflow (incomplete fix from #2729)

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1354,8 +1354,14 @@ impl TaskStore {
             updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
          WHERE id = ?",
         )
-        .bind(i64::try_from(input).unwrap_or(i64::MAX))
-        .bind(i64::try_from(output).unwrap_or(i64::MAX))
+        .bind(i64::try_from(input).unwrap_or_else(|_| {
+            tracing::warn!(input, "input_tokens overflows i64, clamping to MAX");
+            i64::MAX
+        }))
+        .bind(i64::try_from(output).unwrap_or_else(|_| {
+            tracing::warn!(output, "output_tokens overflows i64, clamping to MAX");
+            i64::MAX
+        }))
         .bind(cost.input_cost_usd)
         .bind(cost.output_cost_usd)
         .bind(cost.total_cost_usd)
@@ -1684,8 +1690,20 @@ impl TaskStore {
         .bind(run.parsed)
         .bind(run.outcome)
         .bind(run.error)
-        .bind(i64::try_from(run.tokens.input_tokens).unwrap_or(i64::MAX))
-        .bind(i64::try_from(run.tokens.output_tokens).unwrap_or(i64::MAX))
+        .bind(i64::try_from(run.tokens.input_tokens).unwrap_or_else(|_| {
+            tracing::warn!(
+                run.tokens.input_tokens,
+                "input_tokens overflows i64, clamping to MAX"
+            );
+            i64::MAX
+        }))
+        .bind(i64::try_from(run.tokens.output_tokens).unwrap_or_else(|_| {
+            tracing::warn!(
+                run.tokens.output_tokens,
+                "output_tokens overflows i64, clamping to MAX"
+            );
+            i64::MAX
+        }))
         .bind(run.tokens.total_cost_usd)
         .bind(run.tokens.duration_secs)
         .bind(run.run_id)


### PR DESCRIPTION
## Summary

Fixed silent token overflow clamping in src/store/tasks.rs by adding tracing warnings when u64→i64 conversion fails

### What was done

- Added tracing::warn! logs when input_tokens overflows i64 in increment_task_tokens
- Added tracing::warn! logs when output_tokens overflows i64 in increment_task_tokens
- Added tracing::warn! logs when input_tokens overflows i64 in update_task_run
- -added tracing::warn! logs when output_tokens overflows i64 in update_task_run


### Files changed

- `src/store/tasks.rs`


Closes #2816

---
*Task #2816 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*