### PR TITLE
bug: list_source_ids_by_source uses panicking .get() instead of .try_get()

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -941,7 +941,16 @@ impl TaskStore {
         .bind(&cutoff)
         .fetch_all(&self.pool)
         .await?;
-        Ok(rows.iter().map(|r| r.get::<String, _>(0)).collect())
+
+        let mut ids = Vec::with_capacity(rows.len());
+        for row in &rows {
+            ids.push(row.try_get::<String, _>("source_id").map_err(|e| {
+                anyhow::anyhow!(
+                    "list_source_ids_by_source: failed to decode source_id for repo={repo}, source={source}: {e}"
+                )
+            })?);
+        }
+        Ok(ids)
     }
 
     /// List all active (non-done) tasks for a repo.


### PR DESCRIPTION
## Summary

Replaced panicking row decoding in list_source_ids_by_source with fallible decoding and contextual error propagation, then validated and committed the fix.

### What was done

- Updated `src/store/tasks.rs` `list_source_ids_by_source` to stop using `Row::get::<String, _>(0)`.
- Implemented `try_get::<String, _>("source_id")` in a loop and propagated decode failures via `anyhow` with repo/source context.
- Ran required checks successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (3304 passed, 19 skipped).
- Committed the change with conventional commit message: `fix(store): avoid panic decoding source_id rows`.


### Files changed

- `src/store/tasks.rs`


Closes #2853

---
*Task #2853 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*