### PR TITLE
bug: invalid task status filters silently fall back to status:new

### DIFF
--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -252,7 +252,10 @@ async fn list_from_global_store(
             store.list_all_global().await?
         } else {
             let task_status = crate::store::TaskStatus::from_str(status_str)
-                .unwrap_or(crate::store::TaskStatus::New);
+                .ok_or_else(|| anyhow::anyhow!(
+                    "invalid status: '{}'. allowed: new, routed, in_progress, needs_review, in_review, blocked, done, all",
+                    status_str
+                ))?;
             store.list_all_by_status_global(task_status).await?
         }
     } else {

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -206,7 +206,11 @@ impl TaskManager {
 
         if let Some(status_str) = &filter.status {
             if !is_all {
-                let task_status = TaskStatus::from_str(status_str).unwrap_or(TaskStatus::New);
+                let task_status = TaskStatus::from_str(status_str)
+                    .ok_or_else(|| anyhow::anyhow!(
+                        "invalid status: '{}'. allowed: new, routed, in_progress, needs_review, in_review, blocked, done, all",
+                        status_str
+                    ))?;
                 let backend_status = match status_str.as_str() {
                     "new" => Status::New,
                     "routed" => Status::Routed,
@@ -215,7 +219,7 @@ impl TaskManager {
                     "blocked" => Status::Blocked,
                     "in_review" => Status::InReview,
                     "needs_review" => Status::NeedsReview,
-                    _ => Status::New,
+                    _ => unreachable!(),
                 };
 
                 // Get internal tasks from store


### PR DESCRIPTION
Resolves #2837

Auto-created by orch review gate (agent forgot to open PR)