### PR TITLE
bug: read_task_snapshot silently swallows store.get() errors with no logging

### DIFF
--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -738,7 +738,14 @@ impl TaskManager {
                 };
                 (snapshot, Some(store_id))
             }
-            Err(_) => (TaskSnapshot::default(), None),
+            Err(e) => {
+                tracing::warn!(
+                    task_id = store_id,
+                    err = %e,
+                    "failed to read task snapshot for event enrichment — event context will be empty"
+                );
+                (TaskSnapshot::default(), None)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Added warn logging when read_task_snapshot fails at src/engine/tasks.rs:741, with task_id and err fields for observability

### What was done

- Replaced silent Err(_) with tracing::warn! logging that includes task_id and error details
- Allows debugging DB failures that cause empty event enrichment context


### Files changed

- `src/engine/tasks.rs`


Closes #2852

---
*Task #2852 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*