### PR TITLE
bug: CI-failure-blocked tasks stay stuck for 24h even when PR is already closed

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -651,10 +651,14 @@ fn ci_failure_unblock_cooldown_elapsed(task: &crate::store::Task) -> bool {
         return true;
     }
 
+    // Short cooldowns — the PR may close quickly after the first check.
+    // We never permanently block (no `_ => return false`): eventually the PR
+    // will close or a human will intervene.
     let required = match task.auto_unblock_count {
-        1 => chrono::Duration::hours(24),
-        2 => chrono::Duration::days(3),
-        _ => return false,
+        1 => chrono::Duration::minutes(10),
+        2 => chrono::Duration::hours(1),
+        3 => chrono::Duration::hours(6),
+        _ => chrono::Duration::hours(24),
     };
 
     let last_at = &task.auto_unblock_last_at;

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -4597,25 +4597,42 @@ mod tests {
     }
 
     #[test]
-    fn ci_failure_cooldown_count_3_never() {
-        // count=3 or more means permanent block
-        let mut task = make_task(None);
-        task.auto_unblock_count = 3;
-        task.auto_unblock_last_at = "2020-01-01T00:00:00Z".to_string();
-        assert!(!ci_failure_unblock_cooldown_elapsed(&task));
-
-        let mut task = make_task(None);
-        task.auto_unblock_count = 99;
-        task.auto_unblock_last_at = "2020-01-01T00:00:00Z".to_string();
-        assert!(!ci_failure_unblock_cooldown_elapsed(&task));
-    }
-
-    #[test]
     fn ci_failure_cooldown_invalid_timestamp_immediate() {
         // invalid timestamp should not block
         let mut task = make_task(None);
         task.auto_unblock_count = 1;
         task.auto_unblock_last_at = "not-a-timestamp".to_string();
         assert!(ci_failure_unblock_cooldown_elapsed(&task));
+    }
+
+    #[test]
+    fn ci_failure_cooldown_high_count_still_eventually_elapses() {
+        // count >= 3 must NOT be a permanent block — verify a sufficiently old
+        // timestamp eventually elapses the cooldown.
+        let long_ago = (chrono::Utc::now() - chrono::Duration::days(30)).to_rfc3339();
+        for count in [3i32, 5, 99] {
+            let mut task = make_task(None);
+            task.auto_unblock_count = count;
+            task.auto_unblock_last_at = long_ago.clone();
+            assert!(
+                ci_failure_unblock_cooldown_elapsed(&task),
+                "count={count} should eventually elapse"
+            );
+        }
+    }
+
+    #[test]
+    fn ci_failure_cooldown_recent_timestamp_still_blocks() {
+        // A recent timestamp should still gate the check at every count.
+        let just_now = chrono::Utc::now().to_rfc3339();
+        for count in [1i32, 2, 3, 99] {
+            let mut task = make_task(None);
+            task.auto_unblock_count = count;
+            task.auto_unblock_last_at = just_now.clone();
+            assert!(
+                !ci_failure_unblock_cooldown_elapsed(&task),
+                "count={count} should still be cooling down"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixed CI-failure blocked tasks staying stuck for 24h+ by reducing cooldown intervals and removing the permanent block.

### What was done

- Changed `ci_failure_unblock_cooldown_elapsed` cooldown schedule from 24h/3d/permanent to 10min/1h/6h/24h (repeating)
- Removed `_ => return false` which permanently prevented tasks from being re-checked after 3 attempts
- Tasks with closed PRs will now be unblocked within 10 minutes of the next sync tick after the PR closes


### Files changed

- `src/engine/sync.rs`


Closes #3065

---
*Task #3065 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*