### PR TITLE
bug(parser): normalize_status missing 'NO_SETUPS', 'alerts' (plural), 'not_configured' — 5 task failures in 7 days

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -169,6 +169,7 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         | "green"
         | "no_changes_needed"
         | "no_trades_no_positions"
+        | "no_setups"
         | "changes_made"
         | "change_made"
         | "changes_pushed"
@@ -181,7 +182,9 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         | "review_addressed"
         | "already_finalized_in_attempt_1"
         | "alert"
-        | "alerts_sent" => "done".to_string(),
+        | "alerts"
+        | "alerts_sent"
+        | "not_configured" => "done".to_string(),
         // Canonical progress statuses.
         // `partial` is used by some models to indicate partial progress —
         // treat it as in_progress so the task remains open for follow-up.


### PR DESCRIPTION
## Summary

Fixed normalize_status() in src/parser.rs to handle three missing status aliases: NO_SETUPS, alerts (plural), and not_configured

### What was done

- Added 'no_setups' to the done arm in normalize_status() for NO_SETUPS status
- Added 'alerts' to the done arm for plural alerts status (distinct from 'alert' and 'alerts_sent')
- Added 'not_configured' to the done arm for not_configured status
- All parser tests pass (64 tests)
- cargo fmt and cargo clippy pass


### Files changed

- `src/parser.rs`


Closes #3291

---
*Task #3291 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/nemotron-3-ultra-free`*