### PR TITLE
bug(deployment): service at v0.73.13 missing 3 critical fixes in v0.73.14-v0.73.16 — codex network blocked, ThinkingBlockConflict unclassified, arg-parse masking active

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -178,6 +178,9 @@ pub struct EngineConfig {
     /// How often to check for a newer orch release and notify channels (seconds).
     /// Set to 0 to disable. Default: 3600 (1 hour).
     pub upgrade_check_interval: u64,
+    /// Automatically run `brew upgrade orch` and restart the service when a newer
+    /// release is detected. Default: true. Set `engine.auto_upgrade: false` to disable.
+    pub auto_upgrade: bool,
 }
 
 impl Default for EngineConfig {
@@ -195,6 +198,7 @@ impl Default for EngineConfig {
             silence_grace_period: 300,
             silence_cooldown: 3600,
             upgrade_check_interval: 3600,
+            auto_upgrade: true,
         }
     }
 }
@@ -299,6 +303,10 @@ impl EngineConfig {
             } else {
                 tracing::warn!(key = "engine.upgrade_check_interval", value = %val, default = config.upgrade_check_interval, "invalid value for engine.upgrade_check_interval, using default");
             }
+        }
+
+        if let Ok(val) = crate::config::get("engine.auto_upgrade") {
+            config.auto_upgrade = !val.eq_ignore_ascii_case("false");
         }
 
         config
@@ -716,7 +724,38 @@ async fn fetch_latest_release_version() -> Option<String> {
     }
 }
 
-/// Check if a newer orch release is available and send channel notifications.
+/// Run `brew upgrade orch` then send SIGTERM to the current process so launchd
+/// restarts the service with the new binary. The signal is sent only after the
+/// brew command succeeds; on failure, nothing is restarted and the next check
+/// will try again.
+async fn perform_auto_upgrade(latest: &str) {
+    tracing::info!(latest = %latest, "auto-upgrading orch via brew");
+
+    let status = Command::new("brew")
+        .args(["upgrade", "orch"])
+        .status()
+        .await;
+
+    match status {
+        Ok(s) if s.success() => {
+            tracing::info!(latest = %latest, "brew upgrade orch succeeded — restarting service");
+            // Send SIGTERM to self; launchd / brew services will restart the process
+            // with the newly installed binary.
+            let pid = std::process::id().to_string();
+            let _ = Command::new("kill").args(["-TERM", &pid]).status().await;
+        }
+        Ok(s) => {
+            tracing::warn!(exit_code = ?s.code(), "brew upgrade orch failed — will retry at next check");
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to spawn brew upgrade orch");
+        }
+    }
+}
+
+/// Check if a newer orch release is available. When `auto_upgrade` is true,
+/// runs `brew upgrade orch` and restarts the service. Otherwise sends channel
+/// notifications asking the operator to upgrade manually.
 ///
 /// Uses the store's KV to throttle checks (`upgrade:last_check_at`) and
 /// deduplicate notifications (`upgrade:last_notified_version`). Each distinct
@@ -727,6 +766,7 @@ async fn check_and_notify_upgrade(
     channels: &Arc<ChannelRegistry>,
     current_version: &str,
     check_interval: std::time::Duration,
+    auto_upgrade: bool,
 ) {
     let last_check_key = "upgrade:last_check_at";
     let last_notified_key = "upgrade:last_notified_version";
@@ -757,6 +797,31 @@ async fn check_and_notify_upgrade(
         return;
     }
 
+    tracing::warn!(
+        current_version = %current_version,
+        latest_version = %latest,
+        "orch upgrade available"
+    );
+
+    // When auto_upgrade is enabled, upgrade via brew and restart — no manual
+    // channel notification needed since the restart is self-evident.
+    if auto_upgrade {
+        // Deduplicate: don't re-trigger brew upgrade for the same latest version
+        // unless a previous attempt failed (in which case the key won't be set).
+        if let Ok(Some(last_notified)) = store.kv_get(last_notified_key).await {
+            if last_notified == latest {
+                tracing::debug!(latest = %latest, "auto-upgrade already attempted for this version");
+                return;
+            }
+        }
+        // Mark before attempting so a crash during brew doesn't cause a rapid retry loop.
+        let _ = store.kv_set(last_notified_key, &latest).await;
+        perform_auto_upgrade(&latest).await;
+        return;
+    }
+
+    // Manual upgrade path: send channel notifications.
+
     // Deduplicate: don't re-notify for the same latest version.
     if let Ok(Some(last_notified)) = store.kv_get(last_notified_key).await {
         if last_notified == latest {
@@ -764,12 +829,6 @@ async fn check_and_notify_upgrade(
             return;
         }
     }
-
-    tracing::warn!(
-        current_version = %current_version,
-        latest_version = %latest,
-        "orch upgrade available"
-    );
 
     let msg_telegram = format!(
         "⚠️ <b>Orch Upgrade Available</b>\n\n\
@@ -1928,9 +1987,16 @@ pub async fn serve() -> anyhow::Result<()> {
                         let current = env!("ORCH_VERSION").to_string();
                         let check_interval =
                             std::time::Duration::from_secs(config.upgrade_check_interval);
+                        let auto_upgrade = config.auto_upgrade;
                         tokio::spawn(async move {
-                            check_and_notify_upgrade(&store, &channels, &current, check_interval)
-                                .await;
+                            check_and_notify_upgrade(
+                                &store,
+                                &channels,
+                                &current,
+                                check_interval,
+                                auto_upgrade,
+                            )
+                            .await;
                         });
                     }
                     last_upgrade_check = std::time::Instant::now();
@@ -2334,6 +2400,7 @@ mod tests {
             std::time::Duration::from_secs(600)
         );
         assert_eq!(config.upgrade_check_interval, 3600);
+        assert!(config.auto_upgrade, "auto_upgrade default must be true");
     }
 
     #[test]
@@ -2350,6 +2417,8 @@ mod tests {
             std::time::Duration::from_secs(600)
         );
         assert_eq!(config.upgrade_check_interval, 3600);
+        // auto_upgrade may be overridden by user config; default is true
+        // (user config may disable it, so only check default struct)
     }
 
     #[test]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -728,7 +728,9 @@ async fn fetch_latest_release_version() -> Option<String> {
 /// restarts the service with the new binary. The signal is sent only after the
 /// brew command succeeds; on failure, nothing is restarted and the next check
 /// will try again.
-async fn perform_auto_upgrade(latest: &str) {
+///
+/// Returns `true` if brew succeeded and SIGTERM was sent, `false` on any failure.
+async fn perform_auto_upgrade(latest: &str) -> bool {
     tracing::info!(latest = %latest, "auto-upgrading orch via brew");
 
     let status = Command::new("brew")
@@ -743,12 +745,15 @@ async fn perform_auto_upgrade(latest: &str) {
             // with the newly installed binary.
             let pid = std::process::id().to_string();
             let _ = Command::new("kill").args(["-TERM", &pid]).status().await;
+            true
         }
         Ok(s) => {
             tracing::warn!(exit_code = ?s.code(), "brew upgrade orch failed — will retry at next check");
+            false
         }
         Err(e) => {
             tracing::warn!(error = %e, "failed to spawn brew upgrade orch");
+            false
         }
     }
 }
@@ -814,9 +819,14 @@ async fn check_and_notify_upgrade(
                 return;
             }
         }
-        // Mark before attempting so a crash during brew doesn't cause a rapid retry loop.
+        // Mark before attempting so a crash/restart mid-upgrade doesn't cause a rapid
+        // retry loop. On explicit failure the key is cleared below so the next hourly
+        // check can retry.
         let _ = store.kv_set(last_notified_key, &latest).await;
-        perform_auto_upgrade(&latest).await;
+        if !perform_auto_upgrade(&latest).await {
+            // Brew failed — clear the dedup key so the next check cycle will retry.
+            let _ = store.kv_delete(last_notified_key).await;
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary

Implemented actual auto-upgrade in the engine: when a newer release is detected, the service now runs `brew upgrade orch` and sends SIGTERM to self so launchd restarts with the new binary. Previously issue #3161 only sent channel notifications. The new default is `auto_upgrade: true`; set `engine.auto_upgrade: false` to fall back to notifications only.

### What was done

- Added `auto_upgrade: bool` field to `EngineConfig` (default: `true`, configurable via `engine.auto_upgrade: false`)
- Added `perform_auto_upgrade()` function that runs `brew upgrade orch` then sends SIGTERM to the current process (launchd restarts with new binary)
- Updated `check_and_notify_upgrade()` signature and body: when `auto_upgrade` is true it calls `perform_auto_upgrade` with per-version dedup guard; when false it uses the existing channel-notification path
- Updated the serve-loop call site to pass `auto_upgrade` flag
- Added test assertion for `auto_upgrade` default being `true`
- All 3561 tests pass; `cargo fmt` and `cargo clippy --all-targets -- -D warnings` clean


### Remaining

- Service still at v0.73.13 at time of commit — the auto-upgrade will fire within the next upgrade_check_interval (default 1 hour) after this PR is merged and deployed via the normal release pipeline. For the immediate gap, the operator can run `brew update && brew upgrade orch && brew services restart orch` manually.


### Files changed

- `src/engine/mod.rs`


Closes #3211

---
*Task #3211 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*