### PR TITLE
bug(parser): normalize_status missing "partial", "no_changes_needed", "complete" agent responses

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -154,9 +154,16 @@ pub fn parse(raw: &str) -> anyhow::Result<AgentResponse> {
 fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
     resp.status = match resp.status.as_str() {
         // Canonical completion statuses.
-        "done" | "completed" | "ok" | "success" => "done".to_string(),
+        // Some agents return `complete` or `no_changes_needed` to indicate
+        // a successful run with no further edits required — treat them as
+        // `done` so the run is classified as successful.
+        "done" | "completed" | "complete" | "ok" | "success" | "no_changes_needed" => {
+            "done".to_string()
+        }
         // Canonical progress statuses.
-        "in_progress" | "running" => "in_progress".to_string(),
+        // `partial` is used by some models to indicate partial progress —
+        // treat it as in_progress so the task remains open for follow-up.
+        "in_progress" | "running" | "partial" => "in_progress".to_string(),
         "in_review" | "reviewing" => "in_review".to_string(),
         "needs_review" | "pending_review" | "ready_for_review" => "needs_review".to_string(),
         // Canonical error statuses.
@@ -1036,7 +1043,10 @@ Some output here.
             ("ok", "done"),
             ("success", "done"),
             ("completed", "done"),
+            ("complete", "done"),
+            ("no_changes_needed", "done"),
             ("running", "in_progress"),
+            ("partial", "in_progress"),
             ("reviewing", "in_review"),
             ("pending_review", "needs_review"),
             ("ready_for_review", "needs_review"),


### PR DESCRIPTION
## Summary

```json
{"decision":"complete","commits":["fix(parser): normalize \"partial\", \"complete\", \"no_changes_needed\" agent statuses"],"summary":"Updated normalize_status() in src/parser.rs to map three missing non-canonical agent statuses to their canonical equivalents: \"complete\" and \"no_changes_needed\" → \"done\", \"partial\" → \"in_progress\". Added the new aliases to the regression alias test. All 98 parser tests pass."}
```

### Files changed

- `src/parser.rs`


Closes #2986

---
*Task #2986 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*