### PR TITLE
bug(runner): is_retryable_blocked_reason misses 'worktree git lock' phrasing — codex lockfile blocks task instead of auto-retrying

### DIFF
--- a/src/engine/runner/response_handler.rs
+++ b/src/engine/runner/response_handler.rs
@@ -1101,6 +1101,9 @@ fn is_retryable_blocked_reason(reason: &str) -> bool {
         "service down",
         "permission denied",
         "worktree lock",
+        "git lock",
+        "lockfile permission",
+        "lock permission",
         "resource busy",
         "could not resolve host",
         // Credential providers in headless/tmux sessions can fail transiently
@@ -2150,6 +2153,12 @@ mod tests {
         ));
         assert!(is_retryable_blocked_reason(
             "final commit blocked by git worktree lock permission error"
+        ));
+        assert!(is_retryable_blocked_reason(
+            "could not commit due a worktree git lock permission error"
+        ));
+        assert!(is_retryable_blocked_reason(
+            "git lockfile permission restrictions in this environment"
         ));
         assert!(is_retryable_blocked_reason(
             "API rate limit hit, try again later"


### PR DESCRIPTION
## Summary

Broadened is_retryable_blocked_reason() to catch the reordered 'worktree git lock' phrasing. Added 'git lock', 'lockfile permission', and 'lock permission' to the transient patterns list in src/engine/runner/response_handler.rs, plus two unit test assertions covering both word orders. Verified cargo fmt, cargo clippy --all-targets -D warnings, and cargo nextest run (74 tests pass).

### Files changed

- `src/engine/runner/response_handler.rs`


Closes #3176

---
*Task #3176 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*