### PR TITLE
enhancement: warn when deployed service is behind latest release

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -29,6 +29,7 @@ use tokio::sync::broadcast;
 ///
 /// Shows CLI version and, if the service is running, the service version.
 /// Warns when they differ so operators can detect CLI/service drift.
+/// Also fetches the latest GitHub release and warns when the local build is behind.
 pub fn version() {
     let cli_version = env!("ORCH_VERSION");
     println!("CLI:     {cli_version}");
@@ -48,6 +49,40 @@ pub fn version() {
         None => {
             println!("Service: not running (no service.version file)");
         }
+    }
+
+    if let Some(latest) = fetch_latest_release_version() {
+        if latest != cli_version {
+            println!("Latest:  {latest}  ⚠  upgrade available — run: brew update && brew upgrade orch && brew services restart orch");
+        } else {
+            println!("Latest:  {latest}  ✓ up to date");
+        }
+    }
+}
+
+/// Fetch the latest orch release tag from GitHub via the `gh` CLI.
+///
+/// Returns the version string (without the leading "v"), or `None` if the
+/// check fails (no network, unauthenticated, `gh` not installed, etc.).
+fn fetch_latest_release_version() -> Option<String> {
+    let output = std::process::Command::new("gh")
+        .args([
+            "api",
+            "repos/gabrielkoerich/orch/releases/latest",
+            "--jq",
+            ".tag_name",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let tag = String::from_utf8(output.stdout).ok()?;
+    let version = tag.trim().trim_start_matches('v').to_string();
+    if version.is_empty() {
+        None
+    } else {
+        Some(version)
     }
 }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -677,6 +677,33 @@ fn read_project_channel_config(project_dir: &std::path::Path) -> ProjectChannelC
     }
 }
 
+/// Fetch the latest orch release tag from GitHub via the `gh` CLI (async).
+///
+/// Returns the version string (without the leading "v"), or `None` when the
+/// check fails (no network, unauthenticated, `gh` not installed, etc.).
+async fn fetch_latest_release_version() -> Option<String> {
+    let output = Command::new("gh")
+        .args([
+            "api",
+            "repos/gabrielkoerich/orch/releases/latest",
+            "--jq",
+            ".tag_name",
+        ])
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let tag = String::from_utf8(output.stdout).ok()?;
+    let version = tag.trim().trim_start_matches('v').to_string();
+    if version.is_empty() {
+        None
+    } else {
+        Some(version)
+    }
+}
+
 /// Start the orch service.
 ///
 /// This is the main entry point — called by `orch serve`.
@@ -744,6 +771,22 @@ pub async fn serve() -> anyhow::Result<()> {
             ?e,
             "failed to start event websocket server, continuing without it"
         );
+    }
+
+    // Check for a newer orch release in the background and warn if the service is behind.
+    {
+        let current = env!("ORCH_VERSION").to_string();
+        tokio::spawn(async move {
+            if let Some(latest) = fetch_latest_release_version().await {
+                if latest != current {
+                    tracing::warn!(
+                        current_version = %current,
+                        latest_version = %latest,
+                        "orch service is behind the latest release — run: brew update && brew upgrade orch && brew services restart orch"
+                    );
+                }
+            }
+        });
     }
 
     // Re-create task managers with shared store and event bus


### PR DESCRIPTION
## Summary

Implemented version freshness check for `orch version` and service startup as requested in issue #3079

### What was done

- Added `fetch_latest_release_version()` to `src/cli/mod.rs` — calls `gh api repos/gabrielkoerich/orch/releases/latest` and compares tag against CLI version
- Updated `version()` in `src/cli/mod.rs` to print `Latest: X.Y.Z  ⚠  upgrade available — run: brew update && brew upgrade orch && brew services restart orch` when behind
- Added async `fetch_latest_release_version()` to `src/engine/mod.rs` for service startup
- Engine startup now logs a `WARN` if the running service version is behind the latest release
- All 3483 tests pass, clippy clean, fmt clean


### Files changed

- `src/cli/mod.rs`
- `src/engine/mod.rs`


Closes #3079

---
*Task #3079 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*