### PR TITLE
bug(router): opencode dispatches dead model 'github-copilot/gpt-5.3' and gpt-5.3-codex alias not handled

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -507,6 +507,19 @@ pub async fn record_persistent_model_failure(agent_name: &str, model: &str) {
     set_cooldown_async(&key, cooldown_until, "persistent_model_error").await;
 }
 
+/// Apply an immediate maximum-duration cooldown when a model is known to be
+/// permanently unavailable ("Model not found").
+///
+/// Unlike `record_persistent_model_failure` (4h base → 7d max), "not found"
+/// errors are deterministic — the model was decommissioned and will not
+/// reappear. Jumping to the max (7 days) prevents 3-4 wasteful retries over
+/// the normal escalation window.
+pub async fn record_model_permanently_gone(agent_name: &str, model: &str) {
+    let key = format!("{agent_name}:{model}");
+    let cooldown_until = chrono::Utc::now().timestamp() + PERSISTENT_MODEL_BACKOFF_MAX_SECS;
+    set_cooldown_async(&key, cooldown_until, "model_not_found").await;
+}
+
 /// Set a model cooldown with a custom duration (in seconds).
 ///
 /// Used by silence detection to cooldown the specific model that failed to
@@ -1289,6 +1302,30 @@ mod tests {
             .expect("kv read should succeed")
             .expect("failure count should be written");
         assert_eq!(stored_count, "2");
+    }
+
+    #[tokio::test]
+    async fn record_model_permanently_gone_applies_max_cooldown_immediately() {
+        let store = test_store().await;
+        *cooldown_store().lock().await = Some(store.clone());
+
+        let agent = "testagent_gone";
+        let model = "testmodel_gone";
+        let key = format!("{agent}:{model}");
+
+        assert!(!is_model_in_cooldown(agent, model));
+        record_model_permanently_gone(agent, model).await;
+        assert!(is_model_in_cooldown(agent, model));
+
+        let remaining = cooldown_until(&key)
+            .map(|u| u - chrono::Utc::now().timestamp())
+            .expect("cooldown should exist");
+        // Should be ~7 days (max), not 4h (base)
+        let seven_days = PERSISTENT_MODEL_BACKOFF_MAX_SECS;
+        assert!(
+            remaining >= seven_days - 5,
+            "permanently-gone cooldown should be ~7d, got {remaining}s"
+        );
     }
 
     #[test]

--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -274,14 +274,14 @@ pub async fn handle_error(
             format!("missing tool: {tool}"),
         ),
         agents::AgentError::ModelUnavailable { model, message } => {
-            // "Model not found" is a permanent failure — the model has been decommissioned
-            // and will never return. Apply persistent backoff (4h base → 7d max) instead
-            // of the standard transient backoff (5min base → 4h max) to prevent indefinite
-            // 4h retry cycles against a dead model.
+            // "Model not found" is deterministic — the model is decommissioned and
+            // will never return. Skip the escalating backoff and jump straight to the
+            // 7-day max to prevent 3-4 wasteful retries over the 4h→12h→36h ramp.
+            // All other model-unavailable signals use the standard escalating backoff.
             let lower = message.to_lowercase();
             let is_permanently_gone = lower.contains("not found");
             if is_permanently_gone {
-                crate::engine::cooldown::record_persistent_model_failure(agent_name, model).await;
+                crate::engine::cooldown::record_model_permanently_gone(agent_name, model).await;
             } else {
                 response::record_model_failure(agent_name, model).await;
             }


### PR DESCRIPTION
## Summary

Fixed the root cause: when opencode returns 'Model not found: X', the previous code used record_persistent_model_failure (4h base → 7d max), requiring 3–4 retries over ~53 hours before the dead model reached max cooldown. Added record_model_permanently_gone() that immediately applies the 7-day max cooldown on the first 'not found' failure, stopping wasteful retries in one shot. No hardcoded model names — purely a generic cooldown duration fix as prescribed by CLAUDE.md.

### What was done

- Added record_model_permanently_gone(agent, model) to src/engine/cooldown.rs — directly sets 7-day cooldown without escalation ramp
- Updated src/engine/runner/fallback.rs to call record_model_permanently_gone instead of record_persistent_model_failure when is_permanently_gone (lower.contains('not found')) is true
- Added unit test record_model_permanently_gone_applies_max_cooldown_immediately verifying the cooldown is ~7d not ~4h
- All 3501 tests pass, cargo clippy clean, cargo fmt clean


### Files changed

- `src/engine/cooldown.rs`
- `src/engine/runner/fallback.rs`


Closes #3118

---
*Task #3118 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*