### PR TITLE
bug(review): billing-limit fast-fail review attempt creates no task_run — missing audit trail

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -614,6 +614,18 @@ async fn invoke_review_agent(
         Ok(session) => session,
         Err(e) => {
             tracing::error!(task_id = task.id.0, error = %e, "failed to spawn review agent");
+            complete_review_run(
+                store,
+                run_id,
+                None,
+                "",
+                &e.to_string(),
+                "",
+                "failed",
+                &format!("spawn failed: {e}"),
+                RunTokenUsage::default(),
+            )
+            .await;
             return ReviewPhase::EarlyReturn(ReviewDecision::Failed(format!("spawn failed: {e}")));
         }
     };

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1232,16 +1232,16 @@ impl TaskStore {
     /// they must accumulate across attempts to enforce their circuit breakers,
     /// just like `review_cycles`.
     ///
-    /// NOTE: `attempts` is intentionally NOT reset here. It must increase monotonically
-    /// across the task's lifetime so that `(task_id, attempt, run_type)` keys in
-    /// `task_runs` remain unique. Resetting it caused subsequent retries to overwrite
-    /// earlier audit trail records via the ON CONFLICT UPSERT in `start_run()`.
+    /// NOTE: `attempts` and `review_invocations` are intentionally NOT reset here.
+    /// Both must increase monotonically across the task's lifetime so that
+    /// `(task_id, attempt, run_type)` keys in `task_runs` remain unique. Resetting
+    /// either causes subsequent retries to overwrite earlier audit trail records via
+    /// the ON CONFLICT UPSERT in `start_run()`.
     pub async fn reset_failure_counters(&self, id: i64) -> anyhow::Result<()> {
         sqlx::query(
             "UPDATE tasks SET
             route_attempts = 0,
             review_agent_failures = 0,
-            review_invocations = 0,
             pr_create_failures = 0,
             push_failures = 0,
             network_retries = 0,

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -679,7 +679,10 @@ async fn helper_store_reset_failure_counters_preserves_review_cycles_and_merge_c
 
     let task = store.get(id).await.unwrap();
     assert_eq!(task.review_cycles, 1);
-    assert_eq!(task.review_invocations, 0);
+    assert_eq!(
+        task.review_invocations, 1,
+        "review_invocations must be preserved (monotonic — same reason as attempts)"
+    );
     assert_eq!(task.attempts, 1, "attempts must be preserved (monotonic)");
     assert_eq!(
         task.merge_conflict_retries, 1,
@@ -1758,12 +1761,15 @@ async fn reset_failure_counters_preserves_review_cycles_and_merge_conflict_retri
     store.increment(id, "ci_merge_failures").await.unwrap();
     store.increment(id, "ci_merge_failures").await.unwrap();
     store.increment(id, "attempts").await.unwrap();
+    store.increment(id, "review_invocations").await.unwrap();
     store.increment(id, "review_agent_failures").await.unwrap();
     store.increment(id, "merge_conflict_retries").await.unwrap();
     store.increment(id, "network_retries").await.unwrap();
 
     // reset_failure_counters must zero transient counters but preserve
-    // review_cycles, ci_merge_failures, merge_conflict_retries, and attempts.
+    // review_cycles, ci_merge_failures, merge_conflict_retries, attempts, and
+    // review_invocations. Both attempts and review_invocations must be monotonic
+    // so that (task_id, attempt, run_type) keys in task_runs remain unique.
     store.reset_failure_counters(id).await.unwrap();
 
     let task = store.get(id).await.unwrap();
@@ -1777,6 +1783,10 @@ async fn reset_failure_counters_preserves_review_cycles_and_merge_conflict_retri
         "merge_conflict_retries must be preserved"
     );
     assert_eq!(task.attempts, 1, "attempts must be preserved (monotonic)");
+    assert_eq!(
+        task.review_invocations, 1,
+        "review_invocations must be preserved (monotonic — same reason as attempts)"
+    );
     assert_eq!(task.review_agent_failures, 0);
     assert_eq!(task.network_retries, 0);
 }
@@ -4806,6 +4816,151 @@ async fn get_last_run_filters_by_type() {
     // No route run exists
     let no_route = store.get_last_run(task_id, "route").await.unwrap();
     assert!(no_route.is_none());
+}
+
+/// Regression test for issue #3386.
+///
+/// `reset_failure_counters` used to reset `review_invocations` to 0.  When a
+/// new review cycle started after that reset the first dispatch received
+/// `attempt=1` again, and `start_run()`'s `ON CONFLICT DO UPDATE` overwrote the
+/// previous `attempt=1` record — erasing the audit trail for the earlier review.
+///
+/// The production path is: `review_invocations` is incremented each time
+/// `build_review_context()` runs and the resulting value is used directly as the
+/// `attempt` key in `start_run()`.  When `reset_failure_counters` zeroed
+/// `review_invocations`, the next invocation produced `attempt=1` again, causing
+/// the ON CONFLICT clause to silently overwrite the previous record.
+#[tokio::test]
+async fn review_invocations_preserved_across_reset_prevents_task_run_overwrite() {
+    let store = TaskStore::open_memory().await.unwrap();
+    let task_id = store
+        .create_internal("owner/repo", "task", "body", "manual", "", None)
+        .await
+        .unwrap();
+
+    // ── Cycle A: a previous successful review reset the counter. ─────────────
+    // Simulate: one review dispatch completed (attempt=1), then
+    // reset_failure_counters was called (e.g. on Approve).
+    store.increment(task_id, "review_invocations").await.unwrap(); // → 1
+    let prev_run_id = store
+        .start_run(&StartRun {
+            task_id,
+            attempt: 1,
+            run_type: "review",
+            agent: "prev-agent",
+            model: "prev-model",
+            command: "",
+            prompt: "",
+        })
+        .await
+        .unwrap();
+    store
+        .complete_run(&CompleteRun {
+            run_id: prev_run_id,
+            exit_code: Some(0),
+            stdout: "",
+            stderr: "",
+            parsed: "",
+            outcome: "success",
+            error: "",
+            tokens: RunTokenUsage::default(),
+        })
+        .await
+        .unwrap();
+    // End of cycle A: reset_failure_counters is called (Approve path).
+    // With the OLD code this zeroed review_invocations back to 0.
+    // With the fix it stays at 1.
+    store.reset_failure_counters(task_id).await.unwrap();
+
+    let after_reset = store.get(task_id).await.unwrap();
+    assert_eq!(
+        after_reset.review_invocations, 1,
+        "review_invocations must survive reset_failure_counters (issue #3386)"
+    );
+
+    // ── Cycle B: codex billing-limit fast-fail, then kimi succeeds. ──────────
+    // Increment → attempt=2 for codex (not 1, because review_invocations is 1).
+    let codex_attempt = store.increment(task_id, "review_invocations").await.unwrap() as i32; // → 2
+    let codex_run_id = store
+        .start_run(&StartRun {
+            task_id,
+            attempt: codex_attempt,
+            run_type: "review",
+            agent: "codex",
+            model: "gpt-5.4",
+            command: "",
+            prompt: "",
+        })
+        .await
+        .unwrap();
+    store
+        .complete_run(&CompleteRun {
+            run_id: codex_run_id,
+            exit_code: Some(1),
+            stdout: "",
+            stderr: "billing limit",
+            parsed: "",
+            outcome: "rate_limit",
+            error: "codex rate limit: billing cycle exhausted",
+            tokens: RunTokenUsage::default(),
+        })
+        .await
+        .unwrap();
+
+    // Kimi is dispatched as the retry (attempt=3).
+    let kimi_attempt = store.increment(task_id, "review_invocations").await.unwrap() as i32; // → 3
+    let kimi_run_id = store
+        .start_run(&StartRun {
+            task_id,
+            attempt: kimi_attempt,
+            run_type: "review",
+            agent: "kimi",
+            model: "kimi-model",
+            command: "",
+            prompt: "",
+        })
+        .await
+        .unwrap();
+    store
+        .complete_run(&CompleteRun {
+            run_id: kimi_run_id,
+            exit_code: Some(0),
+            stdout: "",
+            stderr: "",
+            parsed: r#"{"decision":"approve"}"#,
+            outcome: "success",
+            error: "",
+            tokens: RunTokenUsage::default(),
+        })
+        .await
+        .unwrap();
+
+    // All three records must be visible — codex's audit trail was NOT
+    // overwritten because review_invocations was NOT zeroed by the earlier reset.
+    let all_runs = store.get_runs(task_id).await.unwrap();
+    let review_runs: Vec<_> = all_runs.iter().filter(|r| r.run_type == "review").collect();
+    assert_eq!(
+        review_runs.len(),
+        3,
+        "all three review runs must be in the audit trail"
+    );
+
+    let prev_run = review_runs.iter().find(|r| r.agent == "prev-agent");
+    assert!(prev_run.is_some(), "cycle-A run must still be present");
+    assert_eq!(prev_run.unwrap().attempt, 1);
+
+    let codex_run = review_runs.iter().find(|r| r.agent == "codex");
+    assert!(
+        codex_run.is_some(),
+        "codex billing-limit run must be present (was erased by the bug)"
+    );
+    assert_eq!(codex_run.unwrap().outcome, "rate_limit");
+    assert_eq!(codex_run.unwrap().attempt, 2);
+
+    let kimi_run = review_runs.iter().find(|r| r.agent == "kimi");
+    assert!(kimi_run.is_some(), "kimi success run must be present");
+    assert_eq!(kimi_run.unwrap().outcome, "success");
+    assert_eq!(kimi_run.unwrap().attempt, 3);
 }
 
 // ── prune_old_runs ──────────────────────────────────────────────

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -4841,7 +4841,10 @@ async fn review_invocations_preserved_across_reset_prevents_task_run_overwrite()
     // ── Cycle A: a previous successful review reset the counter. ─────────────
     // Simulate: one review dispatch completed (attempt=1), then
     // reset_failure_counters was called (e.g. on Approve).
-    store.increment(task_id, "review_invocations").await.unwrap(); // → 1
+    store
+        .increment(task_id, "review_invocations")
+        .await
+        .unwrap(); // → 1
     let prev_run_id = store
         .start_run(&StartRun {
             task_id,
@@ -4880,7 +4883,10 @@ async fn review_invocations_preserved_across_reset_prevents_task_run_overwrite()
 
     // ── Cycle B: codex billing-limit fast-fail, then kimi succeeds. ──────────
     // Increment → attempt=2 for codex (not 1, because review_invocations is 1).
-    let codex_attempt = store.increment(task_id, "review_invocations").await.unwrap() as i32; // → 2
+    let codex_attempt = store
+        .increment(task_id, "review_invocations")
+        .await
+        .unwrap() as i32; // → 2
     let codex_run_id = store
         .start_run(&StartRun {
             task_id,
@@ -4908,7 +4914,10 @@ async fn review_invocations_preserved_across_reset_prevents_task_run_overwrite()
         .unwrap();
 
     // Kimi is dispatched as the retry (attempt=3).
-    let kimi_attempt = store.increment(task_id, "review_invocations").await.unwrap() as i32; // → 3
+    let kimi_attempt = store
+        .increment(task_id, "review_invocations")
+        .await
+        .unwrap() as i32; // → 3
     let kimi_run_id = store
         .start_run(&StartRun {
             task_id,


### PR DESCRIPTION
## Summary

Fixed missing task_run audit trail entries for review billing-limit fast-fail attempts. Root cause: reset_failure_counters() was zeroing review_invocations, causing subsequent review cycles to get attempt=1 again and silently overwrite earlier task_run records via the ON CONFLICT DO UPDATE in start_run(). Secondary fix: added complete_review_run() call in the spawn-failure path so task_runs created by start_run() are never left with outcome=NULL.

### What was done

- Identified root cause: reset_failure_counters() reset review_invocations to 0, causing subsequent dispatches to get duplicate attempt numbers and overwrite previous task_run records via ON CONFLICT DO UPDATE in start_run()
- Removed review_invocations = 0 from reset_failure_counters() in src/store/tasks.rs — same invariant as attempts (must be monotonically increasing)
- Updated doc comment to cover both attempts and review_invocations
- Fixed secondary gap: added complete_review_run() in the spawn_in_tmux() failure path of invoke_review_agent() so any task_run created by start_run() always gets a final outcome rather than NULL
- Updated two existing tests that incorrectly asserted review_invocations == 0 after reset (now assert == 1, matching the preserved value)
- Added regression test review_invocations_preserved_across_reset_prevents_task_run_overwrite that verifies all three review runs across a reset are visible in the audit trail
- All 3759 tests pass, cargo fmt clean, cargo clippy clean


### Files changed

- `src/store/tasks.rs`
- `src/engine/review.rs`
- `src/store/tests.rs`


Closes #3386

---
*Task #3386 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*