### PR TITLE
bug(router): system-wide agent cooldown cascade has no recovery mechanism — tasks blocked after max retries with no escape hatch

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -22,6 +22,43 @@ pub mod weights;
 pub use config::{parse_pool_entry, RouterConfig};
 pub use weights::AgentWeights;
 
+/// Error returned when all agents/models are in cooldown and routing is temporarily unavailable.
+///
+/// This is a transient error that should not count against `max_route_attempts` since
+/// no agent was actually invoked. The caller should back off and retry later.
+#[derive(Debug, thiserror::Error)]
+pub enum AllAgentsCooledError {
+    #[error("all agents/models in cooldown for {scope}")]
+    AllCooled {
+        scope: String,
+        remaining_secs: Option<u64>,
+    },
+}
+
+impl AllAgentsCooledError {
+    /// Create a new error for the given scope.
+    pub fn new(scope: String, remaining_secs: Option<u64>) -> Self {
+        Self::AllCooled {
+            scope,
+            remaining_secs,
+        }
+    }
+
+    /// Get the scope of the cooldown (e.g., "medium", "all agents", "router pool").
+    pub fn scope(&self) -> &str {
+        match self {
+            Self::AllCooled { scope, .. } => scope,
+        }
+    }
+
+    /// Remaining cooldown duration in seconds when available.
+    pub fn remaining_secs(&self) -> Option<u64> {
+        match self {
+            Self::AllCooled { remaining_secs, .. } => *remaining_secs,
+        }
+    }
+}
+
 /// Typed error returned by [`get_route_result`].
 #[derive(Debug, thiserror::Error)]
 pub enum RouteResultError {
@@ -156,19 +193,6 @@ pub struct Router {
     /// Current round-robin index into router_pool
     pub(crate) pool_index: usize,
 }
-
-#[derive(Debug)]
-struct AllCooledError {
-    scope: String,
-}
-
-impl std::fmt::Display for AllCooledError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "all agents/models in cooldown for {}", self.scope)
-    }
-}
-
-impl std::error::Error for AllCooledError {}
 
 impl Router {
     /// Create a new router with the given configuration.
@@ -503,9 +527,10 @@ impl Router {
         "all agents degraded (no cooldown timestamp available) — skipping task, will retry after backoff"
     );
             // Return an error similar to the cooldown case to trigger backoff in the tick loop
-            return Err(AllCooledError {
-                scope: complexity.unwrap_or("all agents").to_string(),
-            }
+            return Err(AllAgentsCooledError::new(
+                complexity.unwrap_or("all agents").to_string(),
+                None,
+            )
             .into());
         };
 
@@ -519,7 +544,7 @@ impl Router {
             );
             // Return a domain error indicating all candidates are cooled so the
             // caller can handle it (tick will skip this task and retry later).
-            return Err(AllCooledError { scope: scope_str }.into());
+            return Err(AllAgentsCooledError::new(scope_str, Some(remaining as u64)).into());
         }
 
         Ok(())
@@ -1017,8 +1042,8 @@ impl Router {
                     return Ok(result);
                 }
                 Err(e) => {
-                    if let Some(err) = e.downcast_ref::<AllCooledError>() {
-                        let scope = err.scope.as_str();
+                    if let Some(err) = e.downcast_ref::<AllAgentsCooledError>() {
+                        let scope = err.scope();
                         tracing::warn!(scope = %scope, "router cooldown gate tripped");
                         // "router pool" scope means all router LLM pool entries were pre-cooled.
                         // Pass None so wait_for_cooldown queries all agent+model cooldowns generically
@@ -1175,10 +1200,7 @@ impl Router {
             .cloned()
             .collect();
         if uncooled_agents.is_empty() {
-            return Err(AllCooledError {
-                scope: "all agents".to_string(),
-            }
-            .into());
+            return Err(AllAgentsCooledError::new("all agents".to_string(), None).into());
         }
         let llm_agents = uncooled_agents;
 

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -19,7 +19,7 @@ use crate::engine::cooldown::{
 };
 use crate::engine::dispatch_guard::DispatchGuard;
 use crate::engine::jobs;
-use crate::engine::router::{get_route_result, RouteResultError, Router};
+use crate::engine::router::{get_route_result, AllAgentsCooledError, RouteResultError, Router};
 use crate::engine::runner::{TaskRunner, WeightSignal};
 use crate::engine::tasks::{is_internal_id, TaskManager};
 use crate::repo_context::REPO_CONTEXT;
@@ -1072,10 +1072,20 @@ pub(crate) async fn tick_route_tasks(
     let max_per_tick = crate::engine::router::config::max_tasks_per_routing_tick();
     for task in routable.into_iter().take(max_per_tick) {
         let _task_span = tracing::info_span!("engine.route", task_id = %task.id.0).entered();
+        if let Some(remaining_secs) = route_defer_remaining_secs(store, repo, &task.id.0).await {
+            tracing::debug!(
+                task_id = %task.id.0,
+                remaining_secs,
+                "routing deferred while all agents are cooled"
+            );
+            continue;
+        }
+
         let task_start = Instant::now();
         match router.route(task, store, repo).await {
             Ok(result) => {
                 tracing::debug!(task_id = %task.id.0, duration_ms = task_start.elapsed().as_millis(), "route completed");
+                clear_route_defer(store, repo, &task.id.0).await;
                 // Store route result in store
                 if let Err(e) = router
                     .store_route_result(&task.id.0, &result, store, repo)
@@ -1234,11 +1244,77 @@ pub(crate) async fn tick_route_tasks(
                 );
             }
             Err(e) => {
+                if let Some(cooled) = e.downcast_ref::<AllAgentsCooledError>() {
+                    let defer_secs = compute_route_defer_secs(cooled.remaining_secs());
+                    set_route_defer_until(store, repo, &task.id.0, defer_secs).await;
+                    tracing::warn!(
+                        task_id = %task.id.0,
+                        scope = %cooled.scope(),
+                        remaining_secs = ?cooled.remaining_secs(),
+                        defer_secs,
+                        "all agents cooled — deferring task routing"
+                    );
+                    continue;
+                }
                 tracing::error!(task_id = task.id.0, ?e, "routing failed, skipping task");
             }
         }
     }
     Ok(())
+}
+
+fn route_defer_key(repo: &str, task_id: &str) -> String {
+    format!("route_defer_until:{repo}:{task_id}")
+}
+
+fn compute_route_defer_secs(remaining_secs: Option<u64>) -> u64 {
+    match remaining_secs {
+        Some(remaining) if remaining > 0 => remaining.saturating_div(2).max(10),
+        _ => 30,
+    }
+}
+
+async fn route_defer_remaining_secs(store: &TaskStore, repo: &str, task_id: &str) -> Option<u64> {
+    let key = route_defer_key(repo, task_id);
+    let value = match store.kv_get(&key).await {
+        Ok(value) => value,
+        Err(err) => {
+            tracing::warn!(task_id, error = %err, "failed to read route defer key");
+            return None;
+        }
+    }?;
+
+    let until = match value.parse::<i64>() {
+        Ok(ts) => ts,
+        Err(err) => {
+            tracing::warn!(task_id, value, error = %err, "invalid route defer timestamp; clearing key");
+            let _ = store.kv_delete(&key).await;
+            return None;
+        }
+    };
+
+    let now = chrono::Utc::now().timestamp();
+    if until <= now {
+        let _ = store.kv_delete(&key).await;
+        return None;
+    }
+
+    Some((until - now) as u64)
+}
+
+async fn set_route_defer_until(store: &TaskStore, repo: &str, task_id: &str, defer_secs: u64) {
+    let key = route_defer_key(repo, task_id);
+    let until = chrono::Utc::now().timestamp() + defer_secs as i64;
+    if let Err(err) = store.kv_set(&key, &until.to_string()).await {
+        tracing::warn!(task_id, error = %err, "failed to persist route defer key");
+    }
+}
+
+async fn clear_route_defer(store: &TaskStore, repo: &str, task_id: &str) {
+    let key = route_defer_key(repo, task_id);
+    if let Err(err) = store.kv_delete(&key).await {
+        tracing::warn!(task_id, error = %err, "failed to clear route defer key");
+    }
 }
 
 /// Phase 3b of tick: spawn agents for all status:routed tasks up to the parallel limit.
@@ -2181,6 +2257,39 @@ mod tests {
         assert_eq!(updates.len(), 1, "stuck InReview task should be recovered");
         assert_eq!(updates[0].0, "99");
         assert_eq!(updates[0].1, Status::NeedsReview);
+    }
+
+    #[test]
+    fn compute_route_defer_secs_halves_remaining_with_floor() {
+        assert_eq!(compute_route_defer_secs(Some(120)), 60);
+        assert_eq!(compute_route_defer_secs(Some(17)), 10);
+        assert_eq!(compute_route_defer_secs(Some(1)), 10);
+        assert_eq!(compute_route_defer_secs(None), 30);
+    }
+
+    #[tokio::test]
+    async fn route_defer_remaining_secs_clears_expired_key() {
+        let store = TaskStore::open_memory().await.unwrap();
+        let repo = "owner/repo";
+        let task_id = "123";
+
+        set_route_defer_until(&store, repo, task_id, 30).await;
+        let remaining = route_defer_remaining_secs(&store, repo, task_id).await;
+        assert!(
+            matches!(remaining, Some(secs) if secs > 0),
+            "expected positive defer window, got {remaining:?}"
+        );
+
+        let key = route_defer_key(repo, task_id);
+        let past = chrono::Utc::now().timestamp() - 1;
+        store.kv_set(&key, &past.to_string()).await.unwrap();
+
+        let expired = route_defer_remaining_secs(&store, repo, task_id).await;
+        assert!(expired.is_none(), "expired defer key should be ignored");
+        assert!(
+            store.kv_get(&key).await.unwrap().is_none(),
+            "expired defer key should be deleted"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Implemented router cooldown recovery so all-agents-cooled periods no longer burn retry budget and now defer per-task routing attempts until later.

### What was done

- Added a typed transient router error (`AllAgentsCooledError`) that carries cooldown scope and optional `remaining_secs`, replacing the old untyped internal cooldown error handling in `src/engine/router/mod.rs`.
- Ensured all-agents-cooled paths are treated as transient in router flow (no route-attempt increment on this condition) while preserving existing fallback behavior for real routing failures.
- Added routing deferral in `tick_route_tasks` (`src/engine/tick.rs`): when `AllAgentsCooledError` is returned, the task gets a persisted defer-until timestamp in KV and is skipped until defer expires.
- Implemented defer helpers in tick (`route_defer_key`, `compute_route_defer_secs`, `route_defer_remaining_secs`, `set_route_defer_until`, `clear_route_defer`) using the existing `kv` table; successful routing clears defer state.
- Added tests for defer behavior in `src/engine/tick.rs`: defer duration calculation and expired defer-key cleanup.
- Ran required quality gates successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (all passing).
- Committed changes with conventional commit: `fix(router): defer routing when all agents are cooled`.


### Files changed

- `src/engine/router/mod.rs`
- `src/engine/tick.rs`


Closes #2940

---
*Task #2940 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*