### PR TITLE
ops: GitHub Actions billing failures on gabrielkoerich/bean blocking automated tasks

### DIFF
--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -955,6 +955,12 @@ pub async fn unblock(id: &str) -> anyhow::Result<()> {
             }
         }
 
+        // Clear the repo billing failure marker so the next dispatch
+        // attempt is not blocked by the stale marker.
+        if let Some(ref s) = store {
+            crate::engine::cooldown::clear_repo_billing_failure(&repo, s).await;
+        }
+
         let total = external_count + internal_count;
         println!(
             "Unblocked {} tasks ({} external, {} internal) (attempts reset)",
@@ -976,6 +982,7 @@ pub async fn unblock(id: &str) -> anyhow::Result<()> {
                     "Unblocked internal task #{} (attempts reset, will be re-routed)",
                     parsed
                 );
+                crate::engine::cooldown::clear_repo_billing_failure(&repo, s).await;
                 return Ok(());
             }
         }
@@ -989,6 +996,7 @@ pub async fn unblock(id: &str) -> anyhow::Result<()> {
                         "Unblocked internal task #{} (attempts reset, will be re-routed)",
                         parsed
                     );
+                    crate::engine::cooldown::clear_repo_billing_failure(&repo, s).await;
                     return Ok(());
                 }
             }
@@ -999,6 +1007,9 @@ pub async fn unblock(id: &str) -> anyhow::Result<()> {
     store::store_reset_counters(&store, &repo, &ext_id.0).await;
     update_status_store_first(&store, &backend, &repo, &ext_id, Status::New).await?;
     println!("Unblocked task #{} (attempts reset)", id);
+    if let Some(ref s) = store {
+        crate::engine::cooldown::clear_repo_billing_failure(&repo, s).await;
+    }
 
     Ok(())
 }

--- a/src/engine/auto_merge.rs
+++ b/src/engine/auto_merge.rs
@@ -1268,6 +1268,10 @@ pub(crate) async fn auto_merge_pr(
                         pr_number,
                         "GitHub Actions billing failure detected — blocking for human intervention"
                     );
+                    // Persist a repo-level billing failure marker so the router
+                    // can skip dispatching new agents for this repo until billing
+                    // is resolved (24h TTL, auto-clears).
+                    crate::engine::cooldown::set_repo_billing_failure(repo, store).await;
                     let fields = [(
                         "block_reason",
                         serde_json::json!(

--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -783,6 +783,21 @@ pub async fn clear_cooldown(key: &str, store: &Arc<crate::store::TaskStore>) {
                 }
             }
         }
+        // Also clear any repo billing failure markers so tasks can be
+        // re-dispatched after a billing issue is resolved.
+        if let Ok(bf_entries) = store.kv_list_prefix(REPO_BILLING_FAILURE_PREFIX).await {
+            for (bf_key, _) in &bf_entries {
+                if let Err(e) = store.kv_delete(bf_key).await {
+                    tracing::warn!(key = bf_key, err = %e, "failed to clear repo billing failure marker");
+                }
+            }
+            if !bf_entries.is_empty() {
+                tracing::info!(
+                    count = bf_entries.len(),
+                    "cleared repo billing failure markers"
+                );
+            }
+        }
         tracing::info!(
             count = keys.len(),
             "cleared all cooldowns and failure counts"
@@ -807,6 +822,86 @@ pub async fn clear_cooldown(key: &str, store: &Arc<crate::store::TaskStore>) {
             tracing::warn!(key = credit_fc_key, err = %e, "failed to reset credit failure count");
         }
         tracing::info!(key, "cleared cooldown and failure count");
+    }
+}
+
+/// KV prefix for per-repo billing failure markers.
+const REPO_BILLING_FAILURE_PREFIX: &str = "repo_billing_failure:";
+
+/// TTL for repo billing failure markers: 24 hours.
+const REPO_BILLING_FAILURE_TTL_SECS: i64 = 24 * 60 * 60;
+
+/// Persist a repo-level billing failure marker so the router skips this repo
+/// and avoids wasting agent compute on tasks whose CI will never succeed.
+pub async fn set_repo_billing_failure(repo: &str, store: &Arc<crate::store::TaskStore>) {
+    let now = chrono::Utc::now().timestamp();
+    let kv_key = format!("{REPO_BILLING_FAILURE_PREFIX}{repo}");
+    if let Err(e) = store.kv_set(&kv_key, &now.to_string()).await {
+        tracing::warn!(repo, err = %e, "failed to persist repo billing failure marker");
+    } else {
+        tracing::info!(
+            repo,
+            ttl_hours = REPO_BILLING_FAILURE_TTL_SECS / 3600,
+            "persisted repo billing failure marker"
+        );
+    }
+}
+
+/// Check if a repo has an active billing failure marker from a recent CI failure.
+///
+/// Returns `true` when an agent should not be dispatched for this repo — any CI
+/// runs triggered by the agent's PR will fail before a runner can start. The
+/// marker has a 24-hour TTL so the system self-recovers once billing is resolved.
+pub async fn is_repo_billing_blocked(store: &Arc<crate::store::TaskStore>, repo: &str) -> bool {
+    let kv_key = format!("{REPO_BILLING_FAILURE_PREFIX}{repo}");
+    match store.kv_get(&kv_key).await {
+        Ok(Some(raw)) => match raw.parse::<i64>() {
+            Ok(ts) => {
+                let now = chrono::Utc::now().timestamp();
+                let age_secs = now - ts;
+                if age_secs < REPO_BILLING_FAILURE_TTL_SECS {
+                    let remaining_hours = (REPO_BILLING_FAILURE_TTL_SECS - age_secs) / 3600;
+                    tracing::debug!(
+                        repo,
+                        remaining_hours,
+                        "repo billing failure marker still active — skipping agent dispatch"
+                    );
+                    true
+                } else {
+                    if let Err(e) = store.kv_delete(&kv_key).await {
+                        tracing::debug!(
+                            repo,
+                            err = %e,
+                            "failed to delete expired repo billing failure marker"
+                        );
+                    }
+                    false
+                }
+            }
+            Err(e) => {
+                tracing::warn!(repo, err = %e, "failed to parse repo billing failure timestamp");
+                false
+            }
+        },
+        Ok(None) => false,
+        Err(e) => {
+            tracing::debug!(
+                repo,
+                err = %e,
+                "failed to check repo billing failure — allowing dispatch"
+            );
+            false
+        }
+    }
+}
+
+/// Clear a repo billing failure marker. Called when a human unblocks tasks,
+/// allowing the next dispatch to attempt again.
+pub async fn clear_repo_billing_failure(repo: &str, store: &Arc<crate::store::TaskStore>) {
+    let kv_key = format!("{REPO_BILLING_FAILURE_PREFIX}{repo}");
+    match store.kv_delete(&kv_key).await {
+        Ok(_) => tracing::info!(repo, "cleared repo billing failure marker"),
+        Err(e) => tracing::warn!(repo, err = %e, "failed to clear repo billing failure marker"),
     }
 }
 

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -13,9 +13,9 @@ use crate::backends::{ExternalBackend, ExternalId, ExternalTask, Status};
 use crate::channels::capture::CaptureService;
 use crate::config;
 use crate::engine::cooldown::{
-    github_circuit_remaining_secs, is_github_circuit_open, record_agent_failure_with_message,
-    record_silence_detection, set_agent_cooldown, set_model_cooldown, SILENCE_AGENT_COOLDOWN_SECS,
-    SILENCE_EXTENDED_COOLDOWN_SECS,
+    github_circuit_remaining_secs, is_github_circuit_open, is_repo_billing_blocked,
+    record_agent_failure_with_message, record_silence_detection, set_agent_cooldown,
+    set_model_cooldown, SILENCE_AGENT_COOLDOWN_SECS, SILENCE_EXTENDED_COOLDOWN_SECS,
 };
 use crate::engine::dispatch_guard::DispatchGuard;
 use crate::engine::jobs;
@@ -1195,6 +1195,32 @@ pub(crate) async fn tick_route_tasks(
     let max_per_tick = crate::engine::router::config::max_tasks_per_routing_tick();
     for task in routable.into_iter().take(max_per_tick) {
         let _task_span = tracing::info_span!("engine.route", task_id = %task.id.0).entered();
+
+        // Check for active repo billing failure before routing.
+        // If this repo's CI is blocked by GitHub Actions billing, skip
+        // the LLM routing call and block the task immediately to avoid
+        // wasting agent compute on work that can never land.
+        if is_repo_billing_blocked(store, repo).await {
+            tracing::error!(
+                task_id = %task.id.0,
+                repo,
+                "repo billing failure active — blocking task without dispatching agent"
+            );
+            let fields = [(
+                "block_reason",
+                serde_json::json!(
+                    "GitHub Actions billing failure — check Billing & plans settings \
+                     (jobs are not starting due to payment failure or spending limit)"
+                ),
+            )];
+            if let Err(e) = task_manager
+                .update_task_status_and_result(&task.id, Status::Blocked, &fields)
+                .await
+            {
+                tracing::error!(task_id = %task.id.0, err = %e, "failed to block task for repo billing failure");
+            }
+            continue;
+        }
 
         let task_start = Instant::now();
         match router.route(task, store, repo).await {


### PR DESCRIPTION
## Summary

Added repo-level billing failure circuit breaker: when a GitHub Actions billing failure is detected during auto-merge, a KV marker is persisted per-repo. The routing phase checks this marker before LLM routing and blocks tasks immediately instead of dispatching agents for wasted compute.

### What was done

- Identified the root cause: GitHub Actions billing failures on gabrielkoerich/bean were only detected AFTER agent work, review, and PR creation, wasting compute on 6+ tasks
- Added `set_repo_billing_failure()` / `is_repo_billing_blocked()` / `clear_repo_billing_failure()` in cooldown.rs — persists a per-repo KV marker with 24h TTL at billing failure detection point
- Added repo billing check in `tick_route_tasks()` before LLM routing call — blocks task immediately with billing failure message if marker is active, saving LLM routing + agent dispatch costs
- Wired `clear_repo_billing_failure()` into `orch task unblock` (all paths: internal, external, --all) so human-unblocked tasks can re-dispatch after billing is fixed
- Wired cleanup into `clear_cooldown("*")` so `orch cooldown clear --all` also clears billing failure markers


### Remaining

- The existing 1 blocked bean task (#154007) still needs manual unblock after billing is fixed on GitHub


### Files changed

- `src/engine/cooldown.rs`
- `src/engine/auto_merge.rs`
- `src/engine/tick.rs`
- `src/cli/task.rs`


Closes #3332

---
*Task #3332 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/deepseek-v4-flash-free`*