### PR TITLE
bug(parser): status aliases 'changes_made', 'acknowledged', 'flat' not normalized — 5 wasted task runs in 7 days

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -165,7 +165,13 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         | "ok"
         | "success"
         | "no_changes_needed"
-        | "no_trades_no_positions" => "done".to_string(),
+        | "no_trades_no_positions"
+        | "changes_made"
+        | "change_made"
+        | "acknowledged"
+        | "flat"
+        | "no_action"
+        | "no_action_needed" => "done".to_string(),
         // Canonical progress statuses.
         // `partial` is used by some models to indicate partial progress —
         // treat it as in_progress so the task remains open for follow-up.


### PR DESCRIPTION
## Summary

Commit successful! The fix is complete and all tests pass.

## Summary

I've successfully fixed the missing status alias normalization in the parser:

**What was fixed:**
- Added 6 new status aliases to `src/parser.rs:normalize_status()` that map to "done"
  - `changes_made` (observed in 3 failures)
  - `change_made` (singular variant)
  - `acknowledged` (observed in 1 failure)
  - `flat` (observed in 1 failure from kimi:opus)
  - `no_action` (preemptive addition)
  - `no_action_needed` (preempt

### What was done

- What was fixed:**
- Added 6 new status aliases to `src/parser.rs:normalize_status()` that map to "done"
- `changes_made` (observed in 3 failures)
- `change_made` (singular variant)
- `acknowledged` (observed in 1 failure)
- `flat` (observed in 1 failure from kimi:opus)
- `no_action` (preemptive addition)
- `no_action_needed` (preemptive addition)
- Quality gates:** ✅ All 3561 tests passed, no formatting/clippy issues
- Commit:** `77799ba4` — "fix(parser): add missing status aliases — changes_made, acknowledged, flat"


### Files changed

- `src/parser.rs`


Closes #3210

---
*Task #3210 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*