### PR TITLE
bug(review): kimi review runs with terminal_reason:completed fall through to parse_error — collect_assistant_messages_text not used

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -881,11 +881,67 @@ async fn parse_review_output(
             } else {
                 // Guard: if the raw NDJSON signals a completed session
                 // (terminal_reason:completed without is_error:true), do NOT run
-                // generic pattern-based rate-limit detection over it.  Token
+                // generic pattern-based rate-limit detection over it. Token
                 // counts in the telemetry blob can contain bare "429" values
                 // that would otherwise be misclassified as HTTP 429 errors.
                 let ndjson_completed = raw_output.contains("\"terminal_reason\":\"completed\"")
                     && !raw_output.contains("\"is_error\":true");
+
+                // When ndjson_completed is true, try to recover the review response
+                // from assistant messages first. This handles agents like kimi/minimax
+                // that exit with non-zero code but have valid responses embedded in
+                // earlier assistant messages (see PR #3130).
+                if ndjson_completed {
+                    let assistant_text = runner::agents::collect_assistant_messages_text(
+                        &ctx.review_agent,
+                        &raw_output,
+                    );
+                    if !assistant_text.is_empty() {
+                        if let Ok(response) =
+                            runner::response::parse_review_response(&assistant_text)
+                        {
+                            tracing::debug!(
+                                task_id = task.id.0,
+                                agent = %ctx.review_agent,
+                                "found review response JSON in assistant message (terminal_reason:completed)"
+                            );
+                            let review_notes_for_comment = response.notes.clone();
+                            let decision = review_decision_from_response(response);
+                            return ReviewPhase::Ready(ParsedReview {
+                                run_id: run.run_id,
+                                exit_code,
+                                stderr,
+                                raw_output,
+                                text_for_review: assistant_text,
+                                token_usage,
+                                review_notes_for_comment,
+                                decision,
+                            });
+                        }
+                        if let Some(response) =
+                            runner::response::infer_review_response(&assistant_text)
+                        {
+                            tracing::warn!(
+                                task_id = task.id.0,
+                                agent = %ctx.review_agent,
+                                "inferred review response from assistant message (terminal_reason:completed)"
+                            );
+                            let review_notes_for_comment = response.notes.clone();
+                            let decision = review_decision_from_response(response);
+                            return ReviewPhase::Ready(ParsedReview {
+                                run_id: run.run_id,
+                                exit_code,
+                                stderr,
+                                raw_output,
+                                text_for_review: assistant_text,
+                                token_usage,
+                                review_notes_for_comment,
+                                decision,
+                            });
+                        }
+                    }
+                }
+
                 if let Some(runner::agents::AgentError::RateLimit { message }) = (!ndjson_completed)
                     .then(|| runner::agents::patterns::detect_rate_limit(&text_for_review))
                     .flatten()


### PR DESCRIPTION
## Summary

Fix complete. The change adds a rescue path in `src/engine/review.rs` (lines 890-942) that:

1. **Extracts assistant message text** from the NDJSON stream when `terminal_reason:completed` is detected (using `collect_assistant_messages_text`)
2. **Tries to parse it** as a structured ReviewResponse
3. **Falls back to keyword inference** if structured parsing fails
4. **Only falls through to parse_error** if both attempts fail

This mirrors the fix from PR #3130 (`e6102533`) that was applied to `ru

### What was done

- **Extracts assistant message text** from the NDJSON stream when `terminal_reason:completed` is detected (using `collect_assistant_messages_text`)
- **Tries to parse it** as a structured ReviewResponse
- **Falls back to keyword inference** if structured parsing fails
- **Only falls through to parse_error** if both attempts fail
- Result:**
- cargo fmt: OK
- cargo clippy: OK
- cargo nextest run: 3507 passed, 19 skipped```json


### Files changed

- `runner/mod.rs`
- `src/engine/review.rs`


Closes #3134

---
*Task #3134 · Created by glm[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*