### PR TITLE
bug(review): no-code/internal tasks sent to review agent causing 'no worktree found' → blocked

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -297,6 +297,27 @@ async fn build_review_context(
         }
     };
 
+    let no_code_review = stored_task.as_ref().is_some_and(|t| {
+        t.worktree.trim().is_empty() && t.branch.trim().is_empty() && t.pr_number.is_none()
+    });
+    if no_code_review {
+        tracing::info!(
+            task_id = task.id.0,
+            "no worktree/branch/pr for needs_review task — skipping review and marking done"
+        );
+        if let Err(e) = task_manager
+            .update_task_status(&task.id, Status::Done)
+            .await
+        {
+            tracing::error!(
+                task_id = task.id.0,
+                err = %e,
+                "update_task_status(Done) failed for no-code review skip"
+            );
+        }
+        return Ok(ReviewPhase::EarlyReturn(ReviewDecision::Skipped));
+    }
+
     let mut worktree_path = match stored_task.as_ref().map(|t| t.worktree.as_str()) {
         Some(w) if !w.is_empty() => std::path::PathBuf::from(w),
         _ => {

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -160,6 +160,51 @@ pub fn spawn(
                         continue;
                     };
 
+                    if let Some(stored) =
+                        opt_store_get_task(&Some(store.clone()), &repo, &task.id.0).await
+                    {
+                        let no_code_review = stored.worktree.trim().is_empty()
+                            && stored.branch.trim().is_empty()
+                            && stored.pr_number.is_none();
+                        if no_code_review {
+                            tracing::info!(
+                                task_id,
+                                "no worktree/branch/pr for needs_review task — skipping review dispatch and marking done"
+                            );
+                            crate::store::store_reset_failure_counters(
+                                &Some(store.clone()),
+                                &repo,
+                                &task.id.0,
+                            )
+                            .await;
+                            if let Err(e) = crate::store::store_set_result(
+                                &Some(store.clone()),
+                                &repo,
+                                &task.id.0,
+                                &[("needs_review_refires", serde_json::json!(0))],
+                            )
+                            .await
+                            {
+                                tracing::warn!(
+                                    task_id,
+                                    err = %e,
+                                    "failed to reset needs_review_refires while skipping no-code review"
+                                );
+                            }
+                            if let Err(e) = task_manager
+                                .update_task_status(&task.id, Status::Done)
+                                .await
+                            {
+                                tracing::error!(
+                                    task_id,
+                                    err = %e,
+                                    "failed to mark no-code needs_review task as done"
+                                );
+                            }
+                            continue;
+                        }
+                    }
+
                     // If no agents are currently routable (all cooled, degraded, or without
                     // an available review model), wait until the earliest cooldown expires.
                     // Using router.healthy_agent_count covers agent cooldowns, degradation,


### PR DESCRIPTION
## Summary

Fixed review pipeline to skip no-code/internal tasks without worktree context and mark them done instead of failing with "no worktree found".

### What was done

- Added an early no-code guard in `src/engine/review.rs` (`build_review_context`) that detects tasks with empty worktree/branch and no PR, marks them `done`, and returns `ReviewDecision::Skipped`.
- Added a pre-dispatch guard in `src/engine/subscribers/review.rs` to avoid spawning review flows for no-code `needs_review` tasks with no worktree/branch/PR, reset transient review counters, and mark them `done`.
- Ran required quality gates successfully: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (3383 passed, 19 skipped).
- Committed changes in `37901ccf` with message `fix(review): skip no-code tasks in review flow`.


### Files changed

- `src/engine/review.rs`
- `src/engine/subscribers/review.rs`


Closes #2975

---
*Task #2975 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*