### PR TITLE
bug(runner): opencode 'Upstream idle timeout exceeded' classified as generic AgentFailed — no model cooldown applied, 31 failures across 29 tasks in 12 days

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -1352,6 +1352,8 @@ pub(crate) mod patterns {
             "the operation was aborted",
             "network request failed",
             "fetch failed",
+            // Upstream HTTP-layer timeouts from model provider APIs (e.g. opencode/nemotron)
+            "upstream idle timeout",
         ];
         // Map the byte offset from `lower` back to `text` via char-count (same
         // rationale as detect_rate_limit: Unicode case-folding can change byte lengths).
@@ -1979,6 +1981,8 @@ mod tests {
         assert!(patterns::detect_network_error("Unable to connect to API").is_some());
         assert!(patterns::detect_network_error("ECONNREFUSED").is_some());
         assert!(patterns::detect_network_error("network unreachable").is_some());
+        assert!(patterns::detect_network_error("Upstream idle timeout exceeded").is_some());
+        assert!(patterns::detect_network_error("upstream idle timeout").is_some());
         assert!(patterns::detect_network_error("all systems operational").is_none());
     }
 

--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -691,6 +691,11 @@ fn classify_opencode_message(message: &str) -> AgentError {
         };
     }
 
+    // Transient network/transport errors (e.g. "Upstream idle timeout exceeded")
+    if let Some(e) = super::patterns::detect_network_error(message) {
+        return e;
+    }
+
     AgentError::AgentFailed {
         message: message.to_string(),
     }
@@ -1386,6 +1391,17 @@ mod tests {
         assert!(
             matches!(err_with_detail, AgentError::RateLimit { .. }),
             "expected RateLimit, got: {err_with_detail:?}"
+        );
+    }
+
+    #[test]
+    fn classify_opencode_upstream_idle_timeout() {
+        // Issue #3301: "Upstream idle timeout exceeded" must produce NetworkError so
+        // fallback.rs applies a model-level cooldown instead of retrying immediately.
+        let err = classify_opencode_message("Upstream idle timeout exceeded");
+        assert!(
+            matches!(err, AgentError::NetworkError { .. }),
+            "expected NetworkError, got: {err:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Classified opencode 'Upstream idle timeout exceeded' as NetworkError so the generic model cooldown (exponential backoff starting at 5 min) is applied on future routing, stopping immediate retry against a timing-out provider.

### What was done

- Added 'upstream idle timeout' pattern to detect_network_error in src/engine/runner/agents/mod.rs
- Added detect_network_error call in classify_opencode_message (opencode.rs) before the AgentFailed fallthrough
- Added regression test classify_opencode_upstream_idle_timeout in opencode.rs verifying NetworkError classification
- Added assertions for the new pattern in the existing pattern_detect_network_error test in mod.rs
- All 4 tests pass (pattern_detect_network_error x2, classify_opencode_upstream_idle_timeout x2); clippy clean; cargo fmt clean


### Files changed

- `src/engine/runner/agents/mod.rs`
- `src/engine/runner/agents/opencode.rs`


Closes #3301

---
*Task #3301 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*