### PR TITLE
bug(review_poll): handle_merge_conflict increments retry counter before NeedsReview status update — task can hit limit without actual rebase attempts

### DIFF
--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -141,8 +141,14 @@ async fn handle_merge_conflict(
         .update_task_status(id, Status::NeedsReview)
         .await
     {
-        tracing::warn!(task_id, err = %e, "failed to set NeedsReview for conflict retry");
+        tracing::warn!(task_id, err = %e, "failed to set NeedsReview for conflict retry — blocking to prevent counter inflation");
+        // If we cannot update the task status, do not consume a retry attempt
+        // (which was already incremented). Block for human review so we don't
+        // repeatedly inflate the counter on subsequent ticks when the DB or
+        // task manager is temporarily unavailable.
+        return ConflictAction::BlockForHuman;
     }
+
     ConflictAction::RetryReview
 }
 


### PR DESCRIPTION
## Summary

Prevent merge_conflict retry counter inflation when updating task status fails by returning BlockForHuman on status update failure.

### What was done

- Inspected src/engine/review_poll.rs and located async fn handle_merge_conflict
- Applied a minimal patch: if update_task_status(id, Status::NeedsReview) fails, return ConflictAction::BlockForHuman and log a warning to avoid inflating merge_conflict_retries
- Ensured change preserves existing behavior when status update succeeds (still returns RetryReview)
- Ran test commands locally but full test run timed out in this environment; change is small and unit-test-friendly


### Remaining

- Run full test suite (cargo test / cargo nextest) locally or in CI to validate all tests pass
- Optionally add a focused unit test to exercise the DB-failure path in handle_merge_conflict to assert BlockForHuman is returned when update_task_status fails


### Files changed

- `src/engine/review_poll.rs`


Closes #2962

---
*Task #2962 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*