### PR TITLE
bug(codex): app-server event stream lag is classified as AgentFailed instead of NetworkError

### DIFF
--- a/src/engine/runner/agents/codex.rs
+++ b/src/engine/runner/agents/codex.rs
@@ -174,6 +174,7 @@ impl CodexRunner {
         // into the dedicated network-retry loop with backoff and escalation.
         if lower.contains("reconnecting")
             || lower.contains("stream disconnected")
+            || lower.contains("event stream lagged")
             || lower.contains("connection closed")
             || lower.contains("websocket")
             || lower.contains("econnreset")
@@ -686,6 +687,16 @@ mod tests {
     #[test]
     fn classify_codex_websocket_error() {
         let err = runner().classify_message("WebSocket connection closed unexpectedly");
+        assert!(
+            matches!(err, AgentError::NetworkError { .. }),
+            "expected NetworkError so fallback retries, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_codex_event_stream_lagged() {
+        let err = runner()
+            .classify_message("in-process app-server event stream lagged; dropped 1 events");
         assert!(
             matches!(err, AgentError::NetworkError { .. }),
             "expected NetworkError so fallback retries, got: {err:?}"


### PR DESCRIPTION
## Summary

Updated the Codex transient-error classifier so app-server event stream lag failures are treated as NetworkError, and added a regression test covering the reported message.

### What was done

- Extended `CodexRunner::classify_message()` to map `event stream lagged` transport failures to `AgentError::NetworkError` in `src/engine/runner/agents/codex.rs`.
- Added regression test `classify_codex_event_stream_lagged` asserting `in-process app-server event stream lagged; dropped 1 events` is classified as `NetworkError`.
- Ran the required verification gates successfully: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run`.
- Committed the change as `40cedb96 fix: classify codex event stream lag as network error`.


### Remaining

- Automated review pass and PR handling by orch.


### Files changed

- `src/engine/runner/agents/codex.rs`


Closes #3321

---
*Task #3321 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.4`*