### PR TITLE
bug(runner): agent-returned blocked responses lose their reason in task state

### DIFF
--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -1926,7 +1926,10 @@ mod tests {
             ..Default::default()
         };
         let reason = agent_blocked_reason(&resp);
-        assert!(reason.contains("CDP endpoint not reachable"), "reason: {reason}");
+        assert!(
+            reason.contains("CDP endpoint not reachable"),
+            "reason: {reason}"
+        );
         assert!(reason.contains("Remaining:"), "reason: {reason}");
         assert!(reason.contains("x-twitter-brave"), "reason: {reason}");
     }
@@ -1942,7 +1945,10 @@ mod tests {
             ..Default::default()
         };
         let reason = agent_blocked_reason(&resp);
-        assert_eq!(reason, "Could not access required data sources in sandboxed environment");
+        assert_eq!(
+            reason,
+            "Could not access required data sources in sandboxed environment"
+        );
     }
 
     /// No error or summary — returns generic fallback.

--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -991,6 +991,29 @@ async fn detect_no_code_reroutes(
 
 // ── Post-decision side-effect helpers ─────────────────────────────────────────
 
+/// Build a human-readable reason string from a "blocked" agent response.
+///
+/// Priority: explicit `error` field → `summary` → fallback.
+/// Appends `remaining` items if present so operators know what was left to do.
+fn agent_blocked_reason(resp: &crate::parser::AgentResponse) -> String {
+    let summary_opt = if !resp.summary.is_empty() {
+        Some(resp.summary.as_str())
+    } else {
+        None
+    };
+    let base = resp
+        .error
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .or(summary_opt)
+        .unwrap_or("agent returned blocked status without a reason");
+    if resp.remaining.is_empty() {
+        base.to_string()
+    } else {
+        format!("{base}. Remaining: {}", resp.remaining.join("; "))
+    }
+}
+
 /// Apply tracing and store writes that depend on the final status decision.
 #[allow(clippy::too_many_arguments)]
 async fn apply_post_decision_effects(
@@ -1468,6 +1491,16 @@ pub async fn handle_success(
     )
     .await;
 
+    // When the agent explicitly returned "blocked", persist its explanation into
+    // last_error so `orch task get` surfaces the reason without requiring manual
+    // inspection of task_runs.parsed_response.  The apply_post_decision_effects
+    // branches above only fire on push/no-code scenarios; a raw agent-blocked
+    // response falls through all of them and would leave last_error empty.
+    if resp.status == "blocked" && final_status == "blocked" {
+        let reason = agent_blocked_reason(&resp);
+        ctx.set(&[("last_error", serde_json::json!(reason))]).await;
+    }
+
     ctx.set(&[("summary", serde_json::json!(resp.summary))])
         .await;
 
@@ -1878,5 +1911,58 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(status, "done");
+    }
+
+    // ── agent_blocked_reason — regression tests for issue #3012 ──────────────
+
+    /// Agent explicitly returned blocked with an error field — use error as reason.
+    #[test]
+    fn agent_blocked_reason_prefers_error_field() {
+        let resp = crate::parser::AgentResponse {
+            status: "blocked".to_string(),
+            error: Some("CDP endpoint not reachable".to_string()),
+            summary: "Could not complete research".to_string(),
+            remaining: vec!["Run x-twitter-brave with reachable endpoint".to_string()],
+            ..Default::default()
+        };
+        let reason = agent_blocked_reason(&resp);
+        assert!(reason.contains("CDP endpoint not reachable"), "reason: {reason}");
+        assert!(reason.contains("Remaining:"), "reason: {reason}");
+        assert!(reason.contains("x-twitter-brave"), "reason: {reason}");
+    }
+
+    /// No error field — falls back to summary.
+    #[test]
+    fn agent_blocked_reason_falls_back_to_summary() {
+        let resp = crate::parser::AgentResponse {
+            status: "blocked".to_string(),
+            error: None,
+            summary: "Could not access required data sources in sandboxed environment".to_string(),
+            remaining: vec![],
+            ..Default::default()
+        };
+        let reason = agent_blocked_reason(&resp);
+        assert_eq!(reason, "Could not access required data sources in sandboxed environment");
+    }
+
+    /// No error or summary — returns generic fallback.
+    #[test]
+    fn agent_blocked_reason_generic_fallback() {
+        let resp = crate::parser::AgentResponse {
+            status: "blocked".to_string(),
+            ..Default::default()
+        };
+        let reason = agent_blocked_reason(&resp);
+        assert_eq!(reason, "agent returned blocked status without a reason");
+    }
+
+    /// Agent-returned "blocked" status passes through classify_final_status unchanged.
+    #[test]
+    fn classify_agent_blocked_passes_through() {
+        let status = classify_final_status(&DecisionInput {
+            agent_status: "blocked",
+            ..Default::default()
+        });
+        assert_eq!(status, "blocked");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,7 @@ static TRAILING_COMMA_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r",(\s*[}\]])").expect("trailing comma regex is valid"));
 
 /// Normalized agent response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AgentResponse {
     pub status: String,
     #[serde(default)]


### PR DESCRIPTION
## Summary

Fixed bug where agent-returned blocked responses lost their reason in task state. When an agent returns {"status":"blocked","summary":"...","error":"..."}, the task was blocked with empty last_error and NULL block_reason. Added agent_blocked_reason() pure helper that derives a human-readable message from the response (error field → summary → fallback + remaining items appended). handle_success now calls this helper and writes last_error via ctx.set() whenever resp.status == "blocked" && final_status == "blocked". Also derived Default on AgentResponse to enable struct-update syntax in tests. Added 4 regression tests: error field priority, summary fallback, generic fallback, and classify pass-through.

### What was done

- Added agent_blocked_reason() pure helper in response_handler.rs that builds reason from error/summary/remaining
- Called helper in handle_success after apply_post_decision_effects to persist last_error for agent-blocked responses
- Derived Default on AgentResponse in parser.rs to support test struct-update syntax
- Added 4 regression tests: agent_blocked_reason_prefers_error_field, agent_blocked_reason_falls_back_to_summary, agent_blocked_reason_generic_fallback, classify_agent_blocked_passes_through
- All 3447 tests pass, cargo clippy clean


### Files changed

- `src/engine/runner/response_handler.rs`
- `src/parser.rs`


Closes #3012

---
*Task #3012 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*