### PR TITLE
bug(router): LLM router pool uses full API model ID for cooldown keys, diverging from task routing alias-based keys

### DIFF
--- a/src/engine/router/config.rs
+++ b/src/engine/router/config.rs
@@ -224,7 +224,7 @@ impl Default for RouterConfig {
         Self {
             mode: "round_robin".to_string(),
             router_agent: "claude".to_string(),
-            router_model: "claude-haiku-4-5-20251001".to_string(),
+            router_model: "haiku".to_string(),
             timeout_seconds: 45,
             fallback_executor: "codex".to_string(),
             agents: DEFAULT_AGENTS.iter().map(|s| s.to_string()).collect(),

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -1661,7 +1661,7 @@ mod tests {
 
         assert_eq!(config.mode, "round_robin");
         assert_eq!(config.router_agent, "claude");
-        assert_eq!(config.router_model, "claude-haiku-4-5-20251001");
+        assert_eq!(config.router_model, "haiku");
         assert_eq!(config.fallback_executor, "codex");
         assert_eq!(config.max_route_attempts, 3);
         assert!(!config.allowed_tools.is_empty());


### PR DESCRIPTION
## Summary

bug(router): LLM router pool uses full API model ID for cooldown keys, diverging from task routing alias-based keys

### Files changed

- `src/engine/router/config.rs`
- `src/engine/router/mod.rs`


Closes #3325

---
*Task #3325 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*