### PR TITLE
bug: repo-scoped rate-limit metrics can undercount due to cross-repo id collisions

### DIFF
--- a/src/store/metrics.rs
+++ b/src/store/metrics.rs
@@ -356,10 +356,16 @@ impl TaskStore {
         let rate_limits: (i64,) = sqlx::query_as(
             "SELECT COUNT(*)
              FROM rate_limits r
-             LEFT JOIN tasks t ON r.task_id = CAST(t.id AS TEXT)
-                 OR (r.task_id = t.external_id AND NOT EXISTS (
-                     SELECT 1 FROM tasks t2 WHERE t2.id = CAST(r.task_id AS INTEGER)
-                 ))
+             LEFT JOIN tasks t ON (
+                 -- If any task exists with this value as an external_id, prefer
+                 -- external_id matching (global preference). This avoids mapping a
+                 -- rate-limit that references an external task to an unrelated
+                 -- repo that merely happens to have an internal numeric id equal
+                 -- to the same string.
+                 (EXISTS (SELECT 1 FROM tasks te WHERE te.external_id = r.task_id) AND r.task_id = t.external_id)
+                 OR
+                 (NOT EXISTS (SELECT 1 FROM tasks te WHERE te.external_id = r.task_id) AND r.task_id = CAST(t.id AS TEXT))
+             )
              WHERE r.occurred_at >= datetime('now', ?)
              AND t.repo = ?",
         )

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -5146,6 +5146,57 @@ async fn metrics_summary_rate_limits_no_duplication_on_id_external_id_collision(
 }
 
 #[tokio::test]
+async fn metrics_summary_rate_limits_cross_repo_numeric_collision() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    // Create an internal task in repo B which will get id = 1
+    let id_b = store
+        .create_internal("owner/bean", "Task B", "", "test", "", None)
+        .await
+        .unwrap();
+
+    // Upsert an external task in repo A with external_id equal to id_b (numeric string)
+    let id_a = store
+        .upsert_external(&UpsertExternal {
+            repo: "owner/orch",
+            ext_id: &id_b.to_string(),
+            title: "External A",
+            body: "",
+            author: "user",
+            url: "https://github.com/owner/orch/issues/1",
+            labels: &[],
+            origin: "github",
+        })
+        .await
+        .unwrap();
+
+    // Record a rate limit event that references task_id = "<id_b>" — it should
+    // resolve to the external task in owner/orch, not be suppressed by the
+    // existence of an unrelated internal task with the same numeric id in owner/bean.
+    store
+        .record_rate_limit("claude", "rate_limit", Some(&id_b.to_string()))
+        .await
+        .unwrap();
+
+    let orch_summary = store
+        .get_metrics_summary_by_repo("owner/orch", 24)
+        .await
+        .unwrap();
+
+    assert_eq!(orch_summary.rate_limits_24h, 1,
+        "orch should see its rate limit event even when an unrelated repo has the same numeric id");
+
+    let bean_summary = store
+        .get_metrics_summary_by_repo("owner/bean", 24)
+        .await
+        .unwrap();
+
+    // bean should not see the orch event (it belongs to orch)
+    assert_eq!(bean_summary.rate_limits_24h, 0,
+        "bean must not see orch's rate limit event")
+}
+
+#[tokio::test]
 async fn subscription_round_trip_with_multiple_channels() {
     let store = TaskStore::open_memory().await.unwrap();
 

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -5156,7 +5156,7 @@ async fn metrics_summary_rate_limits_cross_repo_numeric_collision() {
         .unwrap();
 
     // Upsert an external task in repo A with external_id equal to id_b (numeric string)
-    let id_a = store
+    let _id_a = store
         .upsert_external(&UpsertExternal {
             repo: "owner/orch",
             ext_id: &id_b.to_string(),
@@ -5183,8 +5183,10 @@ async fn metrics_summary_rate_limits_cross_repo_numeric_collision() {
         .await
         .unwrap();
 
-    assert_eq!(orch_summary.rate_limits_24h, 1,
-        "orch should see its rate limit event even when an unrelated repo has the same numeric id");
+    assert_eq!(
+        orch_summary.rate_limits_24h, 1,
+        "orch should see its rate limit event even when an unrelated repo has the same numeric id"
+    );
 
     let bean_summary = store
         .get_metrics_summary_by_repo("owner/bean", 24)
@@ -5192,8 +5194,10 @@ async fn metrics_summary_rate_limits_cross_repo_numeric_collision() {
         .unwrap();
 
     // bean should not see the orch event (it belongs to orch)
-    assert_eq!(bean_summary.rate_limits_24h, 0,
-        "bean must not see orch's rate limit event")
+    assert_eq!(
+        bean_summary.rate_limits_24h, 0,
+        "bean must not see orch's rate limit event"
+    )
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fix repo-scoped task id collision in rate_limit metrics join and add regression test.

### What was done

- Updated the rate_limits join logic in get_metrics_summary_by_repo() to avoid cross-repo numeric id collisions by preferring external_id matches and ensuring repo-scoped resolution.
- Added a regression test metrics_summary_rate_limits_cross_repo_numeric_collision to verify a numeric id in an unrelated repo does not cause mis-attribution of rate limit events.
- Ran the relevant unit tests locally to validate the new test and targeted metrics tests passed.


### Remaining

- Run the full test suite in CI (some unrelated tests in other modules fail locally on my machine; those are pre-existing and outside this change's scope).
- Optionally review other queries for similar pattern mismatches (but the fix mirrors existing patterns used elsewhere).


### Files changed

- `src/store/metrics.rs`
- `src/store/tests.rs`


Closes #2856

---
*Task #2856 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*