### PR TITLE
Daily morning review

### DIFF
--- a/docs/content/posts/morning-review-2026-05-30.md
+++ b/docs/content/posts/morning-review-2026-05-30.md
@@ -1,0 +1,150 @@
++++
+title = "Morning Review — 2026-05-30"
+date = 2026-05-30
+description = "Daily morning review and operational priorities."
++++
+
+# Morning Review — 2026-05-30
+
+## Recent Commits (Last 24h)
+
+| Commit | Description |
+|--------|-------------|
+| `4e42781f` | docs(posts): add evening retrospective for 2026-05-29 (#3208) |
+| `11d623cb` | fix(runner): classify claude opus 400 thinking-block conflict as ThinkingBlockConflict (#3207) |
+| `3c31f524` | fix(runner): move codex -c flags after exec to restore network access (#3206) |
+| `63d623b2` | bug(service): orch version falsely reports 'in sync' — PID-bind fix (#3203) |
+| `15a5f34f` | docs(posts): add morning review for 2026-05-29 (#3202) |
+
+Three code fixes and one docs commit. All three code fixes from yesterday's retro are now merged and deployed (service at 0.73.15).
+
+## Operational Health
+
+**Overall: Recovering. Service is now on 0.73.15 with all three fixes deployed. Codex failure rate dropped from 86% → 57% after restart. kimi/minimax/glm cooldowns expire ~20:00-21:00 UTC today. CLI lags service by two minor versions. One WATCHDOG stall at startup (single, self-recovered).**
+
+### Service Version
+
+```
+CLI:     0.73.13
+Service: 40050   0.73.15  ✗ mismatch — service is ahead of CLI
+Latest:  0.73.16  ⚠  upgrade available
+```
+
+The service is on 0.73.15 (PID 40050 confirmed via PID-binding fix). The CLI is behind at 0.73.13. Operator needs one command to close both gaps:
+
+```bash
+brew update && brew upgrade orch && brew services restart orch
+orch version  # expect: CLI and Service both on 0.73.16, PID-bound
+```
+
+### Agent/Model Health (Last 24h)
+
+| Agent | Model | Outcome | Count |
+|-------|-------|---------|-------|
+| claude | sonnet | success | 31 |
+| opencode | deepseek-v4-flash-free | success | 22 |
+| claude | opus | success | 21 |
+| codex | gpt-5.3-codex | **failed** | **14** |
+| codex | gpt-5.3-codex | success | 11 |
+| opencode | mimo-v2.5-free | success | 10 |
+| codex | gpt-5.4 | success | 5 |
+| claude | opus | **failed** | 3 |
+| claude | sonnet | **failed** | 2 |
+| codex | gpt-5.3-codex | blocked | 2 |
+| opencode | nemotron-3-super-free | success | 1 |
+
+Key observations:
+
+- **Codex failure rate: ~57%** (14 failed / 27 total excluding blocked). Down significantly from yesterday's 86%. The #3206 fix (codex `-c` flags placement) and #3190 (remove `--ask-for-approval`) are now deployed. Some failures in this window predate the restart.
+- **Claude remains strong**: sonnet near-perfect (31/33), opus 87% (21/24). The 3 opus failures and 2 sonnet failures are within normal variance; likely ThinkingBlockConflict events handled by the new error class.
+- **opencode/deepseek-v4-flash-free** continues strong at 22 successes — now the second most active model overall.
+- **opencode/mimo-v2.5-free** at 10 successes — steady contributor.
+
+### Active Cooldowns (10:01 UTC)
+
+| Key | Remaining | Reason |
+|-----|-----------|--------|
+| glm | 10h55m | persisted |
+| kimi | 10h18m | persisted |
+| minimax | 10h50m | persisted |
+| opencode:github-copilot/gpt-5-mini | 5d11h | persisted |
+
+kimi/minimax/glm all clear this evening (~20:00-21:00 UTC). The routing pool will fully recover when they return.
+
+### Task Activity (Last 12h)
+
+| Event | Count |
+|-------|-------|
+| status_change | 409 |
+| branch_delete | 142 |
+| dispatch | 131 |
+| push | 111 |
+| review_start | 65 |
+| routed | 61 |
+| review_decision | 51 |
+| pr_create | 48 |
+| error | 22 |
+| rerouted | 3 |
+
+Solid throughput: 48 PRs created, 131 dispatches. Error count (22) is proportional to volume and lower than yesterday's 33. No crash-level errors.
+
+### Log Patterns
+
+- **WATCHDOG stall at 10:01:15 UTC** (69s, threshold 60s): caused by this task's routing — glm LLM router timed out at 45s. Fallback to weighted round-robin succeeded; task dispatched to claude:sonnet. Single event, self-recovered.
+- **Recurring WARN**: `multi-agent degradation detected` for kimi/minimax/glm every tick — expected, cosmetic noise until ~21:00 UTC.
+- **One transient HTTP error**: GitHub GraphQL send failed (attempt 0, auto-retry). Not a pattern.
+- **Rebase conflict** on bean repo worktree (internal:150944, commit `1b05c03b "uv"`): runner handled gracefully with "continuing with current state". Agent proceeding.
+- **Error log is 0 bytes** — clean service run.
+
+## Stuck / Blocked Tasks
+
+- **internal:149337** — blocked (Day 19). SSH agent signing failure on auto-merge push. Operator action required:
+  ```bash
+  ssh-add ~/.ssh/default_id_ed25519
+  orch task unblock all
+  ```
+
+## Retro Follow-ups
+
+| Item | Status |
+|------|--------|
+| Service restart / upgrade to 0.73.15 | ✓ Done yesterday |
+| Codex -c flags fix (#3206) | ✓ Deployed (0.73.15) |
+| ThinkingBlockConflict class (#3207) | ✓ Deployed (0.73.15) |
+| orch version PID-binding (#3203) | ✓ Deployed (0.73.15) |
+| Upgrade to 0.73.16 | **NOT DONE** — CLI also needs upgrade |
+| Unblock internal:149337 (ssh-add) | **NOT DONE** (Day 19) |
+| Prune dead opencode model entries from config | **NOT DONE** |
+| kimi/minimax/glm cooldown expiry | Pending — clears ~20:00-21:00 UTC today |
+| Verify codex recovery post-restart | Partial ✓ — rate improving (86% → 57%); monitor through day |
+| Watch claude:opus ThinkingBlockConflict rate | 3 failures in 24h — within normal range |
+
+## Priorities For Today
+
+### CRITICAL (operator)
+
+1. **Unblock internal:149337** (Day 19):
+   ```bash
+   ssh-add ~/.ssh/default_id_ed25519
+   orch task unblock all
+   ```
+
+2. **Complete the upgrade to 0.73.16** (closes CLI/service mismatch):
+   ```bash
+   brew update && brew upgrade orch && brew services restart orch
+   orch version   # expect PID-bound output, CLI and Service in sync on 0.73.16
+   ```
+
+### Monitoring
+
+3. **Watch codex failure rate through day** — expect continued improvement as all pre-restart failures age out. A rate above 30% by end of day warrants investigation of root cause beyond the fixed flags.
+4. **kimi/minimax/glm cooldown expiry (~20:00-21:00 UTC)** — verify they re-enter routing pool cleanly without immediately re-entering cooldown.
+5. **Monitor WATCHDOG stalls** — today's single event was from this task's routing and is not alarming. A second stall warrants investigation.
+
+### Maintenance
+
+6. **Prune dead opencode model entries** from `~/.orch/config.yml` (`github-copilot/gpt-5.3`, `github-copilot/claude-opus-4.6`) — reduces router WARN noise every tick.
+
+---
+
+Prepared by Orch automation (internal:150943)


### PR DESCRIPTION
## Summary

Morning review for 2026-05-30 written and pushed. Service is on 0.73.15 (post-restart, all three fixes deployed). Codex failure rate improved from 86% to 57%. kimi/minimax/glm cooldowns expire ~20:00-21:00 UTC today. One WATCHDOG stall at startup (self-recovered). internal:149337 still blocked (Day 19, SSH). CLI lags service at 0.73.13 vs 0.73.15 (latest 0.73.16). No new issues filed — board is clean, all problems are known operator actions or self-recovering.

### Files changed

- `docs/content/posts/morning-review-2026-05-30.md`


---
*Task internal-150943 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*