### PR TITLE
bug(auto_merge): SSH-fetch failure traps task in infinite review-reroute loop — merge_conflict_retries reset on every Approve defeats circuit breaker

### DIFF
--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -88,6 +88,13 @@ fn should_skip_ci_check(stored: &crate::store::Task) -> bool {
         || block_reason.contains("CI failure limit")
 }
 
+fn is_ssh_agent_fetch_failure(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("sign_and_send_pubkey")
+        || lower.contains("agent refused operation")
+        || lower.contains("communication with agent failed")
+}
+
 /// Record that CI was checked for this task, updating the timestamp in KV store.
 async fn record_ci_check(store: &Arc<TaskStore>, task_id: &str) -> anyhow::Result<()> {
     let key = format!("ci_check_ts:{}", task_id);
@@ -221,8 +228,53 @@ async fn handle_merge_conflict(
                     .await
                 }
                 Ok(out) => {
-                    // fetch failed — not a content conflict; leave task in InReview for retry
                     let stderr = String::from_utf8_lossy(&out.stderr);
+                    if is_ssh_agent_fetch_failure(&stderr) {
+                        let block_reason = format!(
+                            "auto-merge git fetch failed due to SSH agent error: {}",
+                            stderr.trim()
+                        );
+                        tracing::error!(
+                            task_id = task.id.0,
+                            stderr = %stderr,
+                            "git fetch failed before rebase due to SSH agent error — blocking for human review"
+                        );
+                        let fields = [("block_reason", serde_json::json!(block_reason.clone()))];
+                        if let Err(e) = task_manager
+                            .update_task_status_and_result(&task.id, Status::Blocked, &fields)
+                            .await
+                        {
+                            tracing::error!(task_id = task.id.0, err = %e, "failed to write SSH-fetch block_reason and set Blocked");
+                            return Ok(());
+                        }
+                        let footer = crate::engine::attribution_footer(
+                            "Commented",
+                            review_agent,
+                            Some(review_model),
+                        );
+                        let comment = format!(
+                            "Auto-merge could not rebase because `git fetch origin` failed with an SSH agent error: {}",
+                            stderr.trim()
+                        );
+                        if let Err(e) = gh
+                            .add_comment(
+                                repo,
+                                &pr_number.to_string(),
+                                &format!("{}{}", comment, footer),
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                task_id = task.id.0,
+                                pr_number,
+                                err = %e,
+                                "handle_merge_conflict: failed to post SSH-fetch failure comment on PR"
+                            );
+                        }
+                        return Ok(());
+                    }
+
+                    // Fetch failed for a non-SSH reason — this is still not a content conflict.
                     tracing::warn!(
                         task_id = task.id.0,
                         stderr = %stderr,

--- a/src/engine/review_poll.rs
+++ b/src/engine/review_poll.rs
@@ -90,11 +90,16 @@ async fn handle_merge_conflict(
     id: &ExternalId,
     pr_number: u64,
     retries: u64,
+    attempts: u64,
     task_manager: &Arc<TaskManager>,
     store: &Arc<TaskStore>,
     store_id: i64,
 ) -> ConflictAction {
     let task_id = &id.0;
+    let max_attempts: u64 = config::get("workflow.max_attempts")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5);
     if retries >= MAX_MERGE_CONFLICT_RETRIES {
         tracing::error!(
             task_id,
@@ -123,6 +128,36 @@ async fn handle_merge_conflict(
             .await
         {
             tracing::error!(task_id, err = %e, "failed to write block_reason and set Blocked");
+        }
+        return ConflictAction::BlockForHuman;
+    }
+    if attempts >= max_attempts {
+        tracing::error!(
+            task_id,
+            pr_number,
+            attempts,
+            max_attempts,
+            "PR approved but merge-conflict reroute would exceed max attempts — blocking for human review"
+        );
+        let fields = [
+            (
+                "block_reason",
+                serde_json::json!(format!(
+                    "approved PR still needs merge-conflict resolution but task already hit max attempts ({attempts}/{max_attempts}); manual intervention required"
+                )),
+            ),
+            (
+                "last_error",
+                serde_json::json!(format!(
+                    "review_poll refused merge-conflict reroute because task exceeded max attempts ({attempts}/{max_attempts})"
+                )),
+            ),
+        ];
+        if let Err(e) = task_manager
+            .update_task_status_and_result(id, Status::Blocked, &fields)
+            .await
+        {
+            tracing::error!(task_id, err = %e, "failed to write max-attempts block_reason and set Blocked");
         }
         return ConflictAction::BlockForHuman;
     }
@@ -661,6 +696,7 @@ pub(crate) async fn review_open_prs(
                         &task.id,
                         pr_number,
                         retries,
+                        stored_task.attempts.max(0) as u64,
                         task_manager,
                         store,
                         task_info.store_id,
@@ -1809,6 +1845,96 @@ mod tests {
         // Task status must be unchanged.
         let after = store.get(task_id).await.unwrap();
         assert_eq!(after.status, TaskStatus::InReview);
+    }
+
+    #[tokio::test]
+    async fn review_open_prs_conflict_with_max_attempts_blocks_instead_of_reroute() {
+        let store = make_store().await;
+        let backend: Arc<dyn crate::backends::ExternalBackend> = Arc::new(MockBackend);
+        let tm = Arc::new(crate::engine::tasks::TaskManager::with_store(
+            Arc::clone(&backend),
+            Arc::clone(&store),
+            "owner/repo".to_string(),
+        ));
+
+        let task_id = store
+            .create(&NewTask {
+                repo: "owner/repo".to_string(),
+                origin: "github".to_string(),
+                title: "task-conflict".to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let _ = crate::store::store_set_by_id(
+            &Some(&store),
+            task_id,
+            &[
+                ("branch", serde_json::json!("feat-conflict")),
+                ("pr_number", serde_json::json!(77i64)),
+                ("attempts", serde_json::json!(99i64)),
+            ],
+        )
+        .await;
+        store
+            .update_status(task_id, TaskStatus::InReview)
+            .await
+            .unwrap();
+        let stored = store.get(task_id).await.unwrap();
+        let snapshot = crate::engine::sync::ReviewTaskSnapshot {
+            external: crate::engine::tasks::store_task_to_external(&stored),
+            stored,
+        };
+
+        let mut gh = MockGh::default();
+        gh.batch_data.insert(
+            77,
+            PrReviewBatchData {
+                merged: false,
+                mergeable: Some(false),
+                reviews: vec![make_review(
+                    1,
+                    "reviewer",
+                    "APPROVED",
+                    "2026-01-01T00:00:00Z",
+                    None,
+                )],
+                review_comments: vec![],
+                issue_comments: vec![],
+            },
+        );
+
+        let dispatching: Arc<DashMap<String, String>> = Arc::new(DashMap::new());
+        let in_flight = Arc::new(DashSet::new());
+        review_open_prs(
+            &backend,
+            "owner/repo",
+            &default_config(),
+            &tm,
+            &store,
+            &dispatching,
+            &in_flight,
+            &[snapshot],
+            &gh,
+            &crate::engine::router::RouterConfig::default(),
+        )
+        .await
+        .unwrap();
+
+        let after = store.get(task_id).await.unwrap();
+        assert_eq!(after.status, TaskStatus::Blocked);
+        assert_eq!(
+            after.merge_conflict_retries, 0,
+            "review_poll must not increment merge_conflict_retries when reroute is impossible"
+        );
+        assert!(
+            after
+                .block_reason
+                .as_deref()
+                .unwrap_or("")
+                .contains("max attempts"),
+            "block_reason should explain that reroute was refused after max attempts"
+        );
     }
 
     #[test]

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1227,12 +1227,14 @@ impl TaskStore {
         Ok(())
     }
 
-    /// Reset transient failure/retry counters to zero, preserving `review_cycles` and `ci_merge_failures`.
+    /// Reset transient failure/retry counters to zero, preserving
+    /// `review_cycles`, `ci_merge_failures`, and `merge_conflict_retries`.
     ///
     /// Use this after `RequestChanges` to clear per-attempt noise without
     /// undoing the review-cycle count that `handle_review_changes` just set.
-    /// `ci_merge_failures` is preserved here because it must accumulate across attempts
-    /// to enforce `MAX_CI_MERGE_FAILURES`, just like `review_cycles`.
+    /// `ci_merge_failures` and `merge_conflict_retries` are preserved here because
+    /// they must accumulate across attempts to enforce their circuit breakers,
+    /// just like `review_cycles`.
     ///
     /// NOTE: `attempts` is intentionally NOT reset here. It must increase monotonically
     /// across the task's lifetime so that `(task_id, attempt, run_type)` keys in
@@ -1244,7 +1246,6 @@ impl TaskStore {
             route_attempts = 0,
             review_agent_failures = 0,
             review_invocations = 0,
-            merge_conflict_retries = 0,
             pr_create_failures = 0,
             push_failures = 0,
             network_retries = 0,
@@ -1578,7 +1579,8 @@ impl TaskStore {
 
     /// Reset transient failure/retry counters for multiple tasks in a single transaction.
     ///
-    /// Preserves `review_cycles` and `ci_merge_failures` (same semantics as
+    /// Preserves `review_cycles`, `ci_merge_failures`, and
+    /// `merge_conflict_retries` (same semantics as
     /// [`reset_failure_counters`]).
     /// Test-only helper for bulk counter resets used by tests.
     #[cfg(test)]
@@ -1600,7 +1602,6 @@ impl TaskStore {
             route_attempts = 0,
             review_agent_failures = 0,
             review_invocations = 0,
-            merge_conflict_retries = 0,
             pr_create_failures = 0,
             push_failures = 0,
             network_retries = 0,

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -682,7 +682,7 @@ async fn helper_store_reset_counters_noop_without_store() {
 }
 
 #[tokio::test]
-async fn helper_store_reset_failure_counters_preserves_review_cycles() {
+async fn helper_store_reset_failure_counters_preserves_review_cycles_and_merge_conflict_retries() {
     let store = Arc::new(TaskStore::open_memory().await.unwrap());
     let id = store
         .create(&NewTask {
@@ -715,7 +715,10 @@ async fn helper_store_reset_failure_counters_preserves_review_cycles() {
     assert_eq!(task.review_cycles, 1);
     assert_eq!(task.review_invocations, 0);
     assert_eq!(task.attempts, 1, "attempts must be preserved (monotonic)");
-    assert_eq!(task.merge_conflict_retries, 0);
+    assert_eq!(
+        task.merge_conflict_retries, 1,
+        "merge_conflict_retries must be preserved"
+    );
 }
 
 #[tokio::test]
@@ -1800,7 +1803,7 @@ async fn reset_counters_preserves_other_fields() {
 }
 
 #[tokio::test]
-async fn reset_failure_counters_preserves_review_cycles() {
+async fn reset_failure_counters_preserves_review_cycles_and_merge_conflict_retries() {
     let store = TaskStore::open_memory().await.unwrap();
 
     let id = store
@@ -1820,7 +1823,8 @@ async fn reset_failure_counters_preserves_review_cycles() {
         .await
         .unwrap();
 
-    // Simulate counters after a review cycle: review_cycles=1, ci_merge_failures=2, plus transient failures
+    // Simulate counters after a review cycle: review_cycles=1,
+    // ci_merge_failures=2, merge_conflict_retries=1, plus transient failures.
     store.increment(id, "review_cycles").await.unwrap();
     store.increment(id, "ci_merge_failures").await.unwrap();
     store.increment(id, "ci_merge_failures").await.unwrap();
@@ -1829,7 +1833,8 @@ async fn reset_failure_counters_preserves_review_cycles() {
     store.increment(id, "merge_conflict_retries").await.unwrap();
     store.increment(id, "network_retries").await.unwrap();
 
-    // reset_failure_counters must zero transient counters but preserve review_cycles, ci_merge_failures, and attempts
+    // reset_failure_counters must zero transient counters but preserve
+    // review_cycles, ci_merge_failures, merge_conflict_retries, and attempts.
     store.reset_failure_counters(id).await.unwrap();
 
     let task = store.get(id).await.unwrap();
@@ -1838,9 +1843,12 @@ async fn reset_failure_counters_preserves_review_cycles() {
         task.ci_merge_failures, 2,
         "ci_merge_failures must be preserved"
     );
+    assert_eq!(
+        task.merge_conflict_retries, 1,
+        "merge_conflict_retries must be preserved"
+    );
     assert_eq!(task.attempts, 1, "attempts must be preserved (monotonic)");
     assert_eq!(task.review_agent_failures, 0);
-    assert_eq!(task.merge_conflict_retries, 0);
     assert_eq!(task.network_retries, 0);
 }
 
@@ -6336,7 +6344,7 @@ async fn batch_increment_rejects_disallowed_field() {
 }
 
 #[tokio::test]
-async fn batch_reset_failure_counters_preserves_review_cycles() {
+async fn batch_reset_failure_counters_preserves_review_cycles_and_merge_conflict_retries() {
     let store = TaskStore::open_memory().await.unwrap();
     let id1 = make_task(&store).await;
     let id2 = make_task(&store).await;
@@ -6357,7 +6365,10 @@ async fn batch_reset_failure_counters_preserves_review_cycles() {
     for id in [id1, id2] {
         let t = store.get(id).await.unwrap();
         assert_eq!(t.attempts, 1, "attempts must be preserved (monotonic)");
-        assert_eq!(t.merge_conflict_retries, 0);
+        assert_eq!(
+            t.merge_conflict_retries, 1,
+            "merge_conflict_retries must be preserved"
+        );
         assert_eq!(
             t.needs_review_refires, 0,
             "needs_review_refires must be reset"


### PR DESCRIPTION
## Summary

Stopped the infinite auto-merge review/reroute loop by preserving merge-conflict retry state across approvals, blocking SSH-agent fetch failures during auto-merge, and preventing review_poll from rerouting tasks that already exhausted max attempts.

### What was done

- Preserved `merge_conflict_retries` in transient counter resets so the merge-conflict circuit breaker now survives repeated `Approve` cycles.
- Updated auto-merge conflict recovery to detect SSH-agent `git fetch` failures (`sign_and_send_pubkey`, `agent refused operation`, `communication with agent failed`) and block the task with a PR comment instead of silently leaving it in review.
- Added a review-poll guard that blocks approved conflict tasks when rerouting would exceed `workflow.max_attempts`, avoiding pointless `Routed` transitions that `task_init` will reject.
- Expanded store and review-poll tests to cover the preserved merge-conflict counter semantics and the new max-attempts block behavior.
- Ran `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` successfully.
- Committed the changes as `813f2009 fix(auto-merge): stop infinite review reroute loop`.


### Remaining

- Automated review/push/PR handling by orch.


### Files changed

- `src/engine/auto_merge.rs`
- `src/engine/review_poll.rs`
- `src/store/tasks.rs`
- `src/store/tests.rs`


Closes #3044

---
*Task #3044 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.4`*