### PR TITLE
bug(parser): normalize_status missing 'fixed' alias causes completed task to fail

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -187,7 +187,8 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         | "not_configured"
         | "healthy"
         | "alerts_fired"
-        | "verified" => "done".to_string(),
+        | "verified"
+        | "fixed" => "done".to_string(),
         // Canonical progress statuses.
         // `partial` is used by some models to indicate partial progress —
         // treat it as in_progress so the task remains open for follow-up.
@@ -1028,6 +1029,13 @@ Some output here.
     }
 
     #[test]
+    fn parse_normalizes_fixed_alias_to_done() {
+        let input = r#"{"status":"fixed","summary":"bug has been fixed","accomplished":["fixed bug"],"remaining":[],"files":["src/parser.rs"]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "done");
+    }
+
+    #[test]
     fn parse_normalizes_alerts_fired_alias_to_done() {
         let input = r#"{"status":"alerts_fired","summary":"alerts dispatched","accomplished":[],"remaining":[],"files":[]}"#;
         let resp = parse(input).unwrap();
@@ -1192,6 +1200,7 @@ Some output here.
             ("changes_made", "done"),
             ("changes_pushed", "done"),
             ("changes_addressed", "done"),
+            ("fixed", "done"),
             ("running", "in_progress"),
             ("partial", "in_progress"),
             ("reviewing", "in_review"),


### PR DESCRIPTION
## Summary

Looking at the code, I can see the issue. The `normalize_status()` function at line 154 maps many completion aliases to "done", but "fixed" is missing from the list. I'll add it and also add a test case.
Now I'll add a test case for the "fixed" status alias.
Now let me add "fixed" to the comprehensive alias normalization test:
Now let me run the tests to verify the fix works:
Perfect! All tests pass including the new `parse_normalizes_fixed_alias_to_done` test. Now let me run the linter and form

### What was done

- Problem**: The `normalize_status()` function was missing the `"fixed"` alias, causing agents that return `status: "fixed"` to fail with `unrecognized status: fixed`.
- Added `"fixed"` to the canonical completion aliases in `normalize_status()` (line 190)
- Added a dedicated test case `parse_normalizes_fixed_alias_to_done()`
- Added `"fixed"` to the comprehensive alias normalization regression test
- ✅ All 142 parser tests pass (including the new test)
- ✅ Cargo fmt check passes
- ✅ Cargo clippy check passes
- ✅ Changes committed to branch


### Files changed

- `src/parser.rs`


Closes #3330

---
*Task #3330 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*