### PR TITLE
bug(runner): opencode/nemotron "Streaming response failed" classified as AgentFailed — should be NetworkError to match Upstream idle timeout handling

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -1372,6 +1372,8 @@ pub(crate) mod patterns {
             "fetch failed",
             // Upstream HTTP-layer timeouts from model provider APIs (e.g. opencode/nemotron)
             "upstream idle timeout",
+            "streaming response failed",
+            "upstream request failed",
         ];
         // Map the byte offset from `lower` back to `text` via char-count (same
         // rationale as detect_rate_limit: Unicode case-folding can change byte lengths).
@@ -2044,6 +2046,8 @@ mod tests {
         assert!(patterns::detect_network_error("network unreachable").is_some());
         assert!(patterns::detect_network_error("Upstream idle timeout exceeded").is_some());
         assert!(patterns::detect_network_error("upstream idle timeout").is_some());
+        assert!(patterns::detect_network_error("Streaming response failed").is_some());
+        assert!(patterns::detect_network_error("Upstream request failed").is_some());
         assert!(patterns::detect_network_error("all systems operational").is_none());
     }
 


### PR DESCRIPTION
## Summary

Classified opencode/nemotron streaming transport failures as `NetworkError` by extending the runner’s network-error patterns and test coverage.

### What was done

- Added `streaming response failed` and `upstream request failed` to `detect_network_error()` in `src/engine/runner/agents/mod.rs`.
- Extended `pattern_detect_network_error` to assert both new strings are recognized as network errors.
- Ran `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` successfully.
- Committed the change as `fix(runner): classify nemotron streaming transport failures`.


### Files changed

- `/Users/gb/.orch/worktrees/orch/gh-issue-3378-bug-runner-opencode-nemotron-streaming-r/src/engine/runner/agents/mod.rs`


Closes #3378

---
*Task #3378 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.4-mini`*