### PR TITLE
docs(posts): daily review 2026-07-07

### DIFF
--- a/docs/content/posts/daily-review-2026-07-07.md
+++ b/docs/content/posts/daily-review-2026-07-07.md
@@ -1,0 +1,124 @@
++++
+title = "Daily Review — 2026-07-07"
+date = 2026-07-07
+description = "Daily review: what shipped, what failed, operational health, and priorities for tomorrow."
++++
+
+# Daily Review — 2026-07-07
+
+## What Shipped (Last 24h)
+
+**1 commit** landed today — the daily review doc for 2026-07-06 (`717af271`, #3389). No code changes shipped. The BillingCycleExhausted fix series (#3382–#3388) that closed over the past two days is now complete and stable in the running service (orch 0.80.43).
+
+---
+
+## Operational Health
+
+### Throughput
+
+`task_activity` comparison vs yesterday:
+
+| Event | Today | Yesterday (07-06) |
+|-------|-------|------------------|
+| `status_change` | 244 | 338 |
+| `dispatch` | 71 | 106 |
+| `push` | 70 | 87 |
+| `review_start` | 48 | 55 |
+| `review_decision` | 34 | 41 |
+| `routed` | 29 | 48 |
+| `timeout` | 11 | 9 |
+| `error` | 7 | 16 |
+| `rerouted` | 1 | 5 |
+
+Overall volume dropped (~32% on dispatches). This is normal day-to-day variation; the quality signal remains strong. **Errors fell 56% (16 → 7) and reroutes fell 80% (5 → 1)**. Timeouts ticked up slightly (9 → 11), driven by `north-mini-code-free` (see below).
+
+### Agent / Model Outcomes (last 24h)
+
+| Agent | Model | Outcome | Count |
+|-------|-------|---------|-------|
+| claude | sonnet | success | 41 |
+| kimi | opus | success | 15 |
+| opencode | deepseek-v4-flash-free | success | 7 |
+| opencode | mimo-v2.5-free | success | 5 |
+| opencode | north-mini-code-free | timeout | 5 |
+| claude | sonnet | failed | 3 |
+| claude | sonnet | (in-progress/cancelled) | 2 |
+| opencode | nemotron-3-ultra-free | failed | 2 |
+| codex | gpt-5.4 | timeout | 1 |
+| opencode | mimo-v2.5-free | parse_error | 1 |
+
+Claude/sonnet continues to carry the heaviest load (41 successes). Kimi/opus improved: 0 failures today vs 3 yesterday. `north-mini-code-free` returned from its cooldown and immediately accumulated 5 timeouts, triggering a new extended cooldown. `nemotron-3-ultra-free` had 2 failures, earning a new cooldown.
+
+### Active Cooldowns
+
+| Key | Remaining | Notes |
+|-----|-----------|-------|
+| codex | ~1d17h | persisted; down from 2d17h yesterday |
+| minimax:opus | ~1d11h | persisted; expires ~2026-07-09 |
+| opencode/north-mini-code-free | ~10h | re-cooked today after 5 timeouts post-expiry |
+| opencode/nemotron-3-ultra-free | ~1d9h | new today; 2 failures triggered cooldown |
+
+The minimax cooldown expires tomorrow (~2026-07-09). The daily `routing sanity warning` on internal tasks (minimax selected → rerouted to claude) will resolve then.
+
+### Blocked Inventory
+
+| Reason | Count |
+|--------|-------|
+| CI failure limit reached | ~43 |
+| GitHub Actions billing failure | 5 |
+| No block reason recorded | 4 |
+| Review agent rebroadcast escalation | 1 |
+| Max review cycles exceeded | 1 |
+| **Total blocked** | **~54** |
+
+The blocked count grew slightly (51 → ~54). All new entries appear to be CI-failure blocks on open PRs. **`orch task unblock all` is still the recommended manual path** to drain this backlog — tasks that re-block immediately warrant inspection; tasks that clear were stale.
+
+---
+
+## What Failed
+
+### 1. opencode/north-mini-code-free: expired cooldown → 5 timeouts → re-cooked
+
+Yesterday's review flagged the `north-mini-code-free` cooldown expiring in ~3h and asked to watch it. The result: it expired, re-dispatched, produced 5 timeouts, and is now back in cooldown at ~10h1m. The model appears unreliable at the moment. The exponential backoff is working correctly — each recurrence will extend the cooldown further.
+
+### 2. opencode/nemotron-3-ultra-free: 2 failures → new cooldown
+
+`nemotron-3-ultra-free` accumulated 2 failures and received a ~1d9h cooldown. Not a new pattern (this model had 2 failures yesterday too) but now has a persistent cooldown backing the exclusion.
+
+### 3. LLM router still selects minimax for internal tasks
+
+Both `internal:154805` and `internal:154806` (daily-review, evening-retrospective) had the LLM router select minimax before the cooldown fallback fired and re-assigned to claude. The `routing sanity warning` will persist until ~2026-07-09 when the minimax cooldown clears. No action needed.
+
+---
+
+## Routing Accuracy
+
+Dispatch accuracy is good. No wrong complexity tier visible. Claude/sonnet on medium complexity and claude for complex (evening-retrospective) are appropriate assignments. The one `rerouted` event was the expected minimax fallback.
+
+---
+
+## Log Health
+
+Sync ticks are clean: 1.5–2.1s elapsed with no errors or HTTP retry failures in the 200-line tail. One 42.6s slow tick occurred when both internal tasks (154805, 154806) were routed and dispatched in the same tick — expected burst latency, not a regression.
+
+---
+
+## Open Issues
+
+`gh issue list --state open` returned **no open issues** in `gabrielkoerich/orch`.
+
+No new issues filed. The `north-mini-code-free` re-failure and `nemotron-3-ultra-free` cooldown are handled generically by the existing cooldown system.
+
+---
+
+## Priorities for Tomorrow
+
+1. **minimax cooldown expires ~2026-07-09** — routing sanity warnings on internal tasks will stop. Verify the LLM router assigns minimax cleanly once the cooldown clears.
+2. **north-mini-code-free cooldown expires ~tomorrow morning (~10h)** — watch again. Two consecutive cooldown cycles suggest this model has a persistent reliability issue. If it re-fails a third time, the backoff will extend to ~30h.
+3. **nemotron-3-ultra-free** expires in ~1d9h. Monitor post-expiry performance.
+4. **CI-failure backlog at ~54 tasks** — run `orch task unblock all` to drain stale entries. If tasks re-block immediately, inspect the specific CI failure message.
+5. **kimi/opus improved today** (0 failures vs 3 yesterday) — trend is positive; watch for stability.
+
+---
+
+*Prepared by Orch automation (internal:154805) at 2026-07-07 UTC.*


### PR DESCRIPTION
Daily review post for 2026-07-07.

**Summary**: No code changes today. Operational health strong — errors down 56% (16→7), reroutes down 80% (5→1). Key observations:
- `north-mini-code-free` re-cooled after 5 timeouts post-expiry; watching third cycle tomorrow
- `nemotron-3-ultra-free` earned new ~1d9h cooldown (2 failures)
- minimax cooldown expires ~2026-07-09; routing sanity warnings resolve then
- CI-failure backlog grew slightly (~51→~54)
- kimi/opus improved: 0 failures vs 3 yesterday

---
*Task internal-154805 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*