### PR TITLE
bug(classify): detect_network_error misses 'socket connection was closed' / 'socket hang up' — claude-protocol agents misclassified as Unknown(exit 1) with garbage error message

### DIFF
--- a/src/engine/runner/agents/claude.rs
+++ b/src/engine/runner/agents/claude.rs
@@ -386,7 +386,24 @@ impl AgentRunner for ClaudeRunner {
     }
 
     fn classify_error(&self, exit_code: i32, stdout: &str, stderr: &str) -> AgentError {
-        let combined = format!("{stdout}\n{stderr}");
+        // For claude-protocol agents the real error string lives in the `result`
+        // field of the NDJSON result line (when is_error=true). Prepend it to the
+        // combined text so the classifier sees it before the raw metadata tail.
+        let error_result: Option<String> = (|| {
+            let trimmed = stdout.trim();
+            let (line, _) = find_ndjson_result_line(trimmed)?;
+            let val: serde_json::Value = serde_json::from_str(line).ok()?;
+            let obj = val.as_object()?;
+            if obj.get("is_error").and_then(|v| v.as_bool()) != Some(true) {
+                return None;
+            }
+            let result_str = obj.get("result")?.as_str()?;
+            Some(result_str.to_string())
+        })();
+        let combined = match error_result {
+            Some(ref r) => format!("{r}\n{stdout}\n{stderr}"),
+            None => format!("{stdout}\n{stderr}"),
+        };
         super::patterns::classify_from_text(exit_code, &combined)
     }
 

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -1126,6 +1126,17 @@ pub(crate) mod patterns {
             "unable to connect",
             "econnrefused",
             "network unreachable",
+            // Socket / HTTP transport errors (Node fetch / undici / http module)
+            "socket connection was closed",
+            "socket hang up",
+            "econnreset",
+            "connection reset",
+            "etimedout",
+            "connect etimedout",
+            "aborterror",
+            "the operation was aborted",
+            "network request failed",
+            "fetch failed",
         ];
         // Map the byte offset from `lower` back to `text` via char-count (same
         // rationale as detect_rate_limit: Unicode case-folding can change byte lengths).
@@ -1988,6 +1999,46 @@ mod tests {
         assert!(
             err.to_string().contains("stale session"),
             "error display must contain 'stale session' for recovery code to trigger"
+        );
+    }
+
+    #[test]
+    fn classify_from_text_detects_socket_closed() {
+        // Regression test for issue #3045: "socket connection was closed" must be
+        // classified as NetworkError, not Unknown.
+        let text = "API Error: The socket connection was closed unexpectedly. \
+             For more information, pass `verbose: true` in the second argument to fetch()";
+        let err = patterns::classify_from_text(1, text);
+        assert!(
+            matches!(err, AgentError::NetworkError { .. }),
+            "socket closed must be NetworkError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_from_text_detects_socket_hang_up() {
+        let err = patterns::classify_from_text(1, "Error: socket hang up");
+        assert!(
+            matches!(err, AgentError::NetworkError { .. }),
+            "socket hang up must be NetworkError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_from_text_detects_fetch_failed() {
+        let err = patterns::classify_from_text(1, "TypeError: fetch failed");
+        assert!(
+            matches!(err, AgentError::NetworkError { .. }),
+            "fetch failed must be NetworkError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_from_text_detects_econnreset() {
+        let err = patterns::classify_from_text(1, "read ECONNRESET");
+        assert!(
+            matches!(err, AgentError::NetworkError { .. }),
+            "ECONNRESET must be NetworkError, got: {err:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Extended detect_network_error with 10 additional socket/HTTP patterns and improved claude.rs classify_error to extract the real error string from the NDJSON result envelope before classifying. Added 4 regression tests. All 3481 tests pass.

### What was done

- Extended detect_network_error patterns in src/engine/runner/agents/mod.rs to include: socket connection was closed, socket hang up, econnreset, connection reset, etimedout, connect etimedout, aborterror, the operation was aborted, network request failed, fetch failed
- Improved ClaudeAgent::classify_error in src/engine/runner/agents/claude.rs to prepend the result field from the NDJSON envelope (when is_error=true) before the raw stdout/stderr tail, so the classifier sees the real error string instead of metadata bytes
- Added 4 regression tests: classify_from_text_detects_socket_closed, classify_from_text_detects_socket_hang_up, classify_from_text_detects_fetch_failed, classify_from_text_detects_econnreset
- Ran cargo fmt, cargo clippy --all-targets -- -D warnings, and cargo nextest run — all clean (3481 passed)
- Committed all changes


### Files changed

- `src/engine/runner/agents/mod.rs`
- `src/engine/runner/agents/claude.rs`


Closes #3045

---
*Task #3045 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*