### PR TITLE
fix(store): ensure every task_run gets a terminal outcome

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1895,9 +1895,14 @@ pub async fn serve() -> anyhow::Result<()> {
                         // tmux sessions will be killed when the process exits.
                         let mut reset_count = 0u32;
                         let mut review_reset_count = 0u32;
+                        let mut task_ids_to_abort: Vec<i64> = Vec::new();
+
                         for engine in &project_engines {
                             if let Ok(tasks) = engine.task_manager.list_external_by_status(Status::InProgress).await {
                                 for task in &tasks {
+                                    if let Ok(Some(store_id)) = engine.store.resolve_task_id(&engine.repo, &task.id.0).await {
+                                        task_ids_to_abort.push(store_id);
+                                    }
                                     if let Err(e) = engine.task_manager.update_task_status(&task.id, Status::Routed).await {
                                         tracing::warn!(task_id = task.id.0, ?e, "failed to reset task on shutdown");
                                     } else {
@@ -1908,6 +1913,7 @@ pub async fn serve() -> anyhow::Result<()> {
                             // Also reset internal in_progress tasks
                             if let Ok(tasks) = engine.store.list_internal_by_status(&engine.repo, crate::store::TaskStatus::InProgress).await {
                                 for task in &tasks {
+                                    task_ids_to_abort.push(task.id);
                                     let task_id = format!("internal:{}", task.id);
                                     if let Err(e) = engine.task_manager.update_task_status(
                                         &crate::backends::ExternalId(task_id.clone()),
@@ -1922,6 +1928,9 @@ pub async fn serve() -> anyhow::Result<()> {
                             // Reset in_review tasks — review agent sessions die on shutdown
                             if let Ok(tasks) = engine.task_manager.list_external_by_status(Status::InReview).await {
                                 for task in &tasks {
+                                    if let Ok(Some(store_id)) = engine.store.resolve_task_id(&engine.repo, &task.id.0).await {
+                                        task_ids_to_abort.push(store_id);
+                                    }
                                     if let Err(e) = engine.task_manager.update_task_status(&task.id, Status::NeedsReview).await {
                                         tracing::warn!(task_id = task.id.0, ?e, "failed to reset in_review task on shutdown");
                                     } else {
@@ -1933,6 +1942,7 @@ pub async fn serve() -> anyhow::Result<()> {
                             // Also reset internal in_review tasks
                             if let Ok(tasks) = engine.store.list_internal_by_status(&engine.repo, crate::store::TaskStatus::InReview).await {
                                 for task in &tasks {
+                                    task_ids_to_abort.push(task.id);
                                     let task_id = format!("internal:{}", task.id);
                                     if let Err(e) = engine.task_manager.update_task_status(
                                         &crate::backends::ExternalId(task_id.clone()),
@@ -1951,6 +1961,23 @@ pub async fn serve() -> anyhow::Result<()> {
                         }
                         if review_reset_count > 0 {
                             tracing::info!(review_reset_count, "reset in_review tasks to needs_review for re-dispatch");
+                        }
+
+                        // Abort incomplete runs for all tasks being reset.
+                        // This ensures no task_runs have outcome IS NULL after shutdown.
+                        if !task_ids_to_abort.is_empty() {
+                            if let Some(first_engine) = project_engines.first() {
+                                match first_engine.store.abort_runs_for_tasks(&task_ids_to_abort, "graceful shutdown: task reset to routed/needs_review").await {
+                                    Ok(aborted) => {
+                                        if aborted > 0 {
+                                            tracing::info!(aborted, "aborted incomplete task_runs during shutdown");
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(error = %e, "failed to abort incomplete task_runs during shutdown");
+                                    }
+                                }
+                            }
                         }
 
                         // Kill all orch-managed tmux sessions so stale sessions don't

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -1007,16 +1007,61 @@ impl TaskRunner {
             None
         };
 
-        // Run the task
-        let run_result = self
+        // Run the task. We wrap this to capture errors and ensure we always call complete_run.
+        let run_result = match self
             .run(task_id, agent, model, Some(&**backend), &started_at)
-            .await?;
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                // On error, complete the run with the error before propagating
+                if let (Some(run_id), Some(store)) = (run_audit_id, self.store.as_ref()) {
+                    let _ = store
+                        .complete_run(&crate::store::CompleteRun {
+                            run_id,
+                            exit_code: None,
+                            stdout: "",
+                            stderr: "",
+                            parsed: &serde_json::json!({"error": e.to_string()}).to_string(),
+                            outcome: "failed",
+                            error: &format!("run() failed: {e}"),
+                            tokens: crate::store::RunTokenUsage {
+                                input_tokens: 0,
+                                output_tokens: 0,
+                                total_cost_usd: 0.0,
+                                duration_secs: run_duration_secs(&started_at),
+                            },
+                        })
+                        .await;
+                }
+                return Err(e.context("task execution failed"));
+            }
+        };
 
-        // If the runner guard skipped the task, do not re-post stale data as a new comment.
+        // If the runner guard skipped the task, mark it as skipped and return early.
         let (status, exit_code_opt, run_audit) = match run_result {
             Some(result) => (result.status, result.exit_code, result.audit),
             None => {
                 tracing::info!(task_id, "guard skipped task — not posting stale result");
+                if let (Some(run_id), Some(store)) = (run_audit_id, self.store.as_ref()) {
+                    let _ = store
+                        .complete_run(&crate::store::CompleteRun {
+                            run_id,
+                            exit_code: None,
+                            stdout: "",
+                            stderr: "",
+                            parsed: &serde_json::json!({"skipped": true}).to_string(),
+                            outcome: "skipped",
+                            error: "task skipped by guard (max attempts, budget exceeded, etc.)",
+                            tokens: crate::store::RunTokenUsage {
+                                input_tokens: 0,
+                                output_tokens: 0,
+                                total_cost_usd: 0.0,
+                                duration_secs: run_duration_secs(&started_at),
+                            },
+                        })
+                        .await;
+                }
                 return Ok(WeightSignal::None);
             }
         };

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1859,6 +1859,49 @@ impl TaskStore {
         Ok(())
     }
 
+    /// Abort incomplete runs for given task IDs.
+    ///
+    /// This is called during graceful shutdown to ensure all task_runs have a terminal
+    /// outcome. Runs with `outcome IS NULL` are marked as `aborted` with a structured
+    /// error message and `completed_at` timestamp.
+    ///
+    /// Returns the count of runs that were aborted.
+    pub async fn abort_runs_for_tasks(
+        &self,
+        task_ids: &[i64],
+        reason: &str,
+    ) -> anyhow::Result<usize> {
+        if task_ids.is_empty() {
+            return Ok(0);
+        }
+
+        // Chunk task IDs to avoid SQLite parameter limits (commonly 999)
+        const CHUNK_SIZE: usize = 500;
+        let mut aborted_count = 0;
+
+        for chunk in task_ids.chunks(CHUNK_SIZE) {
+            let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+            let sql = format!(
+                "UPDATE task_runs SET
+                outcome = 'aborted',
+                error = ?,
+                completed_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+                WHERE task_id IN ({placeholders}) AND outcome IS NULL"
+            );
+
+            let mut query = sqlx::query(&sql).bind(reason);
+            for &task_id in chunk {
+                query = query.bind(task_id);
+            }
+
+            let result: sqlx::sqlite::SqliteQueryResult = query.execute(&self.pool).await?;
+
+            aborted_count += result.rows_affected() as usize;
+        }
+
+        Ok(aborted_count)
+    }
+
     /// Get all runs for a task, ordered by attempt.
     pub async fn get_runs(&self, task_id: i64) -> anyhow::Result<Vec<TaskRun>> {
         let rows = sqlx::query(&format!(


### PR DESCRIPTION
## Summary

- Fix `run_with_context` to always call `complete_run` on early-return paths: error from `run()` now sets `outcome=failed`, guard-skip now sets `outcome=skipped`
- Fix graceful shutdown (`engine/mod.rs`) to abort incomplete runs for all tasks being reset (in_progress + in_review), setting `outcome=aborted`
- Add `abort_runs_for_tasks(task_ids, reason)` helper to `TaskStore` that chunks by 500 to stay within SQLite parameter limits

## Root cause

`start_run` writes rows with `outcome = NULL` by design, but three exit paths never called `complete_run`:
1. `run()` returning `Err` — `?` operator in `run_with_context` propagated immediately
2. Guard skipping — returned early without finalizing the run
3. Graceful shutdown — reset task statuses and killed sessions but left runs orphaned

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes  
- [x] `cargo nextest run` passes (3368 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)