### PR TITLE
Avoid using lowercased string indices to slice original string (general guidance / audit)

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -871,7 +871,19 @@ pub(crate) mod patterns {
         ];
         // Find the earliest match position so we can extract context around the
         // actual error message rather than the tail (which may be unrelated JSON).
-        let match_pos = patterns.iter().filter_map(|p| lower.find(p)).min();
+        // Map the byte offset from `lower` back to `text` via char-count to avoid
+        // using a lowercased byte index on the original string (Unicode case-folding
+        // can change byte lengths, e.g. İ→i̇).
+        let match_pos = patterns
+            .iter()
+            .filter_map(|p| lower.find(p))
+            .min()
+            .map(|lower_pos| {
+                let char_idx = lower[..lower_pos].chars().count();
+                text.char_indices()
+                    .nth(char_idx)
+                    .map_or(text.len(), |(i, _)| i)
+            });
         let has_429 = lower.contains("429");
         // HTTP 529 is used by Cloudflare for rate limiting. Only match in HTTP status
         // contexts (e.g. "HTTP 529", "status: 529") to avoid false positives from bare
@@ -897,10 +909,9 @@ pub(crate) mod patterns {
 
     /// Extract up to `window` bytes of context centred around `byte_pos`.
     ///
-    /// Because `byte_pos` is derived from a lowercased copy, it is exact for
-    /// ASCII patterns (the vast majority of agent output).  For non-ASCII edge
-    /// cases the window may shift slightly but remains far more useful than
-    /// `safe_tail`.
+    /// `byte_pos` must be a valid byte offset in `text` (not derived from a
+    /// transformed copy).  Both ends are snapped to char boundaries to avoid
+    /// splitting multi-byte codepoints.
     fn extract_context_around(text: &str, byte_pos: usize, window: usize) -> String {
         let half = window / 2;
         let start = byte_pos.saturating_sub(half);
@@ -992,7 +1003,18 @@ pub(crate) mod patterns {
             "econnrefused",
             "network unreachable",
         ];
-        let match_pos = patterns.iter().filter_map(|p| lower.find(p)).min();
+        // Map the byte offset from `lower` back to `text` via char-count (same
+        // rationale as detect_rate_limit: Unicode case-folding can change byte lengths).
+        let match_pos = patterns
+            .iter()
+            .filter_map(|p| lower.find(p))
+            .min()
+            .map(|lower_pos| {
+                let char_idx = lower[..lower_pos].chars().count();
+                text.char_indices()
+                    .nth(char_idx)
+                    .map_or(text.len(), |(i, _)| i)
+            });
         if let Some(pos) = match_pos {
             return Some(AgentError::NetworkError {
                 message: extract_context_around(text, pos, 300),


### PR DESCRIPTION
## Summary

Fixed two unsafe lowercased-string index usages in src/engine/runner/agents/mod.rs. Both detect_rate_limit() and detect_network_error() were computing byte positions in a lowercased string and using them to index the original string, which is unsound when Unicode case-folding changes byte lengths (e.g. Turkish İ→i̇). Applied the same char-count mapping technique already present in detect_stale_session() to correctly translate lowercased byte offsets to original-string byte offsets. All 3320 tests pass.

### Files changed

- `src/engine/runner/agents/mod.rs`


Closes #2864

---
*Task #2864 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*