### PR TITLE
bug(task_runs): runs can remain NULL outcome indefinitely after early-return and shutdown paths

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1901,6 +1901,25 @@ pub async fn serve() -> anyhow::Result<()> {
                                     if let Err(e) = engine.task_manager.update_task_status(&task.id, Status::Routed).await {
                                         tracing::warn!(task_id = task.id.0, ?e, "failed to reset task on shutdown");
                                     } else {
+                                        if let Ok(Some(store_id)) =
+                                            engine.store.resolve_task_id(&engine.repo, &task.id.0).await
+                                        {
+                                            if let Err(e) = engine
+                                                .store
+                                                .finalize_incomplete_runs(
+                                                    store_id,
+                                                    "aborted",
+                                                    "graceful shutdown: reset in_progress task to routed",
+                                                )
+                                                .await
+                                            {
+                                                tracing::warn!(
+                                                    task_id = task.id.0,
+                                                    ?e,
+                                                    "failed to finalize incomplete runs on shutdown"
+                                                );
+                                            }
+                                        }
                                         reset_count += 1;
                                     }
                                 }
@@ -1915,6 +1934,21 @@ pub async fn serve() -> anyhow::Result<()> {
                                     ).await {
                                         tracing::warn!(task_id, ?e, "failed to reset internal task on shutdown");
                                     } else {
+                                        if let Err(e) = engine
+                                            .store
+                                            .finalize_incomplete_runs(
+                                                task.id,
+                                                "aborted",
+                                                "graceful shutdown: reset in_progress task to routed",
+                                            )
+                                            .await
+                                        {
+                                            tracing::warn!(
+                                                task_id,
+                                                ?e,
+                                                "failed to finalize incomplete internal runs on shutdown"
+                                            );
+                                        }
                                         reset_count += 1;
                                     }
                                 }
@@ -1926,6 +1960,25 @@ pub async fn serve() -> anyhow::Result<()> {
                                         tracing::warn!(task_id = task.id.0, ?e, "failed to reset in_review task on shutdown");
                                     } else {
                                         set_review_session_expected(&engine.store, &engine.repo, &task.id.0, false).await;
+                                        if let Ok(Some(store_id)) =
+                                            engine.store.resolve_task_id(&engine.repo, &task.id.0).await
+                                        {
+                                            if let Err(e) = engine
+                                                .store
+                                                .finalize_incomplete_runs(
+                                                    store_id,
+                                                    "aborted",
+                                                    "graceful shutdown: reset in_review task to needs_review",
+                                                )
+                                                .await
+                                            {
+                                                tracing::warn!(
+                                                    task_id = task.id.0,
+                                                    ?e,
+                                                    "failed to finalize incomplete review runs on shutdown"
+                                                );
+                                            }
+                                        }
                                         review_reset_count += 1;
                                     }
                                 }
@@ -1941,6 +1994,21 @@ pub async fn serve() -> anyhow::Result<()> {
                                         tracing::warn!(task_id, ?e, "failed to reset internal in_review task on shutdown");
                                     } else {
                                         set_review_session_expected(&engine.store, &engine.repo, &task_id, false).await;
+                                        if let Err(e) = engine
+                                            .store
+                                            .finalize_incomplete_runs(
+                                                task.id,
+                                                "aborted",
+                                                "graceful shutdown: reset in_review task to needs_review",
+                                            )
+                                            .await
+                                        {
+                                            tracing::warn!(
+                                                task_id,
+                                                ?e,
+                                                "failed to finalize incomplete internal review runs on shutdown"
+                                            );
+                                        }
                                         review_reset_count += 1;
                                     }
                                 }

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -1007,15 +1007,70 @@ impl TaskRunner {
             None
         };
 
-        // Run the task
-        let run_result = self
+        // Run the task.
+        // Always finalize the run audit row, even on early-return/error paths.
+        let run_result = match self
             .run(task_id, agent, model, Some(&**backend), &started_at)
-            .await?;
+            .await
+        {
+            Ok(run_result) => run_result,
+            Err(e) => {
+                if let Some(run_id) = run_audit_id {
+                    if let Some(ref store) = self.store {
+                        if let Err(complete_err) = store
+                            .complete_run(&crate::store::CompleteRun {
+                                run_id,
+                                exit_code: Some(-1),
+                                stdout: "",
+                                stderr: "",
+                                parsed: "",
+                                outcome: "failed",
+                                error: &e.to_string(),
+                                tokens: crate::store::RunTokenUsage::default(),
+                            })
+                            .await
+                        {
+                            tracing::warn!(
+                                task_id,
+                                run_id,
+                                error = %complete_err,
+                                "failed to record run completion in audit trail after runner error"
+                            );
+                        }
+                    }
+                }
+                return Err(e);
+            }
+        };
 
         // If the runner guard skipped the task, do not re-post stale data as a new comment.
         let (status, exit_code_opt, run_audit) = match run_result {
             Some(result) => (result.status, result.exit_code, result.audit),
             None => {
+                if let Some(run_id) = run_audit_id {
+                    if let Some(ref store) = self.store {
+                        if let Err(e) = store
+                            .complete_run(&crate::store::CompleteRun {
+                                run_id,
+                                exit_code: Some(-1),
+                                stdout: "",
+                                stderr: "",
+                                parsed: "",
+                                outcome: "aborted",
+                                error: "run skipped by guard",
+                                tokens: crate::store::RunTokenUsage::default(),
+                            })
+                            .await
+                        {
+                            tracing::warn!(
+                                task_id,
+                                run_id,
+                                error = %e,
+                                "failed to record skipped run completion in audit trail"
+                            );
+                        }
+                    }
+                }
                 tracing::info!(task_id, "guard skipped task — not posting stale result");
                 return Ok(WeightSignal::None);
             }

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1859,6 +1859,44 @@ impl TaskStore {
         Ok(())
     }
 
+    /// Finalize all incomplete runs for a task.
+    ///
+    /// This is used on runner early-return/error paths and engine shutdown
+    /// paths to ensure every `start_run` has a terminal record.
+    pub async fn finalize_incomplete_runs(
+        &self,
+        task_id: i64,
+        outcome: &str,
+        error: &str,
+    ) -> anyhow::Result<u64> {
+        let rows: Vec<(i64,)> = sqlx::query_as(
+            "SELECT id FROM task_runs
+             WHERE task_id = ?
+               AND outcome IS NULL
+               AND completed_at IS NULL
+             ORDER BY id ASC",
+        )
+        .bind(task_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        for (run_id,) in &rows {
+            self.complete_run(&CompleteRun {
+                run_id: *run_id,
+                exit_code: Some(-1),
+                stdout: "",
+                stderr: "",
+                parsed: "",
+                outcome,
+                error,
+                tokens: RunTokenUsage::default(),
+            })
+            .await?;
+        }
+
+        Ok(rows.len() as u64)
+    }
+
     /// Get all runs for a task, ordered by attempt.
     pub async fn get_runs(&self, task_id: i64) -> anyhow::Result<Vec<TaskRun>> {
         let rows = sqlx::query(&format!(

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -954,6 +954,106 @@ async fn complete_run_stores_null_error_for_empty_string() {
 }
 
 #[tokio::test]
+async fn finalize_incomplete_runs_marks_open_runs_aborted() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let task_id = store
+        .create(&NewTask {
+            repo: "owner/repo".to_string(),
+            origin: "internal".to_string(),
+            title: "Test".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let _agent_run = store
+        .start_run(&StartRun {
+            task_id,
+            attempt: 1,
+            run_type: "agent",
+            agent: "claude",
+            model: "sonnet",
+            command: "claude -p ...",
+            prompt: "system prompt",
+        })
+        .await
+        .unwrap();
+
+    let _review_run = store
+        .start_run(&StartRun {
+            task_id,
+            attempt: 1,
+            run_type: "review",
+            agent: "codex",
+            model: "gpt-5.3-codex",
+            command: "codex --model gpt-5.3-codex",
+            prompt: "review prompt",
+        })
+        .await
+        .unwrap();
+
+    let finalized = store
+        .finalize_incomplete_runs(task_id, "aborted", "graceful shutdown")
+        .await
+        .unwrap();
+    assert_eq!(finalized, 2);
+
+    let runs = store.get_runs(task_id).await.unwrap();
+    assert_eq!(runs.len(), 2);
+    assert!(runs.iter().all(|r| r.outcome == "aborted"));
+    assert!(runs.iter().all(|r| r.completed_at.is_some()));
+    assert!(runs.iter().all(|r| r.exit_code == Some(-1)));
+}
+
+#[tokio::test]
+async fn finalize_incomplete_runs_ignores_completed_runs() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let task_id = store
+        .create(&NewTask {
+            repo: "owner/repo".to_string(),
+            origin: "internal".to_string(),
+            title: "Test".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let run_id = store
+        .start_run(&StartRun {
+            task_id,
+            attempt: 1,
+            run_type: "agent",
+            agent: "claude",
+            model: "sonnet",
+            command: "claude -p ...",
+            prompt: "system prompt",
+        })
+        .await
+        .unwrap();
+    store
+        .complete_run(&CompleteRun {
+            run_id,
+            exit_code: Some(0),
+            stdout: "",
+            stderr: "",
+            parsed: "{}",
+            outcome: "success",
+            error: "",
+            tokens: RunTokenUsage::default(),
+        })
+        .await
+        .unwrap();
+
+    let finalized = store
+        .finalize_incomplete_runs(task_id, "aborted", "graceful shutdown")
+        .await
+        .unwrap();
+    assert_eq!(finalized, 0);
+}
+
+#[tokio::test]
 async fn set_fields_updates_task() {
     let store = TaskStore::open_memory().await.unwrap();
 


### PR DESCRIPTION
## Summary

Implemented end-to-end task run finalization so `task_runs` rows no longer remain NULL on runner early-exit/error or graceful shutdown reset paths.

### What was done

- Added `TaskStore::finalize_incomplete_runs(task_id, outcome, error)` to close all open `task_runs` rows for a task via `complete_run` with terminal metadata.
- Updated `run_with_context` to always finalize the started run audit row when `run()` returns `Err` and when guard skip returns `Ok(None)`.
- Updated graceful shutdown in `src/engine/mod.rs` to finalize incomplete runs as `aborted` for tasks reset from `in_progress -> routed` and `in_review -> needs_review` (external and internal tasks).
- Added store tests covering finalization behavior: aborting open runs and ignoring already completed runs.
- Ran required quality gates successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run`.


### Remaining

- Automated review pass and PR validation in CI.


### Files changed

- `src/store/tasks.rs`
- `src/store/tests.rs`
- `src/engine/runner/mod.rs`
- `src/engine/mod.rs`


Closes #2937

---
*Task #2937 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*