### PR TITLE
is_transient_github_api_error() doesn't match 'circuit-breaker' in error strings

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -1506,6 +1506,12 @@ pub(crate) fn is_transient_github_api_error(err_str: &str) -> bool {
         || lower.contains("gh api")
         || lower.contains("gh pr")
         || lower.contains("gh error")
+        // `circuit-breaker` is orch's internal GitHub 5xx protection, set
+        // exclusively by GhHttp.  It can never originate from agent/runtime
+        // failures, so treating it as a GitHub-context marker is safe even
+        // when upstream wrapping strips the "GitHub API" prefix.
+        || lower.contains("circuit-breaker")
+        || lower.contains("circuit breaker")
 }
 
 /// Extract the HTTP status code from a GhHttp error string.
@@ -1868,6 +1874,27 @@ mod tests {
         ));
         assert!(!is_transient_github_api_error(
             "codex failed: Reconnecting... (stream disconnected before completion: Broken pipe)"
+        ));
+    }
+
+    #[test]
+    fn is_transient_github_api_error_matches_circuit_breaker() {
+        // Full message from GhHttp
+        assert!(is_transient_github_api_error(
+            "GitHub API transient 5xx circuit-breaker active for 240s"
+        ));
+        // Wrapped through PrCreateError + response_handler
+        assert!(is_transient_github_api_error(
+            "create PR failed: GitHub API error: GitHub API transient 5xx circuit-breaker active"
+        ));
+        // Shortened form where upstream wrapping stripped the "GitHub API" prefix —
+        // circuit-breaker alone must still be recognized as a GitHub signal.
+        assert!(is_transient_github_api_error(
+            "create PR failed: circuit-breaker"
+        ));
+        // Spaced variant
+        assert!(is_transient_github_api_error(
+            "create PR failed: circuit breaker tripped"
         ));
     }
 


### PR DESCRIPTION
## Summary

Added 'circuit-breaker' / 'circuit breaker' to the GitHub-context markers in is_transient_github_api_error() so that errors like 'create PR failed: circuit-breaker' are correctly classified as transient. The circuit-breaker is orch's internal GitHub 5xx protection (set exclusively by GhHttp in src/github/http.rs), so it can never originate from agent/runtime failures — making it a safe marker even when upstream wrapping strips the 'GitHub API' prefix. This unsticks tasks whose last_error short-form lacked explicit GitHub keywords, allowing review_poll and review reroute paths to skip persistent counters and let the engine retry.

### What was done

- Updated is_transient_github_api_error() in src/engine/runner/git_ops.rs to recognize 'circuit-breaker' / 'circuit breaker' as GitHub-context markers
- Added a new test is_transient_github_api_error_matches_circuit_breaker covering the full GhHttp message, the wrapped 'create PR failed: GitHub API error: ...' chain, the shortened 'create PR failed: circuit-breaker' form, and the spaced 'circuit breaker' variant
- Verified cargo fmt --check, cargo clippy --all-targets -- -D warnings, and cargo nextest run on the affected tests all pass


### Files changed

- `src/engine/runner/git_ops.rs`


Closes #3029

---
*Task #3029 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*