### PR TITLE
bug(review): timeout path doesn't apply model cooldown — same slow models retried indefinitely

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -718,6 +718,9 @@ async fn invoke_review_agent(
         Err(_) => {
             tracing::error!(task_id = task.id.0, "review agent timed out");
             let _ = tmux.kill_session(&session).await;
+            if let Some(model) = ctx.review_model.as_deref() {
+                crate::engine::cooldown::record_model_failure(&ctx.review_agent, model).await;
+            }
             complete_review_run(
                 store,
                 run_id,


### PR DESCRIPTION
## Summary

You've hit your session limit · resets 7:30pm (America/Sao_Paulo)

### Files changed

- `src/engine/review.rs`


Closes #3307

---
*Task #3307 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/mimo-v2.5-free`*