### PR TITLE
bug: credential decryption failure blocks tasks when pass store GPG unavailable

### DIFF
--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -1103,6 +1103,18 @@ fn is_retryable_blocked_reason(reason: &str) -> bool {
         "worktree lock",
         "resource busy",
         "could not resolve host",
+        // Credential providers in headless/tmux sessions can fail transiently
+        // when GPG agent/passphrase is unavailable.
+        "gpg decryption fails",
+        "gpg decryption failed",
+        "gpg agent",
+        "no passphrase available",
+        "passphrase unavailable",
+        "pass store",
+        "passwordstoreprovider",
+        "agentvaultprovider",
+        "onepasswordprovider",
+        "decryption failed in this agent session",
     ];
     transient_patterns.iter().any(|p| r.contains(p))
 }
@@ -2141,6 +2153,12 @@ mod tests {
         ));
         assert!(is_retryable_blocked_reason(
             "API rate limit hit, try again later"
+        ));
+        assert!(is_retryable_blocked_reason(
+            "Credential bean/hyperliquid-address exists in the pass store but GPG decryption fails in this agent session — no passphrase available."
+        ));
+        assert!(is_retryable_blocked_reason(
+            "credential resolution failed via PasswordStoreProvider; AgentVaultProvider unavailable"
         ));
     }
 


### PR DESCRIPTION
## Summary

Implemented a runner-side fix so pass-store/GPG decryption failures in headless tmux sessions are treated as transient retryable blockers instead of permanently blocking tasks.

### What was done

- Updated `is_retryable_blocked_reason` in `src/engine/runner/response_handler.rs` to recognize pass-store/GPG/session-passphrase failure signatures (including provider-name clues) as transient.
- Added regression assertions in `retryable_blocked_reason_detects_transient_patterns` to cover real-world pass-store GPG failure messages.
- Ran required quality checks successfully: `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (3509 passed, 19 skipped).
- Committed changes in `18996d97` with message `fix(runner): auto-retry transient pass-store gpg decryption blockers`.


### Files changed

- `src/engine/runner/response_handler.rs`


Closes #3140

---
*Task #3140 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*