### PR TITLE
bug(parser): normalize 'no_trades_no_positions' agent status instead of failing the run

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -157,9 +157,13 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         // Some agents return `complete` or `no_changes_needed` to indicate
         // a successful run with no further edits required — treat them as
         // `done` so the run is classified as successful.
-        "done" | "completed" | "complete" | "ok" | "success" | "no_changes_needed" => {
-            "done".to_string()
-        }
+        "done"
+        | "completed"
+        | "complete"
+        | "ok"
+        | "success"
+        | "no_changes_needed"
+        | "no_trades_no_positions" => "done".to_string(),
         // Canonical progress statuses.
         // `partial` is used by some models to indicate partial progress —
         // treat it as in_progress so the task remains open for follow-up.
@@ -1079,6 +1083,7 @@ Some output here.
             ("completed", "done"),
             ("complete", "done"),
             ("no_changes_needed", "done"),
+            ("no_trades_no_positions", "done"),
             ("running", "in_progress"),
             ("partial", "in_progress"),
             ("reviewing", "in_review"),


### PR DESCRIPTION
## Summary

Normalized the non-canonical parser status `no_trades_no_positions` to `done` and added regression coverage to prevent failed runs/reroutes for successful no-trade outcomes.

### What was done

- Updated `normalize_status()` in `src/parser.rs` to map `no_trades_no_positions` to canonical `done`.
- Extended the parser alias regression matrix test to include `no_trades_no_positions -> done`.
- Ran required checks successfully: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run`.
- Committed the fix with conventional commit `a5e6585b`.


### Files changed

- `src/parser.rs`


Closes #3022

---
*Task #3022 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*