### PR TITLE
Add PR-time Zola docs build check or front-matter linter

### DIFF
--- a/.github/workflows/orch-review.yml
+++ b/.github/workflows/orch-review.yml
@@ -12,6 +12,36 @@ permissions:
   issues: read
 
 jobs:
+  docs-build:
+    name: Docs Build (Zola)
+    runs-on: ubuntu-latest
+    if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect docs changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+
+      - name: Install zola
+        if: steps.changes.outputs.docs == 'true'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: zola@0.22.1
+
+      - name: Build docs
+        if: steps.changes.outputs.docs == 'true'
+        run: zola --root docs build
+
+      - name: Skip docs build when no docs changed
+        if: steps.changes.outputs.docs != 'true'
+        run: echo "No docs changes detected; skipping zola build."
+
   review-gate:
     runs-on: ubuntu-latest
     if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)


### PR DESCRIPTION
## Summary

Implemented a docs-only Zola build gate in the Orch Review workflow, but could not commit due a worktree git lock permission error outside the writable sandbox.

### What was done

- Updated `.github/workflows/orch-review.yml` to add a new `docs-build` job (`Docs Build (Zola)`).
- Configured docs change detection with `dorny/paths-filter@v3` for `docs/**`.
- Added conditional Zola install (`taiki-e/install-action@v2`, `zola@0.22.1`) and `zola --root docs build` execution only when docs changed.
- Added explicit skip step when no docs files changed so the required job still completes cleanly.
- Ran `bash scripts/lint-frontmatter.sh` locally; it passed.


### Remaining

- Commit the staged workflow change once worktree git lock permissions are available.
- Mark `Docs Build (Zola)` as a required status check in GitHub branch protection rules (cannot be changed from this repo code).


### Files changed

- `.github/workflows/orch-review.yml`


Closes #3103

---
*Task #3103 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*