### PR TITLE
bug(transport): broadcast output silently dropped when all receivers disconnect

### DIFF
--- a/src/channels/transport.rs
+++ b/src/channels/transport.rs
@@ -189,7 +189,9 @@ impl Transport {
         if chunk.content.is_empty() {
             let bindings = self.bindings.read().await;
             if let Some(binding) = bindings.get(&skey) {
-                let _ = binding.output_tx.send(chunk.clone());
+                if let Err(e) = binding.output_tx.send(chunk.clone()) {
+                    tracing::warn!(repo = %repo, task_id = %task_id, error = %e, "all broadcast receivers dropped — output chunk lost");
+                }
             }
             return;
         }
@@ -204,7 +206,9 @@ impl Transport {
             };
             let bindings = self.bindings.read().await;
             if let Some(binding) = bindings.get(&skey) {
-                let _ = binding.output_tx.send(part_chunk.clone());
+                if let Err(e) = binding.output_tx.send(part_chunk.clone()) {
+                    tracing::warn!(repo = %repo, task_id = %task_id, error = %e, "all broadcast receivers dropped — output chunk lost");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Log a warning when `broadcast::Sender::send` returns an error in `push_output` at `src/channels/transport.rs:192` and `:207`, making silent output chunk loss visible to operators

## Problem

`push_output` used `let _ = binding.output_tx.send(...)` which silently ignores `SendError`. `SendError` is returned when **all receivers have been dropped** — this can happen when:
1. The transport layer is restarted (e.g., channel reconnection)
2. All subscribers (Discord, Telegram, Slack, stream CLI) have disconnected
3. A subscriber task panicked and its receiver was dropped

This caused output chunks from running agent sessions to be silently lost with no log or warning, making debugging transport issues extremely difficult.

## Solution

Replace `let _ =` with `if let Err(e) =` and log a warning with `tracing::warn!`:

```rust
if let Err(e) = binding.output_tx.send(chunk.clone()) {
    tracing::warn!(repo = %repo, task_id = %task_id, error = %e, "all broadcast receivers dropped — output chunk lost");
}
```

## Test plan

- [ ] `cargo fmt -- --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo nextest run` — all tests pass
- [ ] Verify warning appears in logs when all broadcast receivers are dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task #2966 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*