### PR TITLE
Add /restart command to control plane (Telegram, Discord, chat)

### DIFF
--- a/prompts/control_system.md
+++ b/prompts/control_system.md
@@ -20,6 +20,7 @@ You can run CLI commands to manage tasks, check status, and take actions. Use ba
 - `orch service restart` — restart the service
 - `/model [agent:]<model>` — switch the sticky model (or show current agent:model)
 - `/agent <claude|codex|opencode>` — switch the sticky agent and its default model (or show current)
+- `/restart` — gracefully restart the orch service; sends confirmation when back online
 - `gh pr list` — list open pull requests
 - `gh run list` — list CI workflow runs
 - `gh issue list` — list open issues

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -41,7 +41,7 @@ pub async fn interactive(session_id: &str) -> anyhow::Result<()> {
             break;
         }
 
-        match control::maybe_handle_control_command(&store, session_id, message).await? {
+        match control::maybe_handle_control_command(&store, session_id, None, message).await? {
             Some(response) => {
                 println!("{response}");
                 println!();
@@ -65,7 +65,7 @@ pub async fn interactive(session_id: &str) -> anyhow::Result<()> {
 pub async fn single_message(session_id: &str, message: &str) -> anyhow::Result<()> {
     let store = crate::cli::init_store().await?;
     if let Some(response) =
-        control::maybe_handle_control_command(&store, session_id, message).await?
+        control::maybe_handle_control_command(&store, session_id, None, message).await?
     {
         println!("{response}");
         return Ok(());

--- a/src/control.rs
+++ b/src/control.rs
@@ -64,6 +64,7 @@ pub struct ModelSpec {
 pub enum ControlCommand {
     Model(Option<String>),
     Agent(Option<String>),
+    Restart,
 }
 
 fn default_model_for_agent(agent: &str) -> &'static str {
@@ -89,6 +90,7 @@ pub fn parse_control_command(message: &str) -> Option<ControlCommand> {
         "agent" => Some(ControlCommand::Agent(
             (!args.is_empty()).then(|| args.to_string()),
         )),
+        "restart" => Some(ControlCommand::Restart),
         _ => None,
     }
 }
@@ -393,6 +395,7 @@ fn format_switched_spec(spec: &ModelSpec) -> String {
 async fn handle_control_command(
     store: &TaskStore,
     session_id: &str,
+    channel_thread: Option<&str>,
     command: ControlCommand,
 ) -> Result<String> {
     match command {
@@ -413,6 +416,22 @@ async fn handle_control_command(
             reset_session_uuid(store, session_id).await?;
             Ok(format_switched_spec(&spec))
         }
+        ControlCommand::Restart => {
+            // Store the conversation key so the post-restart startup check can send a confirmation.
+            if let Some(ct) = channel_thread {
+                store.kv_set("control:restart_pending", ct).await.ok();
+            }
+            // Delay the SIGTERM slightly so the acknowledgment reply is delivered first.
+            tokio::spawn(async {
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                let pid = std::process::id().to_string();
+                let _ = tokio::process::Command::new("kill")
+                    .args(["-TERM", &pid])
+                    .status()
+                    .await;
+            });
+            Ok("Restarting orch service\u{2026} I'll confirm here when back online.".to_string())
+        }
     }
 }
 
@@ -420,10 +439,13 @@ async fn handle_control_command(
 pub async fn maybe_handle_control_command(
     store: &TaskStore,
     session_id: &str,
+    channel_thread: Option<&str>,
     message: &str,
 ) -> Result<Option<String>> {
     Ok(match parse_control_command(message) {
-        Some(command) => Some(handle_control_command(store, session_id, command).await?),
+        Some(command) => {
+            Some(handle_control_command(store, session_id, channel_thread, command).await?)
+        }
         None => None,
     })
 }
@@ -659,7 +681,9 @@ pub async fn send_message(
     message: &str,
 ) -> Result<String> {
     // Handle control commands — don't store as messages.
-    if let Some(response) = maybe_handle_control_command(store, session_id, message).await? {
+    if let Some(response) =
+        maybe_handle_control_command(store, session_id, channel_thread, message).await?
+    {
         return Ok(response);
     }
 
@@ -1047,6 +1071,10 @@ mod tests {
                 "opencode:deepseek-r1".to_string()
             )))
         );
+        assert_eq!(
+            parse_control_command("/restart"),
+            Some(ControlCommand::Restart)
+        );
         assert_eq!(parse_control_command("/kill"), None);
         assert_eq!(parse_control_command("/session"), None);
     }
@@ -1059,7 +1087,7 @@ mod tests {
             .map(|caps| caps[1].to_string())
             .collect::<std::collections::BTreeSet<_>>();
 
-        let expected = ["agent", "model"]
+        let expected = ["agent", "model", "restart"]
             .into_iter()
             .map(str::to_string)
             .collect::<std::collections::BTreeSet<_>>();
@@ -1124,7 +1152,8 @@ mod tests {
         set_agent(&store, "claude").await.unwrap();
 
         // Try switching to an unknown agent — should fail
-        let result = maybe_handle_control_command(&store, "default", "/agent bogusagent").await;
+        let result =
+            maybe_handle_control_command(&store, "default", None, "/agent bogusagent").await;
         assert!(result.is_err(), "should reject unknown agent");
         assert!(result.unwrap_err().to_string().contains("unknown agent"));
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1194,6 +1194,53 @@ pub async fn serve() -> anyhow::Result<()> {
         });
     }
 
+    // Post-restart confirmation: if the service was restarted via the /restart control command,
+    // a KV marker was stored before shutdown. Send a confirmation to the originating channel now
+    // that we're back online. Use a short delay to let the channel connections re-establish.
+    {
+        let restart_channels = channel_registry.clone();
+        let restart_store = project_engines.first().map(|e| e.store.clone());
+        if let Some(store) = restart_store {
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                match store.kv_get("control:restart_pending").await {
+                    Ok(Some(conv_key)) => {
+                        if let Some((ch_name, thread_id, topic_id)) =
+                            crate::channels::transport::parse_conversation_key(&conv_key)
+                        {
+                            for ch in restart_channels.iter() {
+                                if ch.name() == ch_name {
+                                    let msg = OutgoingMessage {
+                                        thread_id: thread_id.to_string(),
+                                        body: "orch restarted successfully.".to_string(),
+                                        reply_to: None,
+                                        metadata: serde_json::json!({}),
+                                        topic_id: topic_id.map(|t| t.to_string()),
+                                    };
+                                    if let Err(e) = ch.send(&msg).await {
+                                        tracing::warn!(
+                                            channel = ch_name,
+                                            error = %e,
+                                            "failed to send restart confirmation"
+                                        );
+                                    }
+                                    break;
+                                }
+                            }
+                        }
+                        if let Err(e) = store.kv_delete("control:restart_pending").await {
+                            tracing::warn!(error = %e, "failed to clear control:restart_pending");
+                        }
+                    }
+                    Ok(None) => {} // no pending restart, nothing to do
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed to read control:restart_pending");
+                    }
+                }
+            });
+        }
+    }
+
     // Spawn notification dispatcher — reads task completion notifications
     // from transport and broadcasts to configured channels.
     //


### PR DESCRIPTION
## Summary

Added /restart command to control plane (Telegram, Discord, orch chat). Stores restart_pending KV marker before sending SIGTERM to self, posts confirmation on next startup.

### Files changed

- `prompts/control_system.md`
- `src/cli/chat.rs`
- `src/control.rs`
- `src/engine/mod.rs`


Closes #3263

---
*Task #3263 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*