### PR TITLE
bug(router): router LLM ignores agent-level cooldown, causes repeated 45s timeouts and tick stalls

### DIFF
--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -828,7 +828,12 @@ impl LlmRouter {
     ) -> anyhow::Result<String> {
         use crate::engine::runner::direct::{run_direct_command_raw, DirectCommandError};
 
-        // Skip immediately if this specific agent+model is on cooldown
+        // Skip immediately if the agent itself is on cooldown (agent-level)
+        if crate::engine::cooldown::is_agent_in_cooldown(agent) {
+            anyhow::bail!("router LLM {agent} (agent) is on cooldown");
+        }
+
+        // Skip immediately if this specific agent+model is on cooldown (model-level)
         let model_str = model.unwrap_or("");
         if crate::engine::runner::response::is_model_in_cooldown(agent, model_str) {
             anyhow::bail!("router LLM {agent}:{model_str} is on cooldown");


### PR DESCRIPTION
## Summary

Added agent-level cooldown check (`is_agent_in_cooldown`) in `call_router_llm()` before the existing model-level check, so agents on agent-wide cooldown are skipped in microseconds instead of timing out after 45s. All 3681 tests pass.

### Files changed

- `src/engine/router/llm.rs`


Closes #3286

---
*Task #3286 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*