### PR TITLE
bug(runner): 'You have exceeded your monthly quota' (GitHub Copilot) not detected as rate_limit — model retried immediately, 4 failures on same task in 3h

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -1096,6 +1096,7 @@ pub(crate) mod patterns {
             "session limit", // catches "You've hit your session limit · resets …"
             "weekly limit",  // catches "You've hit your weekly limit · resets …"
             "quota exceeded",
+            "monthly quota", // GitHub Copilot: "You have exceeded your monthly quota"
             "overloaded",
             "capacity",
             "throttled",
@@ -1853,6 +1854,18 @@ mod tests {
         assert!(
             msg.contains("weekly limit"),
             "error message should reference weekly limit, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn detect_rate_limit_github_copilot_monthly_quota() {
+        // Regression test for issue #3302: "You have exceeded your monthly quota"
+        // was not matched because detect_rate_limit only checked "quota exceeded"
+        // (reversed word order), causing 4 immediate retries with no cooldown.
+        let err = patterns::detect_rate_limit("You have exceeded your monthly quota");
+        assert!(
+            matches!(err, Some(AgentError::RateLimit { .. })),
+            "monthly quota exhaustion must be detected as rate limit, got: {err:?}"
         );
     }
 

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -115,7 +115,7 @@ fn classify_run_error_type(last_error: &str) -> &'static str {
         "success"
     } else if last_error.contains("timeout") {
         "timeout"
-    } else if last_error.contains("billing cycle") {
+    } else if last_error.contains("billing cycle") || last_error.contains("monthly quota") {
         "billing_cycle_exhausted"
     } else if last_error.contains("rate limit") || last_error.contains("usage limit") {
         "rate_limit"
@@ -1938,6 +1938,22 @@ mod tests {
         assert_eq!(
             classify_run_error_type("billing account suspended"),
             "failed"
+        );
+    }
+
+    #[test]
+    fn classify_run_error_type_monthly_quota_is_billing_cycle() {
+        // Regression test for issue #3302: GitHub Copilot "You have exceeded your
+        // monthly quota" must map to billing_cycle_exhausted, not "failed".
+        assert_eq!(
+            classify_run_error_type(
+                "opencode failed: agent failed: You have exceeded your monthly quota"
+            ),
+            "billing_cycle_exhausted"
+        );
+        assert_eq!(
+            classify_run_error_type("You have exceeded your monthly quota"),
+            "billing_cycle_exhausted"
         );
     }
 


### PR DESCRIPTION
## Summary

Added 'monthly quota' to detect_rate_limit() so GitHub Copilot's 'You have exceeded your monthly quota' is recognized as a rate limit and routed to BillingCycleExhausted (24h→7d cooldown) rather than falling through to AgentFailed with no cooldown.

### What was done

- Added 'monthly quota' pattern to detect_rate_limit() in src/engine/runner/agents/mod.rs (line 1099) — fixes the root cause where reversed word order ('exceeded ... quota' instead of 'quota exceeded') caused pattern miss
- Added 'monthly quota' to classify_run_error_type() in src/engine/runner/mod.rs so metrics accurately record billing_cycle_exhausted instead of failed
- Added regression test detect_rate_limit_github_copilot_monthly_quota verifying detect_rate_limit('You have exceeded your monthly quota') returns Some(AgentError::RateLimit { .. })
- Added regression test classify_run_error_type_monthly_quota_is_billing_cycle verifying full error string maps to billing_cycle_exhausted
- Verified detect_credit_exhaustion() in cooldown.rs already had 'monthly quota' in billing_cycle_patterns — so the downstream chain (fallback.rs → record_credit_exhaustion(agent, BillingCycleExhausted)) already works correctly once detect_rate_limit() fires
- All quality gates passed: cargo fmt clean, clippy -D warnings clean (both --lib and --all-targets), 2/2 regression tests pass via nextest


### Files changed

- `src/engine/runner/agents/mod.rs`
- `src/engine/runner/mod.rs`


Closes #3302

---
*Task #3302 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*