### PR TITLE
bug(cooldown): past retry_at timestamp skips exponential backoff in record_agent_failure_with_message

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -2041,6 +2041,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn vendor_past_retry_falls_back_to_backoff() {
+        // If a vendor-provided "try again at" date is in the past, the
+        // code must NOT early-return and must instead apply the normal
+        // exponential backoff (increment failure count and set a future cooldown).
+        let store = test_store().await;
+        *cooldown_store().lock().await = Some(store.clone());
+
+        let agent = "test_vendor_past_retry";
+
+        // Ensure no pre-existing cooldown
+        {
+            let mut map = cooldowns().lock().unwrap();
+            map.remove(agent);
+        }
+
+        // A clearly past date that parse_retry_at can parse
+        let past_msg = "You've hit the limit; try again at Jan 01, 2000 01:00 AM.";
+
+        record_agent_failure_with_message(agent, past_msg).await;
+
+        // After handling a past vendor timestamp, we should have applied
+        // exponential backoff (base = BACKOFF_BASE_SECS) and a persisted
+        // failure count of 1.
+        assert!(is_agent_in_cooldown(agent), "agent should be in cooldown after failure");
+
+        let remaining = {
+            let map = cooldowns().lock().unwrap();
+            let entry = map.get(agent).expect("cooldown entry should exist");
+            entry.cooldown_until - chrono::Utc::now().timestamp()
+        };
+
+        assert!(
+            remaining >= BACKOFF_BASE_SECS - 5,
+            "expected backoff of ~{BACKOFF_BASE_SECS}s when vendor timestamp is past, got {remaining}s"
+        );
+
+        // Verify the failure count was incremented and persisted to KV
+        let kv_key = format!("{FAILURE_COUNT_PREFIX}{agent}");
+        let stored = store.kv_get(&kv_key).await.unwrap().expect("failure count should be stored");
+        assert_eq!(stored, "1");
+    }
+
+    #[tokio::test]
     async fn record_agent_success_resets_backoff() {
         let store = test_store().await;
         *cooldown_store().lock().await = Some(store.clone());

--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -333,10 +333,21 @@ pub async fn record_agent_success(agent_name: &str, model: &str) {
 /// If `error_message` contains "try again at {date}", that vendor date is used
 /// instead of the computed backoff (vendor dates are always authoritative).
 pub async fn record_agent_failure_with_message(agent_name: &str, error_message: &str) {
-    // Vendor-specified retry date takes priority over backoff.
+    // Vendor-specified retry date takes priority over backoff — but only
+    // if it is in the present or future. If the parsed timestamp is in the
+    // past (stale vendor message), fall through to the exponential backoff
+    // path instead of returning early and bypassing backoff entirely.
     if let Some(cooldown_until) = parse_retry_at(error_message) {
-        set_cooldown_async(agent_name, cooldown_until, "agent_error").await;
-        return;
+        let now = chrono::Utc::now().timestamp();
+        if cooldown_until > now {
+            set_cooldown_async(agent_name, cooldown_until, "agent_error").await;
+            return;
+        }
+        tracing::debug!(
+            agent = agent_name,
+            cooldown_until,
+            "vendor retry_at is in the past — using backoff instead"
+        );
     }
 
     let store_opt = cooldown_store().lock().await.clone();

--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -2064,7 +2064,10 @@ mod tests {
         // After handling a past vendor timestamp, we should have applied
         // exponential backoff (base = BACKOFF_BASE_SECS) and a persisted
         // failure count of 1.
-        assert!(is_agent_in_cooldown(agent), "agent should be in cooldown after failure");
+        assert!(
+            is_agent_in_cooldown(agent),
+            "agent should be in cooldown after failure"
+        );
 
         let remaining = {
             let map = cooldowns().lock().unwrap();
@@ -2079,7 +2082,11 @@ mod tests {
 
         // Verify the failure count was incremented and persisted to KV
         let kv_key = format!("{FAILURE_COUNT_PREFIX}{agent}");
-        let stored = store.kv_get(&kv_key).await.unwrap().expect("failure count should be stored");
+        let stored = store
+            .kv_get(&kv_key)
+            .await
+            .unwrap()
+            .expect("failure count should be stored");
         assert_eq!(stored, "1");
     }
 


### PR DESCRIPTION
## Summary

Fix cooldown early-return when vendor "try again at" timestamp is in the past so expired vendor timestamps do not bypass exponential backoff.

### What was done

- Updated record_agent_failure_with_message to only honour vendor-provided retry_at timestamps that are in the present or future
- Added a debug log when a parsed vendor timestamp is in the past and backoff will be used instead
- Verified the change location and logic in src/engine/cooldown.rs


### Remaining

- Run the full test suite locally / in CI (cargo test) to validate all tests pass end-to-end
- Optional: add a focused unit test covering the expired-vendor-timestamp fall-through if additional coverage is desired (current repo already contains parse_retry_at tests)


### Files changed

- `src/engine/cooldown.rs`


Closes #2950

---
*Task #2950 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*