### PR TITLE
bug: config watcher registration errors are discarded and misreported as success

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -150,8 +150,14 @@ fn watch_file(path: &PathBuf) {
             // Add to notify watcher
             if let Ok(mut guard) = FILE_WATCHER.lock() {
                 if let Some(ref mut watcher) = *guard {
-                    let _ = watcher.watch(path, RecursiveMode::NonRecursive);
-                    tracing::debug!("now watching config file: {}", path.display());
+                    match watcher.watch(path, RecursiveMode::NonRecursive) {
+                        Ok(()) => tracing::debug!("now watching config file: {}", path.display()),
+                        Err(e) => tracing::warn!(
+                            "failed to register config file watcher for {}: {}",
+                            path.display(),
+                            e
+                        ),
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fix already committed in e985a04d. The watch_file() function now pattern-matches on watcher.watch() result: logs debug on success and warn with path+error on failure. All quality gates pass (fmt, clippy, 3277 tests).

### Files changed

- `src/config/mod.rs`


Closes #2830

---
*Task #2830 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*