### PR TITLE
bug(review): kimi exit-1 + terminal_reason:completed hits is_hard_failure path — PR #3136 rescue never reached

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -848,7 +848,11 @@ async fn parse_review_output(
     };
 
     let agent_result_is_error = agent_result.as_ref().map(|r| r.is_error).unwrap_or(false);
-    let is_hard_failure = raw_output.is_empty() || agent_result_is_error;
+    let ndjson_completed_no_error = raw_output.contains("\"terminal_reason\":\"completed\"")
+        && !raw_output.contains("\"is_error\":true");
+    // Do not short-circuit completed NDJSON sessions before rescue parsing.
+    let is_hard_failure =
+        !ndjson_completed_no_error && (raw_output.is_empty() || agent_result_is_error);
 
     if is_hard_failure {
         tracing::warn!(
@@ -907,8 +911,7 @@ async fn parse_review_output(
                 // generic pattern-based rate-limit detection over it. Token
                 // counts in the telemetry blob can contain bare "429" values
                 // that would otherwise be misclassified as HTTP 429 errors.
-                let ndjson_completed = raw_output.contains("\"terminal_reason\":\"completed\"")
-                    && !raw_output.contains("\"is_error\":true");
+                let ndjson_completed = ndjson_completed_no_error;
 
                 // When ndjson_completed is true, try to recover the review response
                 // from assistant messages first. This handles agents like kimi/minimax


### PR DESCRIPTION
## Summary

Fixed review failure routing so kimi/minimax NDJSON runs with terminal_reason:completed are no longer treated as hard failures before the existing rescue path.

### What was done

- Updated `src/engine/review.rs` hard-failure gate to exempt completed NDJSON outputs (`terminal_reason:"completed"` without `"is_error":true`).
- Reused the same completed-NDJSON signal in the parse error/rescue branch to keep behavior consistent and avoid duplicate logic drift.
- Ran required checks successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (3519 passed, 19 skipped).
- Committed the fix as `81b8717e` with message `fix(review): avoid hard-fail on completed kimi ndjson`.


### Files changed

- `src/engine/review.rs`


Closes #3159

---
*Task #3159 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*