### PR TITLE
bug(parser): JSONL domain output can be misread as orch agent status

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -95,7 +95,10 @@ fn status_is_known(status: &str) -> bool {
 pub fn parse(raw: &str) -> anyhow::Result<AgentResponse> {
     let mut last_err: Option<anyhow::Error> = None;
     let mut saw_jsonish_candidate = false;
-    let mut best_candidate: Option<AgentResponse> = None;
+    // Pair: (parsed response, raw candidate string) so we can check the raw object
+    // for substantive fields that map_generic_response handles but that direct
+    // deserialization into AgentResponse ignores (e.g. "output", "message").
+    let mut best_candidate: Option<(AgentResponse, String)> = None;
 
     for candidate in json_candidates(raw) {
         match parse_candidate(&candidate) {
@@ -107,7 +110,7 @@ pub fn parse(raw: &str) -> anyhow::Result<AgentResponse> {
                 }
                 // Non-canonical status - remember it but keep looking for better.
                 if best_candidate.is_none() {
-                    best_candidate = Some(resp);
+                    best_candidate = Some((resp, candidate));
                 }
             }
             Err(err) => {
@@ -126,8 +129,8 @@ pub fn parse(raw: &str) -> anyhow::Result<AgentResponse> {
     // be deserialized into AgentResponse, but they carry no orch fields like
     // `summary`, `accomplished`, `files`, etc. Returning them would silently
     // promote a domain value (e.g. "inbound-not-submitted") as the task status.
-    if let Some(resp) = best_candidate {
-        if has_substantive_fields(&resp) {
+    if let Some((resp, raw_candidate)) = best_candidate {
+        if has_substantive_fields(&raw_candidate) {
             return Ok(resp);
         }
     }
@@ -288,20 +291,22 @@ fn find_closing_fence_at_line_boundary(content: &str) -> Option<usize> {
     None
 }
 
-/// Returns true if the response has at least one substantive orch control field beyond `status`.
+/// Returns true if the raw JSON candidate has at least one substantive orch control field.
 ///
-/// Domain JSON records (career pipeline entries, trading alerts, etc.) parse successfully
-/// as `AgentResponse` because all fields except `status` are `#[serde(default)]`, but they
-/// carry none of these control fields. Checking this prevents a domain `status` value
-/// (e.g. "inbound-not-submitted") from being promoted as the orch task status.
-fn has_substantive_fields(resp: &AgentResponse) -> bool {
-    !resp.summary.is_empty()
-        || !resp.accomplished.is_empty()
-        || !resp.remaining.is_empty()
-        || !resp.files.is_empty()
-        || !resp.learnings.is_empty()
-        || !resp.delegations.is_empty()
-        || resp.error.is_some()
+/// Operates on the raw string (not the deserialized `AgentResponse`) so that fields like
+/// `output` and `message` — which `map_generic_response` maps to `summary` but which are
+/// not struct fields on `AgentResponse` and are silently ignored by direct deserialization —
+/// are correctly treated as substantive. This prevents domain JSON records (career pipeline
+/// entries, trading alerts, etc.) whose only orch-like field is `status` from being promoted
+/// as the task status.
+fn has_substantive_fields(raw: &str) -> bool {
+    if let Ok(serde_json::Value::Object(obj)) = serde_json::from_str::<serde_json::Value>(raw) {
+        return SUBSTANTIVE_RESPONSE_FIELDS
+            .iter()
+            .any(|key| obj.contains_key(*key))
+            || obj.contains_key("error");
+    }
+    false
 }
 
 /// Fields that indicate a JSON blob is an AgentResponse (higher score = better match).
@@ -1403,5 +1408,25 @@ The fix from attempt #8 was already committed. All quality gates pass.
             "Career radar written to md/career/2026-06-15-radar.md"
         );
         assert_eq!(resp.files, vec!["md/career/2026-06-15-radar.md"]);
+    }
+
+    #[test]
+    fn parse_regression_3336_noncanonical_with_output_accepted() {
+        // A non-canonical status with `output` (handled by map_generic_response but not a
+        // struct field on AgentResponse) must still be accepted — not rejected with a parse
+        // error. Previously `has_substantive_fields` checked the deserialized struct and
+        // missed `output`, causing this to fail with "JSON object lacks substantive".
+        let input = r#"{"status":"mystery_status","output":"All tests passed"}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "mystery_status");
+    }
+
+    #[test]
+    fn parse_regression_3336_noncanonical_with_message_accepted() {
+        // Same as above for `message` — also substantive but absent from the AgentResponse
+        // struct, so direct deserialization leaves summary empty.
+        let input = r#"{"status":"mystery_status","message":"All tests passed"}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "mystery_status");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -120,9 +120,16 @@ pub fn parse(raw: &str) -> anyhow::Result<AgentResponse> {
     }
 
     // If we found a candidate with non-canonical status but no known-status
-    // candidate was found, use the best one we have.
+    // candidate was found, use the best one we have — but only if it has at
+    // least one substantive orch control field. Domain JSON records (career
+    // pipeline entries, trading alerts, etc.) have a `status` field that can
+    // be deserialized into AgentResponse, but they carry no orch fields like
+    // `summary`, `accomplished`, `files`, etc. Returning them would silently
+    // promote a domain value (e.g. "inbound-not-submitted") as the task status.
     if let Some(resp) = best_candidate {
-        return Ok(resp);
+        if has_substantive_fields(&resp) {
+            return Ok(resp);
+        }
     }
 
     if saw_jsonish_candidate {
@@ -279,6 +286,22 @@ fn find_closing_fence_at_line_boundary(content: &str) -> Option<usize> {
         search_from = after_nl;
     }
     None
+}
+
+/// Returns true if the response has at least one substantive orch control field beyond `status`.
+///
+/// Domain JSON records (career pipeline entries, trading alerts, etc.) parse successfully
+/// as `AgentResponse` because all fields except `status` are `#[serde(default)]`, but they
+/// carry none of these control fields. Checking this prevents a domain `status` value
+/// (e.g. "inbound-not-submitted") from being promoted as the orch task status.
+fn has_substantive_fields(resp: &AgentResponse) -> bool {
+    !resp.summary.is_empty()
+        || !resp.accomplished.is_empty()
+        || !resp.remaining.is_empty()
+        || !resp.files.is_empty()
+        || !resp.learnings.is_empty()
+        || !resp.delegations.is_empty()
+        || resp.error.is_some()
 }
 
 /// Fields that indicate a JSON blob is an AgentResponse (higher score = better match).
@@ -1323,5 +1346,62 @@ The fix from attempt #8 was already committed. All quality gates pass.
         let input = r#"{"status": "done", "summary": "done", "files_modified": ["src/foo.rs", "src/bar.rs"]}"#;
         let resp = parse(input).unwrap();
         assert_eq!(resp.files, vec!["src/foo.rs", "src/bar.rs"]);
+    }
+
+    // ── Regression tests for gh-issue-3336 ───────────────────────────────
+
+    #[test]
+    fn parse_regression_3336_jsonl_domain_status_field_rejected() {
+        // Career pipeline JSONL output. Neither record has an orch canonical status
+        // and neither has any substantive orch fields — must be rejected, not returned
+        // with domain status "inbound-not-submitted" as the task status.
+        let input = r#"{"date":"2026-06-15","role":"Senior Solana Engineer","company":"M0","status":"inbound-not-submitted","source":"referral"}
+{"date":"2026-06-15","role":"Rust Engineer (Solana)","company":"Exo Tech","status":"applied-follow-up-overdue","source":"linkedin"}"#;
+        let err = parse(input).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("agent output is not valid JSON or a supported JSON wrapper")
+                || msg.contains("JSON object lacks substantive"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_regression_3336_single_domain_record_rejected() {
+        // A single domain JSON record with a non-canonical status and no orch fields.
+        let input = r#"{"status":"inbound-not-submitted","date":"2026-06-15","role":"Engineer","company":"Acme"}"#;
+        let err = parse(input).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("agent output is not valid JSON or a supported JSON wrapper")
+                || msg.contains("JSON object lacks substantive"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_regression_3336_noncanonical_status_with_summary_still_accepted() {
+        // A non-canonical orch status WITH a summary is a real agent response and must
+        // still be accepted (not broken by the substantive-field guard).
+        let input = r#"{"status":"fix_deployed","summary":"deployed to staging","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "fix_deployed");
+        assert_eq!(resp.summary, "deployed to staging");
+    }
+
+    #[test]
+    fn parse_regression_3336_jsonl_domain_plus_orch_response_prefers_orch() {
+        // JSONL output where domain records precede an actual orch response with a
+        // canonical status. The parser must pick the orch response.
+        let input = r#"{"date":"2026-06-15","role":"Senior Solana Engineer","company":"M0","status":"inbound-not-submitted","source":"referral"}
+{"date":"2026-06-15","role":"Rust Engineer (Solana)","company":"Exo Tech","status":"applied-follow-up-overdue","source":"linkedin"}
+{"status":"done","summary":"Career radar written to md/career/2026-06-15-radar.md","accomplished":["Wrote career radar"],"remaining":[],"files":["md/career/2026-06-15-radar.md"]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "done");
+        assert_eq!(
+            resp.summary,
+            "Career radar written to md/career/2026-06-15-radar.md"
+        );
+        assert_eq!(resp.files, vec!["md/career/2026-06-15-radar.md"]);
     }
 }


### PR DESCRIPTION
## Summary

Let me read the parser code to understand the current implementation.
Now I understand the issue. The problem is in `parse()` at line 124: when no canonical status is found, it returns `best_candidate` — even if that candidate is a domain JSON record with only a `status` field and no orch control fields. The `serde_json::from_str::<AgentResponse>` deserialization at line 326 succeeds because `AgentResponse` has `#[serde(default)]` on all fields except `status`, so domain records parse cleanly.

### What was done

- Root cause**: `AgentResponse` has `#[serde(default)]` on all fields except `status`, so any JSON object with a `status` key deserializes cleanly. Domain JSONL records (`{"date":…,"role":…,"status":"inbound-not-submitted"}`) landed in `best_candidate` and were returned when no canonical-status object was found.
- Added `has_substantive_fields(resp: &AgentResponse) -> bool` — returns true if any of `summary`, `accomplished`, `remaining`, `files`, `learnings`, `delegations`, or `error` is set.
- Guarded the `best_candidate` fallback at line 130 with this check. Domain records have none of these fields; real agent responses (even malformed ones) almost always have at least a `summary`.
- `parse_regression_3336_jsonl_domain_status_field_rejected` — multi-record JSONL career output errors out
- `parse_regression_3336_single_domain_record_rejected` — single domain record with no orch fields errors out
- `parse_regression_3336_noncanonical_status_with_summary_still_accepted` — non-canonical status WITH summary still works (existing behavior preserved)
- `parse_regression_3336_jsonl_domain_plus_orch_response_prefers_orch` — domain records mixed with real orch response still picks the correct one


### Files changed

- `src/parser.rs`


Closes #3336

---
*Task #3336 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*