### PR TITLE
bug(router): per-entry router timeout cascade still stalls tick loop for minutes

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -1229,11 +1229,18 @@ impl Router {
                     let err_msg = e.to_string();
                     let is_timeout = err_msg.contains(TIMEOUT_PREFIX);
                     if is_timeout {
+                        // Advance pool index so the next tick starts at the next entry,
+                        // then return immediately. Continuing to try further pool entries
+                        // in the same tick would accumulate multiple timeout windows and
+                        // stall the tick loop for minutes (issue #3187).
+                        self.advance_pool_index_after_attempt(idx, n);
                         tracing::warn!(
                             agent,
                             model = model_str,
-                            "router LLM pool entry timed out — skipping cooldown, trying next entry"
+                            next_pool_idx = self.pool_index,
+                            "router LLM pool entry timed out — advancing pool index, will retry next tick"
                         );
+                        return Err(e);
                     } else {
                         tracing::warn!(
                             agent,
@@ -1316,8 +1323,9 @@ impl Router {
                         tracing::warn!(
                             agent = %fb_agent,
                             model = %fb_model_str,
-                            "fallback router LLM timed out — skipping cooldown"
+                            "fallback router LLM timed out — returning immediately to unblock tick loop"
                         );
+                        return Err(e);
                     } else {
                         tracing::warn!(
                             agent = %fb_agent,


### PR DESCRIPTION
## Summary

Fixed router timeout cascade that stalled the tick loop for minutes. When a pool entry times out, the router now advances the pool index and returns immediately, bounding each tick to at most one timeout_seconds window. The next tick starts at the next pool entry.

### What was done

- Identified the cascade in `route_with_llm()` at src/engine/router/mod.rs:1228-1250 — on timeout it continued iterating the pool serially, accumulating N×timeout_seconds stall per tick
- Applied fix: on timeout, advance pool_index and return Err immediately instead of trying next entry in the same tick
- Applied same fix to the fallback router LLM path (previously also logged 'skipping cooldown' and continued)
- All 3529 tests pass, clippy clean, fmt clean
- Committed as fix(router): stop cascading timeouts within a single tick


### Files changed

- `src/engine/router/mod.rs`


Closes #3187

---
*Task #3187 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `github-copilot/claude-sonnet-4.6`*