### PR TITLE
bug(runner): codex "You've hit your usage limit. Upgrade to Pro" not classified as billing_cycle_exhausted — gets short 2.25h cooldown, retried repeatedly

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -497,8 +497,9 @@ pub fn detect_credit_exhaustion(error_message: &str) -> Option<CreditExhaustionR
         "refreshed in the next cycle",
         "weekly/monthly limit exhausted",
         "limit will reset at",
+        "upgrade to pro", // codex/chatgpt plan usage cap: requires billing upgrade
         "upgrade your token plan", // minimax: Token Plan usage limit reached
-        "token plan usage limit",  // minimax: Token Plan usage limit reached
+        "token plan usage limit", // minimax: Token Plan usage limit reached
         "purchase credits for more", // minimax: ...purchase Credits for more usage
     ];
 
@@ -1777,6 +1778,10 @@ mod tests {
         assert!(detect_credit_exhaustion("too many requests").is_none());
         assert!(detect_credit_exhaustion("429 Too Many Requests").is_none());
         assert!(detect_credit_exhaustion("you've hit your usage limit").is_none());
+        assert!(detect_credit_exhaustion(
+            "You've hit your usage limit, try again in a few minutes."
+        )
+        .is_none());
     }
 
     #[serial(cooldown_state)]
@@ -2401,6 +2406,12 @@ mod tests {
         );
         assert_eq!(
             detect_credit_exhaustion("purchase Credits for more usage"),
+            Some(CreditExhaustionReason::BillingCycleExhausted)
+        );
+        assert_eq!(
+            detect_credit_exhaustion(
+                "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits"
+            ),
             Some(CreditExhaustionReason::BillingCycleExhausted)
         );
     }


### PR DESCRIPTION
## Summary

Updated Codex billing-cycle exhaustion detection so the no-date "You've hit your usage limit. Upgrade to Pro" message is treated as a billing-plan exhaustion signal, with regression coverage for both the billing and non-billing variants.

### What was done

- Added "upgrade to pro" to the billing-cycle exhaustion detection patterns in `src/engine/cooldown.rs` so Codex/ChatGPT plan-cap errors no longer fall through to short generic rate-limit cooldowns.
- Added a regression test asserting the full Codex no-date `Upgrade to Pro` message maps to `BillingCycleExhausted`.
- Extended the regular-rate-limit test coverage to keep generic `you've hit your usage limit` variants without billing-upgrade language classified as non-credit-exhaustion.
- Ran validation: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo nextest run`, plus targeted `cargo test detect_credit_exhaustion -- --nocapture` and `cargo test parse_retry_at_codex_format -- --nocapture`.
- Committed the change as `99654cd6 fix(cooldown): classify codex pro upgrade usage cap`.


### Remaining

- Automated review and PR handling by orch.


### Files changed

- `src/engine/cooldown.rs`


Closes #3377

---
*Task #3377 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.4`*