### PR TITLE
bug(store): created_at/updated_at row decode errors silently masked as empty strings in from_row

### DIFF
--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -2120,8 +2120,12 @@ impl TaskStore {
             no_code_last_agent: row
                 .try_get::<String, _>("no_code_last_agent")
                 .unwrap_or_default(),
-            created_at: row.try_get::<String, _>("created_at").unwrap_or_default(),
-            updated_at: row.try_get::<String, _>("updated_at").unwrap_or_default(),
+            created_at: row
+                .try_get::<String, _>("created_at")
+                .map_err(|e| anyhow::anyhow!("task row missing created_at: {e}"))?,
+            updated_at: row
+                .try_get::<String, _>("updated_at")
+                .map_err(|e| anyhow::anyhow!("task row missing updated_at: {e}"))?,
         })
     }
     pub async fn ensure_external_task(


### PR DESCRIPTION
## Summary

Fixed created_at/updated_at decode error masking in from_row function

### What was done

- Replaced unwrap_or_default() with proper error propagation for created_at and updated_at fields in src/store/tasks.rs:2123-2128
- Follows same pattern as other mandatory original columns (id, repo, origin, title)


### Files changed

- `src/store/tasks.rs`


Closes #2874

---
*Task #2874 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/minimax-m2.5-free`*