### PR TITLE
bug(review): record_review_agent_failure doesn't apply BillingCycleExhausted+known_model fix from #3383

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -765,7 +765,22 @@ async fn record_review_agent_failure(
                 "review agent hit error — adding to cooldown"
             );
             if let Some(reason) = crate::engine::cooldown::detect_credit_exhaustion(message) {
-                crate::engine::cooldown::record_credit_exhaustion(review_agent, reason).await;
+                if reason == crate::engine::cooldown::CreditExhaustionReason::BillingCycleExhausted
+                {
+                    if let Some(model) = review_model {
+                        // Quota is model-scoped: don't penalize the whole agent.
+                        crate::engine::cooldown::record_persistent_model_failure(
+                            review_agent,
+                            model,
+                        )
+                        .await;
+                    } else {
+                        crate::engine::cooldown::record_credit_exhaustion(review_agent, reason)
+                            .await;
+                    }
+                } else {
+                    crate::engine::cooldown::record_credit_exhaustion(review_agent, reason).await;
+                }
             } else {
                 runner::response::record_agent_failure_with_message(review_agent, &err.to_string())
                     .await;


### PR DESCRIPTION
## Summary

Ported the BillingCycleExhausted model-scope check from runner/fallback.rs into record_review_agent_failure in review.rs. When a review agent hits a billing cycle limit and the model is known, the fix now applies a model-scoped persistent cooldown instead of an agent-wide cooldown, matching the fix from #3383.

### What was done

- Read src/engine/review.rs and src/engine/runner/fallback.rs to understand the divergent code paths
- Applied the model-scope check to record_review_agent_failure (review.rs:755-771): for BillingCycleExhausted + known model, calls record_persistent_model_failure(agent, model) instead of record_credit_exhaustion(agent, reason)
- Ran cargo fmt, cargo clippy --all-targets -- -D warnings, and cargo nextest run --no-fail-fast — all pass except one pre-existing flaky tmux test (session_blocks_dispatch_cleans_dead_session) that passes in isolation but fails under parallel load
- Committed the fix as fix(review): skip agent-wide cooldown for BillingCycleExhausted with known model


### Files changed

- `src/engine/review.rs`


Closes #3385

---
*Task #3385 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*