### PR TITLE
bug(runner): billing_cycle_exhausted for github-copilot/gpt-5-mini blocks all free opencode models with 72h agent-level cooldown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,7 @@ All cooldowns are **persisted to SQLite KV** (`cooldown:{key}`) so they survive 
 - Silence detection → model cooldown + short 120s agent cooldown → re-route
 - Credit exhaustion (`out_of_credits`) → exponential from 1h, capping at 8h
 - Org-level disabling (`org_level_disabled`) → exponential from 2h, capping at 8h
-- Billing cycle exhaustion → escalating from 24h, capping at 7 days (monthly event; flat 24h caused daily retry-fail cycles)
+- Billing cycle exhaustion → when the failing model is known: persistent model-level cooldown (4h base → 7d cap); when no model is identified: escalating agent-wide cooldown from 24h, capping at 7 days. Model-scoped exhaustion (e.g. a provider sub-model like `github-copilot/gpt-5-mini`) must not block unrelated models on the same agent.
 - On successful completion → failure counts reset via `record_agent_success()` so next failure starts from base again
 
 **Exception for pre-emptive routability checks**: The router performs proactive checks to skip agents/models that are likely to fail based on routing weight decay and cooldown states. This is not considered special-casing because it uses the same generic cooldown system and weight decay mechanisms that feed into the routing decision process.

--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -239,7 +239,22 @@ pub async fn handle_error(
             // is set. Without the model-level cooldown, the model continues to be
             // picked and fails repeatedly (issue #2153).
             if let Some(reason) = crate::engine::cooldown::detect_credit_exhaustion(message) {
-                crate::engine::cooldown::record_credit_exhaustion(agent_name, reason).await;
+                // For billing cycle exhaustion where we know the specific model, apply
+                // model-level persistent cooldown only. The quota is scoped to that
+                // provider sub-model (e.g. github-copilot/gpt-5-mini), not the entire
+                // agent account, so an agent-wide cooldown would incorrectly block
+                // unrelated models on the same agent.
+                if reason == crate::engine::cooldown::CreditExhaustionReason::BillingCycleExhausted
+                {
+                    if let Some(model) = model_name {
+                        crate::engine::cooldown::record_persistent_model_failure(agent_name, model)
+                            .await;
+                    } else {
+                        crate::engine::cooldown::record_credit_exhaustion(agent_name, reason).await;
+                    }
+                } else {
+                    crate::engine::cooldown::record_credit_exhaustion(agent_name, reason).await;
+                }
             } else {
                 crate::engine::cooldown::record_agent_failure_with_message(agent_name, message)
                     .await;
@@ -269,7 +284,19 @@ pub async fn handle_error(
             // agent-level and model-level cooldowns so the router can observe them before
             // concurrent tasks start another run against the same unavailable model.
             if let Some(reason) = crate::engine::cooldown::detect_credit_exhaustion(message) {
-                crate::engine::cooldown::record_credit_exhaustion(agent_name, reason).await;
+                // Billing cycle exhaustion scoped to a known model gets model-level
+                // persistent cooldown only — agent-wide cooldown would block unrelated models.
+                if reason == crate::engine::cooldown::CreditExhaustionReason::BillingCycleExhausted
+                {
+                    if let Some(model) = model_name {
+                        crate::engine::cooldown::record_persistent_model_failure(agent_name, model)
+                            .await;
+                    } else {
+                        crate::engine::cooldown::record_credit_exhaustion(agent_name, reason).await;
+                    }
+                } else {
+                    crate::engine::cooldown::record_credit_exhaustion(agent_name, reason).await;
+                }
             } else {
                 crate::engine::cooldown::record_agent_failure_with_message(agent_name, message)
                     .await;


### PR DESCRIPTION
## Summary

Fixed billing_cycle_exhausted blocking all opencode models. When a specific model (e.g. github-copilot/gpt-5-mini) hits its monthly quota, the runner now applies record_persistent_model_failure on the specific model instead of record_credit_exhaustion on the whole agent. Agent-wide cooldown is only applied when no model name is known. Also applied the same fix to the Auth branch. All 3697 tests pass.

### Files changed

- `src/engine/runner/fallback.rs`
- `AGENTS.md`


Closes #3318

---
*Task #3318 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*