### PR TITLE
bug(codex): --add-dir fix for git common dir is not preventing index.lock failures (regression of #3021)

### DIFF
--- a/src/engine/runner/agent.rs
+++ b/src/engine/runner/agent.rs
@@ -6,6 +6,7 @@
 use crate::engine::runner::agents::shell_single_quote;
 use crate::template::render_template_str;
 use crate::tmux::TmuxManager;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -16,11 +17,14 @@ const ALLOWED_TOOLS_TEMPLATE: &str = include_str!("../../../prompts/allowed_tool
 const REVIEW_PROMPT_TEMPLATE: &str = include_str!("../../../prompts/review_task.md");
 const REVIEW_SYSTEM_TEMPLATE: &str = include_str!("../../../prompts/review_system.md");
 
-/// Run `git rev-parse --git-common-dir` from `work_dir` and canonicalize the
+/// Run `git rev-parse <arg>` from `work_dir` and canonicalize the
 /// result. Returns `Ok(None)` when git is not available or the command fails.
-async fn resolve_git_common_dir(work_dir: &std::path::Path) -> anyhow::Result<Option<PathBuf>> {
+async fn resolve_git_dir_arg(
+    work_dir: &std::path::Path,
+    arg: &str,
+) -> anyhow::Result<Option<PathBuf>> {
     let output = tokio::process::Command::new("git")
-        .args(["rev-parse", "--git-common-dir"])
+        .args(["rev-parse", arg])
         .current_dir(work_dir)
         .output()
         .await?;
@@ -109,23 +113,32 @@ pub async fn spawn_in_tmux(tmux: &TmuxManager, inv: &AgentInvocation) -> anyhow:
     permissions.allowed_edit_paths.push(inv.work_dir.clone());
 
     // For Codex running in workspace-write sandbox mode, grant write access to
-    // the git common dir when it lives outside the worktree root. Without this,
-    // git operations that create index.lock under the main repo's .git/worktrees/
-    // directory fail with "Operation not permitted" inside the sandbox.
+    // git metadata dirs when they live outside the worktree root. We include
+    // both --git-common-dir and --git-dir because index.lock can be created
+    // under the worktree-specific git dir.
     if inv.agent == "codex" {
-        match resolve_git_common_dir(&inv.work_dir).await {
-            Ok(Some(common_dir)) if !common_dir.starts_with(&inv.work_dir) => {
-                permissions.extra_writable_dirs.push(common_dir);
-            }
-            Ok(_) => {}
-            Err(e) => {
-                tracing::debug!(
-                    work_dir = %inv.work_dir.display(),
-                    error = %e,
-                    "failed to resolve git common dir; skipping --add-dir"
-                );
+        let mut extra_dirs = BTreeSet::new();
+        for (arg, label) in [
+            ("--git-common-dir", "git common dir"),
+            ("--git-dir", "git dir"),
+        ] {
+            match resolve_git_dir_arg(&inv.work_dir, arg).await {
+                Ok(Some(dir)) if !dir.starts_with(&inv.work_dir) => {
+                    extra_dirs.insert(dir);
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::debug!(
+                        work_dir = %inv.work_dir.display(),
+                        arg,
+                        error = %e,
+                        "failed to resolve {}; skipping --add-dir",
+                        label
+                    );
+                }
             }
         }
+        permissions.extra_writable_dirs.extend(extra_dirs);
     }
 
     let sys_content = if !permissions.allowed_tools.is_empty() {

--- a/src/engine/runner/agents/codex.rs
+++ b/src/engine/runner/agents/codex.rs
@@ -530,8 +530,8 @@ mod tests {
 
     #[test]
     fn build_command_codex_extra_writable_dirs() {
-        // When the git common dir is outside the worktree sandbox root, the
-        // runner adds it to extra_writable_dirs and build_command must emit
+        // When git metadata dirs are outside the worktree sandbox root, the
+        // runner adds them to extra_writable_dirs and build_command must emit
         // --add-dir flags so Codex can create index.lock there.
         let perms = PermissionRules {
             autonomous: true,
@@ -540,9 +540,10 @@ mod tests {
             allowed_tools: vec![],
             allowed_edit_paths: vec![],
             deny_read_only: false,
-            extra_writable_dirs: vec![std::path::PathBuf::from(
-                "/Users/gb/Projects/bean/.git/worktrees/task-123",
-            )],
+            extra_writable_dirs: vec![
+                std::path::PathBuf::from("/Users/gb/Projects/bean/.git"),
+                std::path::PathBuf::from("/Users/gb/Projects/bean/.git/worktrees/task-123"),
+            ],
         };
         let cmd = runner().build_command(None, "", "/tmp/sys.txt", "/tmp/msg.txt", &perms);
         assert!(
@@ -550,8 +551,17 @@ mod tests {
             "should include --add-dir flag, got: {cmd}"
         );
         assert!(
+            cmd.contains("/Users/gb/Projects/bean/.git'"),
+            "should include git common dir path, got: {cmd}"
+        );
+        assert!(
             cmd.contains("/Users/gb/Projects/bean/.git/worktrees/task-123"),
-            "should include the extra dir path, got: {cmd}"
+            "should include git dir path, got: {cmd}"
+        );
+        assert_eq!(
+            cmd.matches("--add-dir ").count(),
+            2,
+            "should include two --add-dir flags, got: {cmd}"
         );
         assert!(
             cmd.contains("--full-auto"),


### PR DESCRIPTION
## Summary

Fixed Codex workspace-write git lock regression by adding the worktree git dir (`git rev-parse --git-dir`) to Codex `--add-dir` permissions (alongside git common dir), and added regression coverage for multiple `--add-dir` flags.

### What was done

- Refactored git metadata path resolution in `src/engine/runner/agent.rs` to support generic `git rev-parse <arg>` resolution and canonicalization.
- Updated Codex permission setup to resolve and include both `--git-common-dir` and `--git-dir` when they are outside the worktree root.
- Deduplicated extra writable directories before passing to Codex.
- Expanded `src/engine/runner/agents/codex.rs` test to validate two `--add-dir` entries are emitted and include both common-dir and worktree git-dir paths.
- Ran required quality gates successfully: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (3471 passed, 19 skipped).
- Committed the fix as `ee04c3df` with message `fix(runner): add codex git-dir as writable sandbox path`.


### Remaining

- Runtime validation on a live Codex workspace-write task in production environment to confirm index.lock failures are eliminated.


### Files changed

- `src/engine/runner/agent.rs`
- `src/engine/runner/agents/codex.rs`


Closes #3037

---
*Task #3037 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*