### PR TITLE
bug(router/llm): unsafe string slicing in classify_router_llm_failure and parse_llm_response can panic on multi-byte UTF-8

### DIFF
--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -288,7 +288,7 @@ fn classify_router_llm_failure(agent: &str, stdout: &str, stderr: &str) -> Strin
     // No useful error from stdout — fall back to stderr
     let stderr_trimmed = stderr.trim();
     if !stderr_trimmed.is_empty() {
-        let stderr_preview = stderr_trimmed[..stderr_trimmed.len().min(200)].to_string();
+        let stderr_preview = stderr_trimmed[..stderr_trimmed.floor_char_boundary(200)].to_string();
         return stderr_preview;
     }
 
@@ -907,7 +907,7 @@ impl LlmRouter {
             Ok(None) => {
                 anyhow::bail!(
                     "could not parse LLM response as JSON: {}",
-                    &text[..text.len().min(200)]
+                    &text[..text.floor_char_boundary(200)]
                 )
             }
             Err(e) => anyhow::bail!("router LLM returned error payload: {e}"),


### PR DESCRIPTION
## Summary

Fixed unsafe byte-boundary truncation in router to prevent panics on multi-byte UTF-8 characters

### What was done

- Replaced `text.len().min(200)` with `text.floor_char_boundary(200)` on line 284 in classify_router_llm_failure
- Replaced `text.len().min(200)` with `text.floor_char_boundary(200)` on line 903 in parse_llm_response
- All changes now consistent with existing pattern on lines 579, 783, 784


### Files changed

- `src/engine/router/llm.rs`


Closes #2867

---
*Task #2867 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*