### PR TITLE
bug(runner): claude 'session limit' not detected as RateLimit — gets short generic backoff

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -1029,6 +1029,7 @@ pub(crate) mod patterns {
             "rate increased too quickly", // Alibaba / Qwen via OpenCode
             "too many requests",
             "usage limit",
+            "session limit", // catches "You've hit your session limit · resets …"
             "quota exceeded",
             "overloaded",
             "capacity",
@@ -1713,6 +1714,10 @@ mod tests {
         assert!(patterns::detect_rate_limit("Error: rate limit exceeded").is_some());
         assert!(patterns::detect_rate_limit("HTTP 429 Too Many Requests").is_some());
         assert!(patterns::detect_rate_limit("You've hit your usage limit").is_some());
+        assert!(patterns::detect_rate_limit(
+            "You've hit your session limit · resets 10:30am (America/Sao_Paulo)"
+        )
+        .is_some());
         assert!(patterns::detect_rate_limit(
             "Upstream error from Alibaba: Request rate increased too quickly. \
              To ensure system stability, please adjust your client logic to scale requests more smoothly over time."


### PR DESCRIPTION
## Summary

The fix is committed. One-line addition of `"session limit"` to `detect_rate_limit()` patterns in `src/engine/runner/agents/mod.rs:1032`, plus a test case confirming it matches the exact error string seen in production. All 8 `detect_rate_limit` tests pass; fmt and clippy clean.

```json
{
  "summary": "Added \"session limit\" to detect_rate_limit() patterns so claude's 'You\\'ve hit your session limit' error is classified as AgentError::RateLimit (triggering proper rate-limit cooldown) instead 

### Files changed

- `src/engine/runner/agents/mod.rs`


Closes #3231

---
*Task #3231 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*