### PR TITLE
bug: GLM/MiniMax rate_limit and 'Insufficient balance' failures causing multiple task run failures

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -417,6 +417,9 @@ pub fn detect_credit_exhaustion(error_message: &str) -> Option<CreditExhaustionR
         || lower.contains("no credits remaining")
         || lower.contains("insufficient_quota")
         || lower.contains("quota exceeded")
+        || lower.contains("insufficient balance")
+        || lower.contains("please recharge")
+        || lower.contains("no resource package")
     {
         return Some(CreditExhaustionReason::OutOfCredits);
     }
@@ -1553,6 +1556,29 @@ mod tests {
         assert_eq!(
             detect_credit_exhaustion(msg),
             Some(CreditExhaustionReason::OrgLevelDisabled)
+        );
+    }
+
+    #[test]
+    fn detect_credit_exhaustion_glm_insufficient_balance() {
+        // GLM/ZhipuAI 429: "Insufficient balance or no resource package. Please recharge."
+        assert_eq!(
+            detect_credit_exhaustion(
+                "API Error: Request rejected (429) · Insufficient balance or no resource package. Please recharge."
+            ),
+            Some(CreditExhaustionReason::OutOfCredits)
+        );
+        assert_eq!(
+            detect_credit_exhaustion("Insufficient balance"),
+            Some(CreditExhaustionReason::OutOfCredits)
+        );
+        assert_eq!(
+            detect_credit_exhaustion("please recharge your account"),
+            Some(CreditExhaustionReason::OutOfCredits)
+        );
+        assert_eq!(
+            detect_credit_exhaustion("no resource package available"),
+            Some(CreditExhaustionReason::OutOfCredits)
         );
     }
 


### PR DESCRIPTION
## Summary

Fixed detect_credit_exhaustion() in src/engine/cooldown.rs to recognize GLM/ZhipuAI 'Insufficient balance or no resource package. Please recharge.' as an OutOfCredits billing event. These errors now trigger the 1h→8h exponential agent-wide cooldown instead of the 5-min rate-limit backoff, stopping cascading retries when the GLM account has no funds.

### Files changed

- `src/engine/cooldown.rs`


Closes #3150

---
*Task #3150 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*