### PR TITLE
Daily review (last 24h)

### DIFF
--- a/docs/content/posts/daily-review-2026-06-22.md
+++ b/docs/content/posts/daily-review-2026-06-22.md
@@ -1,0 +1,169 @@
++++
+title = "Daily Review — 2026-06-22"
+date = 2026-06-22
+description = "Daily review: what shipped, what failed, operational health, and priorities for tomorrow."
++++
+
+# Daily Review — 2026-06-22
+
+## What Shipped (Last 24h)
+
+**2 commits** landed in the last 24 hours.
+
+| Commit | PR | Description |
+|--------|----|-------------|
+| `b7f960be` | #3345 | fix(engine): silence-detection reroutes no longer convert to needs_review/done |
+| `413cea68` | #3343 | docs(posts): daily review 2026-06-21 |
+
+### Closed Issues (Last 24h)
+
+| Issue | Closed | Description |
+|------|--------|-------------|
+| #3344 | 2026-06-22 | silence-detection reroutes could be converted into false `done` via the no-code `needs_review` path |
+
+The main shipped fix is high leverage: silence-detection retries now stay on the retry path instead of being accidentally promoted into `needs_review`/`done` without real work. That closes a correctness gap in the runner/review handoff.
+
+---
+
+## Operational Health
+
+### Throughput (Last 24h)
+
+| Metric | Count |
+|--------|-------|
+| Status changes | 237 |
+| Dispatches | 74 |
+| Pushes | 66 |
+| Branch deletes | 86 |
+| Routed | 34 |
+| Review starts | 34 |
+| Review decisions | 32 |
+| PRs created | 31 |
+| Errors | 6 |
+| Reroutes | 1 |
+
+Volume stayed healthy. The system kept moving work despite a smaller landed-commit count in this repo.
+
+### Agent / Model Outcomes (Last 24h)
+
+| Agent | Model | Outcome | Count |
+|-------|-------|---------|-------|
+| claude | sonnet | success | 23 |
+| codex | gpt-5.5 | success | 9 |
+| kimi | opus | success | 7 |
+| codex | gpt-5.4 | success | 6 |
+| opencode | mimo-v2.5-free | success | 5 |
+| opencode | deepseek-v4-flash-free | success | 4 |
+| claude | sonnet | failed | 3 |
+| opencode | nemotron-3-ultra-free | success | 2 |
+| opencode | north-mini-code-free | success | 2 |
+| minimax | opus | rate_limit | 1 |
+| opencode | north-mini-code-free | parse_error | 1 |
+
+Aggregate outcomes: **58 successes**, **3 failures**, **2 rate limits**, **1 parse error**, plus **2 no-outcome rows** from runs that were still in-flight or had just been retried when sampled.
+
+### What Went Well
+
+1. **Claude and Codex carried the day.** `claude/sonnet`, `codex/gpt-5.5`, and `codex/gpt-5.4` handled most successful work without any sign of systemic degradation.
+2. **The silence-detection correctness fix landed quickly.** Yesterday's review called out correctness risks around retry/review state transitions; today that exact bug was fixed and closed.
+3. **Failover still worked when Minimax exhausted quota.** Both scheduled nightly jobs initially routed to `minimax/opus`, hit 429 quota errors, and were immediately rerouted instead of being left blocked.
+
+### What Failed
+
+#### 1. Cleanup reconciliation timeout is still live in production
+
+The log still shows repeated:
+
+`timed out listing reconciliation candidates timeout_secs=30`
+
+This happened continuously through the review window. The underlying fix already landed on `main` in `26c4c7f1` / issue `#3340`, but the running service is still behind, so the noise and tick delay remain operationally present.
+
+#### 2. Stale model pool warnings are now the loudest recurring signal
+
+Every sync cycle reported:
+
+`agent model pool appears stale: persistent model failures in heavily cooled pool`
+
+Affected pool:
+
+`opencode:2/4:opencode/nemotron-3-ultra-free,opencode/north-mini-code-free`
+
+This warning is intentional code in `src/engine/sync.rs`: it fires when at least half of an agent's configured pool is cooled and some of those models have persistent-failure markers. The signal is useful, but today it indicates ongoing pool drift rather than a new engine regression.
+
+#### 3. Minimax quota exhaustion hit both nightly jobs
+
+`internal:154230` (this daily review) and `internal:154231` (bean evening retrospective) both first routed to `minimax/opus`, then failed with:
+
+`API Error: Request rejected (429) · Token Plan usage limit reached`
+
+The retry path behaved correctly: Minimax was cooled/degraded and the task rerouted. The problem is capacity, not recovery logic.
+
+### Service / Deployment State
+
+| Item | Value |
+|------|-------|
+| Running version | `0.80.25` |
+| Latest seen in logs | `0.80.29` |
+| Gap | 4 releases |
+
+The service is behind again. That matters because the cleanup reconciliation fix is already merged but not yet deployed here.
+
+---
+
+## Stuck / Blocked Work
+
+### Current active scheduled work
+
+| Task | Status | Attempts | Note |
+|------|--------|----------|------|
+| `internal:154230` | in_progress | 2 | rerouted off Minimax after quota failure |
+| `internal:154231` | new | 1 | evening retrospective also hit Minimax quota first |
+
+### Downstream backlog
+
+The only meaningful blocked backlog is outside this repo:
+
+- `gabrielkoerich/oblivion` has **44 blocked tasks**
+- Almost all are blocked on `CI failure limit (3) reached during auto-merge`
+- Two tasks (`#490`, `#493`) remain `new` after **5 attempts** each
+- One task (`#419`) is blocked on **max review cycles (2) exceeded**
+- One task (`#458`) is still blocked on **review agent rebroadcast escalated after repeated retries**
+
+This is still a downstream-CI throughput problem, not an Orch routing-state bug. The pattern is persistent and large enough to keep showing up in daily operations.
+
+---
+
+## Routing Accuracy
+
+Routing was mostly accurate:
+
+- The daily review was re-routed from Minimax to Codex after the quota hit, which is the right fallback behavior.
+- Claude and Codex were selected for the highest volume of successful work and justified that weighting.
+- The main routing concern is not misclassification; it is **pool health drift** where Opencode retains multiple persistently cooled models in active configuration and Minimax remains quota-limited.
+
+No evidence today of silent-model failure loops like the ones fixed earlier in the month. The current signals are explicit: rate limit, parse error, and stale-pool warnings.
+
+---
+
+## Issues
+
+No new GitHub issues were filed from this review.
+
+Reasons:
+
+1. The cleanup-timeout root cause is already fixed on `main` (`#3340`) and the remaining problem is deployment lag.
+2. The stale-model-pool warning is an existing detector firing on degraded configured pools, not clear evidence of a new code regression.
+3. Minimax quota exhaustion is an external capacity/plan constraint and is already handled correctly by cooldown + reroute.
+
+---
+
+## Priorities for Tomorrow
+
+1. **Upgrade the running service to `0.80.29`.** This should remove the still-live cleanup reconciliation timeout noise and pick up the recent engine fixes already merged.
+2. **Review the Opencode model pool.** Two of four configured models are persistently cooled often enough to trigger the stale-pool alert every sync tick.
+3. **Keep Minimax off critical scheduled jobs until quota stabilizes.** Recovery works, but repeated first-attempt 429s waste the nightly window.
+4. **Triage the Oblivion blocked backlog as a CI/program-health problem.** Orch is surfacing the bottleneck accurately; the queue will not clear until those downstream CI failures are addressed.
+
+---
+
+*Prepared by Orch automation (internal:154230)*


### PR DESCRIPTION
## Summary

Created and committed the 2026-06-22 daily review post summarizing shipped work, operational health, failure patterns, blocked backlog, routing accuracy, and tomorrow priorities.

### What was done

- Gathered last-24h context from git history, prior review post, GitHub issues, orch task state, SQLite task/task_activity/task_runs data, and orch logs.
- Read ~/.claude/skills/orch/SKILL.md to incorporate current operational guidance and known failure-pattern context.
- Wrote docs/content/posts/daily-review-2026-06-22.md with commit/issue summary, throughput metrics, agent/model outcomes, cleanup-timeout status, stale model-pool warnings, Minimax quota failures, blocked backlog, and next priorities.
- Confirmed no new GitHub issues should be filed because the main noisy root cause (#3340 cleanup timeout) is already fixed on main and the remaining signals are deployment/config drift rather than new regressions.
- Committed the post as f5e8470e with message: docs(posts): daily review 2026-06-22.
- Verified clean working tree and confirmed the commit is present in git log main..HEAD.


### Remaining

- Upgrade the running orch service from 0.80.25 to 0.80.29 so the already-landed cleanup reconciliation fix is actually deployed.
- Review the Opencode model pool because persistent cooling of nemotron-3-ultra-free and north-mini-code-free is triggering the stale-pool alert every sync cycle.
- Triage the large blocked downstream Oblivion backlog, which remains dominated by CI failure limit blocks rather than Orch state bugs.


### Files changed

- `docs/content/posts/daily-review-2026-06-22.md`


---
*Task internal-154230 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.4`*