### PR TITLE
bug: review agent uses two-dot git diff, sees stale main commits as scope creep

### DIFF
--- a/src/engine/runner/context.rs
+++ b/src/engine/runner/context.rs
@@ -196,7 +196,7 @@ pub async fn build_repo_tree(project_dir: &Path) -> String {
 /// Build git diff from base branch (only for retries).
 pub async fn build_git_diff(project_dir: &Path, default_branch: &str) -> String {
     let output = Command::new("git")
-        .args(["diff", &format!("origin/{default_branch}")])
+        .args(["diff", &format!("origin/{default_branch}...HEAD")])
         .current_dir(project_dir)
         .output_with_context()
         .await;


### PR DESCRIPTION
## Summary

Fixed `build_git_diff` in `src/engine/runner/context.rs:199` to use three-dot diff (`origin/main...HEAD`) instead of two-dot (`origin/main`). The three-dot form diffs from the merge-base, so only branch-introduced changes are shown — matching what GitHub displays in the PR Files Changed tab. Reversed hunks from commits that landed on main after the branch was created no longer appear, eliminating false scope-creep flags from the review agent.

### Files changed

- `src/engine/runner/context.rs`


Closes #2991

---
*Task #2991 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*