### PR TITLE
auto-merge stalls when CI workflows are filtered out (paths-ignore) — total=0 + has_workflows=true → pending forever

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -940,8 +940,13 @@ pub(crate) async fn auto_merge_pr(
         let (state, total, passing, failing, pending) = {
             let _permit = ci_poll_semaphore().clone().acquire_owned().await;
             if required_contexts.is_empty() {
-                gh.get_combined_status(repo, &head_sha, repo_has_workflows)
-                    .await?
+                gh.get_combined_status(
+                    repo,
+                    &head_sha,
+                    repo_has_workflows,
+                    pr.mergeable_state.as_deref(),
+                )
+                .await?
             } else {
                 let check_runs = gh.get_check_runs(repo, &head_sha).await?;
                 let statuses = gh.get_commit_status_contexts(repo, &head_sha).await?;

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -1786,11 +1786,21 @@ impl GhHttp {
         failing: u64,
         pending: u64,
         has_workflows: bool,
+        mergeable_state: Option<&str>,
     ) -> String {
         if failing > 0 {
             "failure".to_string()
-        } else if pending > 0 || (total == 0 && has_workflows) {
+        } else if pending > 0 {
             "pending".to_string()
+        } else if total == 0 && has_workflows {
+            // No check runs yet. If GitHub already reports mergeable_state="clean"
+            // the PR is ready (e.g. all workflows use paths-ignore and skipped this
+            // commit). Treating it as pending would stall auto-merge forever.
+            if mergeable_state == Some("clean") {
+                "success".to_string()
+            } else {
+                "pending".to_string()
+            }
         } else {
             "success".to_string()
         }
@@ -2370,6 +2380,7 @@ impl GhHttp {
         repo: &str,
         git_ref: &str,
         has_workflows: bool,
+        mergeable_state: Option<&str>,
     ) -> anyhow::Result<(String, u64, u64, u64, u64)> {
         let url = format!("{GITHUB_API}/repos/{repo}/commits/{git_ref}/check-runs");
         let resp: serde_json::Value = self.get_json(&url).await?;
@@ -2406,7 +2417,8 @@ impl GhHttp {
         }
 
         let total = runs.len() as u64;
-        let state = Self::combined_status_state(total, failing, pending, has_workflows);
+        let state =
+            Self::combined_status_state(total, failing, pending, has_workflows, mergeable_state);
 
         Ok((state, total, passing, failing, pending))
     }
@@ -3317,9 +3329,31 @@ mod tests {
 
     #[test]
     fn combined_status_state_treats_empty_checks_as_pending_when_workflows_exist() {
-        assert_eq!(GhHttp::combined_status_state(0, 0, 0, true), "pending");
-        assert_eq!(GhHttp::combined_status_state(0, 0, 0, false), "success");
-        assert_eq!(GhHttp::combined_status_state(3, 1, 0, true), "failure");
+        // No check runs yet and GitHub hasn't said it's clean → pending (wait for CI to queue)
+        assert_eq!(
+            GhHttp::combined_status_state(0, 0, 0, true, None),
+            "pending"
+        );
+        // No workflows configured → no need to wait
+        assert_eq!(
+            GhHttp::combined_status_state(0, 0, 0, false, None),
+            "success"
+        );
+        // Failing check → failure regardless
+        assert_eq!(
+            GhHttp::combined_status_state(3, 1, 0, true, None),
+            "failure"
+        );
+        // paths-ignore filtered out all workflows: no check runs but GitHub says "clean"
+        assert_eq!(
+            GhHttp::combined_status_state(0, 0, 0, true, Some("clean")),
+            "success"
+        );
+        // mergeable_state is dirty/blocked — still pending even with has_workflows
+        assert_eq!(
+            GhHttp::combined_status_state(0, 0, 0, true, Some("dirty")),
+            "pending"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixed auto-merge stall when CI workflows use paths-ignore. Added mergeable_state param to combined_status_state and get_combined_status so that total=0 + has_workflows + mergeable_state='clean' resolves to 'success' instead of 'pending'. All 3459 tests pass.

### What was done

- Modified combined_status_state in src/github/http.rs to accept mergeable_state param and return 'success' when GitHub reports clean but no check runs exist
- Updated get_combined_status signature to accept and thread through mergeable_state
- Updated the auto_merge.rs call site to pass pr.mergeable_state.as_deref()
- Updated and expanded the unit test to cover the new clean/dirty/None cases
- Verified: cargo fmt, cargo clippy -D warnings, cargo nextest run (3459/3459 passed)


### Files changed

- `src/github/http.rs`
- `src/engine/auto_merge.rs`


Closes #3027

---
*Task #3027 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*