### PR TITLE
feat(router): add simple models config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,20 +121,7 @@ workflow:
 
 ## Complexity-based model routing
 
-The router assigns `complexity: simple|medium|complex` instead of specific model names. The actual model is resolved per agent from `config.yml`.
-
-Two config forms are supported. The simple form sets one candidate (or list) per agent, used for all four tiers (`simple`, `medium`, `complex`, `review`):
-
-```yaml
-models:
-  claude: haiku
-  codex: gpt-5.2-codex
-  opencode:
-    - opencode:free
-    - github-copilot/gpt-5-mini
-```
-
-The advanced form maps each complexity tier explicitly. Entries here override `models:` for the specified tier and agent:
+The router assigns `complexity: simple|medium|complex` instead of specific model names. The actual model is resolved per agent from `config.yml`:
 
 ```yaml
 model_map:
@@ -152,7 +139,7 @@ model_map:
     codex: gpt-5.2
 ```
 
-Complexity is set by the router LLM under `mode: "llm"`, or by `complexity:*` labels (defaulting to `medium`) under `round_robin` / `weighted_round_robin`. See `model_for_complexity()` in the router module.
+See `model_for_complexity()` in the router module.
 
 ## Router Module (Rust)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,20 @@ workflow:
 
 ## Complexity-based model routing
 
-The router assigns `complexity: simple|medium|complex` instead of specific model names. The actual model is resolved per agent from `config.yml`:
+The router assigns `complexity: simple|medium|complex` instead of specific model names. The actual model is resolved per agent from `config.yml`.
+
+Two config forms are supported. The simple form sets one candidate (or list) per agent, used for all four tiers (`simple`, `medium`, `complex`, `review`):
+
+```yaml
+models:
+  claude: haiku
+  codex: gpt-5.2-codex
+  opencode:
+    - opencode:free
+    - github-copilot/gpt-5-mini
+```
+
+The advanced form maps each complexity tier explicitly. Entries here override `models:` for the specified tier and agent:
 
 ```yaml
 model_map:
@@ -139,7 +152,7 @@ model_map:
     codex: gpt-5.2
 ```
 
-See `model_for_complexity()` in the router module.
+Complexity is set by the router LLM under `mode: "llm"`, or by `complexity:*` labels (defaulting to `medium`) under `round_robin` / `weighted_round_robin`. See `model_for_complexity()` in the router module.
 
 ## Router Module (Rust)
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -94,8 +94,8 @@ router:
     - git-worktree
 
 # Simple model config. Each agent's candidates are used for simple, medium,
-# complex, and review tasks. When multiple candidates are listed, orch selects
-# uniformly across available non-cooled models.
+# complex, and review tasks. When multiple candidates are listed, orch picks
+# one based on the router mode and skips cooled / unavailable models.
 models:
   claude: haiku
   codex: gpt-5.2-codex

--- a/config.example.yml
+++ b/config.example.yml
@@ -55,7 +55,7 @@ engine:
   # silence_cooldown: 3600
 
 router:
-  mode: "llm"              # "llm" (default), "local", or "round_robin"
+  mode: "round_robin"      # "round_robin" (default), "llm", or "local"
   agent: "claude"          # Which agent performs routing
   model: "haiku"           # Model for routing (fast/cheap)
   timeout_seconds: 60
@@ -72,7 +72,7 @@ router:
   #   claude: 0.25
   #   codex: 0.1
   #   opencode: 0.25
-  # Routing pool for LLM router (agent:model pairs)
+  # Routing pool for LLM router (agent:model pairs; only used when mode: "llm")
   # pool:
   #   - claude:haiku
   #   - opencode:free
@@ -93,44 +93,31 @@ router:
     - gh
     - git-worktree
 
-model_map:
-  simple:
-    claude: haiku
-    codex: gpt-5.2-codex
-    opencode:
-      - opencode:free
-      - github-copilot/gpt-5-mini
-    kimi: sonnet
-    minimax: sonnet
-    # olm: qwen3.5
-  medium:
-    claude: sonnet
-    codex: gpt-5.3-codex
-    opencode:
-      - opencode:free
-      - github-copilot/claude-sonnet-4.6
-      - github-copilot/gpt-5.4
-    kimi: opus
-    minimax: opus
-    # olm: gemma4
-  complex:
-    claude: opus
-    codex: gpt-5.4
-    opencode:
-      - github-copilot/claude-opus-4.6
-      - github-copilot/gpt-5.4
-    kimi: opus
-    minimax: opus
-    # olm: gemma4
-  review:
-    claude: sonnet
-    codex: gpt-5.3-codex
-    opencode:
-      - opencode:free
-      - github-copilot/gpt-5-mini
-    kimi: opus
-    minimax: opus
-    # olm: qwen3.5
+# Simple model config. Each agent's candidates are used for simple, medium,
+# complex, and review tasks. When multiple candidates are listed, orch selects
+# uniformly across available non-cooled models.
+models:
+  claude: haiku
+  codex: gpt-5.2-codex
+  opencode:
+    - opencode:free
+    - github-copilot/gpt-5-mini
+  kimi: sonnet
+  minimax: sonnet
+  # olm: qwen3.5
+
+# Advanced model config. Use this only when an agent needs different model
+# candidates for different complexity tiers. Entries here override `models:`
+# for the specified tier and agent.
+# model_map:
+#   simple:
+#     codex: gpt-5.2-codex
+#   medium:
+#     codex: gpt-5.3-codex
+#   complex:
+#     codex: gpt-5.4
+#   review:
+#     codex: gpt-5.3-codex
 
 gh:
   repo: "owner/repo"

--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -222,7 +222,7 @@ pub fn parse_pool_entry(entry: &str) -> (String, String) {
 impl Default for RouterConfig {
     fn default() -> Self {
         Self {
-            mode: "llm".to_string(),
+            mode: "round_robin".to_string(),
             router_agent: "claude".to_string(),
             router_model: "claude-haiku-4-5-20251001".to_string(),
             timeout_seconds: 45,
@@ -434,37 +434,39 @@ impl RouterConfig {
             }
         }
 
+        // Load top-level model shorthand from config (models.{agent}).
+        //
+        // These candidates apply to every complexity tier by default. More
+        // specific model_map.{complexity}.{agent} entries below override the
+        // shorthand for that one tier.
+        let known_agents = crate::engine::configured_agents();
+        let known_complexities = ["simple", "medium", "complex", "review"];
+        for agent in &known_agents {
+            let key = format!("models.{agent}");
+            if let Some(models) = Self::read_model_pool_from_config(&key) {
+                for complexity in known_complexities {
+                    config
+                        .model_map
+                        .entry(complexity.to_string())
+                        .or_default()
+                        .insert(agent.to_string(), models.clone());
+                }
+            }
+        }
+
         // Load model_map overrides from config (model_map.{complexity}.{agent})
         // Value may be a single string ("model-name") or a JSON array (["m1","m2"]).
         // Iterate over all known complexity tiers regardless of what is in model_map —
         // the Default impl has no hardcoded entries, so iterating over keys() would be a no-op.
-        let known_agents = crate::engine::configured_agents();
-        let known_complexities = ["simple", "medium", "complex", "review"];
         for complexity in known_complexities {
             for agent in &known_agents {
                 let key = format!("model_map.{complexity}.{agent}");
-                // Try as list first (YAML arrays), fall back to single string
-                if let Ok(list) = crate::config::get_list(&key) {
-                    if !list.is_empty() {
-                        let normalized: Vec<String> = list
-                            .iter()
-                            .map(|m| RouterConfig::normalize_model_identifier(m))
-                            .collect();
-                        config
-                            .model_map
-                            .entry(complexity.to_string())
-                            .or_default()
-                            .insert(agent.to_string(), normalized);
-                    }
-                } else if let Ok(val) = crate::config::get(&key) {
-                    if !val.is_empty() {
-                        let normalized = RouterConfig::normalize_model_identifier(&val);
-                        config
-                            .model_map
-                            .entry(complexity.to_string())
-                            .or_default()
-                            .insert(agent.to_string(), vec![normalized]);
-                    }
+                if let Some(models) = Self::read_model_pool_from_config(&key) {
+                    config
+                        .model_map
+                        .entry(complexity.to_string())
+                        .or_default()
+                        .insert(agent.to_string(), models);
                 }
             }
         }
@@ -589,6 +591,24 @@ impl RouterConfig {
     /// a model string might have been incorrectly formatted.
     pub fn normalize_model_identifier(model: &str) -> String {
         model.trim_end_matches('/').to_string()
+    }
+
+    fn read_model_pool_from_config(key: &str) -> Option<Vec<String>> {
+        if let Ok(list) = crate::config::get_list(key) {
+            if !list.is_empty() {
+                return Some(
+                    list.iter()
+                        .map(|m| RouterConfig::normalize_model_identifier(m))
+                        .collect(),
+                );
+            }
+        } else if let Ok(val) = crate::config::get(key) {
+            if !val.is_empty() {
+                return Some(vec![RouterConfig::normalize_model_identifier(&val)]);
+            }
+        }
+
+        None
     }
 
     fn expanded_model_pool(&self, agent: &str, complexity: &str) -> Option<Vec<String>> {
@@ -1038,6 +1058,106 @@ model_map:
         assert_eq!(
             config.model_for_complexity("claude", "simple", "test-task"),
             Some("haiku".to_string()),
+        );
+    }
+
+    #[serial(cooldown_state)]
+    #[test]
+    fn from_config_loads_models_shorthand_for_all_complexities() {
+        let _lock = cwd_mutex().lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".orch.yml"),
+            r#"
+agents:
+  - shorthand
+models:
+  shorthand:
+    - gpt-5.2
+    - gpt-5.5
+"#,
+        )
+        .unwrap();
+        let _guard = CurrentDirGuard::set(dir.path());
+
+        let config = RouterConfig::from_config();
+
+        for complexity in ["simple", "medium", "complex", "review"] {
+            assert_eq!(
+                config.model_map[complexity]["shorthand"],
+                vec!["gpt-5.2".to_string(), "gpt-5.5".to_string()],
+                "models.shorthand should populate {complexity}"
+            );
+        }
+    }
+
+    #[serial(cooldown_state)]
+    #[test]
+    fn from_config_loads_single_model_shorthand_for_all_complexities() {
+        let _lock = cwd_mutex().lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".orch.yml"),
+            r#"
+agents:
+  - shorthand
+models:
+  shorthand: gpt-5.2
+"#,
+        )
+        .unwrap();
+        let _guard = CurrentDirGuard::set(dir.path());
+
+        let config = RouterConfig::from_config();
+
+        for complexity in ["simple", "medium", "complex", "review"] {
+            assert_eq!(
+                config.model_map[complexity]["shorthand"],
+                vec!["gpt-5.2".to_string()],
+                "models.shorthand should populate {complexity}"
+            );
+        }
+    }
+
+    #[serial(cooldown_state)]
+    #[test]
+    fn from_config_model_map_overrides_models_shorthand_per_tier() {
+        let _lock = cwd_mutex().lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".orch.yml"),
+            r#"
+agents:
+  - shorthand
+models:
+  shorthand:
+    - gpt-5.2
+    - gpt-5.5
+model_map:
+  review:
+    shorthand: gpt-5.6-review
+"#,
+        )
+        .unwrap();
+        let _guard = CurrentDirGuard::set(dir.path());
+
+        let config = RouterConfig::from_config();
+
+        assert_eq!(
+            config.model_map["simple"]["shorthand"],
+            vec!["gpt-5.2".to_string(), "gpt-5.5".to_string()]
+        );
+        assert_eq!(
+            config.model_map["medium"]["shorthand"],
+            vec!["gpt-5.2".to_string(), "gpt-5.5".to_string()]
+        );
+        assert_eq!(
+            config.model_map["complex"]["shorthand"],
+            vec!["gpt-5.2".to_string(), "gpt-5.5".to_string()]
+        );
+        assert_eq!(
+            config.model_map["review"]["shorthand"],
+            vec!["gpt-5.6-review".to_string()]
         );
     }
 

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -1651,7 +1651,7 @@ mod tests {
             .or_default()
             .insert("claude".to_string(), vec!["haiku".to_string()]);
 
-        assert_eq!(config.mode, "llm");
+        assert_eq!(config.mode, "round_robin");
         assert_eq!(config.router_agent, "claude");
         assert_eq!(config.router_model, "claude-haiku-4-5-20251001");
         assert_eq!(config.fallback_executor, "codex");

--- a/tests/integration_engine.rs
+++ b/tests/integration_engine.rs
@@ -137,7 +137,7 @@ fn router_config_parses() {
     // In test context there's no config file, so it uses defaults.
     let config = orch::engine::router::config::RouterConfig::from_config();
     assert!(!config.agents.is_empty(), "should have default agents");
-    assert_eq!(config.mode, "llm");
+    assert_eq!(config.mode, "round_robin");
 }
 
 /// Verify that the mock backend passes the health check.


### PR DESCRIPTION
## Summary

- add top-level `models:` shorthand that applies each agent's model candidates to simple, medium, complex, and review tiers
- keep `model_map:` as the advanced per-complexity override path
- make `round_robin` the default router mode and update the example config around the simple/advanced split

## Testing

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q engine::router::config::tests`
- `cargo nextest run` (rerun with escalation after sandbox blocked the webhook port-binding test; full suite passed: 3597 passed, 19 skipped)
