### PR TITLE
fix: word-boundary check + normalize_status tests (addressing #3275 review)

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -1065,6 +1065,24 @@ pub(crate) mod patterns {
     use super::AgentError;
     use std::time::Duration;
 
+    /// Returns true if the pattern found at `lower_pos` (byte offset in lowercase text)
+    /// is at a word boundary in the original `text` — i.e., surrounded by non-identifier
+    /// chars. Used to suppress false positives from identifiers like `record_rate_limit_returns_id`.
+    fn is_word_boundary(text: &str, lower_pos: usize, pattern: &str) -> bool {
+        let after_match = lower_pos + pattern.len();
+        let prev_is_boundary = lower_pos == 0
+            || !text[..lower_pos]
+                .chars()
+                .last()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        let next_is_boundary = after_match >= text.len()
+            || !text[after_match..]
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        prev_is_boundary && next_is_boundary
+    }
+
     /// Check for rate limit / usage limit patterns in text.
     pub fn detect_rate_limit(text: &str) -> Option<AgentError> {
         let lower = text.to_lowercase();
@@ -1112,20 +1130,15 @@ pub(crate) mod patterns {
                     .is_some_and(|c| c.is_ascii_digit())
             }));
 
-        // Guard against false positives: if "rate_limit" appears near the start of the
-        // text without an error-context indicator nearby, it may be from test output
-        // (e.g. nextest progress lines) or a stored-error prefix rather than a real
-        // rate limit error. Require an error indicator (429/http/error/failed) nearby.
-        if let Some(pos) = match_pos {
-            if pos < 100 {
-                let window_start = pos.saturating_sub(50);
-                let window_end = (pos + 100).min(lower.len());
-                let context = &lower[window_start..window_end];
-                let has_error_context =
-                    context.contains("429") || context.contains("http")
-                    || context.contains("error") || context.contains("failed");
-                if !has_error_context {
-                    return None;
+        // Guard: skip "rate_limit"/"ratelimit" unless at a word boundary — prevents
+        // false positives from test identifiers like `record_rate_limit_returns_id`.
+        // Other patterns (natural-language phrases) are low risk.
+        if let Some(lower_pos) = match_pos {
+            for pat in ["rate_limit", "ratelimit"] {
+                if let Some(pat_pos) = lower.find(pat) {
+                    if pat_pos == lower_pos && !is_word_boundary(text, lower_pos, pat) {
+                        return None;
+                    }
                 }
             }
         }

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -1111,6 +1111,25 @@ pub(crate) mod patterns {
                     .next()
                     .is_some_and(|c| c.is_ascii_digit())
             }));
+
+        // Guard against false positives: if "rate_limit" appears near the start of the
+        // text without an error-context indicator nearby, it may be from test output
+        // (e.g. nextest progress lines) or a stored-error prefix rather than a real
+        // rate limit error. Require an error indicator (429/http/error/failed) nearby.
+        if let Some(pos) = match_pos {
+            if pos < 100 {
+                let window_start = pos.saturating_sub(50);
+                let window_end = (pos + 100).min(lower.len());
+                let context = &lower[window_start..window_end];
+                let has_error_context =
+                    context.contains("429") || context.contains("http")
+                    || context.contains("error") || context.contains("failed");
+                if !has_error_context {
+                    return None;
+                }
+            }
+        }
+
         if match_pos.is_some() || has_429 || has_529 {
             let message = if let Some(pos) = match_pos {
                 extract_context_around(text, pos, 300)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -993,6 +993,36 @@ Some output here.
     }
 
     #[test]
+    fn parse_normalizes_noop_alias_to_done() {
+        // noop / green / alerts_sent → done, matching #3273 alias map.
+        let input = r#"{"status":"noop","summary":"nothing to do","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "done");
+    }
+
+    #[test]
+    fn parse_normalizes_green_alias_to_done() {
+        let input = r#"{"status":"green","summary":"all passing","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "done");
+    }
+
+    #[test]
+    fn parse_normalizes_alerts_sent_alias_to_done() {
+        let input = r#"{"status":"alerts_sent","summary":"notifications dispatched","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "done");
+    }
+
+    #[test]
+    fn parse_normalizes_waiting_alias_to_in_progress() {
+        // waiting → in_progress (distinct from running/partial in the alias map).
+        let input = r#"{"status":"waiting","summary":"blocked on upstream","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "in_progress");
+    }
+
+    #[test]
     fn parse_normalizes_changes_pushed_alias_to_done() {
         let input = r#"{"status":"changes_pushed","summary":"changes pushed to branch","accomplished":[],"remaining":[],"files":[]}"#;
         let resp = parse(input).unwrap();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -165,6 +165,8 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         | "skip"
         | "ok"
         | "success"
+        | "noop"
+        | "green"
         | "no_changes_needed"
         | "no_trades_no_positions"
         | "changes_made"
@@ -178,11 +180,12 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         | "changes_addressed"
         | "review_addressed"
         | "already_finalized_in_attempt_1"
-        | "alert" => "done".to_string(),
+        | "alert"
+        | "alerts_sent" => "done".to_string(),
         // Canonical progress statuses.
         // `partial` is used by some models to indicate partial progress —
         // treat it as in_progress so the task remains open for follow-up.
-        "in_progress" | "running" | "partial" => "in_progress".to_string(),
+        "in_progress" | "running" | "partial" | "waiting" => "in_progress".to_string(),
         "in_review" | "reviewing" => "in_review".to_string(),
         "needs_review" | "pending_review" | "ready_for_review" => "needs_review".to_string(),
         // Canonical error statuses.


### PR DESCRIPTION
This PR replaces the failed guard approach in the existing PR #3275 with a word-boundary check, and adds the missing normalize_status tests.

## Changes

### Fix 2 — detect_rate_limit word-boundary check
- Removed the  positional guard that broke legitimate messages like "You've hit your usage limit" (position 0, no nearby error context)
- Added  helper: checks the chars immediately before/after the pattern are not alphanumeric or underscore
- Applied to  and  patterns only — these are the only ones that appear inside identifiers like 
- Natural-language phrases (, , , etc.) are NOT affected

### Fix 1 — normalize_status alias tests
- Added  test
- Added  test
- Added  test
- Added  test

## Reviewer feedback addressed
- Fix 1: added tests as requested (was the only blocker for landing)
- Fix 2: replaced the broken guard entirely with word-boundary approach
- Split suggestion: Fix 1 and Fix 2 are now in this single PR; happy to close #3275 and land this instead

Closes #3273