### PR TITLE
bug(runner): minimax 'Token Plan usage limit reached' classified as rate_limit instead of billing_cycle_exhausted

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -493,6 +493,9 @@ pub fn detect_credit_exhaustion(error_message: &str) -> Option<CreditExhaustionR
         "refreshed in the next cycle",
         "weekly/monthly limit exhausted",
         "limit will reset at",
+        "upgrade your token plan", // minimax: Token Plan usage limit reached
+        "token plan usage limit",  // minimax: Token Plan usage limit reached
+        "purchase credits for more", // minimax: ...purchase Credits for more usage
     ];
 
     if billing_cycle_patterns.iter().any(|p| lower.contains(p)) {
@@ -2284,6 +2287,29 @@ mod tests {
             detect_credit_exhaustion(
                 "Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-04-23 18:33:48"
             ),
+            Some(CreditExhaustionReason::BillingCycleExhausted)
+        );
+    }
+
+    #[serial(cooldown_state)]
+    #[test]
+    fn detect_credit_exhaustion_billing_cycle_minimax() {
+        assert_eq!(
+            detect_credit_exhaustion(
+                "minimax rate limit: API Error: Request rejected (429) · Token Plan usage limit reached: Upgrade your Token Plan or purchase Credits for more usage."
+            ),
+            Some(CreditExhaustionReason::BillingCycleExhausted)
+        );
+        assert_eq!(
+            detect_credit_exhaustion("Upgrade your Token Plan"),
+            Some(CreditExhaustionReason::BillingCycleExhausted)
+        );
+        assert_eq!(
+            detect_credit_exhaustion("Token Plan usage limit reached"),
+            Some(CreditExhaustionReason::BillingCycleExhausted)
+        );
+        assert_eq!(
+            detect_credit_exhaustion("purchase Credits for more usage"),
             Some(CreditExhaustionReason::BillingCycleExhausted)
         );
     }


### PR DESCRIPTION
## Summary

{"outcome":"success","summary":"Added three billing_cycle patterns to detect_credit_exhaustion() in src/engine/cooldown.rs: \"upgrade your token plan\", \"token plan usage limit\", and \"purchase credits for more\". Minimax's 429 Token Plan quota error now classifies as BillingCycleExhausted (24h→7d escalating cooldown) instead of rate_limit (4h max). Added test detect_credit_exhaustion_billing_cycle_minimax covering the full minimax error string and each sub-pattern. All 20 credit-exhaustion 

### Files changed

- `src/engine/cooldown.rs`


Closes #3348

---
*Task #3348 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*