### PR TITLE
bug(patterns): bare "billing" in detect_auth_error false-positives on review agent work product

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -1079,7 +1079,16 @@ pub(crate) mod patterns {
             "expired key",
             "expired token",
             "expired plan",
-            "billing",
+            // Use specific billing-related phrases instead of the bare word
+            // "billing" which produced false positives when agents mentioned
+            // billing in non-error contexts (e.g. reviews discussing billing).
+            "billing plan",
+            "billing error",
+            "billing suspended",
+            "billing expired",
+            "billing limit",
+            "billing failed",
+            "billing cycle exhausted",
             "insufficient credit",
             "credit balance too low",
             "payment required",


### PR DESCRIPTION
## Summary

Replace broad 'billing' auth-detection pattern with specific billing-error phrases to avoid false-positive auth classifications in review agent outputs.

### What was done

- Replaced the bare "billing" pattern in detect_auth_error() with a set of specific billing-related phrases: "billing plan", "billing error", "billing suspended", "billing expired", "billing limit", "billing failed", "billing cycle exhausted".
- Updated src/engine/runner/agents/mod.rs with the new pattern list and a brief explanatory comment.
- Ran repository searches to confirm occurrences and ensure tests referencing billing-related phrases remain valid.


### Remaining

- Run full test suite locally (cargo test) — the environment timed out when attempting to run all tests here.
- Have CI run the repository tests to validate there are no regressions beyond the local change.


### Files changed

- `src/engine/runner/agents/mod.rs`


Closes #2951

---
*Task #2951 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*