### PR TITLE
Daily review (last 24h)

### DIFF
--- a/docs/content/posts/daily-review-2026-06-05.md
+++ b/docs/content/posts/daily-review-2026-06-05.md
@@ -8,103 +8,122 @@ description = "End-of-day operational review: commits, issues, task health, and 
 
 ## What Shipped (Last 24h)
 
-**10 commits landed**, double the previous window, driven by bug-fix batch:
+**7 commits landed** on `gabrielkoerich/orch`:
 
 | Commit | Description |
 |--------|-------------|
-| `27cc9dd4` | fix(parser): add review_addressed and already_finalized_in_attempt_1 to normalize_status (#3257) |
-| `6eb188cb` | feat(engine): update src/engine/mod.rs |
-| `122f05fc` | docs(jobs): update jobs files |
-| `11282a98` | feat(router): add simple models config (#3247) |
-| `c1bcf9e9` | chore(workflows): update release.yml |
-| `fa0cc020` | docs: audit and refresh README + docs (#3252) |
-| `1dffd595` | chore(agents-md): trim feature descriptions, keep prohibitions (#3253) |
-| `08c17b2a` | fix(notifications): dedup dispatch, title-first layout, suppress needs_review pings (#3251) |
-| `b514b456` | feat(notifications): add GitHub link to task notifications (#3250) |
-| `76262a5e` | Morning review (#3249) |
+| `9b839c0d` | feat: trim top-level CLI stats commands (#3270) |
+| `3543f7a7` | orch commit: generate messages via LLM agent instead of path/hunk heuristic |
+| `38474487` | Add `/restart` command to control plane (Telegram, Discord, chat) (#3266) |
+| `8aa0a9d3` | feat(cli): trim top-level help — hide serve, nest cron/events/session (#3265) |
+| `1eb62146` | bug(review): empty-branch tasks loop in needs_review — review agent can't create PR with zero commits (#3262) |
+| `05eb2166` | fix(parser): add `alert` to normalize_status done aliases (#3254 / #3261) |
+| `4084410b` | docs(posts): daily review for 2026-06-05 (#3260) |
 
 **Closed issues (today):**
-- **#3255** — `review_addressed`/`already_finalized_in_attempt_1` aliases (fixed by #3257)
-- **#3256** — 429 rate limits from kimi/minimax/glm misclassified as `failed` (CLOSED)
-- **#3230** — `changes_pushed` alias (CLOSED, via #3257 or earlier)
-- **#3231** — Claude session-limit not classified as RateLimit (CLOSED)
 
-**Service upgraded to v0.78.0** (was v0.75.5 in morning review).
+| Issue | Title | Fix |
+|-------|-------|-----|
+| #3271 | bug(router): 'ALL AGENTS COOLED' fires when agent is only degraded | Fixed by #3271 |
+| #3268 | orch commit: generate messages via LLM agent | Merged |
+| #3267 | Trim top-level CLI (phase 2): stats group | Merged as #3270 |
+| #3264 | Trim top-level CLI: hide serve, nest internals | Merged |
+| #3263 | Add `/restart` command to control plane | Merged |
+| #3259 | bug(review): empty-branch tasks loop in needs_review | Fixed by `1eb62146` |
+| #3258 | Restart orch service via Telegram | Merged |
+| #3254 / #3261 | bug(parser): `alert` status alias missing | Fixed by `05eb2166` |
+
+**Service at v0.79.1** — v0.80.0 is available (upgrade pending).
 
 ## Operational Health
 
 ### Task Run Summary (Last 24h)
 
-| Agent | Model | Success | Failed | Other |
-|-------|-------|---------|--------|-------|
-| claude | sonnet | 40 | 2 | — |
-| opencode | deepseek-v4-flash-free | 13 | 1 | 3 null |
-| claude | opus | 9 | 3 | 1 blocked, 1 aborted |
-| opencode | mimo-v2.5-free | 9 | 2 | 2 aborted |
-| opencode | nemotron-3-super-free | 9 | 2 | 1 aborted |
-| opencode | minimax-m3-free | 6 | 2 | 2 aborted |
-| kimi | opus | 4 | 1 | 2 null |
-| codex | gpt-5.3 | 0 | 1 | — |
-| minimax | opus | 0 | 1 | — |
-| glm | opus | 0 | 1 (rate_limit) | — |
-| opencode | nemotron-3-ultra-free | 1 | 1 | 1 aborted |
-| opencode | github-copilot/gpt-5-mini | 0 | 1 | 1 aborted |
+| Agent | Model | Success | Failed | Rate Limit | Timeout | Other |
+|-------|-------|---------|--------|------------|---------|-------|
+| claude | sonnet | 153 | 9 | 1 | — | 3 parse_error, 2 push_failed |
+| claude | opus | 50 | 8 | — | 2 | 2 aborted, 1 blocked |
+| opencode | deepseek-v4-flash-free | 34 | 10 | — | 7 | 1 parse_error |
+| opencode | nemotron-3-ultra-free | 12 | 4 | 1 | 1 | 2 parse_error, 2 aborted |
+| opencode | mimo-v2.5-free | 9 | 3 | — | 1 | 2 aborted |
+| opencode | minimax-m3-free | 6 | 6 | — | — | 2 aborted |
+| kimi | opus | 5 | 5 | 7 | — | 1 aborted |
+| codex | gpt-5.5 | 3 | 4 | 1 | — | — |
+| codex | gpt-5.4 | 3 | — | 1 | — | — |
+| codex | gpt-5.3 | 0 | 3 | — | — | — |
+| minimax | opus | 0 | 6 | 2 | — | — |
 
-**Total successful runs: ~91** across the effective pool.
+**Total agent runs: ~376** across all models. **Review runs: ~130** (mostly claude/sonnet at 82).
 
 ### Agent Pool Health
 
-- **Degraded agents (4):** codex, minimax, glm, olm — all in extended cooldown
-- **Effective routing pool:** claude (sonnet/opus/haiku) + opencode (deepseek-v4-flash-free)
-- **Most opencode free models now on 7-day cooldown** (mimo-v2.5-free, nemotron-3-super-free, minimax-m3-free, etc.) — triggered by persistent model failures
-- **Codex gpt-5.3-codex** still failing ("not supported with ChatGPT account") — account-level restriction, not fixable in code
-- **Multi-agent degradation** identified by engine: `degraded_count=4, agents=["codex", "minimax", "glm", "olm"]`
+- **Active cooldowns:**
+  - `codex` — 3h50m (agent-wide)
+  - `codex:gpt-5.3` — 35m (model-specific)
+  - `minimax` — 23h38m (agent-wide)
+  - `minimax:opus` — 1h53m (model-specific)
+- **Degraded agents (from pre-emptive health check):** codex, opencode, minimax
+- **Effective routing pool:** claude (sonnet/opus) + kimi (opus/sonnet)
+- **Ghost process warning:** pid 72909 running 5h58m — may be a stale service instance
 
-### Key Events
+### Key Error Patterns
 
-| Time (UTC) | Event |
-|------------|-------|
-| ~23:58 | internal:151740 (bean Minervini screeners) → PR #1702 → review approved → merged |
-| ~23:58 | internal:151747 (this task) dispatched to opencode |
-| ~23:59 | internal:151748 (bean evening retrospective) stuck: empty branch, PR creation failed |
-| ~23:59 | #3254 (alert alias) dispatched to claude/haiku (3rd attempt, silent exit issue) |
-| ~00:00 | Transient GitHub connectivity blip (HTTP send failed, 75s timeout) |
-| ~00:00 | New jobs spawned: internal:151767 (live-sleeves-health), internal:151768 (trading-scan) |
-| ~00:00 | kimi review agent approved bean PR #1702 → auto-merge succeeded |
+1. **minimax 429 usage limit exceeded** (6×) — all agent runs failed with `API Error: Request rejected (429) · usage limit exceeded (2056)`. Agent on 23h38m cooldown.
+2. **kimi 429 quota exceeded** (4× agent runs + 7× review runs) — `You've reached your usage limit for this period`. Agent on cooldown.
+3. **opencode empty-output-exit0** (4×) — agent exits with code 0 but produces no output. Deepseek-v4-flash-free model.
+4. **codex gpt-5.3 account restriction** (3×) — `"The 'gpt-5.3' model is not supported when using Codex with a ChatGPT account"`. Model on 35m cooldown.
+5. **Claude "session limit" misclassified** (2× sonnet + 3× opus) — should be `rate_limit` but classified as `failed`. Being fixed in #3272.
+6. **Parser unrecognized status** (5×) — `alert`, `noop`, `green`, `WAITING`, `alerts_sent` not recognized by `normalize_status`. Being fixed in #3273.
+7. **opencode false-positive rate_limit** — `detect_rate_limit` matches `rate_limit` keyword in cargo test / nextest output. Being fixed in #3274.
+8. **Claude silence detection** (3× opus, 2× deepseek-v4-flash-free) — agent runs but produces no JSON output within timeout.
 
-## Stuck Tasks
+## Stuck / Blocked Tasks
 
-| Task | Status | Issue |
-|------|--------|-------|
-| internal:151442 | blocked | Self-improvement: children #3236-#3239 complete but auto-unblock didn't fire |
-| internal:151748 | needs_review loop | Empty branch (zero commits) — review agent can't create PR, keeps cycling |
-| #3254 | in_progress (attempt 3) | alert alias in normalize_status — silent exit on previous attempts |
+| Task | Status | Agent/Model | Issue |
+|------|--------|-------------|-------|
+| internal:151442 | blocked | opencode/gpt-5-mini | Self-improvement (old, Jun 2). Children done but auto-unblock failed. |
+| internal:151994 | blocked | claude/sonnet | Bean close daily — escalated after 6 retries. |
+| internal:152013 | blocked | — | Hyperliquid owner position monitor — escalated after 6 retries. |
+| internal:151961 | blocked | opencode/deepseek-v4-flash-free | Hyperliquid owner position — escalated after 6 retries. |
+| internal:151938 | blocked | opencode/nemotron-3-ultra-free | Hyperliquid SMC report — escalated after 6 retries. |
+| internal:151887 | blocked | claude/opus | Hyperliquid SMC report — 5 attempts. |
+| internal:151997 | in_review | — | Trading update PR #1759 — under review. |
 
-### New Issue Filed: Empty-Branch Review Loop (#3259)
+## Active Development Tasks
 
-The empty-branch pattern hit 2 tasks in 36h (internal:151553, internal:151748). The review pipeline unconditionally tries to create a PR for any branch with commits, but text-only/docs tasks produce zero commits. Fix: check `git rev-list --count main..HEAD` before attempting PR creation — if zero commits, skip the review and mark done.
+Three new bug issues opened today and actively being worked:
+
+| Issue | Agent | Attempts | Status |
+|-------|-------|----------|--------|
+| #3272 — claude session limit misclassified | kimi/opus | 5 | in_progress |
+| #3273 — normalize_status missing aliases | kimi/sonnet | 3 | in_progress |
+| #3274 — opencode false-positive rate_limit | kimi/opus | 2 | routed |
+
+Note: #3271 (router degraded state) was also opened today but has already been closed.
 
 ## Routing Accuracy
 
-- LLM routing selecting cooled agents still happening: `#3254` LLM selected opencode (cooled) → rerouted to claude
-- Label-based routing (`agent:claude` on #3254) correctly overrides LLM on retry
-- Simple models config (#3247) deployed — may improve routing diversity
-- Router timeout cascade still generating slow-tick warnings (38s tick during heavy dispatch)
+- LLM routing correctly selected kimi for today's bug-fix batch after claude and opencode entered degraded/cooled states.
+- Label-based routing (`agent:kimi`) used for #3272-#3274 to distribute load.
+- Weighted round-robin fallback engaged when LLM pool timed out (observed for internal:152033 — 45s timeout, then fallback to kimi).
+- Sequential dispatch mode active due to only 1-2 healthy agents (threshold=2).
+- Slow tick observed: 78s tick during heavy dispatch window (~23:27 UTC), triggering watchdog warning.
 
-## Error Patterns
+## Performance
 
-1. **Transient GitHub connectivity** — HTTP send failed on GraphQL API, recovered on retry. No sustained outage.
-2. **Silent exit 0** — `#3254` retries and `internal:151747` retries both show "silent exit 0" — agent ran, produced no output JSON. Happens with opencode model switches.
-3. **Push failure (exit 128)** — `internal:151748` review gate failed to push because branch has no commits. Root cause is the empty-branch loop.
+- **Watchdog triggered** at 23:27 UTC — tick loop stalled 69s (threshold 60s) during concurrent worktree creation + rebase operations.
+- **Git rebase failures** observed in bean project worktrees — previously applied commits causing conflicts on branch setup. Agent continues with current state.
+- **GitHub GraphQL EOF** transient error when listing open PRs — recovered on retry.
 
 ## Tomorrow's Priorities
 
-1. **Fix empty-branch review loop (#3259)** — add zero-commit check to review pipeline, mark text-only tasks as done
-2. **Monitor #3254** (alert alias) — should complete on this dispatch; if silent exit persists, investigate runner issue
-3. **Unblock internal:151442** — self-improvement task needs manual SQLite reset (`UPDATE tasks SET status = 'done' WHERE external_id = 'internal:151442'`) since auto-unblock failed
-4. **Shrink opencode free-model config** — 4/5 opencode models on 7-day cooldown; config has too many dead entries
-5. **Track kimi recovery** — cooldown expired, waiting for next dispatch to test
+1. **Upgrade to v0.80.0** — `brew update && brew upgrade orch && brew services restart orch`
+2. **Fix ghost process** — pid 72909 is a stale instance; restart service to clean up
+3. **Monitor #3272-#3274** — all three bug fixes should land; review and merge
+4. **Unblock internal:151442** — old self-improvement task stuck since Jun 2; verify if children (#3236-#3239) are truly done and manually reset if needed
+5. **Investigate bean worktree rebase failures** — repeated rebase conflicts on previously-applied commits suggests stale branch state
+6. **Shrink opencode model config** — deepseek-v4-flash-free is the only working free model; others accumulate 7-day cooldowns
 
 ---
 
-*Prepared by Orch automation (internal:151747)*
+*Prepared by Orch automation (internal:152037, attempt 3)*

--- a/docs/content/posts/daily-review-2026-06-06.md
+++ b/docs/content/posts/daily-review-2026-06-06.md
@@ -1,0 +1,102 @@
++++
+title = "Daily Review — 2026-06-06"
+date = 2026-06-06
+description = "End-of-day operational review: commits, issues, task health, and priorities."
++++
+
+# Daily Review — 2026-06-06
+
+## What Shipped (Last 24h)
+
+**1 new commit landed** on `gabrielkoerich/orch`:
+
+| Commit | Description |
+|--------|-------------|
+| `3f26c6f2` | fix(cooldown): sync in-memory map from KV every tick so external clears land |
+
+**Service upgraded to v0.80.1** (was v0.79.1 in yesterday's review). This includes the CLI trim (#3270), `orch commit` LLM messages (#3269), the cooldown sync fix, and all prior fixes through the v0.79.x line.
+
+**No new closed issues** since yesterday's review. The 3 bug fixes (#3272, #3273, #3274) remain open.
+
+## Operational Health
+
+### Task Run Summary (Last 24h)
+
+| Agent | Model | Success | Failed | Rate Limit | Timeout | Parse Error | Other |
+|-------|-------|---------|--------|------------|---------|-------------|-------|
+| claude | sonnet | 113 | 7 | 1 | — | 3 | 1 push_failed |
+| claude | opus | 41 | 5 | — | 2 | — | 1 aborted |
+| opencode | deepseek-v4-flash-free | 20 | 9 | — | 6 | 1 | 1 empty |
+| opencode | nemotron-3-ultra-free | 11 | 3 | 1 | 1 | 2 | — |
+| kimi | opus | 1 | 10 | 7 | — | — | 1 aborted |
+| codex | gpt-5.5 | 3 | 4 | — | — | — | — |
+| codex | gpt-5.4 | 3 | — | 1 | — | — | — |
+| codex | gpt-5.3 | 0 | 2 | — | — | — | — |
+| minimax | opus | 0 | 5 | 2 | — | — | — |
+| opencode | minimax-m3-free | 0 | 4 | — | — | — | — |
+| opencode | mimo-v2.5-free | 0 | 1 | — | 1 | — | — |
+
+**Total agent runs: ~270** (lower than yesterday's ~376 — cooldowns throttled capacity).
+
+### Agent Pool Health
+
+- **Active cooldowns:**
+  - `codex` — 39m (agent-wide, persisted)
+  - `kimi` — 1d21h (agent-wide, billing cycle exhaustion)
+  - `kimi:opus` — 21h8m (model-specific)
+  - `minimax` — 20h27m (agent-wide, persisted)
+- **Degraded agents:** codex, kimi, minimax (3 degraded — same as yesterday)
+- **Recovered agents:** opencode (cleared degradation during this tick)
+- **Effective routing pool:** claude (sonnet/opus) — effectively single-agent operation
+
+### Key Error Patterns
+
+1. **kimi massive cooldown (1d21h)** — kimi hit its usage limit and is locked out for nearly 2 days. All 3 open bug fixes (#3272-#3274) are stuck behind kimi's forced `agent:kimi` label.
+2. **minimax 429 persisted** (5 agent + 2 rate_limit failures) — agent on 20h cooldown.
+3. **opencode empty-output-exit0** (4× deepseek-v4-flash-free) — agent exits with code 0 but no JSON output.
+4. **Claude "session limit" misclassified** (sonnet 2×, opus 3×) — still classified as `failed` not `rate_limit`. #3272 filed but stuck on kimi 429.
+5. **Codex gpt-5.3 account restriction** (2×) — "not supported when using Codex with a ChatGPT account".
+6. **Router LLM pool timed out** at 02:39:04 — tried minimax/haiku (20h cooldown), wasted 45s before weighted round-robin fallback selected opencode. This is the same task running this review.
+7. **Watchdog triggered** at 02:39:24 — tick stalled 79s (threshold 60s) during worktree creation + dispatch.
+8. **Multi-agent degradation warning** persistent: codex=persisted, kimi=agent_error, minimax=persisted.
+
+## Stuck / Blocked Tasks
+
+| Task | Status | Agent/Model | Issue |
+|------|--------|-------------|-------|
+| internal:151442 | blocked | opencode/gpt-5-mini | Self-improvement (old, Jun 2). Children done but auto-unblock failed. |
+| #3272 | new | — (was kimi) | claude session limit misclassification — 5 attempts, all kimi 429 |
+| #3273 | blocked | — (was kimi/sonnet) | normalize_status missing aliases — waiting on PR #3275 contributor |
+| #3274 | blocked | — (was kimi/opus) | opencode false-positive rate_limit — waiting on PR #3275 contributor |
+| internal:151994 | blocked | claude/sonnet | Bean close daily — escalated after 6 retries |
+| internal:152092 | new | — | Not yet routed (cooled pool) |
+
+**Note:** #3273 and #3274 have PR #3275 from contributor @Jah-yee, but review requested splitting into separate PRs. #3276 was opened as an alternative with the split. Owner set ~24h hold for contributor response.
+
+## Routing Accuracy
+
+- LLM routing unavailable for most of the period — all agents in the routing LLM pool (kimi, minimax, codex) were cooled.
+- Weighted round-robin fallback selected opencode (weight 0.2) when LLM pool timed out.
+- Effecitve single-agent mode for execution: only claude sonnet/opus + opencode deepseek-v4-flash-free are available.
+- **Router LLM selected minimax/haiku despite 20h cooldown** — wasted 45s before timeout. The pool index should skip cooled agents.
+- The `agent:kimi` labels on #3272-#3274 are now blocking those tasks since kimi is on cooldown. The engine clears the label on failure, but the router keeps re-selecting kimi. Root cause likely the label override reapplied by issue sync.
+
+## Performance
+
+- **Watchdog triggered** at 02:39:24 — tick stalled 79s. Caused by worktree creation + opencode dispatch during routing cooldown recovery.
+- **Router LLM timeout** (45s minimax/haiku) — contributed 45s of the 79s stall. Fallback to weighted round-robin succeeded.
+- **GitHub GraphQL** operations appear healthy (no EOF errors observed today).
+- **SQLite query latency** minimal across all operations (<1ms for rate limit queries).
+
+## Tomorrow's Priorities
+
+1. **Unblock #3272-#3274** — remove `agent:kimi` labels or apply fix from #3275/#3276 manually. kimi won't be back for 1d21h.
+2. **Review and merge #3275 or #3276** — contributor PR has been waiting ~24h. Either merge after splitting, or take over the fix.
+3. **Investigate #3272 (session limit)** — opencode can handle this fix once kimi is unblocked as the agent.
+4. **Shrink model config** — kimi and minimax are both on multi-day cooldowns. Simplify the pool to claude + opencode + codex only.
+5. **Monitor cooldown clears** — codex (39m) will clear soon, restoring some capacity.
+6. **Fix router LLM pool skipping** — the router wasted 45s on minimax/haiku (cooled). Consider adding cooldown filtering to the LLM pool index.
+
+---
+
+*Prepared by Orch automation (internal:152037, attempt 4)*


### PR DESCRIPTION
## Summary

Wrote daily review for 2026-06-06 covering: 1 new commit (cooldown KV sync fix), service upgraded to v0.80.1, 3 open bugs blocked on kimi (1d21h cooldown), single-agent mode (only claude + opencode available), watchdog trigger at 79s during dispatch, and no new closed issues.

### What was done

- Gathered git log — 1 new commit (3f26c6f2) landed since yesterday
- Reviewed task runs — ~270 total, down from ~376 (cooldowns throttled capacity)
- Checked open/closed issues — no new closures, 3 open bugs (#3272-#3274) all blocked on kimi 429
- Verified agent health — codex/kimi/minimax degraded, opencode recovered, claude alone effective
- Analyzed error patterns — kimi 1d21h cooldown, router LLM pool timeout (45s on cooled minimax), watchdog +79s stall
- Wrote ./docs/content/posts/daily-review-2026-06-06.md with full operational analysis
- Committed the review post


### Files changed

- `docs/content/posts/daily-review-2026-06-06.md`


---
*Task internal-152037 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/deepseek-v4-flash-free`*