### PR TITLE
Fix CI - main workflow not passing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,6 @@ jobs:
 
   # Determine if a release is needed and what version to use
   check-release:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       skip: ${{ steps.check.outputs.skip }}


### PR DESCRIPTION
## Summary

Fix CI workflow by ensuring check-release job runs on all refs to prevent dependent jobs from failing when running on non-main branches.

### What was done

- Removed an overly-restrictive 'if: github.ref == refs/heads/main' condition from the check-release job in .github/workflows/release.yml so the job executes on non-main refs
- Committed the change on the current feature branch with a descriptive commit message


### Remaining

- Verify the change on CI by running the workflow on a PR or branch to ensure dependent jobs that reference check-release outputs no longer error
- If CI still needs adjustments, inspect any other jobs that assume check-release ran and add defensive gating around uses of its outputs where appropriate


### Files changed

- `.github/workflows/release.yml`


Closes #3085

---
*Task #3085 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/gpt-5-mini`*