### PR TITLE
bug(codex): workspace-write worktree runs cannot commit when git common dir is outside the worktree

### DIFF
--- a/src/engine/runner/agent.rs
+++ b/src/engine/runner/agent.rs
@@ -16,6 +16,37 @@ const ALLOWED_TOOLS_TEMPLATE: &str = include_str!("../../../prompts/allowed_tool
 const REVIEW_PROMPT_TEMPLATE: &str = include_str!("../../../prompts/review_task.md");
 const REVIEW_SYSTEM_TEMPLATE: &str = include_str!("../../../prompts/review_system.md");
 
+/// Run `git rev-parse --git-common-dir` from `work_dir` and canonicalize the
+/// result. Returns `Ok(None)` when git is not available or the command fails.
+async fn resolve_git_common_dir(work_dir: &std::path::Path) -> anyhow::Result<Option<PathBuf>> {
+    let output = tokio::process::Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .current_dir(work_dir)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw.is_empty() {
+        return Ok(None);
+    }
+
+    // The path may be relative to work_dir; canonicalize to absolute.
+    let candidate = if std::path::Path::new(&raw).is_absolute() {
+        PathBuf::from(&raw)
+    } else {
+        work_dir.join(&raw)
+    };
+
+    let canonical = tokio::fs::canonicalize(&candidate)
+        .await
+        .unwrap_or(candidate);
+    Ok(Some(canonical))
+}
+
 fn render_prompt_template(template: &str, vars: HashMap<String, String>) -> String {
     match render_template_str(template, &vars) {
         Ok(rendered) => rendered,
@@ -76,6 +107,26 @@ pub async fn spawn_in_tmux(tmux: &TmuxManager, inv: &AgentInvocation) -> anyhow:
         }
     }
     permissions.allowed_edit_paths.push(inv.work_dir.clone());
+
+    // For Codex running in workspace-write sandbox mode, grant write access to
+    // the git common dir when it lives outside the worktree root. Without this,
+    // git operations that create index.lock under the main repo's .git/worktrees/
+    // directory fail with "Operation not permitted" inside the sandbox.
+    if inv.agent == "codex" {
+        match resolve_git_common_dir(&inv.work_dir).await {
+            Ok(Some(common_dir)) if !common_dir.starts_with(&inv.work_dir) => {
+                permissions.extra_writable_dirs.push(common_dir);
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::debug!(
+                    work_dir = %inv.work_dir.display(),
+                    error = %e,
+                    "failed to resolve git common dir; skipping --add-dir"
+                );
+            }
+        }
+    }
 
     let sys_content = if !permissions.allowed_tools.is_empty() {
         let tools_list = permissions

--- a/src/engine/runner/agents/claude.rs
+++ b/src/engine/runner/agents/claude.rs
@@ -925,6 +925,7 @@ mod tests {
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let cmd = r.build_command(
             Some("opus"),
@@ -950,6 +951,7 @@ mod tests {
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let cmd = r.build_command(None, "", "/tmp/sys.txt", "/tmp/msg.txt", &perms);
         assert!(cmd.contains("--permission-mode acceptEdits"));
@@ -970,6 +972,7 @@ mod tests {
             ],
             allowed_edit_paths: vec![std::path::PathBuf::from("/home/user/worktree")],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let cmd = r.build_command(None, "", "/tmp/sys.txt", "/tmp/msg.txt", &perms);
 
@@ -1140,6 +1143,7 @@ mod tests {
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let cmd = r.build_command(
             Some("sonnet"),
@@ -1170,6 +1174,7 @@ mod tests {
             ],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let cmd = r.build_command(None, "", "/tmp/sys.txt", "/tmp/msg.txt", &perms);
 
@@ -1209,6 +1214,7 @@ mod tests {
             allowed_tools: vec![], // empty = use disallowed_tools
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let cmd = r.build_command(None, "", "/tmp/sys.txt", "/tmp/msg.txt", &perms);
 

--- a/src/engine/runner/agents/codex.rs
+++ b/src/engine/runner/agents/codex.rs
@@ -243,9 +243,23 @@ impl AgentRunner for CodexRunner {
             format!("--ask-for-approval suggest --sandbox {sandbox}")
         };
 
+        // Extra writable dirs (e.g. the git common dir when running inside a
+        // worktree whose .git metadata lives outside the sandbox root).
+        let add_dir_flags: String = permissions
+            .extra_writable_dirs
+            .iter()
+            .map(|p| {
+                format!(
+                    "\\\n  --add-dir {}",
+                    super::shell_single_quote(&p.to_string_lossy())
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+
         format!(
             r#"cat "{sys_file}" "{msg_file}" | {timeout_cmd} codex {model_flag} \
-  {permission_flags} \
+  {permission_flags} {add_dir_flags}\
   -c 'sandbox_workspace_write.network_access=true' \
   -c 'shell_environment_policy.inherit=all' \
   exec --json -"#,
@@ -254,6 +268,7 @@ impl AgentRunner for CodexRunner {
             timeout_cmd = timeout_cmd,
             model_flag = model_flag,
             permission_flags = permission_flags,
+            add_dir_flags = add_dir_flags,
         )
     }
 
@@ -504,11 +519,58 @@ mod tests {
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let cmd = runner().build_command(None, "", "/tmp/sys.txt", "/tmp/msg.txt", &perms);
         assert!(
             cmd.contains("--dangerously-bypass-approvals-and-sandbox"),
             "full access codex should use dangerously-bypass, got: {cmd}"
+        );
+    }
+
+    #[test]
+    fn build_command_codex_extra_writable_dirs() {
+        // When the git common dir is outside the worktree sandbox root, the
+        // runner adds it to extra_writable_dirs and build_command must emit
+        // --add-dir flags so Codex can create index.lock there.
+        let perms = PermissionRules {
+            autonomous: true,
+            sandbox: SandboxLevel::WorkspaceWrite,
+            disallowed_tools: vec![],
+            allowed_tools: vec![],
+            allowed_edit_paths: vec![],
+            deny_read_only: false,
+            extra_writable_dirs: vec![std::path::PathBuf::from(
+                "/Users/gb/Projects/bean/.git/worktrees/task-123",
+            )],
+        };
+        let cmd = runner().build_command(None, "", "/tmp/sys.txt", "/tmp/msg.txt", &perms);
+        assert!(
+            cmd.contains("--add-dir"),
+            "should include --add-dir flag, got: {cmd}"
+        );
+        assert!(
+            cmd.contains("/Users/gb/Projects/bean/.git/worktrees/task-123"),
+            "should include the extra dir path, got: {cmd}"
+        );
+        assert!(
+            cmd.contains("--full-auto"),
+            "should still include --full-auto, got: {cmd}"
+        );
+        assert!(
+            cmd.contains("exec --json -"),
+            "should still include exec --json -, got: {cmd}"
+        );
+    }
+
+    #[test]
+    fn build_command_codex_no_extra_writable_dirs() {
+        // With no extra_writable_dirs, --add-dir must not appear in the command.
+        let perms = PermissionRules::default();
+        let cmd = runner().build_command(None, "", "/tmp/sys.txt", "/tmp/msg.txt", &perms);
+        assert!(
+            !cmd.contains("--add-dir"),
+            "should not include --add-dir when no extra dirs, got: {cmd}"
         );
     }
 

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -43,6 +43,11 @@ pub struct PermissionRules {
     /// Agents translate this into their native permission model.
     #[allow(dead_code)]
     pub deny_read_only: bool,
+    /// Additional directories that must be writable (e.g. the git common dir
+    /// when running inside a worktree whose `.git` metadata lives outside the
+    /// sandbox root). Codex translates these into `--add-dir` flags; other
+    /// agents ignore the field.
+    pub extra_writable_dirs: Vec<PathBuf>,
 }
 
 /// Sandbox level — how much filesystem access the agent gets.
@@ -69,6 +74,7 @@ impl Default for PermissionRules {
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         }
     }
 }
@@ -138,6 +144,7 @@ impl PermissionRules {
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: true,
+            extra_writable_dirs: vec![],
         }
     }
 }
@@ -2323,6 +2330,7 @@ world"}"#;
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let sys = "/tmp/sys.md";
         let msg = "/tmp/msg.md";
@@ -2354,6 +2362,7 @@ world"}"#;
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let sys = "/tmp/sys.md";
         let msg = "/tmp/msg.md";
@@ -2385,6 +2394,7 @@ world"}"#;
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let codex = get_runner("codex");
         let cmd = codex.build_command(None, "", "/tmp/sys.md", "/tmp/msg.md", &perms);
@@ -2409,6 +2419,7 @@ world"}"#;
             ],
             allowed_edit_paths: vec![PathBuf::from("/home/user/worktree")],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let claude = get_runner("claude");
         let cmd = claude.build_command(None, "", "/tmp/sys.md", "/tmp/msg.md", &perms);
@@ -2436,6 +2447,7 @@ world"}"#;
             allowed_tools: vec![],
             allowed_edit_paths: vec![PathBuf::from("/home/user/project")],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let codex = get_runner("codex");
         let cmd = codex.build_command(None, "", "/tmp/sys.md", "/tmp/msg.md", &perms);
@@ -2455,6 +2467,7 @@ world"}"#;
             allowed_tools: vec![],
             allowed_edit_paths: vec![PathBuf::from("/home/user/project")],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let opencode = get_runner("opencode");
         let cmd = opencode.build_command(None, "", "/tmp/sys.md", "/tmp/msg.md", &perms);
@@ -2478,6 +2491,7 @@ world"}"#;
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let claude = get_runner("claude");
         let cmd = claude.build_command(None, "", "/tmp/sys.md", "/tmp/msg.md", &perms);
@@ -2496,6 +2510,7 @@ world"}"#;
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let codex = get_runner("codex");
         let cmd = codex.build_command(None, "", "/tmp/sys.md", "/tmp/msg.md", &perms);
@@ -2515,6 +2530,7 @@ world"}"#;
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let claude = get_runner("claude");
         let cmd = claude.build_command(None, "", "/tmp/sys.md", "/tmp/msg.md", &perms);
@@ -2534,6 +2550,7 @@ world"}"#;
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
         let sys = "/tmp/sys.md";
         let msg = "/tmp/msg.md";
@@ -2562,6 +2579,7 @@ world"}"#;
             allowed_tools: vec!["Edit".to_string(), "Bash".to_string(), "git".to_string()],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
 
         for agent in &["kimi", "minimax"] {
@@ -2596,6 +2614,7 @@ world"}"#;
             ],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
 
         let claude = get_runner("claude");
@@ -2620,6 +2639,7 @@ world"}"#;
             allowed_tools: vec!["Edit".to_string(), "git".to_string()],
             allowed_edit_paths: vec![],
             deny_read_only: false,
+            extra_writable_dirs: vec![],
         };
 
         let codex = get_runner("codex");


### PR DESCRIPTION
## Summary

Fixed Codex workspace-write sandbox preventing git commits from worktrees by resolving the git common dir at spawn time and passing it via --add-dir.

### What was done

- Added extra_writable_dirs field to PermissionRules and updated all struct literals and constructors
- Updated codex.rs build_command to emit --add-dir flags for extra_writable_dirs
- Added resolve_git_common_dir helper in agent.rs that runs git rev-parse --git-common-dir
- Populated extra_writable_dirs in spawn_in_tmux for codex tasks when common dir is outside the worktree root
- Added regression tests build_command_codex_extra_writable_dirs and build_command_codex_no_extra_writable_dirs
- All 3459 tests pass, cargo fmt clean, clippy clean


### Files changed

- `src/engine/runner/agent.rs`
- `src/engine/runner/agents/mod.rs`
- `src/engine/runner/agents/codex.rs`
- `src/engine/runner/agents/claude.rs`


Closes #3021

---
*Task #3021 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*