### PR TITLE
Daily review (last 24h)

### DIFF
--- a/docs/content/posts/daily-review-2026-06-27.md
+++ b/docs/content/posts/daily-review-2026-06-27.md
@@ -1,0 +1,158 @@
++++
+title = "Daily Review — 2026-06-27"
+date = 2026-06-27
+description = "Daily review: what shipped, what failed, operational health, and priorities for tomorrow."
++++
+
+# Daily Review — 2026-06-27
+
+## What Shipped (Last 24h)
+
+**2 commits** landed in the last 24 hours.
+
+| Commit | PR | Description |
+|--------|----|-------------|
+| `b79fbd85` | #3357 | fix(sync): edge-trigger stale model-pool alert log |
+| `57994d8d` | #3355 | docs(posts): daily review 2026-06-26 |
+
+### Closed Issues (Last 24h)
+
+| Issue | Closed | Description |
+|------|--------|-------------|
+| #3356 | 2026-06-27 | stale model-pool alert logs every sync tick while the condition persists |
+
+The only code change in the window was targeted and operational: the stale alert log now emits on the edge instead of every sync tick. The main caveat is that the running service had **not** picked up that fix by the end of this review window.
+
+---
+
+## Operational Health
+
+### Throughput (Last 24h)
+
+| Metric | Count |
+|--------|-------|
+| Status changes | 315 |
+| Pushes | 101 |
+| Dispatches | 97 |
+| Branch deletes | 62 |
+| Review starts | 53 |
+| Review decisions | 51 |
+| PRs created | 47 |
+| Routed | 38 |
+| Errors | 9 |
+| Reroutes | 4 |
+
+Throughput stayed healthy. The engine continued to move work at a high rate, and nothing in the last 24 hours looks like a broad dispatch or review outage.
+
+### Agent / Model Outcomes (Last 24h)
+
+| Agent | Model | Outcome | Count |
+|------|-------|---------|-------|
+| claude | sonnet | success | 41 |
+| kimi | opus | success | 15 |
+| codex | gpt-5.4 | success | 7 |
+| opencode | opencode/mimo-v2.5-free | success | 5 |
+| opencode | opencode/deepseek-v4-flash-free | success | 4 |
+| minimax | opus | rate_limit | 3 |
+| opencode | opencode/north-mini-code-free | success | 3 |
+| claude | sonnet | failed | 2 |
+| opencode | opencode/nemotron-3-ultra-free | failed | 2 |
+| opencode | opencode/nemotron-3-ultra-free | success | 2 |
+
+Claude carried most of the successful load again. The main unhealthy pool remains `minimax/opus`, which produced another cluster of rate limits and left the cooldown counters elevated.
+
+### What Went Well
+
+1. **The fix for stale sync alert spam landed quickly.** The problem found in the previous review window was diagnosed, implemented, and merged the same day.
+2. **Overall throughput remained strong.** Nearly one hundred dispatches and more than fifty review starts completed without a system-wide stall.
+3. **Fallback behavior still worked.** Claude, Codex, Kimi, and OpenCode all recorded successful completions; failures stayed localized to specific model pools instead of cascading into a broad outage.
+4. **There is no open GitHub issue backlog in `gabrielkoerich/orch`.** The repo itself remains clean from an issue-tracker perspective.
+
+### What Failed
+
+#### 1. The running service is still one release behind
+
+The latest release is **`v0.80.32`** (published 2026-06-27T21:26:26Z), while the local CLI/service version still reports **`orch 0.80.31`**. The service log also emitted:
+
+```text
+orch upgrade available current_version=0.80.31 latest_version=0.80.32
+```
+
+That matters because the new sync-log fix landed in `#3357`, but the current process is still running the pre-fix build. The log noise in this review window is therefore deployment lag, not evidence that the new fix failed.
+
+#### 2. `minimax:opus` still looks like a degraded pool
+
+The last 200 service-log lines were dominated by repeated warnings of the form:
+
+```text
+agent model pool appears stale: persistent model failures in heavily cooled pool
+affected_agents=["minimax:1/2:opus"]
+```
+
+SQLite state matches the warning:
+
+- `cooldown:minimax:opus` remains active
+- `failure_count:minimax = 4`
+- `failure_count:minimax:haiku = 4`
+- `failure_count:minimax:opus = 4`
+
+The important distinction from yesterday is that a fix for repeated warning spam now exists; the service just has not upgraded to it yet.
+
+#### 3. Blocked backlog remains external, not orch-local
+
+`orch task list --global` still shows blocked work, but the blockers are outside this repo:
+
+- `gabrielkoerich/bean`: three tasks blocked by **GitHub Actions billing failure**
+- `gabrielkoerich/oblivion`: long-standing blocked tasks dominated by **CI failure limit reached during auto-merge**
+
+Those are real operational problems, but they are not fresh regressions in orch itself.
+
+---
+
+## Stuck / Pending Work
+
+| Task | Status | Note |
+|------|--------|------|
+| `internal:154408` | in_progress | This daily review |
+| `internal:154409` | in_progress | Evening retrospective |
+| `internal:154384` | blocked | External repo task blocked by GitHub Actions billing failure |
+| `internal:154349` | blocked | External repo task blocked by GitHub Actions billing failure |
+| `internal:154300` | blocked | External repo task blocked by GitHub Actions billing failure |
+| `491`, `492`, `494`, and related older tasks | blocked | External repo tasks blocked by CI failure limit during auto-merge |
+
+No new stuck task pattern appeared inside `gabrielkoerich/orch` itself. The notable open work is deployment lag plus external blocked queues.
+
+---
+
+## Routing Accuracy
+
+Routing looked mostly healthy in this window:
+
+1. Successful work was distributed across Claude, Codex, Kimi, and OpenCode rather than collapsing onto a single executor.
+2. The main unhealthy signal remained **pool-specific** (`minimax/opus`) rather than a router-wide misclassification pattern.
+3. There is no sign of silent model failure dominating the day. Failures surfaced as explicit rate limits or localized model errors.
+
+The main routing takeaway is that the system is currently spending time around known degraded pools, but that pain is already addressed in code for the sync-log spam case and does not look like a brand-new routing bug.
+
+---
+
+## Issues
+
+**Open issues in `gabrielkoerich/orch`: 0 before this review.**
+
+One issue was filed from this review:
+
+1. **#3358: service lag after `v0.80.32` release.** The stale-alert fix merged, but the running service stayed on `0.80.31`, so the old warning pattern remained visible through the review window.
+
+---
+
+## Priorities for Tomorrow
+
+1. **Upgrade the running service to `v0.80.32`.** Until that happens, the stale model-pool alert behavior visible in logs is not representative of the current code.
+2. **Confirm the warning volume drops after upgrade.** If repeated stale-pool warnings continue on `v0.80.32`, that would justify a new sync/regression issue. If they disappear, today's noise was only rollout lag.
+3. **Keep watching `minimax/opus`.** Even with the log fix, the underlying degraded pool is real and should be monitored for continued rate-limit pressure.
+4. **Track external blocked queues separately from orch health.** Bean billing failures and Oblivion CI-failure blocks should not be misreported as new orch regressions.
+
+---
+
+*Prepared by Orch automation (internal:154408) at 2026-06-27T23:00Z.*


### PR DESCRIPTION
## Summary

Created the 2026-06-27 daily review post, documented the last 24 hours of shipped work and operational health, and filed issue #3358 for the undeployed v0.80.32 service lag.

### What was done

- Gathered the required 24-hour context from git history, the prior daily review, GitHub issues, orch task state, SQLite task/task_activity/task_runs data, orch logs, and the orch skill notes.
- Created `docs/content/posts/daily-review-2026-06-27.md` with shipped commits, closed issues, throughput metrics, agent/model outcome patterns, blocked-task inventory, routing observations, and priorities for tomorrow.
- Identified that the stale model-pool alert spam fix had shipped in v0.80.32 but the running service was still on v0.80.31, making deployment lag the main orch-local operational problem.
- Filed GitHub issue #3358 to track the service-version lag and undeployed stale-alert fix.
- Committed the review post as `9c881d83 docs(posts): daily review 2026-06-27`.
- Verified the worktree is clean with `git status --short` and confirmed the commit is present with `git log --oneline main..HEAD`.


### Remaining

- Upgrade the running service to v0.80.32 so the stale model-pool alert fix is actually deployed.
- Verify after upgrade that stale model-pool warnings only emit on transition rather than every sync tick.
- Continue monitoring the degraded `minimax/opus` pool and the external blocked queues in `gabrielkoerich/bean` and `gabrielkoerich/oblivion`.


### Files changed

- `docs/content/posts/daily-review-2026-06-27.md`


---
*Task internal-154408 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.4`*