### PR TITLE
bug(parser): normalize_status missing 'healthy' — Live sleeves health check fails every run

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -184,7 +184,8 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         | "alert"
         | "alerts"
         | "alerts_sent"
-        | "not_configured" => "done".to_string(),
+        | "not_configured"
+        | "healthy" => "done".to_string(),
         // Canonical progress statuses.
         // `partial` is used by some models to indicate partial progress —
         // treat it as in_progress so the task remains open for follow-up.


### PR DESCRIPTION
Resolves #3295

Auto-created by orch review gate (agent forgot to open PR)