### PR TITLE
bug(runner): claude "weekly limit" misclassified as failed — reset timestamp not parsed

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -1094,6 +1094,7 @@ pub(crate) mod patterns {
             "too many requests",
             "usage limit",
             "session limit", // catches "You've hit your session limit · resets …"
+            "weekly limit",  // catches "You've hit your weekly limit · resets …"
             "quota exceeded",
             "overloaded",
             "capacity",
@@ -1828,6 +1829,31 @@ mod tests {
              To ensure system stability, please adjust your client logic to scale requests more smoothly over time."
         ).is_some());
         assert!(patterns::detect_rate_limit("all good").is_none());
+    }
+
+    #[test]
+    fn classify_from_text_detects_weekly_limit_as_rate_limit() {
+        // Regression test for issue #3283: Claude "weekly limit" errors were
+        // classified as `failed` instead of `rate_limit` because "weekly limit"
+        // was not in the detect_rate_limit pattern list.
+        let system_event = r#"{"type":"system","subtype":"error","error":{"type":"weekly_limit","message":"You've hit your weekly limit · resets Jun 9 at 1am (America/Sao_Paulo)"}}"#;
+        let work_product = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"Working on the task...\"}]}}\n"
+            .repeat(200);
+        let text = format!("{system_event}\n{work_product}");
+        assert!(
+            text.len() > 3000,
+            "test output must exceed tail window to be meaningful"
+        );
+        let err = patterns::classify_from_text(1, &text);
+        assert!(
+            matches!(err, AgentError::RateLimit { .. }),
+            "weekly limit as early system event must be detected via head scan, got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("weekly limit"),
+            "error message should reference weekly limit, got: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

I'll look at the relevant file to implement the fix.
Now let me look at the existing session limit test for reference:
Now I'll make the two changes: add `"weekly limit"` to the patterns and add the regression test.
Now add the regression test after the existing `pattern_detect_rate_limit` test:
Now let me run the relevant tests to verify:
All 6 tests pass. Let me run the required quality gates:
TASK_ID is set — orch-dispatched agent mode. I'll commit only.
Fix committed. Here's the summary:



### What was done

- Added `"weekly limit"` to `detect_rate_limit()` patterns in `src/engine/runner/agents/mod.rs:1096`, alongside the existing `"session limit"` entry.
- Added regression test `classify_from_text_detects_weekly_limit_as_rate_limit` covering the full head-scan path for early NDJSON system events.
- All 6 related tests pass; fmt and clippy are clean.


### Files changed

- `src/engine/runner/agents/mod.rs`


Closes #3283

---
*Task #3283 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*