### PR TITLE
dead code: ChannelRouter::general_target is never called (allow(dead_code) suppresses warning)

### DIFF
--- a/src/channels/routing.rs
+++ b/src/channels/routing.rs
@@ -129,12 +129,6 @@ impl ChannelRouter {
     pub fn projects(&self) -> &[String] {
         &self.project_list
     }
-
-    /// Get the General channel ID for a channel type.
-    #[allow(dead_code)]
-    pub fn general_target(&self, channel: &str) -> Option<&str> {
-        self.general.get(channel).map(|s| s.as_str())
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Resolves #2848

Auto-created by orch review gate (agent forgot to open PR)