### PR TITLE
fix(cron): handle degenerate DOW range 0-0 in normalize_dow

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -29,7 +29,13 @@ pub fn normalize_dow(expression: &str) -> String {
             if part == "0" {
                 "7".to_string()
             } else if let Some(rest) = part.strip_prefix("0-") {
-                format!("1-{rest},7")
+                if rest == "0" {
+                    // 0-0 means only Sunday — same as plain 0
+                    "7".to_string()
+                } else {
+                    // 0-N (N > 0): split into Mon-N plus Sunday
+                    format!("1-{rest},7")
+                }
             } else {
                 part.to_string()
             }
@@ -336,6 +342,16 @@ mod tests {
         // "0-4" = Sunday through Thursday in standard cron
         let result = check("0 9 * * 0-4", None);
         assert!(result.is_ok(), "DOW range 0-4 should parse: {result:?}");
+    }
+
+    #[test]
+    fn normalize_dow_degenerate_zero_to_zero() {
+        // "0-0" means only Sunday — should normalize to "7", not "1-0,7"
+        let normalized = normalize_dow("* * * * 0-0");
+        assert_eq!(normalized, "* * * * 7");
+        // Also verify it parses correctly
+        let result = check("0 9 * * 0-0", None);
+        assert!(result.is_ok(), "DOW range 0-0 should parse: {result:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The `normalize_dow` function converts standard cron DOW field values for the `cron` crate (which uses 1-7 instead of 0-6, where 7=Sunday). For ranges starting at 0 (Sunday), it splits them into a Mon-N range plus Sunday (7):

```rust
format!("1-{rest},7")  // "0-5" → "1-5,7"
```

However, the degenerate case `0-0` (meaning **only Sunday**) was not handled:

```
"0-0" → strip_prefix("0-") gives Some("0") → format!("1-{0},7") → "1-0,7"
```

The range `1-0` has end < start, which is invalid. The `cron` crate rejects it with an error instead of the expected "only Sunday" behavior.

## Fix

Check for the degenerate case before forming the range — when `rest == "0"`, return `"7"` directly (same as plain `"0"`):

```rust
if rest == "0" {
    "7".to_string()
} else {
    format!("1-{rest},7")
}
```

Also adds a test case verifying that `"0-0"` normalizes to `"7"` and parses correctly.

## Test

Added `normalize_dow_degenerate_zero_to_zero` test covering:
- Normalization output: `"* * * * 0-0"` → `"* * * * 7"`
- Full expression parsing: `"0 9 * * 0-0"` succeeds without error

Fixes #2910.