### PR TITLE
bug: list_source_ids_by_source loads all-time mention IDs into memory every sync tick

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -1445,7 +1445,7 @@ async fn scan_comments(
 
     // Dedup set: mention tasks already created (by source_id).
     let existing_mentions: std::collections::HashSet<String> = if let Some(s) = store {
-        match s.list_source_ids_by_source(repo, "mention").await {
+        match s.list_source_ids_by_source(repo, "mention", 30).await {
             Ok(ids) => ids.into_iter().collect(),
             Err(e) => {
                 tracing::warn!(err = %e, "failed to load mention source IDs — skipping to prevent duplicates");

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -922,19 +922,23 @@ impl TaskStore {
         rows.iter().map(Self::row_to_task).collect()
     }
 
-    /// Return only the `source_id` values for internal tasks with a specific source.
+    /// Return only the `source_id` values for internal tasks with a specific source,
+    /// created within the last `since_days` days.
     /// Use this instead of `list_internal_by_source` when only deduplication is needed —
-    /// avoids fetching all 57 task columns.
+    /// avoids fetching all 57 task columns and bounds memory usage to a rolling window.
     pub async fn list_source_ids_by_source(
         &self,
         repo: &str,
         source: &str,
+        since_days: i64,
     ) -> anyhow::Result<Vec<String>> {
+        let cutoff = format!("-{since_days} days");
         let rows = sqlx::query(
-            "SELECT source_id FROM tasks WHERE repo = ? AND origin = 'internal' AND source = ?",
+            "SELECT source_id FROM tasks WHERE repo = ? AND origin = 'internal' AND source = ? AND created_at >= datetime('now', ?)",
         )
         .bind(repo)
         .bind(source)
+        .bind(&cutoff)
         .fetch_all(&self.pool)
         .await?;
         Ok(rows.iter().map(|r| r.get::<String, _>(0)).collect())


### PR DESCRIPTION
## Summary

Fix already implemented and committed - bound list_source_ids_by_source to 30-day rolling window to prevent unbounded memory growth

### What was done

- Modified list_source_ids_by_source in store/tasks.rs to accept since_days parameter and filter by created_at >= datetime('now', '-30 days')
- Updated call site in engine/sync.rs to pass 30 as the time window
- Verified build compiles successfully
- Verified formatting passes


### Files changed

- `src/engine/sync.rs`
- `src/store/tasks.rs`


Closes #2847

---
*Task #2847 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*