### PR TITLE
fix(parser): add missing normalize_status aliases + guard detect_rate_limit false positives

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -1111,6 +1111,25 @@ pub(crate) mod patterns {
                     .next()
                     .is_some_and(|c| c.is_ascii_digit())
             }));
+
+        // Guard against false positives: if "rate_limit" appears near the start of the
+        // text without an error-context indicator nearby, it may be from test output
+        // (e.g. nextest progress lines) or a stored-error prefix rather than a real
+        // rate limit error. Require an error indicator (429/http/error/failed) nearby.
+        if let Some(pos) = match_pos {
+            if pos < 100 {
+                let window_start = pos.saturating_sub(50);
+                let window_end = (pos + 100).min(lower.len());
+                let context = &lower[window_start..window_end];
+                let has_error_context =
+                    context.contains("429") || context.contains("http")
+                    || context.contains("error") || context.contains("failed");
+                if !has_error_context {
+                    return None;
+                }
+            }
+        }
+
         if match_pos.is_some() || has_429 || has_529 {
             let message = if let Some(pos) = match_pos {
                 extract_context_around(text, pos, 300)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -165,6 +165,8 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         | "skip"
         | "ok"
         | "success"
+        | "noop"
+        | "green"
         | "no_changes_needed"
         | "no_trades_no_positions"
         | "changes_made"
@@ -178,11 +180,12 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         | "changes_addressed"
         | "review_addressed"
         | "already_finalized_in_attempt_1"
-        | "alert" => "done".to_string(),
+        | "alert"
+        | "alerts_sent" => "done".to_string(),
         // Canonical progress statuses.
         // `partial` is used by some models to indicate partial progress —
         // treat it as in_progress so the task remains open for follow-up.
-        "in_progress" | "running" | "partial" => "in_progress".to_string(),
+        "in_progress" | "running" | "partial" | "waiting" => "in_progress".to_string(),
         "in_review" | "reviewing" => "in_review".to_string(),
         "needs_review" | "pending_review" | "ready_for_review" => "needs_review".to_string(),
         // Canonical error statuses.


### PR DESCRIPTION
## Summary

Two small fixes for the orch parser:

### Fix 1: normalize_status missing aliases (closes #3273)

`normalize_status` did not recognize `noop`, `green`, `alerts_sent` → `done` and `waiting` → `in_progress`. This caused agent statuses from some providers to not be normalized correctly.

### Fix 2: detect_rate_limit false-positive guard (closes #3274)

`detect_rate_limit` could trigger on bare `rate_limit` strings early in output (e.g. nextest progress lines or stored-error prefixes) without actual error context. Added a guard: when the match position is < 100 bytes from start, require an error indicator (`429`/`http`/`error`/`failed`) within a 150-byte window.

## Changes

- `src/parser.rs`: add `noop`, `green`, `alerts_sent` to `done`; add `waiting` to `in_progress`
- `src/engine/runner/agents/mod.rs`: add early-match error-context guard in `detect_rate_limit`

## Testing

Existing tests in `pattern_detect_rate_limit` and `detect_rate_limit_message_contains_context_not_tail` pass. The new guard is designed to not affect any existing true-positive cases.
