### PR TITLE
feat(jobs): allow task body to load from a prompt file

### DIFF
--- a/src/cli/job.rs
+++ b/src/cli/job.rs
@@ -1,6 +1,7 @@
 use crate::config;
 use crate::engine::jobs::{self, Job, TaskTemplate};
 use anyhow::Context;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// List scheduled jobs (with runtime state from SQLite).
@@ -97,6 +98,7 @@ pub fn add(
             Some(TaskTemplate {
                 title: title.to_string(),
                 body: body.unwrap_or("").to_string(),
+                prompt: None,
                 labels: vec![],
                 agent: None,
             })
@@ -174,7 +176,7 @@ pub async fn run(job_id: &str, project: Option<&str>) -> anyhow::Result<()> {
     use crate::backends::ExternalBackend;
 
     // 1. If inside an orch project (or --project given), try that first
-    let mut resolved: Option<(String, jobs::Job)> = None;
+    let mut resolved: Option<(String, jobs::Job, PathBuf)> = None;
 
     if project.is_none() {
         // Check if CWD is inside an orch project
@@ -182,7 +184,11 @@ pub async fn run(job_id: &str, project: Option<&str>) -> anyhow::Result<()> {
             let jobs_path = jobs::resolve_jobs_path();
             if let Ok(all_jobs) = jobs::load_jobs(&jobs_path) {
                 if let Some(job) = all_jobs.into_iter().find(|j| j.id == job_id) {
-                    resolved = Some((cwd_repo, job));
+                    let base_dir = jobs_path
+                        .parent()
+                        .map(PathBuf::from)
+                        .unwrap_or_else(|| PathBuf::from("."));
+                    resolved = Some((cwd_repo, job, base_dir));
                 }
             }
         }
@@ -190,7 +196,7 @@ pub async fn run(job_id: &str, project: Option<&str>) -> anyhow::Result<()> {
 
     // 2. If not resolved locally, search all projects
     if resolved.is_none() {
-        let mut matches: Vec<(String, jobs::Job)> = Vec::new();
+        let mut matches: Vec<(String, jobs::Job, PathBuf)> = Vec::new();
 
         let projects = crate::config::get_projects_with_paths().unwrap_or_default();
         for (repo, dir) in &projects {
@@ -203,7 +209,7 @@ pub async fn run(job_id: &str, project: Option<&str>) -> anyhow::Result<()> {
             if let Ok(all_jobs) = jobs::load_jobs(&orch_yml) {
                 for job in all_jobs {
                     if job.id == job_id {
-                        matches.push((repo.clone(), job));
+                        matches.push((repo.clone(), job, dir.clone()));
                     }
                 }
             }
@@ -213,7 +219,7 @@ pub async fn run(job_id: &str, project: Option<&str>) -> anyhow::Result<()> {
             0 => anyhow::bail!("job '{}' not found in any project", job_id),
             1 => resolved = matches.pop(),
             _ => {
-                let repos: Vec<&str> = matches.iter().map(|(r, _)| r.as_str()).collect();
+                let repos: Vec<&str> = matches.iter().map(|(r, _, _)| r.as_str()).collect();
                 anyhow::bail!(
                     "job '{}' exists in multiple projects: {}\nUse --project to specify which one, e.g.: orch job run {} --project {}",
                     job_id,
@@ -225,7 +231,7 @@ pub async fn run(job_id: &str, project: Option<&str>) -> anyhow::Result<()> {
         }
     }
 
-    let (repo, job) = match resolved {
+    let (repo, job, base_dir) = match resolved {
         Some(r) => r,
         None => anyhow::bail!("job '{}' not found", job_id),
     };
@@ -276,7 +282,16 @@ pub async fn run(job_id: &str, project: Option<&str>) -> anyhow::Result<()> {
     }
 
     // Execute the job (may mutate state.active_task_id / last_task_status).
-    jobs::execute_job(&job, &mut state, &backend, store.as_ref(), &repo, None).await;
+    jobs::execute_job(
+        &job,
+        &mut state,
+        &backend,
+        store.as_ref(),
+        &repo,
+        None,
+        &base_dir,
+    )
+    .await;
 
     let status = state.last_task_status.as_deref().unwrap_or("unknown");
     if let Some(ref task_id) = state.active_task_id {

--- a/src/engine/jobs.rs
+++ b/src/engine/jobs.rs
@@ -62,10 +62,35 @@ pub struct TaskTemplate {
     pub title: String,
     #[serde(default)]
     pub body: String,
+    /// Path to a file (typically markdown) whose contents are used as the
+    /// task body. Resolved relative to the directory of the config file
+    /// that defines this job. Mutually exclusive with `body`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
     #[serde(default)]
     pub labels: Vec<String>,
     #[serde(default)]
     pub agent: Option<String>,
+}
+
+/// Resolve the body for a task template, reading from `prompt` if set.
+///
+/// `base_dir` is the directory containing the jobs config file (used to
+/// resolve relative `prompt` paths).
+pub fn resolve_template_body(template: &TaskTemplate, base_dir: &Path) -> anyhow::Result<String> {
+    match template.prompt.as_deref() {
+        Some(rel) => {
+            let path = Path::new(rel);
+            let full = if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                base_dir.join(path)
+            };
+            std::fs::read_to_string(&full)
+                .with_context(|| format!("reading prompt file {}", full.display()))
+        }
+        None => Ok(template.body.clone()),
+    }
 }
 
 fn default_job_type() -> String {
@@ -129,6 +154,7 @@ pub fn load_jobs(path: &PathBuf) -> anyhow::Result<Vec<Job>> {
         std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
     let file: ConfigFile =
         serde_norway::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
+    let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
     for job in &file.jobs {
         let expanded = crate::cron::expand_alias(&job.schedule).with_context(|| {
             format!("job '{}': invalid cron schedule '{}'", job.id, job.schedule)
@@ -138,6 +164,29 @@ pub fn load_jobs(path: &PathBuf) -> anyhow::Result<Vec<Job>> {
         Schedule::from_str(&full_expr).with_context(|| {
             format!("job '{}': invalid cron schedule '{}'", job.id, job.schedule)
         })?;
+        if let Some(template) = job.task.as_ref() {
+            if template.prompt.is_some() && !template.body.is_empty() {
+                anyhow::bail!(
+                    "job '{}': set either 'task.body' or 'task.prompt', not both",
+                    job.id
+                );
+            }
+            if let Some(rel) = template.prompt.as_deref() {
+                let candidate = Path::new(rel);
+                let full = if candidate.is_absolute() {
+                    candidate.to_path_buf()
+                } else {
+                    base_dir.join(candidate)
+                };
+                if !full.exists() {
+                    anyhow::bail!(
+                        "job '{}': prompt file not found: {}",
+                        job.id,
+                        full.display()
+                    );
+                }
+            }
+        }
     }
     Ok(file.jobs)
 }
@@ -380,7 +429,8 @@ pub async fn tick(
         }
 
         // Execute the job (may mutate state.active_task_id / last_task_status).
-        execute_job(job, &mut state, backend, store, repo, transport).await;
+        let base_dir = jobs_path.parent().unwrap_or_else(|| Path::new("."));
+        execute_job(job, &mut state, backend, store, repo, transport, base_dir).await;
 
         // Persist updated state (active_task_id, last_task_status) after execution.
         if let Some(s) = store {
@@ -408,10 +458,20 @@ pub async fn execute_job(
     store: Option<&Arc<crate::store::TaskStore>>,
     repo: &str,
     transport: Option<&Arc<Transport>>,
+    base_dir: &Path,
 ) {
     match job.r#type.as_str() {
         "task" => {
             if let Some(ref template) = job.task {
+                let body = match resolve_template_body(template, base_dir) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::error!(job_id = job.id, ?e, "failed to resolve task body");
+                        state.last_task_status = Some("failed".to_string());
+                        return;
+                    }
+                };
+
                 if job.external {
                     let mut labels = template.labels.clone();
                     labels.push("scheduled".to_string());
@@ -423,10 +483,7 @@ pub async fn execute_job(
                         }
                     }
 
-                    match backend
-                        .create_task(&template.title, &template.body, &labels)
-                        .await
-                    {
+                    match backend.create_task(&template.title, &body, &labels).await {
                         Ok(ext_id) => {
                             tracing::info!(
                                 job_id = job.id,
@@ -443,14 +500,7 @@ pub async fn execute_job(
                     }
                 } else if let Some(s) = store {
                     match s
-                        .create_internal(
-                            repo,
-                            &template.title,
-                            &template.body,
-                            "cron",
-                            &job.id,
-                            None,
-                        )
+                        .create_internal(repo, &template.title, &body, "cron", &job.id, None)
                         .await
                     {
                         Ok(internal_id) => {
@@ -574,3 +624,98 @@ pub async fn execute_job(
 // NOTE: self-review analysis is handled by scheduled `task` jobs configured
 // in `.orch.yml` and executed by agents. There is no embedded Rust logic
 // here — this module remains a generic job dispatcher.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write_config(dir: &Path, content: &str) -> PathBuf {
+        let path = dir.join(".orch.yml");
+        fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn load_jobs_reads_prompt_from_file() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir(tmp.path().join("prompts")).unwrap();
+        fs::write(tmp.path().join("prompts/hello.md"), "hello from file").unwrap();
+        let cfg = write_config(
+            tmp.path(),
+            r#"
+jobs:
+  - id: with-prompt
+    schedule: "0 9 * * *"
+    task:
+      title: "Daily"
+      prompt: prompts/hello.md
+"#,
+        );
+
+        let jobs = load_jobs(&cfg).unwrap();
+        assert_eq!(jobs.len(), 1);
+        let body = resolve_template_body(jobs[0].task.as_ref().unwrap(), tmp.path()).unwrap();
+        assert_eq!(body, "hello from file");
+    }
+
+    #[test]
+    fn load_jobs_rejects_both_body_and_prompt() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("p.md"), "x").unwrap();
+        let cfg = write_config(
+            tmp.path(),
+            r#"
+jobs:
+  - id: conflict
+    schedule: "0 9 * * *"
+    task:
+      title: "x"
+      body: "inline"
+      prompt: p.md
+"#,
+        );
+
+        let err = load_jobs(&cfg).unwrap_err().to_string();
+        assert!(err.contains("not both"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn load_jobs_rejects_missing_prompt_file() {
+        let tmp = tempdir().unwrap();
+        let cfg = write_config(
+            tmp.path(),
+            r#"
+jobs:
+  - id: missing
+    schedule: "0 9 * * *"
+    task:
+      title: "x"
+      prompt: does-not-exist.md
+"#,
+        );
+
+        let err = load_jobs(&cfg).unwrap_err().to_string();
+        assert!(
+            err.contains("prompt file not found"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_template_body_falls_back_to_inline_body() {
+        let tmp = tempdir().unwrap();
+        let template = TaskTemplate {
+            title: "t".to_string(),
+            body: "inline body".to_string(),
+            prompt: None,
+            labels: vec![],
+            agent: None,
+        };
+        assert_eq!(
+            resolve_template_body(&template, tmp.path()).unwrap(),
+            "inline body"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an optional `task.prompt: path/to/file.md` field to job task templates. When set, the file contents are used as the task body at dispatch time (resolved relative to the config file's directory), so large bodies can live outside `.orch.yml`.
- `load_jobs` rejects configs that set both `body` and `prompt`, and fails up front if the referenced file is missing.
- Added 4 unit tests covering the happy path, the both-fields conflict, the missing-file error, and the inline-body fallback.

## Example
```yaml
jobs:
  - id: code-review-orch
    schedule: "0 */4 * * *"
    task:
      title: "Code quality review"
      prompt: prompts/code-review.md
```

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run jobs::` — 8 passing
- [ ] Manually verify a job with `task.prompt` dispatches with the file contents as body

🤖 Generated with [Claude Code](https://claude.com/claude-code)