### PR TITLE
Daily review (last 24h)

### DIFF
--- a/docs/content/posts/daily-review-2026-06-13.md
+++ b/docs/content/posts/daily-review-2026-06-13.md
@@ -1,0 +1,141 @@
++++
+title = "Daily Review — 2026-06-13"
+date = 2026-06-13
+description = "Daily review: what shipped, what failed, operational health, and priorities for tomorrow."
++++
+
+# Daily Review — 2026-06-13
+
+## What Shipped (Last 24h)
+
+Five commits landed, all focused on runner/review pipeline correctness:
+
+| Commit | PR | Description |
+|--------|----|-------------|
+| `69a75714` | #3315 | bug(runner): apply persistent cooldown for review `parse_error` and `InvalidResponse` |
+| `4440b673` | #3312 | enhancement(sync): auto-recover rebroadcast-blocked tasks when review agents return |
+| `08496c5c` | #3311 | bug(runner): `find_auth_line_scan` bare '403'/'401' match causes false auth_error on NDJSON timestamps |
+| `2d560843` | #3310 | bug(review): timeout path doesn't apply model cooldown — same slow models retried indefinitely |
+| `8b7f4799` | — | fix(review): drop blocking cooldown sleep in subscriber + skip sync re-fires when cooled |
+
+### Issues Closed
+
+- **#3314** — north-mini-code-free review `parse_error` not applying persistent model cooldown → fixed by #3315
+- **#3309** — auto-recover rebroadcast-blocked tasks → fixed by #3312
+- **#3308** — `find_auth_line_scan` false `auth_error` on NDJSON timestamps → fixed by #3311
+- **#3307** — review timeout path not applying model cooldown → fixed by #3310
+
+Latest release: **v0.80.17** (CI auto-tagged after all 4 PRs merged).
+
+---
+
+## Operational Health
+
+### Volume (Last 24h)
+
+| Metric | Count |
+|--------|-------|
+| Dispatches | 324 |
+| PRs created | 98 |
+| Review decisions | 87 |
+| Status changes | 1181 |
+| Errors logged | 58 |
+| Reroutes | 21 |
+
+High-volume, healthy throughput day.
+
+### Agent / Model Outcomes
+
+| Agent | Model | Outcome | Count |
+|-------|-------|---------|-------|
+| claude | sonnet | success | **115** |
+| opencode | mimo-v2.5-free | success | 21 |
+| codex | gpt-5.5 | success | 17 |
+| opencode | nemotron-3-ultra-free | success | 17 |
+| opencode | north-mini-code-free | success | 11 |
+| opencode | nemotron-3-ultra-free | failed | 9 |
+| claude | sonnet | parse_error | 8 |
+| opencode | deepseek-v4-flash-free | success | 8 |
+| opencode | deepseek-v4-flash-free | failed | 5 |
+| opencode | north-mini-code-free | parse_error | 5 |
+| codex | gpt-5.3 | failed | 2 |
+| codex | gpt-5.2 | failed | 2 |
+
+**claude/sonnet dominates** with 115 successes, confirming it's the only fully-healthy agent right now.
+
+**7 claude/sonnet agent `parse_error` outcomes** ("claude invalid response") — these will benefit from the persistent cooldown fix in #3315 once the service upgrades to v0.80.17. The fix ensures `InvalidResponse` results in an escalating model cooldown rather than immediate retry.
+
+**codex/gpt-5.3**: 2 more failures today ("not supported" error), bringing the total to ~19 since Jun 3. Fix requires human config change (see #3313).
+
+### Routing State
+
+```
+Active cooldowns:
+  claude:haiku          22h51m (persisted)
+  opencode              22h15m (billing_cycle_exhausted)
+  opencode:deepseek-v4-flash-free  10h52m
+  codex:gpt-5.3         9h
+  minimax:opus          14h2m
+  minimax               1d14h
+  kimi                  14h20m
+  kimi:haiku            1d13h
+  minimax:haiku         6h59m
+  codex                 ~42m (expires soon)
+
+Effective routing pool right now:
+  claude:sonnet ✓   claude:opus ✓
+  codex:gpt-5.5 (in ~42m)
+```
+
+`opencode` billing cycle cooldown expires ~22h from now, restoring nemotron/north-mini/mimo routing. kimi resumes ~14h from now.
+
+Task #3313 (`codex gpt-5.3 permanently unavailable`) shows `ALL AGENTS COOLED` in logs (`remaining_secs=2779`) — this resolves when codex agent cooldown expires in ~42 min, and claude can handle it immediately. The routing error log is expected and not a concern.
+
+### Blocked / Stuck Tasks
+
+| Task | Project | Status | Block Reason |
+|------|---------|--------|-------------|
+| internal:153015 | bean | blocked | review agent rebroadcast escalated |
+| internal:153022 | bean | blocked | review agent rebroadcast escalated |
+| 2125 | bean | blocked | review agent rebroadcast escalated |
+| internal:153505 | bean | blocked | review agent failure threshold exceeded |
+| internal:153551 | bean | blocked | CI failure limit (PR #2166 open) |
+
+The three "rebroadcast escalated" bean tasks will **auto-recover on next tick** after upgrading to v0.80.16+ (fix #3312). No manual intervention needed — just upgrade and restart.
+
+---
+
+## Service Lag: CRITICAL ACTION NEEDED
+
+**Running: v0.80.13 — Released: v0.80.17 (4 versions behind, all from today)**
+
+All 4 missing versions ship critical fixes:
+- v0.80.14: review timeout now applies model cooldown
+- v0.80.15: `find_auth_line_scan` false 403/401 fixed
+- v0.80.16: rebroadcast-blocked tasks auto-recover
+- v0.80.17: review `parse_error` / `InvalidResponse` applies persistent model cooldown
+
+```bash
+brew update && brew upgrade orch
+brew services restart orch
+```
+
+---
+
+## Open Issues
+
+| # | Summary | Action |
+|---|---------|--------|
+| #3313 | codex gpt-5.3 permanently unavailable (19 wasted runs since Jun 3) | **Human**: remove `gpt-5.3` from codex model pool in `~/.orch/config.yml` |
+| #3297 | Service deployment lag (now 4 versions behind) | Run upgrade command above |
+
+---
+
+## Tomorrow's Priorities
+
+1. **UPGRADE SERVICE** (v0.80.13 → v0.80.17) — auto-recovers 3 blocked bean tasks, stops parse_error cycling, deploys false auth_error fix
+2. **Remove gpt-5.3 from config** — #3313 is waiting on a human config edit; 2 more wasted dispatches today
+3. **Monitor opencode recovery** — billing cycle expires ~22h from now (Jun 14 ~21:00 UTC); expect routing pool to expand significantly
+
+---
+*Prepared by Orch automation (internal:153781)*


### PR DESCRIPTION
## Summary

Daily review for 2026-06-13 written and committed. Key findings: 5 commits shipped today (v0.80.14–v0.80.17) fixing review timeout cooldown, false auth_error on NDJSON timestamps, rebroadcast-blocked task auto-recovery, and persistent cooldown for parse_error/InvalidResponse. Service still running v0.80.13 — upgrade to v0.80.17 is the top priority for tomorrow (will auto-recover 3 blocked bean tasks). 324 dispatches, 98 PRs created, 87 review decisions. Routing bottleneck: opencode billing cycle cooldown for 22h, kimi for 14h, minimax for 1d14h — only claude:sonnet/opus routing actively. No new issues filed (all patterns covered by existing #3313 and #3297).

### Files changed

- `docs/content/posts/daily-review-2026-06-13.md`


---
*Task internal-153781 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*