### PR TITLE
control: split oversized messages into chunks instead of truncating

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -943,21 +943,66 @@ pub async fn send_message(
             last_text
         }
         DeliveryMode::Single => {
-            // Single message delivery (under-limit messages) — use common persistence below
-            let result = invoke_agent(&agent, &model, &ctx.system, &chunks[0]).await?;
+            // Single message delivery (under-limit messages) — use invoke_agent_with_session
+            // for conversation continuity with --session-id / --resume
+            let mut active_uuid = session_uuid.clone();
+            let mut is_first_chunk = !is_new;
+            let chunk_result = loop {
+                let r = invoke_agent_with_session(
+                    &agent,
+                    &model,
+                    &ctx.system,
+                    &chunks[0],
+                    Some(&active_uuid),
+                    is_first_chunk,
+                )
+                .await;
+                match r {
+                    Ok(result) => break result,
+                    Err(e) => {
+                        let err_str = e.to_string();
+                        let is_stale = err_str.contains("stale session");
+                        let is_timeout = err_str.contains("timeout after")
+                            || err_str.contains("timed out after");
+                        if is_stale || is_timeout {
+                            if is_stale {
+                                tracing::info!(
+                                    session_id,
+                                    "chat session UUID expired; resetting and retrying with fresh session"
+                                );
+                            } else {
+                                tracing::info!(
+                                    session_id,
+                                    "chat session timed out; resetting and retrying with fresh session"
+                                );
+                            }
+                            reset_session_uuid(store, session_id).await?;
+                            let (fresh_uuid, _) =
+                                get_or_create_session_uuid(store, session_id).await?;
+                            active_uuid = fresh_uuid;
+                            is_first_chunk = false;
+                            continue;
+                        } else {
+                            return Err(e);
+                        }
+                    }
+                }
+            };
 
             // Parse response for summary and memory tags
-            let parsed = parse_response(&result.text);
+            let parsed = parse_response(&chunk_result.text);
 
             // Store assistant message with token usage.
             // Must happen before persist_memories so that if the DB write fails the
             // KV store is not left with orphaned memory keys that have no corresponding
             // conversation history entry.
-            let total_tokens =
-                total_tokens_u64_to_i64_saturating(result.input_tokens, result.output_tokens);
-            let input_tokens = opt_token_u64_to_i64_saturating(result.input_tokens);
-            let output_tokens = opt_token_u64_to_i64_saturating(result.output_tokens);
-            let cost_usd = match (result.input_tokens, result.output_tokens) {
+            let total_tokens = total_tokens_u64_to_i64_saturating(
+                chunk_result.input_tokens,
+                chunk_result.output_tokens,
+            );
+            let input_tokens = opt_token_u64_to_i64_saturating(chunk_result.input_tokens);
+            let output_tokens = opt_token_u64_to_i64_saturating(chunk_result.output_tokens);
+            let cost_usd = match (chunk_result.input_tokens, chunk_result.output_tokens) {
                 (Some(input), Some(output)) => {
                     let pricing = crate::store::pricing_for_model(&model);
                     let usage = crate::store::TokenUsage {

--- a/src/control.rs
+++ b/src/control.rs
@@ -52,6 +52,11 @@ const SYSTEM_TEMPLATE: &str = include_str!("../prompts/control_system.md");
 /// Timeout for agent invocations (2 minutes).
 const AGENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
+/// Maximum bytes for a single control-session turn payload.
+/// When the combined state + user message exceeds this limit, the payload is split
+/// across multiple sequential turns so the user's question is never truncated.
+const MAX_CONTROL_MESSAGE_BYTES: usize = 32 * 1024;
+
 /// Parsed model specification from `/model` command.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ModelSpec {
@@ -729,67 +734,122 @@ pub async fn send_message(
     // Get or create a session UUID for conversation continuity
     let (session_uuid, is_new) = get_or_create_session_uuid(store, session_id).await?;
 
-    // Invoke agent one-shot with --session-id (new) or --resume (existing) for conversation continuity
-    let result = match invoke_agent_with_session(
-        &agent,
-        &model,
-        &ctx.system,
-        &full_message,
-        Some(&session_uuid),
-        !is_new,
-    )
-    .await
-    {
-        Ok(r) => r,
-        Err(e) => {
-            // If the session UUID has expired server-side, reset it and retry
-            // with a fresh session. This handles the "No conversation found with
-            // session ID: <uuid>" error that Claude returns when a session expires.
-            // The AgentError is converted to a string by anyhow::bail! in direct.rs,
-            // so we match on the Display representation of StaleSession.
-            let err_str = e.to_string();
-            let is_stale = err_str.contains("stale session");
-            // A timeout (exit code 124 from the `timeout` CLI tool) also means
-            // the session can no longer be resumed — reset and start fresh rather
-            // than surfacing "Control session error: timeout after 1800s" to the user.
-            let is_timeout =
-                err_str.contains("timeout after") || err_str.contains("timed out after");
-            if is_stale || is_timeout {
-                if is_stale {
-                    tracing::info!(
-                        session_id,
-                        "chat session UUID expired; resetting and retrying with fresh session"
-                    );
-                } else {
-                    tracing::info!(
-                        session_id,
-                        "chat session timed out; resetting and retrying with fresh session"
-                    );
-                }
-                reset_session_uuid(store, session_id).await?;
-                // Fresh invocation — no resume, generates a new UUID
-                let (fresh_uuid, _) = get_or_create_session_uuid(store, session_id).await?;
-                let fresh_result = invoke_agent_with_session(
-                    &agent,
-                    &model,
-                    &ctx.system,
-                    &full_message,
-                    Some(&fresh_uuid),
-                    false, // not resuming — new session
-                )
-                .await?;
-                if is_timeout {
-                    InvokeResult {
-                        text: format!("_(New session started.)_\n\n{}", fresh_result.text),
-                        ..fresh_result
+    // When the combined payload exceeds the per-turn limit, split it across multiple
+    // sequential turns so the user's question (trailing content) is never truncated.
+    // For session-supporting agents (claude, kimi, minimax), use --resume for continuity.
+    // For other agents (codex, opencode), send chunks as independent invocations.
+    let agent_has_sessions = matches!(agent.as_str(), "claude" | "kimi" | "minimax");
+    let chunks: Vec<String> = if full_message.len() > MAX_CONTROL_MESSAGE_BYTES {
+        tracing::info!(
+            bytes = full_message.len(),
+            limit = MAX_CONTROL_MESSAGE_BYTES,
+            agent = %agent,
+            agent_has_sessions,
+            "control session payload exceeds limit; splitting across multiple turns"
+        );
+        build_control_chunks(&ctx.state, message, agent_has_sessions)
+    } else {
+        vec![full_message]
+    };
+
+    let num_chunks = chunks.len();
+
+    // Deliver chunks. For session-supporting agents, use --resume for continuity.
+    // For other agents, each chunk is an independent invocation.
+    let result = if agent_has_sessions {
+        // Session-based delivery (claude, kimi, minimax)
+        let (active_uuid, first_result): (String, InvokeResult) = {
+            let r = invoke_agent_with_session(
+                &agent,
+                &model,
+                &ctx.system,
+                &chunks[0],
+                Some(&session_uuid),
+                !is_new,
+            )
+            .await;
+            match r {
+                Ok(result) => (session_uuid.clone(), result),
+                Err(e) => {
+                    let err_str = e.to_string();
+                    let is_stale = err_str.contains("stale session");
+                    let is_timeout =
+                        err_str.contains("timeout after") || err_str.contains("timed out after");
+                    if is_stale || is_timeout {
+                        if is_stale {
+                            tracing::info!(
+                                session_id,
+                                "chat session UUID expired; resetting and retrying with fresh session"
+                            );
+                        } else {
+                            tracing::info!(
+                                session_id,
+                                "chat session timed out; resetting and retrying with fresh session"
+                            );
+                        }
+                        reset_session_uuid(store, session_id).await?;
+                        let (fresh_uuid, _) = get_or_create_session_uuid(store, session_id).await?;
+                        let fresh_result = invoke_agent_with_session(
+                            &agent,
+                            &model,
+                            &ctx.system,
+                            &chunks[0],
+                            Some(&fresh_uuid),
+                            false,
+                        )
+                        .await?;
+                        let result = if is_timeout {
+                            InvokeResult {
+                                text: format!("_(New session started.)_\n\n{}", fresh_result.text),
+                                ..fresh_result
+                            }
+                        } else {
+                            fresh_result
+                        };
+                        (fresh_uuid, result)
+                    } else {
+                        return Err(e);
                     }
-                } else {
-                    fresh_result
                 }
-            } else {
-                return Err(e);
+            }
+        };
+
+        if num_chunks == 1 {
+            first_result
+        } else {
+            let _ = first_result; // intermediate turn — discard
+            let mut last: Option<InvokeResult> = None;
+            for chunk in &chunks[1..] {
+                last = Some(
+                    invoke_agent_with_session(
+                        &agent,
+                        &model,
+                        &ctx.system,
+                        chunk,
+                        Some(&active_uuid),
+                        true,
+                    )
+                    .await?,
+                );
+            }
+            last.expect("chunks[1..] is non-empty when num_chunks >= 2")
+        }
+    } else {
+        // Non-session delivery (codex, opencode) — each chunk is independent
+        let mut last: Option<InvokeResult> = None;
+        for (i, chunk) in chunks.iter().enumerate() {
+            last = Some(invoke_agent(&agent, &model, &ctx.system, chunk).await?);
+            // For intermediate chunks, we could log progress but don't store responses
+            if i < num_chunks - 1 {
+                tracing::debug!(
+                    session_id,
+                    chunk = i + 1,
+                    total = num_chunks,
+                    "delivered intermediate chunk for non-session agent"
+                );
             }
         }
+        last.expect("chunks is non-empty")
     };
 
     // Parse response for summary and memory tags
@@ -856,6 +916,90 @@ pub async fn send_message(
     }
 
     Ok(parsed.clean_text)
+}
+
+/// Split `text` into chunks of at most `max_bytes` bytes each.
+/// Prefers splitting at newline boundaries to preserve readability.
+fn chunk_text(text: &str, max_bytes: usize) -> Vec<String> {
+    if text.len() <= max_bytes {
+        return vec![text.to_string()];
+    }
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    let total = text.len();
+
+    while start < total {
+        let mut end = (start + max_bytes).min(total);
+        // Respect UTF-8 char boundaries
+        while end > start && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        if end == start {
+            // Single char exceeds limit — advance past it
+            if let Some(ch) = text[start..].chars().next() {
+                end = start + ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+        // Prefer splitting at a newline within the chunk
+        if end < total {
+            if let Some(nl_offset) = text[start..end].rfind('\n') {
+                end = start + nl_offset + 1;
+            }
+        }
+        chunks.push(text[start..end].to_string());
+        start = end;
+    }
+    chunks
+}
+
+/// Build control session message chunks for agents with or without session support.
+///
+/// For session-supporting agents (claude, kimi, minimax), chunks are raw text pieces
+/// that will be sent sequentially with `--resume` for conversation continuity.
+///
+/// For non-session agents (codex, opencode), each chunk is prefixed with a header
+/// indicating its position in the sequence, since each invocation is independent.
+fn build_control_chunks(state: &str, message: &str, agent_has_sessions: bool) -> Vec<String> {
+    let header_reserve = if agent_has_sessions { 0 } else { 200 };
+    let effective_limit = MAX_CONTROL_MESSAGE_BYTES.saturating_sub(header_reserve);
+    let mut parts = Vec::new();
+
+    // Split state into chunks
+    let state_chunks = chunk_text(state, effective_limit);
+    for (i, chunk) in state_chunks.iter().enumerate() {
+        let prefixed = if agent_has_sessions {
+            chunk.clone()
+        } else {
+            format!(
+                "[Context chunk {}/{}]\n{}",
+                i + 1,
+                state_chunks.len(),
+                chunk
+            )
+        };
+        parts.push(prefixed);
+    }
+
+    // Split user message if needed, then add as final chunk(s)
+    let msg_chunks = chunk_text(message, effective_limit);
+    for (i, chunk) in msg_chunks.iter().enumerate() {
+        let prefixed = if agent_has_sessions {
+            chunk.clone()
+        } else if msg_chunks.len() == 1 {
+            format!("[Context complete. User question:]\n{}", chunk)
+        } else {
+            format!(
+                "[User question chunk {}/{}]\n{}",
+                i + 1,
+                msg_chunks.len(),
+                chunk
+            )
+        };
+        parts.push(prefixed);
+    }
+    parts
 }
 
 #[cfg(test)]
@@ -1300,6 +1444,144 @@ mod tests {
                 !is_timeout,
                 "pattern must not be detected as timeout: {msg:?}"
             );
+        }
+    }
+
+    // ── chunk_text ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn chunk_text_under_limit_returns_single_chunk() {
+        let text = "hello world";
+        let chunks = chunk_text(text, 100);
+        assert_eq!(chunks, vec!["hello world".to_string()]);
+    }
+
+    #[test]
+    fn chunk_text_exact_limit_returns_single_chunk() {
+        let text = "abcde";
+        let chunks = chunk_text(text, 5);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], "abcde");
+    }
+
+    #[test]
+    fn chunk_text_splits_and_reassembles() {
+        let text = "line1\nline2\nline3\nline4\nline5";
+        let chunks = chunk_text(text, 12);
+        let reassembled: String = chunks.join("");
+        assert_eq!(reassembled, text);
+    }
+
+    #[test]
+    fn chunk_text_respects_utf8_boundaries() {
+        // 4-byte emoji placed at the split boundary
+        let content = "x".repeat(97) + "😀"; // 101 bytes; limit=100 cuts inside emoji
+        let chunks = chunk_text(&content, 100);
+        let reassembled: String = chunks.join("");
+        assert_eq!(reassembled, content);
+        for c in &chunks {
+            assert!(
+                std::str::from_utf8(c.as_bytes()).is_ok(),
+                "chunk is not valid UTF-8"
+            );
+        }
+    }
+
+    #[test]
+    fn chunk_text_prefers_newline_boundary() {
+        // "aaaa\nbbbb" with limit=6 — should split after the '\n', not mid-word
+        let text = "aaaa\nbbbb";
+        let chunks = chunk_text(text, 6);
+        // First chunk should end with '\n' (split at newline, not byte 6 into "aaaa\nb")
+        assert!(
+            chunks[0].ends_with('\n'),
+            "expected split at newline, got: {:?}",
+            chunks[0]
+        );
+        let reassembled: String = chunks.join("");
+        assert_eq!(reassembled, text);
+    }
+
+    #[test]
+    fn chunk_text_empty_string() {
+        let chunks = chunk_text("", 32);
+        assert!(chunks.is_empty() || chunks == vec!["".to_string()]);
+    }
+
+    // ── build_control_chunks ────────────────────────────────────────────────
+
+    #[test]
+    fn build_control_chunks_session_agent_splits_state_and_message() {
+        // build_control_chunks always splits state and message into separate chunks
+        // (it's only called when full_message exceeds the limit)
+        let state = "state content";
+        let message = "user question";
+        let chunks = build_control_chunks(state, message, true);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0], "state content");
+        assert_eq!(chunks[1], "user question");
+    }
+
+    #[test]
+    fn build_control_chunks_session_agent_long_state_splits() {
+        // Long state gets split into multiple chunks
+        let state = "line\n".repeat(10000); // ~60KB
+        let message = "question";
+        let chunks = build_control_chunks(state, message, true);
+        // Should have multiple state chunks + 1 message chunk
+        assert!(chunks.len() >= 3);
+        // All but last are state chunks
+        for chunk in &chunks[..chunks.len()-1] {
+            assert!(chunk.contains("line"));
+        }
+        // Last is message
+        assert_eq!(chunks.last().unwrap(), "question");
+    }
+
+    #[test]
+    fn build_control_chunks_non_session_agent_adds_headers() {
+        let state = "state content";
+        let message = "user question";
+        let chunks = build_control_chunks(state, message, false);
+        assert_eq!(chunks.len(), 2);
+        assert!(chunks[0].starts_with("[Context chunk 1/1]"));
+        assert!(chunks[0].contains("state content"));
+        assert!(chunks[1].starts_with("[Context complete. User question:]"));
+        assert!(chunks[1].contains("user question"));
+    }
+
+    #[test]
+    fn build_control_chunks_non_session_agent_splits_long_message() {
+        let state = "state";
+        let message = "x".repeat(50000); // Exceeds 32KB limit
+        let chunks = build_control_chunks(state, &message, false);
+        // Should have 1 state chunk + multiple message chunks
+        assert!(chunks.len() >= 2);
+        assert!(chunks[0].starts_with("[Context chunk 1/1]"));
+        // Message chunks should have question headers
+        for chunk in &chunks[1..] {
+            assert!(chunk.starts_with("[User question chunk"));
+        }
+        // Verify reassembly (without headers)
+        let reassembled_state = chunks[0].split_once('\n').map(|(_, r)| r).unwrap_or("");
+        assert_eq!(reassembled_state, "state");
+    }
+
+    #[test]
+    fn build_control_chunks_non_session_agent_long_state_splits() {
+        let state = "line\n".repeat(10000); // ~60KB
+        let message = "question";
+        let chunks = build_control_chunks(state, message, false);
+        // Multiple state chunks + 1 message chunk
+        assert!(chunks.len() >= 3);
+        for (i, chunk) in chunks.iter().enumerate() {
+            if i < chunks.len() - 1 {
+                assert!(chunk.starts_with(&format!("[Context chunk {}/", i + 1)));
+                assert!(chunk.contains("line"));
+            } else {
+                assert!(chunk.starts_with("[Context complete. User question:]"));
+                assert_eq!(chunk.split_once('\n').map(|(_, r)| r).unwrap_or(""), "question");
+            }
         }
     }
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -59,10 +59,12 @@ const MAX_CONTROL_MESSAGE_BYTES: usize = 32 * 1024;
 
 /// Delivery mode for control session messages.
 enum DeliveryMode {
-    /// Single message delivery (non-session agents or under-limit messages)
+    /// Single message delivery (under-limit messages)
     Single,
-    /// Chunked delivery with session continuity (claude, kimi, minimax)
+    /// Chunked delivery with session continuity (claude, kimi, minimax) — uses --resume
     Chunked,
+    /// Chunked delivery without session continuity (codex, opencode) — independent invocations
+    ChunkedNonSession,
 }
 
 /// Parsed model specification from `/model` command.
@@ -744,9 +746,10 @@ pub async fn send_message(
 
     // When the combined payload exceeds the per-turn limit, split it across multiple
     // sequential turns so the user's question (trailing content) is never truncated.
-    // For session-supporting agents (claude, kimi, minimax), use --resume for continuity.
-    // For other agents (codex, opencode), truncate the state portion to fit within the
-    // limit while preserving the complete user question, then send as a single message.
+    // For session-supporting agents (claude, kimi, minimax), use --resume for continuity
+    // and persist ALL intermediate assistant responses so local transcript matches provider.
+    // For other agents (codex, opencode), split into chunks and send each as independent
+    // invocation (no --resume), each getting its own persisted assistant response.
     let agent_has_sessions = matches!(agent.as_str(), "claude" | "kimi" | "minimax");
     let (chunks, delivery_mode) = if full_message.len() > MAX_CONTROL_MESSAGE_BYTES {
         tracing::info!(
@@ -763,47 +766,39 @@ pub async fn send_message(
                 DeliveryMode::Chunked,
             )
         } else {
-            // Non-session agents: truncate state to preserve question, send as single message
-            let separator = "\n\n---\n\n";
-            let max_state_bytes = MAX_CONTROL_MESSAGE_BYTES
-                .saturating_sub(message.len())
-                .saturating_sub(separator.len());
-            let truncated_state = if ctx.state.len() > max_state_bytes {
-                let truncated = &ctx.state[..max_state_bytes.min(ctx.state.len())];
-                // Try to truncate at a newline boundary
-                let truncated = truncated
-                    .rfind('\n')
-                    .map(|pos| &truncated[..=pos])
-                    .unwrap_or(truncated);
-                format!("{truncated}\n\n[... state truncated to fit limit ...]")
-            } else {
-                ctx.state.clone()
-            };
-            let combined = format!("{truncated_state}{separator}{message}");
-            (vec![combined], DeliveryMode::Single)
+            // Non-session agents: split into chunks, send each independently
+            (
+                build_control_chunks(&ctx.state, message, false),
+                DeliveryMode::ChunkedNonSession,
+            )
         }
     } else {
         (vec![full_message], DeliveryMode::Single)
     };
 
-    let num_chunks = chunks.len();
+    let _num_chunks = chunks.len();
 
     // Deliver chunks based on mode
     let result = match delivery_mode {
         DeliveryMode::Chunked => {
             // Session-based delivery (claude, kimi, minimax) — use --resume for continuity
-            let (active_uuid, first_result): (String, InvokeResult) = {
+            // Persist ALL intermediate responses so local DB matches provider transcript.
+            let mut active_uuid = session_uuid.clone();
+            let mut is_first_chunk = !is_new;
+            let mut last_result: Option<InvokeResult> = None;
+
+            for (_i, chunk) in chunks.iter().enumerate() {
                 let r = invoke_agent_with_session(
                     &agent,
                     &model,
                     &ctx.system,
-                    &chunks[0],
-                    Some(&session_uuid),
-                    !is_new,
+                    chunk,
+                    Some(&active_uuid),
+                    is_first_chunk,
                 )
                 .await;
-                match r {
-                    Ok(result) => (session_uuid.clone(), result),
+                let chunk_result = match r {
+                    Ok(result) => result,
                     Err(e) => {
                         let err_str = e.to_string();
                         let is_stale = err_str.contains("stale session");
@@ -824,12 +819,14 @@ pub async fn send_message(
                             reset_session_uuid(store, session_id).await?;
                             let (fresh_uuid, _) =
                                 get_or_create_session_uuid(store, session_id).await?;
+                            active_uuid = fresh_uuid;
+                            is_first_chunk = false;
                             let fresh_result = invoke_agent_with_session(
                                 &agent,
                                 &model,
                                 &ctx.system,
-                                &chunks[0],
-                                Some(&fresh_uuid),
+                                chunk,
+                                Some(&active_uuid),
                                 false,
                             )
                             .await?;
@@ -844,81 +841,150 @@ pub async fn send_message(
                             } else {
                                 fresh_result
                             };
-                            (fresh_uuid, result)
+                            result
                         } else {
                             return Err(e);
                         }
                     }
-                }
-            };
+                };
 
-            if num_chunks == 1 {
-                first_result
-            } else {
-                let _ = first_result; // intermediate turn — discard
-                let mut last: Option<InvokeResult> = None;
-                for chunk in &chunks[1..] {
-                    last = Some(
-                        invoke_agent_with_session(
-                            &agent,
-                            &model,
-                            &ctx.system,
-                            chunk,
-                            Some(&active_uuid),
-                            true,
-                        )
-                        .await?,
-                    );
-                }
-                last.expect("chunks[1..] is non-empty when num_chunks >= 2")
+                // Persist this chunk's assistant response (even intermediate ones)
+                let parsed = parse_response(&chunk_result.text);
+                let total_tokens =
+                    total_tokens_u64_to_i64_saturating(chunk_result.input_tokens, chunk_result.output_tokens);
+                let input_tokens = opt_token_u64_to_i64_saturating(chunk_result.input_tokens);
+                let output_tokens = opt_token_u64_to_i64_saturating(chunk_result.output_tokens);
+                let cost_usd = match (chunk_result.input_tokens, chunk_result.output_tokens) {
+                    (Some(input), Some(output)) => {
+                        let pricing = crate::store::pricing_for_model(&model);
+                        let usage = crate::store::TokenUsage {
+                            input_tokens: input,
+                            output_tokens: output,
+                        };
+                        Some(pricing.estimate_cost_usd(usage).total_cost_usd)
+                    }
+                    _ => None,
+                };
+                store
+                    .insert_control_message(
+                        session_id,
+                        "assistant",
+                        channel,
+                        channel_thread,
+                        &parsed.clean_text,
+                        parsed.summary.as_deref(),
+                        Some(&model),
+                        Some(&agent),
+                        input_tokens,
+                        output_tokens,
+                        total_tokens,
+                        cost_usd,
+                    )
+                    .await?;
+                persist_memories(store, session_id, &parsed.memories).await?;
+
+                last_result = Some(chunk_result);
             }
-        }
+
+            // Return final clean_text directly — all chunks already persisted inline
+            let final_parsed = parse_response(&last_result.expect("at least one chunk").text);
+            final_parsed.clean_text
+        },
+        DeliveryMode::ChunkedNonSession => {
+            // Non-session agents (codex, opencode) — each chunk is independent invocation
+            // No --resume, but each chunk's response is persisted to keep transcript complete.
+            let mut last_text = String::new();
+
+            for chunk in &chunks {
+                let chunk_result = invoke_agent(&agent, &model, &ctx.system, chunk).await?;
+
+                // Persist this chunk's assistant response
+                let parsed = parse_response(&chunk_result.text);
+                let total_tokens =
+                    total_tokens_u64_to_i64_saturating(chunk_result.input_tokens, chunk_result.output_tokens);
+                let input_tokens = opt_token_u64_to_i64_saturating(chunk_result.input_tokens);
+                let output_tokens = opt_token_u64_to_i64_saturating(chunk_result.output_tokens);
+                let cost_usd = match (chunk_result.input_tokens, chunk_result.output_tokens) {
+                    (Some(input), Some(output)) => {
+                        let pricing = crate::store::pricing_for_model(&model);
+                        let usage = crate::store::TokenUsage {
+                            input_tokens: input,
+                            output_tokens: output,
+                        };
+                        Some(pricing.estimate_cost_usd(usage).total_cost_usd)
+                    }
+                    _ => None,
+                };
+                store
+                    .insert_control_message(
+                        session_id,
+                        "assistant",
+                        channel,
+                        channel_thread,
+                        &parsed.clean_text,
+                        parsed.summary.as_deref(),
+                        Some(&model),
+                        Some(&agent),
+                        input_tokens,
+                        output_tokens,
+                        total_tokens,
+                        cost_usd,
+                    )
+                    .await?;
+                persist_memories(store, session_id, &parsed.memories).await?;
+
+                last_text = parsed.clean_text;
+            }
+
+            last_text
+        },
         DeliveryMode::Single => {
-            // Single message delivery (non-session agents or under-limit messages)
-            invoke_agent(&agent, &model, &ctx.system, &chunks[0]).await?
-        }
-    };
+            // Single message delivery (under-limit messages) — use common persistence below
+            let result = invoke_agent(&agent, &model, &ctx.system, &chunks[0]).await?;
 
-    // Parse response for summary and memory tags
-    let parsed = parse_response(&result.text);
+            // Parse response for summary and memory tags
+            let parsed = parse_response(&result.text);
 
-    // Store assistant message with token usage.
-    // Must happen before persist_memories so that if the DB write fails the
-    // KV store is not left with orphaned memory keys that have no corresponding
-    // conversation history entry.
-    let total_tokens =
-        total_tokens_u64_to_i64_saturating(result.input_tokens, result.output_tokens);
-    let input_tokens = opt_token_u64_to_i64_saturating(result.input_tokens);
-    let output_tokens = opt_token_u64_to_i64_saturating(result.output_tokens);
-    let cost_usd = match (result.input_tokens, result.output_tokens) {
-        (Some(input), Some(output)) => {
-            let pricing = crate::store::pricing_for_model(&model);
-            let usage = crate::store::TokenUsage {
-                input_tokens: input,
-                output_tokens: output,
+            // Store assistant message with token usage.
+            // Must happen before persist_memories so that if the DB write fails the
+            // KV store is not left with orphaned memory keys that have no corresponding
+            // conversation history entry.
+            let total_tokens =
+                total_tokens_u64_to_i64_saturating(result.input_tokens, result.output_tokens);
+            let input_tokens = opt_token_u64_to_i64_saturating(result.input_tokens);
+            let output_tokens = opt_token_u64_to_i64_saturating(result.output_tokens);
+            let cost_usd = match (result.input_tokens, result.output_tokens) {
+                (Some(input), Some(output)) => {
+                    let pricing = crate::store::pricing_for_model(&model);
+                    let usage = crate::store::TokenUsage {
+                        input_tokens: input,
+                        output_tokens: output,
+                    };
+                    Some(pricing.estimate_cost_usd(usage).total_cost_usd)
+                }
+                _ => None,
             };
-            Some(pricing.estimate_cost_usd(usage).total_cost_usd)
-        }
-        _ => None,
-    };
-    store
-        .insert_control_message(
-            session_id,
-            "assistant",
-            channel,
-            channel_thread,
-            &parsed.clean_text,
-            parsed.summary.as_deref(),
-            Some(&model),
-            Some(&agent),
-            input_tokens,
-            output_tokens,
-            total_tokens,
-            cost_usd,
-        )
-        .await?;
+            store
+                .insert_control_message(
+                    session_id,
+                    "assistant",
+                    channel,
+                    channel_thread,
+                    &parsed.clean_text,
+                    parsed.summary.as_deref(),
+                    Some(&model),
+                    Some(&agent),
+                    input_tokens,
+                    output_tokens,
+                    total_tokens,
+                    cost_usd,
+                )
+                .await?;
+            persist_memories(store, session_id, &parsed.memories).await?;
 
-    persist_memories(store, session_id, &parsed.memories).await?;
+            parsed.clean_text
+        }
+    };
 
     // Release the per-session lock before eviction check.
     drop(_guard);
@@ -942,7 +1008,7 @@ pub async fn send_message(
         }
     }
 
-    Ok(parsed.clean_text)
+    Ok(result)
 }
 
 /// Split `text` into chunks of at most `max_bytes` bytes each.

--- a/src/control.rs
+++ b/src/control.rs
@@ -57,6 +57,14 @@ const AGENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 /// across multiple sequential turns so the user's question is never truncated.
 const MAX_CONTROL_MESSAGE_BYTES: usize = 32 * 1024;
 
+/// Delivery mode for control session messages.
+enum DeliveryMode {
+    /// Single message delivery (non-session agents or under-limit messages)
+    Single,
+    /// Chunked delivery with session continuity (claude, kimi, minimax)
+    Chunked,
+}
+
 /// Parsed model specification from `/model` command.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ModelSpec {
@@ -737,119 +745,138 @@ pub async fn send_message(
     // When the combined payload exceeds the per-turn limit, split it across multiple
     // sequential turns so the user's question (trailing content) is never truncated.
     // For session-supporting agents (claude, kimi, minimax), use --resume for continuity.
-    // For other agents (codex, opencode), send chunks as independent invocations.
+    // For other agents (codex, opencode), truncate the state portion to fit within the
+    // limit while preserving the complete user question, then send as a single message.
     let agent_has_sessions = matches!(agent.as_str(), "claude" | "kimi" | "minimax");
-    let chunks: Vec<String> = if full_message.len() > MAX_CONTROL_MESSAGE_BYTES {
+    let (chunks, delivery_mode) = if full_message.len() > MAX_CONTROL_MESSAGE_BYTES {
         tracing::info!(
             bytes = full_message.len(),
             limit = MAX_CONTROL_MESSAGE_BYTES,
             agent = %agent,
             agent_has_sessions,
-            "control session payload exceeds limit; splitting across multiple turns"
+            "control session payload exceeds limit"
         );
-        build_control_chunks(&ctx.state, message, agent_has_sessions)
+        if agent_has_sessions {
+            // Session agents: split into chunks for sequential delivery with --resume
+            (
+                build_control_chunks(&ctx.state, message, true),
+                DeliveryMode::Chunked,
+            )
+        } else {
+            // Non-session agents: truncate state to preserve question, send as single message
+            let separator = "\n\n---\n\n";
+            let max_state_bytes = MAX_CONTROL_MESSAGE_BYTES
+                .saturating_sub(message.len())
+                .saturating_sub(separator.len());
+            let truncated_state = if ctx.state.len() > max_state_bytes {
+                let truncated = &ctx.state[..max_state_bytes.min(ctx.state.len())];
+                // Try to truncate at a newline boundary
+                let truncated = truncated
+                    .rfind('\n')
+                    .map(|pos| &truncated[..=pos])
+                    .unwrap_or(truncated);
+                format!("{truncated}\n\n[... state truncated to fit limit ...]")
+            } else {
+                ctx.state.clone()
+            };
+            let combined = format!("{truncated_state}{separator}{message}");
+            (vec![combined], DeliveryMode::Single)
+        }
     } else {
-        vec![full_message]
+        (vec![full_message], DeliveryMode::Single)
     };
 
     let num_chunks = chunks.len();
 
-    // Deliver chunks. For session-supporting agents, use --resume for continuity.
-    // For other agents, each chunk is an independent invocation.
-    let result = if agent_has_sessions {
-        // Session-based delivery (claude, kimi, minimax)
-        let (active_uuid, first_result): (String, InvokeResult) = {
-            let r = invoke_agent_with_session(
-                &agent,
-                &model,
-                &ctx.system,
-                &chunks[0],
-                Some(&session_uuid),
-                !is_new,
-            )
-            .await;
-            match r {
-                Ok(result) => (session_uuid.clone(), result),
-                Err(e) => {
-                    let err_str = e.to_string();
-                    let is_stale = err_str.contains("stale session");
-                    let is_timeout =
-                        err_str.contains("timeout after") || err_str.contains("timed out after");
-                    if is_stale || is_timeout {
-                        if is_stale {
-                            tracing::info!(
-                                session_id,
-                                "chat session UUID expired; resetting and retrying with fresh session"
-                            );
+    // Deliver chunks based on mode
+    let result = match delivery_mode {
+        DeliveryMode::Chunked => {
+            // Session-based delivery (claude, kimi, minimax) — use --resume for continuity
+            let (active_uuid, first_result): (String, InvokeResult) = {
+                let r = invoke_agent_with_session(
+                    &agent,
+                    &model,
+                    &ctx.system,
+                    &chunks[0],
+                    Some(&session_uuid),
+                    !is_new,
+                )
+                .await;
+                match r {
+                    Ok(result) => (session_uuid.clone(), result),
+                    Err(e) => {
+                        let err_str = e.to_string();
+                        let is_stale = err_str.contains("stale session");
+                        let is_timeout = err_str.contains("timeout after")
+                            || err_str.contains("timed out after");
+                        if is_stale || is_timeout {
+                            if is_stale {
+                                tracing::info!(
+                                    session_id,
+                                    "chat session UUID expired; resetting and retrying with fresh session"
+                                );
+                            } else {
+                                tracing::info!(
+                                    session_id,
+                                    "chat session timed out; resetting and retrying with fresh session"
+                                );
+                            }
+                            reset_session_uuid(store, session_id).await?;
+                            let (fresh_uuid, _) =
+                                get_or_create_session_uuid(store, session_id).await?;
+                            let fresh_result = invoke_agent_with_session(
+                                &agent,
+                                &model,
+                                &ctx.system,
+                                &chunks[0],
+                                Some(&fresh_uuid),
+                                false,
+                            )
+                            .await?;
+                            let result = if is_timeout {
+                                InvokeResult {
+                                    text: format!(
+                                        "_(New session started.)_\n\n{}",
+                                        fresh_result.text
+                                    ),
+                                    ..fresh_result
+                                }
+                            } else {
+                                fresh_result
+                            };
+                            (fresh_uuid, result)
                         } else {
-                            tracing::info!(
-                                session_id,
-                                "chat session timed out; resetting and retrying with fresh session"
-                            );
+                            return Err(e);
                         }
-                        reset_session_uuid(store, session_id).await?;
-                        let (fresh_uuid, _) = get_or_create_session_uuid(store, session_id).await?;
-                        let fresh_result = invoke_agent_with_session(
+                    }
+                }
+            };
+
+            if num_chunks == 1 {
+                first_result
+            } else {
+                let _ = first_result; // intermediate turn — discard
+                let mut last: Option<InvokeResult> = None;
+                for chunk in &chunks[1..] {
+                    last = Some(
+                        invoke_agent_with_session(
                             &agent,
                             &model,
                             &ctx.system,
-                            &chunks[0],
-                            Some(&fresh_uuid),
-                            false,
+                            chunk,
+                            Some(&active_uuid),
+                            true,
                         )
-                        .await?;
-                        let result = if is_timeout {
-                            InvokeResult {
-                                text: format!("_(New session started.)_\n\n{}", fresh_result.text),
-                                ..fresh_result
-                            }
-                        } else {
-                            fresh_result
-                        };
-                        (fresh_uuid, result)
-                    } else {
-                        return Err(e);
-                    }
+                        .await?,
+                    );
                 }
-            }
-        };
-
-        if num_chunks == 1 {
-            first_result
-        } else {
-            let _ = first_result; // intermediate turn — discard
-            let mut last: Option<InvokeResult> = None;
-            for chunk in &chunks[1..] {
-                last = Some(
-                    invoke_agent_with_session(
-                        &agent,
-                        &model,
-                        &ctx.system,
-                        chunk,
-                        Some(&active_uuid),
-                        true,
-                    )
-                    .await?,
-                );
-            }
-            last.expect("chunks[1..] is non-empty when num_chunks >= 2")
-        }
-    } else {
-        // Non-session delivery (codex, opencode) — each chunk is independent
-        let mut last: Option<InvokeResult> = None;
-        for (i, chunk) in chunks.iter().enumerate() {
-            last = Some(invoke_agent(&agent, &model, &ctx.system, chunk).await?);
-            // For intermediate chunks, we could log progress but don't store responses
-            if i < num_chunks - 1 {
-                tracing::debug!(
-                    session_id,
-                    chunk = i + 1,
-                    total = num_chunks,
-                    "delivered intermediate chunk for non-session agent"
-                );
+                last.expect("chunks[1..] is non-empty when num_chunks >= 2")
             }
         }
-        last.expect("chunks is non-empty")
+        DeliveryMode::Single => {
+            // Single message delivery (non-session agents or under-limit messages)
+            invoke_agent(&agent, &model, &ctx.system, &chunks[0]).await?
+        }
     };
 
     // Parse response for summary and memory tags
@@ -1527,11 +1554,11 @@ mod tests {
         // Long state gets split into multiple chunks
         let state = "line\n".repeat(10000); // ~60KB
         let message = "question";
-        let chunks = build_control_chunks(state, message, true);
+        let chunks = build_control_chunks(&state, message, true);
         // Should have multiple state chunks + 1 message chunk
         assert!(chunks.len() >= 3);
         // All but last are state chunks
-        for chunk in &chunks[..chunks.len()-1] {
+        for chunk in &chunks[..chunks.len() - 1] {
             assert!(chunk.contains("line"));
         }
         // Last is message
@@ -1571,7 +1598,7 @@ mod tests {
     fn build_control_chunks_non_session_agent_long_state_splits() {
         let state = "line\n".repeat(10000); // ~60KB
         let message = "question";
-        let chunks = build_control_chunks(state, message, false);
+        let chunks = build_control_chunks(&state, message, false);
         // Multiple state chunks + 1 message chunk
         assert!(chunks.len() >= 3);
         for (i, chunk) in chunks.iter().enumerate() {
@@ -1580,7 +1607,10 @@ mod tests {
                 assert!(chunk.contains("line"));
             } else {
                 assert!(chunk.starts_with("[Context complete. User question:]"));
-                assert_eq!(chunk.split_once('\n').map(|(_, r)| r).unwrap_or(""), "question");
+                assert_eq!(
+                    chunk.split_once('\n').map(|(_, r)| r).unwrap_or(""),
+                    "question"
+                );
             }
         }
     }

--- a/src/control.rs
+++ b/src/control.rs
@@ -850,8 +850,10 @@ pub async fn send_message(
 
                 // Persist this chunk's assistant response (even intermediate ones)
                 let parsed = parse_response(&chunk_result.text);
-                let total_tokens =
-                    total_tokens_u64_to_i64_saturating(chunk_result.input_tokens, chunk_result.output_tokens);
+                let total_tokens = total_tokens_u64_to_i64_saturating(
+                    chunk_result.input_tokens,
+                    chunk_result.output_tokens,
+                );
                 let input_tokens = opt_token_u64_to_i64_saturating(chunk_result.input_tokens);
                 let output_tokens = opt_token_u64_to_i64_saturating(chunk_result.output_tokens);
                 let cost_usd = match (chunk_result.input_tokens, chunk_result.output_tokens) {
@@ -889,7 +891,7 @@ pub async fn send_message(
             // Return final clean_text directly — all chunks already persisted inline
             let final_parsed = parse_response(&last_result.expect("at least one chunk").text);
             final_parsed.clean_text
-        },
+        }
         DeliveryMode::ChunkedNonSession => {
             // Non-session agents (codex, opencode) — each chunk is independent invocation
             // No --resume, but each chunk's response is persisted to keep transcript complete.
@@ -900,8 +902,10 @@ pub async fn send_message(
 
                 // Persist this chunk's assistant response
                 let parsed = parse_response(&chunk_result.text);
-                let total_tokens =
-                    total_tokens_u64_to_i64_saturating(chunk_result.input_tokens, chunk_result.output_tokens);
+                let total_tokens = total_tokens_u64_to_i64_saturating(
+                    chunk_result.input_tokens,
+                    chunk_result.output_tokens,
+                );
                 let input_tokens = opt_token_u64_to_i64_saturating(chunk_result.input_tokens);
                 let output_tokens = opt_token_u64_to_i64_saturating(chunk_result.output_tokens);
                 let cost_usd = match (chunk_result.input_tokens, chunk_result.output_tokens) {
@@ -937,7 +941,7 @@ pub async fn send_message(
             }
 
             last_text
-        },
+        }
         DeliveryMode::Single => {
             // Single message delivery (under-limit messages) — use common persistence below
             let result = invoke_agent(&agent, &model, &ctx.system, &chunks[0]).await?;

--- a/src/control.rs
+++ b/src/control.rs
@@ -787,7 +787,7 @@ pub async fn send_message(
             let mut is_first_chunk = !is_new;
             let mut last_result: Option<InvokeResult> = None;
 
-            for (_i, chunk) in chunks.iter().enumerate() {
+            for chunk in chunks.iter() {
                 let r = invoke_agent_with_session(
                     &agent,
                     &model,


### PR DESCRIPTION
## Summary

Now I understand the issue. The problem is in lines 740-754 of `control.rs` - message splitting only happens for agents that support sessions (claude, kimi, minimax). For codex and opencode, large messages are sent as-is and get silently truncated.

Let me implement the fix to split messages for ALL agents, with appropriate handling for non-session agents.
Now I need to update the chunk delivery logic to handle non-session agents properly (without `--resume`):
Now let me verify the code compiles

### Files changed

- `src/control.rs`


Closes #3281

---
*Task #3281 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/nemotron-3-ultra-free`*