### PR TITLE
bug(parser): normalize_status missing 'changes_pushed' status alias

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -169,6 +169,7 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         | "no_trades_no_positions"
         | "changes_made"
         | "change_made"
+        | "changes_pushed"
         | "acknowledged"
         | "flat"
         | "no_action"
@@ -972,6 +973,13 @@ Some output here.
     }
 
     #[test]
+    fn parse_normalizes_changes_pushed_alias_to_done() {
+        let input = r#"{"status":"changes_pushed","summary":"changes pushed to branch","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "done");
+    }
+
+    #[test]
     fn parse_normalizes_running_alias_to_in_progress() {
         let input = r#"{"status":"running","summary":"working","accomplished":[],"remaining":[],"files":[]}"#;
         let resp = parse(input).unwrap();
@@ -1111,6 +1119,9 @@ Some output here.
             ("skip", "done"),
             ("no_changes_needed", "done"),
             ("no_trades_no_positions", "done"),
+            ("changes_made", "done"),
+            ("changes_pushed", "done"),
+            ("changes_addressed", "done"),
             ("running", "in_progress"),
             ("partial", "in_progress"),
             ("reviewing", "in_review"),


### PR DESCRIPTION
## Summary

I'll help you fix this bug. Let me start by reading the current parser.rs file to see the exact location and context of the `normalize_status()` function.
I can see the issue. The `normalize_status()` function at line 156 has a match arm for completion statuses that doesn't include `"changes_pushed"`. Let me add it:
Now let me add a test case to verify the new status alias works correctly:
Now let me update the regression test that lists all normalization aliases to include the new status:
Now l

### What was done

- Fixed:** Bug in `src/parser.rs` where the `normalize_status()` function was rejecting valid `"changes_pushed"` status from agents.
- Changes:**
- Added `"changes_pushed"` to the list of completion status aliases (line 171) that normalize to `"done"`
- Added test case `parse_normalizes_changes_pushed_alias_to_done()` to verify the fix
- Updated the regression test to include `"changes_pushed"` in the list of all known status aliases
- Impact:** Task `internal:151338` (attempt 4) that returned `status="changes_pushed"` will now be correctly recognized as completed instead of failing with "unrecognized status" error.
- Quality checks:** ✓ Format ✓ Clippy ✓ Tests (1739 passed)


### Files changed

- `src/parser.rs`


Closes #3230

---
*Task #3230 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*