### PR TITLE
bug(parser): status alias 'skipped' is not normalized, causing avoidable run failures

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -160,6 +160,8 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         "done"
         | "completed"
         | "complete"
+        | "skipped"
+        | "skip"
         | "ok"
         | "success"
         | "no_changes_needed"
@@ -1082,6 +1084,8 @@ Some output here.
             ("success", "done"),
             ("completed", "done"),
             ("complete", "done"),
+            ("skipped", "done"),
+            ("skip", "done"),
             ("no_changes_needed", "done"),
             ("no_trades_no_positions", "done"),
             ("running", "in_progress"),


### PR DESCRIPTION
## Summary

Implemented parser normalization for `skipped`/`skip` status aliases and added regression coverage, but could not commit due worktree git lockfile permission error in sandbox.

### What was done

- Updated `normalize_status()` in `src/parser.rs` to map `skipped` and `skip` to canonical `done`.
- Extended alias regression coverage in `parse_regression_2880_normalize_aliases` to include `skipped -> done` and `skip -> done`.
- Ran required local quality gates successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (3527 passed, 19 skipped).


### Remaining

- Create commit once git lockfile permissions are available in this worktree.
- Proceed with normal orch flow after commit (push/PR handled by orch).


### Files changed

- `src/parser.rs`


Closes #3168

---
*Task #3168 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*