### PR TITLE
bug(review): kimi exit-1 fix (PR #3066) doesn't rescue runs where output.json hasn't been written yet

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -656,32 +656,25 @@ async fn invoke_review_agent(
             .unwrap_or(-1);
 
             if exit_code != 0 {
-                let output_exists = tokio::task::spawn_blocking({
-                    let output_file = ctx.output_file.clone();
-                    move || output_file.exists()
-                })
-                .await
-                .unwrap_or(false);
-
-                if output_exists {
-                    let raw_output = runner::response::read_output_file(
-                        &ctx.review_task_id,
-                        &ctx.output_file,
-                        repo,
-                    )
-                    .await;
-                    let agent_result =
-                        runner::agents::find_agent_result(&ctx.review_agent, &raw_output);
-                    // Treat as success if we found a valid result without is_error set
-                    if agent_result.as_ref().map(|r| !r.is_error).unwrap_or(false) {
-                        tracing::info!(
-                            task_id = task.id.0,
-                            agent = %ctx.review_agent,
-                            exit_code,
-                            "review agent succeeded despite non-zero exit — proceeding to parse output"
-                        );
-                        return ReviewPhase::Ready(ReviewRun { run_id });
-                    }
+                // Try reading output via read_output_file which checks both the primary path
+                // and all prior attempt dirs as a fallback. This handles agents like kimi/minimax
+                // that exit non-zero even on success, as well as cases where the current attempt's
+                // output.json was not written but a prior attempt's output contains a valid result.
+                let raw_output =
+                    runner::response::read_output_file(&ctx.review_task_id, &ctx.output_file, repo)
+                        .await;
+                let agent_result =
+                    runner::agents::find_agent_result(&ctx.review_agent, &raw_output);
+                // Treat as success if we found a valid result without is_error set
+                if agent_result.as_ref().map(|r| !r.is_error).unwrap_or(false) {
+                    tracing::info!(
+                        task_id = task.id.0,
+                        agent = %ctx.review_agent,
+                        exit_code,
+                        output_found = !raw_output.is_empty(),
+                        "review agent succeeded despite non-zero exit — proceeding to parse output"
+                    );
+                    return ReviewPhase::Ready(ReviewRun { run_id });
                 }
             }
 


### PR DESCRIPTION
## Summary

Fixed review runner to check all attempt dirs for output when exit-1 and output.json is missing from the current attempt

### What was done

- Identified the gap in PR #3066's fix: the `output_exists` guard in `invoke_review_agent` prevented `read_output_file` from running its fallback logic (which scans prior attempt dirs) when the current attempt's output.json was absent
- Replaced the `output_file.exists()` guard + conditional `read_output_file` call with an unconditional `read_output_file` call that leverages the existing fallback logic to find output in any attempt dir
- Added `output_found` field to the success log line for observability
- All 3483 tests pass, fmt + clippy clean


### Files changed

- `src/engine/review.rs`


Closes #3072

---
*Task #3072 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*