### PR TITLE
bug: task_runs.error still contains raw api_retry JSON fragments — regression after #2881

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -28,6 +28,28 @@ fn outcome_for_agent_error(err: &runner::agents::AgentError) -> &'static str {
     }
 }
 
+/// Format an [`AgentError`] as the compact string persisted to `task_runs.error`
+/// and surfaced via [`ReviewDecision::Failed`].
+///
+/// Mirrors the per-variant formatting in `runner::fallback::handle_error` so review
+/// runs never leak raw provider payloads (e.g. truncated `api_retry` NDJSON
+/// fragments) into the audit trail. Without this, `err.to_string()` would expand
+/// `AgentError::RateLimit { message }` via its `Display` impl and persist hundreds
+/// of bytes of raw JSON into `task_runs.error` (issue #3149, regression of #2881).
+fn format_review_error(agent: &str, err: &runner::agents::AgentError) -> String {
+    match err {
+        runner::agents::AgentError::RateLimit { message } => format!(
+            "{agent} rate limit: {}",
+            runner::fallback::summarize_rate_limit_error(message)
+        ),
+        runner::agents::AgentError::Auth { message } => format!("{agent} auth error: {message}"),
+        runner::agents::AgentError::Timeout { elapsed } => {
+            format!("{agent} timed out after {}s", elapsed.as_secs())
+        }
+        other => format!("{agent} agent error: {other}"),
+    }
+}
+
 /// Parse a PR number from a GitHub PR URL.
 ///
 /// Validates that the URL matches the expected GitHub PR URL format
@@ -840,6 +862,7 @@ async fn parse_review_output(
         let err = agent_runner.classify_error(exit_code, &raw_output, &stderr);
         record_review_agent_failure(&task.id.0, &ctx.review_agent, &err).await;
         tracing::error!(task_id = task.id.0, error = %err, "review agent failed");
+        let stored_error = format_review_error(&ctx.review_agent, &err);
         complete_review_run(
             store,
             run.run_id,
@@ -848,11 +871,11 @@ async fn parse_review_output(
             &stderr,
             "",
             outcome_for_agent_error(&err),
-            &err.to_string(),
+            &stored_error,
             token_usage,
         )
         .await;
-        return ReviewPhase::EarlyReturn(ReviewDecision::Failed(format!("agent error: {err}")));
+        return ReviewPhase::EarlyReturn(ReviewDecision::Failed(stored_error));
     }
 
     let text_for_review = agent_result
@@ -956,6 +979,8 @@ async fn parse_review_output(
                         &message,
                     )
                     .await;
+                    let summary = runner::fallback::summarize_rate_limit_error(&message);
+                    let stored_error = format!("{} rate limit: {summary}", ctx.review_agent);
                     complete_review_run(
                         store,
                         run.run_id,
@@ -964,13 +989,11 @@ async fn parse_review_output(
                         &stderr,
                         &text_for_review,
                         "rate_limit",
-                        &format!("rate limit: {message}"),
+                        &stored_error,
                         token_usage,
                     )
                     .await;
-                    return ReviewPhase::EarlyReturn(ReviewDecision::Failed(format!(
-                        "rate limit: {message}"
-                    )));
+                    return ReviewPhase::EarlyReturn(ReviewDecision::Failed(stored_error));
                 }
 
                 if let Some(runner::agents::AgentError::Auth { message }) =
@@ -2422,6 +2445,92 @@ mod tests {
         assert!(result
             .unwrap_err()
             .contains("does not start with 'https://github.com/'"));
+    }
+
+    // ── format_review_error ─────────────────────────────────────────────────
+    //
+    // Regression coverage for issue #3149: review runs were persisting raw
+    // `api_retry` NDJSON fragments into `task_runs.error` because the review
+    // pipeline formatted rate-limit errors with `err.to_string()` instead of
+    // routing the raw provider message through `summarize_rate_limit_error`.
+
+    #[test]
+    fn format_review_error_summarises_rate_limit_fragment_with_api_retry() {
+        // Real-world fragment captured from a minimax review run (issue #3149).
+        // The provider message contains a complete api_retry JSON line so the
+        // summariser should produce a clean `status=… after … attempts` summary.
+        let raw_fragment = "{\"attempt\":6,\"max_retries\":10,\"retry_delay_ms\":17266.789,\"error_status\":429,\"error\":\"rate_limit\",\"session_id\":\"5c7148ee\"}\n\
+                            {\"type\":\"system\",\"subtype\":\"api_retry\",\"attempt\":7,\"max_retries\":10,\"retry_delay_ms\":35162.66,\"error_status\":429,\"error\":\"rate_limit\",\"session_id\":\"5c7148ee\"}";
+        let err = runner::agents::AgentError::RateLimit {
+            message: raw_fragment.to_string(),
+        };
+
+        let stored = format_review_error("minimax", &err);
+
+        // Must not contain raw JSON braces or the api_retry marker — these are
+        // exactly the leaks that filled `task_runs.error` with noisy payloads.
+        assert!(
+            !stored.contains("{\"type\""),
+            "stored error must not contain raw NDJSON envelope, got: {stored}"
+        );
+        assert!(
+            !stored.contains("subtype"),
+            "stored error must not contain raw api_retry fragment, got: {stored}"
+        );
+        assert!(
+            !stored.contains("session_id"),
+            "stored error must not contain session_id from provider payload, got: {stored}"
+        );
+        assert_eq!(
+            stored,
+            "minimax rate limit: status=429 after 7 attempts (last delay 35s)"
+        );
+    }
+
+    #[test]
+    fn format_review_error_summarises_truncated_fragment_without_subtype_marker() {
+        // Mid-object fragment that begins after the `subtype` key was cut off — this
+        // is the shape that landed in `task_runs.error` for rows 13634/13542/9821
+        // before the fix. The summariser's fallback path should emit a compact
+        // hint rather than echoing the raw payload.
+        let raw_fragment = ",\"attempt\":5,\"max_retries\":10,\"retry_delay_ms\":9034.81,\"error_status\":429,\"error\":\"rate_limit\",\"session_id\":\"992e17d3\"";
+        let err = runner::agents::AgentError::RateLimit {
+            message: raw_fragment.to_string(),
+        };
+
+        let stored = format_review_error("glm", &err);
+
+        assert!(stored.starts_with("glm rate limit:"));
+        assert!(
+            !stored.contains("session_id"),
+            "stored error must not leak session_id from truncated fragment, got: {stored}"
+        );
+        // The fragment first-line truncation path is bounded — verify the stored
+        // string stays well under the 512-char cap suggested by the bug report.
+        assert!(
+            stored.len() <= 200,
+            "stored error should be compact (<=200 chars), got {} chars: {stored}",
+            stored.len()
+        );
+    }
+
+    #[test]
+    fn format_review_error_preserves_non_rate_limit_variants() {
+        let err = runner::agents::AgentError::Auth {
+            message: "invalid bearer token".to_string(),
+        };
+        assert_eq!(
+            format_review_error("kimi", &err),
+            "kimi auth error: invalid bearer token"
+        );
+
+        let err = runner::agents::AgentError::Timeout {
+            elapsed: std::time::Duration::from_secs(1801),
+        };
+        assert_eq!(
+            format_review_error("kimi", &err),
+            "kimi timed out after 1801s"
+        );
     }
 
     fn git(dir: &std::path::Path, args: &[&str]) {

--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -16,61 +16,78 @@ use super::{agents, response};
 /// fragment containing `"subtype":"api_retry"`) and extracts `error_status`, `attempt`,
 /// `retry_delay_ms` to return a compact summary.
 /// Returns a compact fallback if no api_retry JSON is found.
-fn summarize_rate_limit_error(raw_output: &str) -> String {
+///
+/// Exposed `pub(crate)` so the review pipeline (`engine::review`) reuses the same
+/// summariser as the task runner. Without this, review runs persisted raw
+/// api_retry JSON fragments into `task_runs.error` (issue #3149).
+pub(crate) fn summarize_rate_limit_error(raw_output: &str) -> String {
     // Find the last line containing "subtype":"api_retry"
     // This handles both complete JSON objects and truncated fragments that begin
     // mid-object (e.g. `,"subtype":"api_retry","attempt":5...`).
-    let last_json = raw_output
+    let last_api_retry_line = raw_output
         .lines()
         .rev()
         .find(|line| line.contains("\"subtype\":\"api_retry\""));
 
-    match last_json {
-        Some(line) => {
-            let error_status = extract_json_field(line, "\"error_status\":")
-                .unwrap_or_else(|| "unknown".to_string());
-            let attempt =
-                extract_json_field(line, "\"attempt\":").unwrap_or_else(|| "unknown".to_string());
-            let retry_delay_ms =
-                extract_json_field(line, "\"retry_delay_ms\":").unwrap_or_else(|| "0".to_string());
+    if let Some(line) = last_api_retry_line {
+        return summarise_api_retry_line(line);
+    }
 
-            // Check if we extracted at least one meaningful numeric field.
-            let has_field = error_status != "unknown"
-                || attempt != "unknown"
-                || (retry_delay_ms != "0" && retry_delay_ms != "unknown");
+    // No `"subtype":"api_retry"` marker but the payload may still be a truncated
+    // api_retry NDJSON fragment that lost the `"subtype"` key earlier in the
+    // stream. If any line contains the characteristic numeric fields
+    // (`error_status`, `attempt`, `retry_delay_ms`), summarise from that line
+    // instead of echoing the raw JSON into `task_runs.error` (issue #3149).
+    let api_retry_field_markers = ["\"error_status\":", "\"attempt\":", "\"retry_delay_ms\":"];
+    let field_line = raw_output
+        .lines()
+        .rev()
+        .find(|line| api_retry_field_markers.iter().any(|m| line.contains(m)));
+    if let Some(line) = field_line {
+        return summarise_api_retry_line(line);
+    }
 
-            if has_field {
-                // Convert delay to seconds for readability
-                let retry_delay_s = retry_delay_ms.parse::<f64>().unwrap_or(0.0) / 1000.0;
-                let retry_delay_s = retry_delay_s as u64;
+    // No api_retry JSON or field markers found — emit a compact first-line
+    // summary, never raw passthrough. Truncate to a tight byte cap so even
+    // long single-line provider payloads cannot bloat `task_runs.error`.
+    const FIRST_LINE_CAP: usize = 120;
+    let first_line = raw_output.lines().next().unwrap_or(raw_output);
+    if first_line.len() > FIRST_LINE_CAP {
+        let cutoff = agents::truncate_at_char_boundary(first_line, FIRST_LINE_CAP);
+        let remaining = raw_output.len().saturating_sub(cutoff);
+        format!("{}... (+{} more chars)", &first_line[..cutoff], remaining)
+    } else {
+        first_line.to_string()
+    }
+}
 
-                format!(
-                    "status={} after {} attempts (last delay {}s)",
-                    error_status, attempt, retry_delay_s
-                )
-            } else {
-                // Fields not extractable from a partial fragment — emit a compact
-                // summary instead of a raw JSON blob to avoid leaking noisy data into
-                // task_runs.error and downstream cooldown parsing.
-                let status_hint = extract_json_field(line, "\"status\":")
-                    .or_else(|| extract_json_field(line, "\"error\":"))
-                    .unwrap_or_else(|| "429".to_string());
-                format!("status={} (api_retry fragment)", status_hint)
-            }
-        }
-        None => {
-            // No api_retry JSON found — emit compact summary, not raw passthrough.
-            let first_line = raw_output.lines().next().unwrap_or(raw_output);
-            if first_line.len() > 120 {
-                format!(
-                    "{}... (+{} more chars)",
-                    &first_line[..120],
-                    raw_output.len() - 120
-                )
-            } else {
-                first_line.to_string()
-            }
-        }
+/// Extract `error_status`, `attempt`, and `retry_delay_ms` from a single
+/// `api_retry`-shaped JSON line (or fragment) and return a compact summary
+/// such as `"status=429 after 7 attempts (last delay 35s)"`. Falls back to
+/// `"status=… (api_retry fragment)"` when no numeric field is recoverable.
+fn summarise_api_retry_line(line: &str) -> String {
+    let error_status =
+        extract_json_field(line, "\"error_status\":").unwrap_or_else(|| "unknown".to_string());
+    let attempt = extract_json_field(line, "\"attempt\":").unwrap_or_else(|| "unknown".to_string());
+    let retry_delay_ms =
+        extract_json_field(line, "\"retry_delay_ms\":").unwrap_or_else(|| "0".to_string());
+
+    let has_field = error_status != "unknown"
+        || attempt != "unknown"
+        || (retry_delay_ms != "0" && retry_delay_ms != "unknown");
+
+    if has_field {
+        let retry_delay_s = retry_delay_ms.parse::<f64>().unwrap_or(0.0) / 1000.0;
+        let retry_delay_s = retry_delay_s as u64;
+        format!(
+            "status={} after {} attempts (last delay {}s)",
+            error_status, attempt, retry_delay_s
+        )
+    } else {
+        let status_hint = extract_json_field(line, "\"status\":")
+            .or_else(|| extract_json_field(line, "\"error\":"))
+            .unwrap_or_else(|| "429".to_string());
+        format!("status={} (api_retry fragment)", status_hint)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixed regression where review pipeline bypassed the rate-limit summariser, persisting raw api_retry JSON fragments into task_runs.error. Reused the runner summariser in review.rs and hardened it for truncated payloads lacking the "subtype":"api_retry" marker.

### What was done

- Made runner::fallback::summarize_rate_limit_error pub(crate) so the review pipeline can share it (src/engine/runner/fallback.rs)
- Hardened summarize_rate_limit_error to also summarise fragments that lost the "subtype":"api_retry" marker but still contain error_status/attempt/retry_delay_ms fields, and cap raw first-line passthrough at 120 bytes via existing agents::truncate_at_char_boundary
- Extracted shared summarise_api_retry_line helper to avoid duplicating extraction logic
- Added format_review_error helper in src/engine/review.rs that mirrors per-variant formatting from runner::fallback::handle_error and routes RateLimit through summarize_rate_limit_error
- Updated the rate-limit detection branch in run_review_pipeline to call format_review_error (was producing `rate limit: {raw}`)
- Updated the hard-failure path that previously wrote err.to_string() (which embeds the raw fragment via AgentError::RateLimit's Display impl) to use format_review_error
- Added 3 regression tests: format_review_error_summarises_rate_limit_fragment_with_api_retry, format_review_error_summarises_truncated_fragment_without_subtype_marker, format_review_error_preserves_non_rate_limit_variants
- Verified: cargo fmt clean, cargo clippy --all-targets -- -D warnings clean, cargo nextest run 3517 tests passed


### Files changed

- `src/engine/review.rs`
- `src/engine/runner/fallback.rs`


Closes #3149

---
*Task #3149 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*