### PR TITLE
bug(parser): status "complete" not normalized to "done" — agents misclassified as failures

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -78,6 +78,7 @@ fn status_is_known(status: &str) -> bool {
             | "in_progress"
             | "done"
             | "completed"
+            | "complete"
             | "ok"
             | "success"
             | "running"
@@ -154,7 +155,7 @@ pub fn parse(raw: &str) -> anyhow::Result<AgentResponse> {
 fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
     resp.status = match resp.status.as_str() {
         // Canonical completion statuses.
-        "done" | "completed" | "ok" | "success" => "done".to_string(),
+        "done" | "completed" | "complete" | "ok" | "success" => "done".to_string(),
         // Canonical progress statuses.
         "in_progress" | "running" => "in_progress".to_string(),
         "in_review" | "reviewing" => "in_review".to_string(),
@@ -1036,6 +1037,7 @@ Some output here.
             ("ok", "done"),
             ("success", "done"),
             ("completed", "done"),
+            ("complete", "done"),
             ("running", "in_progress"),
             ("reviewing", "in_review"),
             ("pending_review", "needs_review"),


### PR DESCRIPTION
## Summary

Normalize agent status alias "complete" to canonical "done" and add regression test case.

### What was done

- Added "complete" to the canonical completion aliases in normalize_status() so agents returning {"status":"complete"} are normalized to "done"
- Added "complete" to the status_is_known() allowlist so normalized responses are recognized as known statuses
- Extended the parse_regression_2880_normalize_aliases() unit test to include ("complete", "done")
- Updated src/parser.rs accordingly (minimal, localized change)


### Remaining

- Run the full test suite locally (cargo test) to verify there are no regressions — the test run timed out in this environment
- If tests pass, create a commit with a concise message (e.g. "fix(parser): normalize 'complete' status to 'done' and add test") and push/create PR per repo workflow (orch will handle push/PR)
- If any CI failures appear, address them and re-run tests


### Files changed

- `src/parser.rs`


Closes #2915

---
*Task #2915 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*