### PR TITLE
bug(parser): normalize_status missing 'MISSED' and 'changes_addressed' — trading tasks fail on valid completions

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -152,7 +152,8 @@ pub fn parse(raw: &str) -> anyhow::Result<AgentResponse> {
 /// Unknown statuses are kept as-is so that downstream code can distinguish
 /// them from canonical ones (e.g. for debugging/metrics).
 fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
-    resp.status = match resp.status.as_str() {
+    let normalized = resp.status.to_ascii_lowercase();
+    resp.status = match normalized.as_str() {
         // Canonical completion statuses.
         // Some agents return `complete` or `no_changes_needed` to indicate
         // a successful run with no further edits required — treat them as
@@ -171,7 +172,9 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         | "acknowledged"
         | "flat"
         | "no_action"
-        | "no_action_needed" => "done".to_string(),
+        | "no_action_needed"
+        | "missed"
+        | "changes_addressed" => "done".to_string(),
         // Canonical progress statuses.
         // `partial` is used by some models to indicate partial progress —
         // treat it as in_progress so the task remains open for follow-up.
@@ -194,7 +197,7 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         // Unknown non-canonical status — keep as-is so the audit trail records
         // exactly what the agent returned. This lets operators identify which
         // statuses need to be added to the normalization map.
-        other => other.to_string(),
+        _ => resp.status.clone(),
     };
     resp
 }
@@ -950,6 +953,20 @@ Some output here.
     #[test]
     fn parse_normalizes_completed_alias_to_done() {
         let input = r#"{"status":"completed","summary":"done","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "done");
+    }
+
+    #[test]
+    fn parse_normalizes_missed_alias_to_done_case_insensitive() {
+        let input = r#"{"status":"MISSED","summary":"no setups found","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "done");
+    }
+
+    #[test]
+    fn parse_normalizes_changes_addressed_alias_to_done() {
+        let input = r#"{"status":"changes_addressed","summary":"feedback addressed","accomplished":[],"remaining":[],"files":[]}"#;
         let resp = parse(input).unwrap();
         assert_eq!(resp.status, "done");
     }


### PR DESCRIPTION
## Summary

Implemented parser status normalization for trading/task completion aliases and added tests; commit created successfully, but full nextest run failed on an existing tmux test unrelated to this parser change.

### What was done

- Updated `normalize_status()` in `src/parser.rs` to normalize status input case-insensitively via `to_ascii_lowercase()` before matching.
- Added `missed` and `changes_addressed` aliases to the completion status arm so both map to canonical `done`.
- Adjusted unknown-status passthrough to preserve the original response status string.
- Added regression tests `parse_normalizes_missed_alias_to_done_case_insensitive` and `parse_normalizes_changes_addressed_alias_to_done`.
- Ran `cargo fmt -- --check` successfully.
- Ran `cargo clippy --all-targets -- -D warnings` successfully.
- Ran targeted parser tests (`cargo test -q parse_normalizes_`) successfully.
- Committed changes in commit `c3bee27e` with message `fix(parser): normalize MISSED and changes_addressed to done`.


### Remaining

- Investigate or rerun failing full-suite test `tmux::tests::session_blocks_dispatch_cleans_dead_session` from `cargo nextest run`.
- Re-run full `cargo nextest run` to green after tmux test issue is resolved.


### Files changed

- `src/parser.rs`


Closes #3221

---
*Task #3221 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*