### PR TITLE
bug(router): canonicalize_model_alias rewrites opencode dead alias to 'gpt-5.3-codex' which opencode rejects (Model not found: gpt-5.3-codex/.)

### DIFF
--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -281,23 +281,15 @@ impl RouterConfig {
     /// Canonicalize known provider aliases that are syntactically valid but
     /// not accepted by the target CLI/provider.
     fn canonicalize_model_alias(agent: &str, model: &str) -> String {
-        if agent != "opencode" {
-            return model.to_string();
-        }
-
-        // OpenCode does not accept this legacy/copilot-prefixed identifier and
-        // suggests `gpt-5.3-codex` instead.
-        match model {
-            "github-copilot/gpt-5.3" | "opencode/github-copilot/gpt-5.3" => {
-                "gpt-5.3-codex".to_string()
-            }
-            _ => model.to_string(),
-        }
+        let _ = agent;
+        model.to_string()
     }
 
     /// Reject known-unavailable aliases that would fail deterministically at
     /// dispatch time.
     fn is_known_unavailable_model(agent: &str, model: &str) -> bool {
+        // github-copilot/gpt-5.3 is a dead copilot alias — opencode rejects it.
+        // There is no valid opencode replacement, so filter it out entirely.
         agent == "opencode"
             && matches!(
                 model,
@@ -633,19 +625,21 @@ impl RouterConfig {
         for model in pool {
             // Normalize the model identifier first to handle edge cases like trailing slashes
             let normalized = Self::normalize_model_identifier(model);
-            let canonical = Self::canonicalize_model_alias(agent, &normalized);
             if normalized == "opencode:free" {
                 has_free = true;
-            } else if Self::is_known_unavailable_model(agent, &canonical) {
+            } else if Self::is_known_unavailable_model(agent, &normalized) {
                 tracing::debug!(
                     agent,
-                    model = canonical,
+                    model = normalized,
                     "skipping known-unavailable model alias in config"
                 );
-            } else if Self::is_valid_model_identifier(&canonical) {
-                expanded_pool.push(canonical);
             } else {
-                tracing::debug!(agent, model, "skipping invalid model identifier in config");
+                let canonical = Self::canonicalize_model_alias(agent, &normalized);
+                if Self::is_valid_model_identifier(&canonical) {
+                    expanded_pool.push(canonical);
+                } else {
+                    tracing::debug!(agent, model, "skipping invalid model identifier in config");
+                }
             }
         }
 
@@ -1072,7 +1066,7 @@ model_map:
     }
 
     #[test]
-    fn expanded_model_pool_canonicalizes_dead_opencode_copilot_alias() {
+    fn expanded_model_pool_filters_dead_opencode_copilot_alias() {
         let mut config = RouterConfig::default();
         config
             .model_map
@@ -1086,7 +1080,38 @@ model_map:
         let pool = config
             .expanded_model_pool("opencode", "complex")
             .expect("pool should exist");
-        assert_eq!(pool, vec!["gpt-5.3-codex".to_string()]);
+        // Dead alias must be filtered out entirely — never rewritten to gpt-5.3-codex
+        assert!(pool.is_empty(), "expected empty pool, got: {pool:?}");
+    }
+
+    #[test]
+    fn expanded_model_pool_does_not_emit_gpt_5_3_codex_for_opencode() {
+        // Regression test for issue #3038: canonicalize_model_alias previously mapped
+        // github-copilot/gpt-5.3 → gpt-5.3-codex which opencode rejects (no provider prefix).
+        let mut config = RouterConfig::default();
+        config
+            .model_map
+            .entry("medium".to_string())
+            .or_default()
+            .insert(
+                "opencode".to_string(),
+                vec![
+                    "github-copilot/gpt-5.3".to_string(),
+                    "opencode/github-copilot/gpt-5.3".to_string(),
+                ],
+            );
+
+        let pool = config
+            .expanded_model_pool("opencode", "medium")
+            .expect("pool should exist");
+        assert!(
+            !pool.contains(&"gpt-5.3-codex".to_string()),
+            "gpt-5.3-codex must never appear in opencode pool: {pool:?}"
+        );
+        assert!(
+            pool.is_empty(),
+            "both dead aliases should be filtered: {pool:?}"
+        );
     }
 
     #[test]
@@ -1109,6 +1134,10 @@ model_map:
             .expect("a model should be selected");
 
         assert_ne!(selected, "github-copilot/gpt-5.3");
-        assert!(selected == "gpt-5.3-codex" || selected == "mimo-v2-omni-free");
+        assert_ne!(
+            selected, "gpt-5.3-codex",
+            "gpt-5.3-codex is not a valid opencode model"
+        );
+        assert_eq!(selected, "mimo-v2-omni-free");
     }
 }


### PR DESCRIPTION
## Summary

Removed the bad github-copilot/gpt-5.3 → gpt-5.3-codex rewrite from canonicalize_model_alias and fixed the unavailability check order in expanded_model_pool so dead aliases are filtered before canonicalization. All 3473 tests pass.

### What was done

- Removed the `github-copilot/gpt-5.3` → `gpt-5.3-codex` arm from `canonicalize_model_alias` — gpt-5.3-codex has no provider prefix and opencode rejects it with 'Model not found: gpt-5.3-codex/.'
- Fixed `expanded_model_pool` to call `is_known_unavailable_model` against `normalized` (before canonicalization), so dead aliases are filtered at the correct stage regardless of any future canonicalization
- Updated existing test `expanded_model_pool_canonicalizes_dead_opencode_copilot_alias` → renamed to `expanded_model_pool_filters_dead_opencode_copilot_alias` and fixed assertion to expect empty pool
- Added regression test `expanded_model_pool_does_not_emit_gpt_5_3_codex_for_opencode` covering both `github-copilot/gpt-5.3` and `opencode/github-copilot/gpt-5.3` aliases
- Updated `model_for_complexity_never_returns_dead_opencode_copilot_alias` to assert only `mimo-v2-omni-free` is selected — never `gpt-5.3-codex`
- All 3473 tests pass, cargo fmt clean, cargo clippy clean


### Files changed

- `src/engine/router/config.rs`


Closes #3038

---
*Task #3038 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*