### PR TITLE
fix(control,tests): prevent orphaned memories on DB failure; fix flaky test paths

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -771,9 +771,10 @@ pub async fn send_message(
     // Parse response for summary and memory tags
     let parsed = parse_response(&result.text);
 
-    persist_memories(store, session_id, &parsed.memories).await?;
-
-    // Store assistant message with token usage
+    // Store assistant message with token usage.
+    // Must happen before persist_memories so that if the DB write fails the
+    // KV store is not left with orphaned memory keys that have no corresponding
+    // conversation history entry.
     let total_tokens =
         total_tokens_u64_to_i64_saturating(result.input_tokens, result.output_tokens);
     let input_tokens = opt_token_u64_to_i64_saturating(result.input_tokens);
@@ -805,6 +806,8 @@ pub async fn send_message(
             cost_usd,
         )
         .await?;
+
+    persist_memories(store, session_id, &parsed.memories).await?;
 
     // Release the per-session lock before eviction check.
     drop(_guard);

--- a/tests/integration_engine.rs
+++ b/tests/integration_engine.rs
@@ -78,7 +78,7 @@ impl ExternalBackend for MockBackend {
 /// the checksum, and the engine loops forever on startup.
 #[tokio::test]
 async fn store_opens_and_migrates() {
-    let tmp = std::env::temp_dir().join(format!("orch-engine-open-{}.db", std::process::id()));
+    let tmp = temp_db("open");
     let store = TaskStore::open(&tmp).await;
     assert!(store.is_ok(), "TaskStore::open failed: {:?}", store.err());
     let _ = std::fs::remove_file(&tmp);
@@ -89,7 +89,7 @@ async fn store_opens_and_migrates() {
 /// Verify that TaskStore migrations are idempotent (open twice).
 #[tokio::test]
 async fn store_migrations_idempotent() {
-    let tmp = std::env::temp_dir().join(format!("orch-engine-test-{}.db", std::process::id()));
+    let tmp = temp_db("migration-idempotent");
 
     // First open (uses real open with max_connections(5) — production path)
     {
@@ -115,7 +115,7 @@ async fn store_migrations_idempotent() {
 /// Verify that tasks table exists and is queryable after migrations.
 #[tokio::test]
 async fn store_tasks_table_exists() {
-    let tmp = std::env::temp_dir().join(format!("orch-engine-table-{}.db", std::process::id()));
+    let tmp = temp_db("table");
     let store = TaskStore::open_single(&tmp).await.expect("open store");
 
     // Just verify the tasks table is queryable (schema is correct)
@@ -150,7 +150,7 @@ async fn mock_backend_health_check() {
 /// Verify that cooldown init works with an in-memory store.
 #[tokio::test]
 async fn cooldown_init_with_store() {
-    let tmp = std::env::temp_dir().join(format!("orch-engine-cooldown-{}.db", std::process::id()));
+    let tmp = temp_db("cooldown");
     let store = Arc::new(TaskStore::open_single(&tmp).await.expect("open store"));
     orch::engine::cooldown::init_cooldown_store(store).await;
     let _ = std::fs::remove_file(&tmp);
@@ -880,7 +880,7 @@ async fn router_healthy_agent_count() {
 async fn update_status_and_fields_records_pre_update_values_in_activity() {
     use orch::store::{TaskActivity, TaskStatus};
 
-    let tmp = std::env::temp_dir().join(format!("orch-update-activity-{}.db", std::process::id()));
+    let tmp = temp_db("update-activity");
     let store = TaskStore::open_single(&tmp).await.expect("open store");
 
     let id = store
@@ -927,7 +927,7 @@ async fn update_status_and_fields_records_pre_update_values_in_activity() {
 async fn update_status_and_fields_propagates_fetch_error_on_missing_row() {
     use orch::store::TaskStatus;
 
-    let tmp = std::env::temp_dir().join(format!("orch-update-norow-{}.db", std::process::id()));
+    let tmp = temp_db("update-norow");
     let store = TaskStore::open_single(&tmp).await.expect("open store");
 
     // Row id 9999 does not exist — fetch_one will return RowNotFound, which
@@ -958,7 +958,7 @@ async fn update_status_and_fields_propagates_fetch_error_on_missing_row() {
 async fn update_status_and_fields_propagates_column_decode_error() {
     use orch::store::{TaskActivity, TaskStatus};
 
-    let tmp = std::env::temp_dir().join(format!("orch-update-decode-{}.db", std::process::id()));
+    let tmp = temp_db("update-decode");
     let store = TaskStore::open_single(&tmp).await.expect("open store");
 
     let id = store


### PR DESCRIPTION
## Summary

- **`src/control.rs`** (#2942): Swap `persist_memories` / `insert_control_message` order so if the DB write fails, KV memory keys are never written — preventing orphaned memories that would inject stale context into future sessions.
- **`tests/integration_engine.rs`** (#2967): Replace all 7 PID-only temp DB paths (`orch-engine-*-{pid}.db`) with the existing `temp_db()` helper which appends an atomic counter, eliminating the race condition when multiple test threads share the same path.

## Test plan

- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo nextest run` — 3383/3383 passed

Closes #2942
Closes #2967

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task internal-2963 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*