### PR TITLE
bug(engine/router): morning cron burst causes repeated LLM routing budget fallbacks and watchdog stale ticks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,7 +523,7 @@ External consumers (CLI, local debugging tools) connect via **localhost-only web
 LLM routing concurrency is governed by exactly two knobs:
 
 - **`router.max_tasks_per_tick`** (default: 1) — caps how many tasks enter the routing loop per tick. With the default of 1, only one LLM classification call can ever be in flight at a time.
-- **`router.llm_budget_secs`** (default: `timeout_seconds`, 45s) — total wall-clock budget for the entire pool cascade before falling back to round-robin. Prevents N pool entries × 45s/each from blocking the tick.
+- **`router.llm_budget_secs`** (default: 30s) — total wall-clock budget for the entire pool cascade before falling back to round-robin. Prevents tick stalls from exceeding the watchdog threshold (6 × tick_interval). The default of 30s ensures at most one slow pool entry can time out before round-robin fallback, preventing a single slow route call from blocking the tick loop.
 
 **Do not add a semaphore, worker pool, or `ORCH_ROUTER_MAX_PARALLEL_LLMS` env var.** Issue #2676 / PR #2677 introduced an `llm_semaphore` field on `Router` that was redundant with `max_tasks_per_tick=1` at its default value and added no protection that the budget timeout doesn't already provide. It was removed as dead complexity.
 

--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -207,8 +207,8 @@ pub struct RouterConfig {
     /// `timeout_seconds` is a *per-entry* limit; `llm_budget_secs` caps the *total*
     /// cascade. With a 3-entry pool each carrying a 45 s per-entry timeout, the
     /// cascade could block for up to 135 s without this budget. Setting the budget
-    /// to `timeout_seconds` (45 s default) ensures at most one entry can fully
-    /// time out before round-robin takes over.
+    /// to 30 s ensures round-robin takes over quickly, preventing tick stalls from
+    /// exceeding the watchdog threshold (6 × tick_interval).
     ///
     /// Configurable via `router.llm_budget_secs` (default: `timeout_seconds`).
     pub llm_budget_secs: u64,
@@ -272,7 +272,7 @@ impl Default for RouterConfig {
             ollama_url: "http://localhost:11434".to_string(),
             ollama_model: "qwen2.5-coder:3b-instruct".to_string(),
             ollama_timeout_seconds: 30,
-            llm_budget_secs: 45,
+            llm_budget_secs: 30,
         }
     }
 }
@@ -439,9 +439,9 @@ impl RouterConfig {
         }
 
         // Parse llm_budget_secs — total time cap for the entire pool cascade.
-        // Defaults to timeout_seconds (already resolved above) so the cascade
-        // can't exceed what a single pool entry would normally take.
-        config.llm_budget_secs = config.timeout_seconds;
+        // Default to 30s so round-robin takes over before tick exceeds watchdog
+        // threshold (6 × tick_interval). User config overrides this.
+        config.llm_budget_secs = 30;
         if let Ok(val) = crate::config::get("router.llm_budget_secs") {
             if let Ok(secs) = val.parse::<u64>() {
                 if secs > 0 {
@@ -530,9 +530,9 @@ impl RouterConfig {
         }
 
         // Parse llm_budget_secs — total time cap for the entire pool cascade.
-        // Defaults to timeout_seconds (already resolved above) so the cascade
-        // can't exceed what a single pool entry would normally take.
-        config.llm_budget_secs = config.timeout_seconds;
+        // Default to 30s so round-robin takes over before tick exceeds watchdog
+        // threshold (6 × tick_interval). User config overrides this.
+        config.llm_budget_secs = 30;
         if let Ok(val) = crate::config::get("router.llm_budget_secs") {
             if let Ok(secs) = val.parse::<u64>() {
                 if secs > 0 {
@@ -1139,5 +1139,18 @@ model_map:
             "gpt-5.3-codex is not a valid opencode model"
         );
         assert_eq!(selected, "mimo-v2-omni-free");
+    }
+
+    #[test]
+    fn default_llm_budget_secs_is_30() {
+        // Bug #3048: llm_budget_secs must be low enough that a single slow pool
+        // entry times out before the tick watchdog fires (6 × tick_interval = 60s).
+        // With a 5-entry pool and 90s per-entry timeout, 30s budget ensures at most
+        // one entry can time out before round-robin fallback, preventing tick stalls.
+        let config = RouterConfig::default();
+        assert_eq!(
+            config.llm_budget_secs, 30,
+            "llm_budget_secs default should be 30s to prevent tick watchdog stalls"
+        );
     }
 }


### PR DESCRIPTION
## Summary

## Summary

**Root cause confirmed**: `llm_budget_secs` default was 45s (or inherited from `timeout_seconds` = 90s), exceeding the tick watchdog threshold of 60s (6 × tick_interval). With a 5-entry pool and 90s per-entry timeout, a single slow LLM route call blocked the tick loop long enough to trigger WATCHDOG alerts.

**Fix applied**: Changed `llm_budget_secs` default from 45s to 30s. This ensures at most one pool entry can time out before round-robin fallback, preventing tick stalls.

**Chan

### Files changed

- `AGENTS.md`
- `src/engine/router/config.rs`


Closes #3048

---
*Task #3048 · Created by minimax[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*