### PR TITLE
bug(cooldown): BillingCycleExhausted RateLimit sets agent-level credit cooldown despite known model — codex blocked 24h after gpt-5.5 Upgrade to Pro

### DIFF
--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -238,6 +238,12 @@ pub async fn handle_error(
             // the same model from being re-selected even when the agent-level cooldown
             // is set. Without the model-level cooldown, the model continues to be
             // picked and fails repeatedly (issue #2153).
+            // Track whether the quota is model-scoped (BillingCycleExhausted + known model).
+            // When true we return ModelUnavailable so handle_failover skips the
+            // agent-level failure counter — the agent itself is healthy, only the
+            // specific model's plan quota was exhausted (issue #3382).
+            let mut billing_cycle_model_scoped = false;
+
             if let Some(reason) = crate::engine::cooldown::detect_credit_exhaustion(message) {
                 // For billing cycle exhaustion where we know the specific model, apply
                 // model-level persistent cooldown only. The quota is scoped to that
@@ -249,6 +255,7 @@ pub async fn handle_error(
                     if let Some(model) = model_name {
                         crate::engine::cooldown::record_persistent_model_failure(agent_name, model)
                             .await;
+                        billing_cycle_model_scoped = true;
                     } else {
                         crate::engine::cooldown::record_credit_exhaustion(agent_name, reason).await;
                     }
@@ -270,8 +277,16 @@ pub async fn handle_error(
                     }
                 }
             }
+            // Use ModelUnavailable when billing cycle is exhausted for a known model so
+            // handle_failover does not call record_agent_failure_with_message (which would
+            // set an unwanted agent-level cooldown). The agent's other models remain available.
+            let retryable = if billing_cycle_model_scoped {
+                response::RetryableError::ModelUnavailable
+            } else {
+                response::RetryableError::UsageLimit
+            };
             (
-                response::RetryableError::UsageLimit,
+                retryable,
                 format!(
                     "{agent_name} rate limit: {}",
                     summarize_rate_limit_error(message)
@@ -283,6 +298,8 @@ pub async fn handle_error(
             // For plain auth failures (expired key, wrong token, etc.) record both the
             // agent-level and model-level cooldowns so the router can observe them before
             // concurrent tasks start another run against the same unavailable model.
+            let mut billing_cycle_model_scoped = false;
+
             if let Some(reason) = crate::engine::cooldown::detect_credit_exhaustion(message) {
                 // Billing cycle exhaustion scoped to a known model gets model-level
                 // persistent cooldown only — agent-wide cooldown would block unrelated models.
@@ -291,6 +308,7 @@ pub async fn handle_error(
                     if let Some(model) = model_name {
                         crate::engine::cooldown::record_persistent_model_failure(agent_name, model)
                             .await;
+                        billing_cycle_model_scoped = true;
                     } else {
                         crate::engine::cooldown::record_credit_exhaustion(agent_name, reason).await;
                     }
@@ -304,10 +322,14 @@ pub async fn handle_error(
                     response::record_model_failure(agent_name, model).await;
                 }
             }
-            (
-                response::RetryableError::AuthError,
-                format!("{agent_name} auth error: {message}"),
-            )
+            // Use ModelUnavailable for model-scoped billing exhaustion so handle_failover
+            // does not set an agent-level failure cooldown (issue #3382).
+            let retryable = if billing_cycle_model_scoped {
+                response::RetryableError::ModelUnavailable
+            } else {
+                response::RetryableError::AuthError
+            };
+            (retryable, format!("{agent_name} auth error: {message}"))
         }
         agents::AgentError::Timeout { elapsed } => (
             response::RetryableError::Timeout,
@@ -1252,6 +1274,55 @@ mod tests {
         assert!(
             crate::engine::cooldown::is_model_in_cooldown(agent, model),
             "model should be in cooldown after InvalidResponse (fixes issue #2750)"
+        );
+    }
+
+    /// BillingCycleExhausted with a known model must set ONLY the model-level cooldown.
+    ///
+    /// Regression test for issue #3382: "upgrade to pro" messages (added to
+    /// billing_cycle_patterns in #3380) were triggering an agent-wide 24h cooldown
+    /// when model_name was None, blocking all codex models even though only the
+    /// specific model's plan quota was exhausted.
+    #[serial(cooldown_state)]
+    #[tokio::test]
+    async fn billing_cycle_exhausted_with_known_model_sets_only_model_cooldown() {
+        crate::engine::cooldown::reset_global_state().await;
+        let runner = MockRunner { free: vec![] };
+        let agent = "codex-3382-billing-cycle";
+        let model = "gpt-5.5";
+
+        let err = AgentError::RateLimit {
+            message: "rate limit: You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro).".to_string(),
+        };
+
+        let _result = handle_error(
+            "test-3382-a",
+            &err,
+            agent,
+            &runner,
+            Some(model),
+            Some("medium"),
+            1,
+            &None,
+            "owner/repo",
+        )
+        .await
+        .unwrap();
+
+        // Agent-level credit cooldown must NOT be set — the quota is model-scoped.
+        assert!(
+            !crate::engine::cooldown::is_agent_in_cooldown(agent),
+            "agent must NOT be in agent-level cooldown when BillingCycleExhausted has a known model (issue #3382)"
+        );
+        // Model-level cooldown MUST be set.
+        assert!(
+            crate::engine::cooldown::is_model_in_cooldown(agent, model),
+            "model must be in cooldown after BillingCycleExhausted (issue #3382)"
+        );
+        // Other models on the same agent must NOT be cooled.
+        assert!(
+            !crate::engine::cooldown::is_model_in_cooldown(agent, "gpt-5.4"),
+            "other models on the same agent must not be cooled by a single model's billing exhaustion"
         );
     }
 

--- a/src/engine/runner/task_init.rs
+++ b/src/engine/runner/task_init.rs
@@ -122,11 +122,19 @@ pub async fn prepare_task(
     attempts: u32,
     store: &Option<Arc<TaskStore>>,
 ) -> anyhow::Result<TaskInitResult> {
-    // Load title from store for branch naming (set by run_with_context before run())
-    let title_for_branch = store::opt_store_get_task(store, repo, task_id)
-        .await
-        .map(|t| t.title)
+    // Load title (and model fallback) from store.
+    // `model` param and `route_result.model` can both be None when a prior
+    // ModelUnavailable failover wrote the new model to tasks.model but did not
+    // update task_routes.model.  Reading tasks.model here ensures model_name is
+    // never None when the task already has a model assigned — which matters for
+    // BillingCycleExhausted handling in fallback.rs (model-known → model-level
+    // cooldown only; model-unknown → agent-wide 24 h cooldown).
+    let initial_task = store::opt_store_get_task(store, repo, task_id).await;
+    let title_for_branch = initial_task
+        .as_ref()
+        .map(|t| t.title.clone())
         .unwrap_or_default();
+    let stored_model = initial_task.and_then(|t| t.model);
 
     // Set up worktree
     let wt = worktree::setup_worktree(task_id, &title_for_branch, project_dir, store, repo).await?;
@@ -180,7 +188,8 @@ pub async fn prepare_task(
 
     let model_name = model
         .map(String::from)
-        .or_else(|| route_result.as_ref().and_then(|r| r.model.clone()));
+        .or_else(|| route_result.as_ref().and_then(|r| r.model.clone()))
+        .or(stored_model);
 
     let complexity = route_result.as_ref().map(|r| r.complexity.clone());
 


### PR DESCRIPTION
## Summary

Fixed BillingCycleExhausted incorrectly setting 24h agent-level cooldown when the failing model is known. Two-part fix: (1) in fallback.rs, return RetryableError::ModelUnavailable instead of UsageLimit when BillingCycleExhausted fires with a known model — handle_failover already skips agent-level failure recording for ModelUnavailable, preventing the unwanted cooldown:codex key; (2) in task_init.rs, add tasks.model as a third fallback in model_name derivation so model_name is never None when the task has a model stored (guards against the route_result.model=None case after a ModelUnavailable failover). Added regression test billing_cycle_exhausted_with_known_model_sets_only_model_cooldown verifying agent-level cooldown is absent and model-level cooldown is present. All 3757 tests pass.

### What was done

- Identified root cause: handle_failover calls record_agent_failure_with_message for RetryableError::UsageLimit, setting agent-level cooldown even when only a model's billing quota is exhausted
- Fixed fallback.rs RateLimit and Auth branches: return RetryableError::ModelUnavailable for BillingCycleExhausted with known model so handle_failover skips agent-level failure recording
- Fixed task_init.rs: added stored_model (from tasks table) as third fallback in model_name derivation to prevent model_name=None when route_result.model is None after a prior ModelUnavailable failover
- Added regression test in fallback.rs tests module
- All 3757 tests pass, fmt and clippy clean


### Files changed

- `src/engine/runner/fallback.rs`
- `src/engine/runner/task_init.rs`


Closes #3382

---
*Task #3382 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*