### PR TITLE
fix(router): downgrade AllCooledError to WARN level, not ERROR

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -158,8 +158,8 @@ pub struct Router {
 }
 
 #[derive(Debug)]
-struct AllCooledError {
-    scope: String,
+pub struct AllCooledError {
+    pub scope: String,
 }
 
 impl std::fmt::Display for AllCooledError {

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -1234,7 +1234,17 @@ pub(crate) async fn tick_route_tasks(
                 );
             }
             Err(e) => {
-                tracing::error!(task_id = task.id.0, ?e, "routing failed, skipping task");
+                // AllCooledError is an expected transient state — downgrade to WARN.
+                // Other routing errors (LLM failure, config error, etc.) remain ERROR.
+                if let Some(err) = e.downcast_ref::<crate::engine::router::AllCooledError>() {
+                    tracing::warn!(
+                        task_id = task.id.0,
+                        scope = %err.scope,
+                        "routing unavailable: all agents cooled, will retry"
+                    );
+                } else {
+                    tracing::error!(task_id = task.id.0, ?e, "routing failed, skipping task");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Downgrade `AllCooledError` routing failures from ERROR to WARN in the tick loop
- `AllCooledError` is an expected transient state — cooldowns expire and routing resumes automatically; it does not require operator intervention
- ERROR-level entries were observed spamming 60+ times per 10 minutes per stuck task during multi-agent degradation events

## Changes

- `src/engine/router/mod.rs`: Make `AllCooledError` `pub` so `tick.rs` can use `downcast_ref`
- `src/engine/tick.rs`: Use `downcast_ref::<AllCooledError>` to distinguish the transient case from other routing errors (LLM failure, config error, etc.), logging it at WARN with the scope included

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (no warnings as errors)
- [x] `cargo nextest run` passes (3368 tests, 0 failures)

Fixes GH issue #2922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)