### PR TITLE
fix: silence detection no-fallback resets to New instead of NeedsReview

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -342,9 +342,9 @@ pub(crate) async fn tick_detect_silent_agents(
         } else {
             tracing::warn!(
                 task_id,
-                "silence detection: no fallback agents available, marking needs_review"
+                "silence detection: no fallback agents available, resetting to new for re-routing"
             );
-            (Status::NeedsReview, None)
+            (Status::New, None)
         };
 
         if use_backend {

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -2450,14 +2450,14 @@ mod tests {
 
         let task = store.get(internal_id).await.unwrap();
         // Silence detection now uses failover: if a fallback agent is found → Routed,
-        // otherwise → NeedsReview. Either is acceptable; the key invariant is that the
-        // task is no longer InProgress.
+        // otherwise → New (reset for re-routing when cooldowns expire). Either is
+        // acceptable; the key invariant is that the task is no longer InProgress.
         assert!(
             matches!(
                 task.status,
-                crate::store::TaskStatus::Routed | crate::store::TaskStatus::NeedsReview
+                crate::store::TaskStatus::Routed | crate::store::TaskStatus::New
             ),
-            "internal task should be routed to fallback or needs_review, got {:?}",
+            "internal task should be routed to fallback or reset to new, got {:?}",
             task.status
         );
     }


### PR DESCRIPTION
## Summary

- When silence detection fires and no fallback agents are available (all in cooldown), the task was incorrectly set to `NeedsReview` status
- `NeedsReview` semantically means "agent work is done, PR exists, dispatch review agent" — but for these tasks, no work was done
- The review pipeline then tried dispatching a review agent, incremented the refire counter, and after 5 refires escalated the task to `Blocked` with `"review agent rebroadcast escalated after repeated retries"`
- Fix: change `Status::NeedsReview` → `Status::New` in the no-fallback path so tasks re-enter the routing pool when cooldowns expire

## Test plan

- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo nextest run` — 3383 tests passed, 19 skipped

Fixes #2949

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task #2949 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*