### PR TITLE
bug(deployment): service PID 2102 running v0.73.13 undetected — 5 critical fixes blocked (v0.73.14–v0.73.18)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -34,38 +34,67 @@ pub fn version() {
     let cli_version = env!("ORCH_VERSION");
     println!("CLI:     {cli_version}");
 
+    let all_pids = crate::home::find_orch_serve_pids(false);
+
     match crate::home::service_version_path()
         .ok()
         .and_then(|p| std::fs::read_to_string(p).ok())
     {
         Some(raw) => {
             let raw = raw.trim();
-            // Parse "{pid}\t{version}" written by engine ≥ fix for #3200.
-            // Fall back to treating the whole string as a plain version for older engines.
             let (pid_opt, svc) = match raw.split_once('\t') {
                 Some((pid_str, ver)) => (pid_str.parse::<u32>().ok(), ver),
                 None => (None, raw),
             };
 
-            // Verify the recorded PID is alive AND is an `orch serve` process,
-            // guarding against PID reuse by an unrelated process after engine exit.
-            // Legacy plain-version files have no PID — assume alive (best-effort).
-            let pid_alive = pid_opt.map(crate::home::pid_is_orch_serve).unwrap_or(true);
-
-            if !pid_alive {
-                println!(
-                    "Service: stale (pid {} no longer running) — run: brew services restart orch",
-                    pid_opt.unwrap()
-                );
+            if let Some(stale_pid) = pid_opt.filter(|pid| !crate::home::pid_is_orch_serve(*pid)) {
+                match all_pids.as_slice() {
+                    [] => println!(
+                        "Service: stale (pid {stale_pid} no longer running) — run: brew services restart orch"
+                    ),
+                    [ghost_pid] => {
+                        let ghost_version = orch_version_from_pid(*ghost_pid)
+                            .unwrap_or_else(|| "unknown".to_string());
+                        println!(
+                            "Service: {ghost_version}  ⚠ ghost process (pid {ghost_pid}) — run: brew services restart orch"
+                        );
+                    }
+                    _ => println!(
+                        "Service: unknown  ⚠ multiple ghost processes (pids: {}) — run: brew services restart orch",
+                        format_pids(&all_pids)
+                    ),
+                }
             } else if svc == cli_version {
-                println!("Service: {svc}  ✓ in sync");
+                if all_pids.len() > 1 {
+                    println!(
+                        "Service: {svc}  ⚠ multiple instances running (pids: {}) — run: brew services restart orch",
+                        format_pids(&all_pids)
+                    );
+                } else {
+                    println!("Service: {svc}  ✓ in sync");
+                }
+            } else if all_pids.len() > 1 {
+                println!(
+                    "Service: {svc}  ✗ mismatch; multiple instances running (pids: {}) — run: brew upgrade orch && brew services restart orch",
+                    format_pids(&all_pids)
+                );
             } else {
-                println!("Service: {svc}  ✗ mismatch — run: brew upgrade orch && brew services restart orch");
+                println!(
+                    "Service: {svc}  ✗ mismatch — run: brew upgrade orch && brew services restart orch"
+                );
             }
         }
-        None => {
-            println!("Service: not running (no service.version file)");
-        }
+        None => match all_pids.as_slice() {
+            [] => println!("Service: not running (no service.version file)"),
+            [pid] => {
+                let ver = orch_version_from_pid(*pid).unwrap_or_else(|| "unknown".to_string());
+                println!("Service: {ver}  ⚠ no service.version file (pid {pid})");
+            }
+            _ => println!(
+                "Service: unknown  ⚠ multiple instances (pids: {}) — no service.version file",
+                format_pids(&all_pids)
+            ),
+        },
     }
 
     if let Some(latest) = fetch_latest_release_version() {
@@ -75,6 +104,33 @@ pub fn version() {
             println!("Latest:  {latest}  ✓ up to date");
         }
     }
+}
+
+fn format_pids(pids: &[u32]) -> String {
+    pids.iter()
+        .map(|pid| pid.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn orch_version_from_pid(pid: u32) -> Option<String> {
+    let output = std::process::Command::new("lsof")
+        .args(["-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_whitespace().last())
+        .find_map(version_from_cellar_orch_path)
+        .map(str::to_string)
+}
+
+fn version_from_cellar_orch_path(path: &str) -> Option<&str> {
+    path.split("/Cellar/orch/").nth(1)?.split('/').next()
 }
 
 /// Fetch the latest orch release tag from GitHub via the `gh` CLI.

--- a/src/engine/events.rs
+++ b/src/engine/events.rs
@@ -134,28 +134,13 @@ impl EventBus {
 
         // Write service version file so `orch version` can detect CLI/service drift.
         // Format: "{pid}\t{version}" so readers can verify the owning process is alive.
-        // Guard: skip writing if a live orch serve already owns the file, which prevents
-        // a transient/failed-restart binary from stamping over a surviving engine.
         if let Ok(path) = crate::home::service_version_path() {
             if let Some(parent) = path.parent() {
                 let _ = tokio::fs::create_dir_all(parent).await;
             }
-            // Only skip writing if the recorded PID is both alive AND is an
-            // `orch serve` process — prevents PID reuse by an unrelated process
-            // from blocking a new real engine from claiming the file.
-            let already_owned = tokio::fs::read_to_string(&path)
-                .await
-                .ok()
-                .and_then(|s| {
-                    let pid: u32 = s.split('\t').next()?.parse().ok()?;
-                    Some(crate::home::pid_is_orch_serve(pid))
-                })
-                .unwrap_or(false);
-            if !already_owned {
-                let pid = std::process::id();
-                let content = format!("{}\t{}", pid, env!("ORCH_VERSION"));
-                let _ = tokio::fs::write(path, content).await;
-            }
+            let pid = std::process::id();
+            let content = format!("{}\t{}", pid, env!("ORCH_VERSION"));
+            let _ = tokio::fs::write(path, content).await;
         }
 
         let tx = self.tx.clone();
@@ -268,9 +253,6 @@ pub async fn cleanup_port_file() {
 }
 
 /// Remove the service.version file on shutdown — only if this process owns it.
-///
-/// A transient binary that was unable to overwrite the file (due to the live-owner
-/// guard in `start_ws_server`) must not delete the surviving engine's file on exit.
 pub fn cleanup_version_file() {
     if let Ok(path) = crate::home::service_version_path() {
         let owned = std::fs::read_to_string(&path)

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -898,6 +898,11 @@ async fn check_and_notify_upgrade(
 ///
 /// This is the main entry point — called by `orch serve`.
 pub async fn serve() -> anyhow::Result<()> {
+    let killed = crate::home::kill_other_orch_serve_processes(std::time::Duration::from_secs(30));
+    if killed > 0 {
+        tracing::info!(count = killed, "terminated stale orch serve processes");
+    }
+
     tracing::info!("orch engine starting");
 
     // Pre-create standard directories with async I/O so subsequent synchronous

--- a/src/home.rs
+++ b/src/home.rs
@@ -123,25 +123,95 @@ pub fn service_version_path() -> anyhow::Result<std::path::PathBuf> {
     Ok(state_dir()?.join("service.version"))
 }
 
-/// Returns `true` if the given PID is alive **and** is an `orch serve` process.
-///
-/// Checks the process command line via `ps -p {pid} -o args=` to guard against
-/// PID reuse by an unrelated process after the real engine exits.
+/// Returns `true` if the given PID is alive and is an `orch serve` process.
 pub fn pid_is_orch_serve(pid: u32) -> bool {
+    process_args(pid)
+        .as_deref()
+        .is_some_and(command_line_is_orch_serve)
+}
+
+/// Find all PIDs of running `orch serve` processes.
+pub fn find_orch_serve_pids(exclude_self: bool) -> Vec<u32> {
+    let output = std::process::Command::new("pgrep")
+        .args(["-x", "orch"])
+        .output()
+        .ok();
+
+    let self_pid = std::process::id();
+    match output {
+        Some(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+            .lines()
+            .filter_map(|line| line.trim().parse::<u32>().ok())
+            .filter(|pid| !exclude_self || *pid != self_pid)
+            .filter(|pid| pid_is_orch_serve(*pid))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Send SIGTERM to other running `orch serve` processes, then SIGKILL stragglers.
+pub fn kill_other_orch_serve_processes(timeout: std::time::Duration) -> u32 {
+    let others = find_orch_serve_pids(true);
+    if others.is_empty() {
+        return 0;
+    }
+
+    for pid in &others {
+        tracing::info!(pid, "sending SIGTERM to stale orch serve process");
+        send_signal(*pid, "TERM");
+    }
+
+    let mut remaining = wait_for_orch_serve_exit(others.clone(), timeout);
+    for pid in &remaining {
+        tracing::warn!(pid, "stale orch serve ignored SIGTERM; sending SIGKILL");
+        send_signal(*pid, "KILL");
+    }
+
+    remaining = wait_for_orch_serve_exit(remaining, std::time::Duration::from_secs(1));
+    for pid in &remaining {
+        tracing::error!(pid, "stale orch serve survived SIGKILL");
+    }
+
+    (others.len() - remaining.len()) as u32
+}
+
+fn process_args(pid: u32) -> Option<String> {
     let output = std::process::Command::new("ps")
         .args(["-p", &pid.to_string(), "-o", "args="])
         .output()
-        .ok();
-    match output {
-        Some(o) if o.status.success() => {
-            let cmdline = String::from_utf8_lossy(&o.stdout);
-            let cmdline = cmdline.trim();
-            // The cmdline is the full argv, e.g. "/path/to/orch serve --flag".
-            // Verify both that the binary is "orch" and "serve" is the subcommand.
-            cmdline.contains("orch") && cmdline.split_whitespace().any(|w| w == "serve")
-        }
-        _ => false,
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|args| !args.is_empty())
+}
+
+fn command_line_is_orch_serve(cmdline: &str) -> bool {
+    let mut args = cmdline.split_whitespace();
+    let Some(program) = args.next() else {
+        return false;
+    };
+    Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "orch")
+        && args.any(|arg| arg == "serve")
+}
+
+fn send_signal(pid: u32, signal: &str) {
+    let _ = std::process::Command::new("kill")
+        .args([format!("-{signal}"), pid.to_string()])
+        .output();
+}
+
+fn wait_for_orch_serve_exit(mut pids: Vec<u32>, timeout: std::time::Duration) -> Vec<u32> {
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout && !pids.is_empty() {
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        pids.retain(|pid| pid_is_orch_serve(*pid));
     }
+    pids
 }
 
 /// Get the path to the worktrees directory (~/.orch/worktrees/).
@@ -321,5 +391,36 @@ mod tests {
         assert_ne!(dir_a, dir_b);
 
         restore_orch_home(prev);
+    }
+
+    #[test]
+    fn pid_is_orch_serve_returns_false_for_nonexistent_pid() {
+        assert!(!pid_is_orch_serve(99999));
+    }
+
+    #[test]
+    fn command_line_is_orch_serve_matches_real_invocations() {
+        assert!(command_line_is_orch_serve("/opt/homebrew/bin/orch serve"));
+        assert!(command_line_is_orch_serve(
+            "/opt/homebrew/Cellar/orch/0.73.18/bin/orch serve --foreground"
+        ));
+        assert!(!command_line_is_orch_serve(
+            "/opt/homebrew/bin/orch version"
+        ));
+        assert!(!command_line_is_orch_serve("/bin/sh -c orch serve"));
+        assert!(!command_line_is_orch_serve("/tmp/not-orch serve"));
+    }
+
+    #[test]
+    fn find_orch_serve_pids_does_not_panic() {
+        let pids = find_orch_serve_pids(false);
+        assert!(pids.iter().all(|pid| pid_is_orch_serve(*pid)));
+    }
+
+    #[test]
+    fn find_orch_serve_pids_excludes_self() {
+        let self_pid = std::process::id();
+        let pids = find_orch_serve_pids(true);
+        assert!(!pids.contains(&self_pid));
     }
 }


### PR DESCRIPTION
## Summary

Implemented structural ghost-process prevention for `orch serve` and strengthened `orch version` runtime detection/reporting so stale `service.version` PIDs no longer hide active old binaries.

### What was done

- Added startup preemption in `serve()` to terminate other running `orch serve` processes before engine initialization (`SIGTERM` then `SIGKILL` fallback).
- Implemented process utilities in `src/home.rs` to detect real `orch serve` PIDs via `pgrep` + `ps args`, list active instances, and kill stale peers with timeout handling.
- Enhanced `orch version` output logic to inspect live running PIDs and report ghost-process states, multi-instance states, and no-`service.version` fallback states using live PID-derived version checks.
- Kept `service.version` writer in event-bus startup as unconditional PID+version ownership write, aligned with new startup stale-process eviction flow.
- Added unit tests in `src/home.rs` for command-line matching and PID discovery behavior.
- Committed all changes in commit `ffe7a7ca` with message: `fix(service): evict ghost orch serve processes and detect stale runtime pids`.
- Verified clean working tree after commit (`git status` clean) and confirmed commit exists in `main..HEAD`.


### Remaining

- Run full local validation suite (`cargo nextest run`) in an environment without stale Cargo build locks, or rely on CI execution for final verification.


### Files changed

- `src/home.rs`
- `src/engine/mod.rs`
- `src/engine/events.rs`
- `src/cli/mod.rs`


Closes #3220

---
*Task #3220 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.3-codex`*