### PR TITLE
Daily review (last 24h)

### DIFF
--- a/docs/content/posts/daily-review-2026-07-08.md
+++ b/docs/content/posts/daily-review-2026-07-08.md
@@ -1,0 +1,125 @@
++++
+title = "Daily Review — 2026-07-08"
+date = 2026-07-08
+description = "Daily review: what shipped, what failed, operational health, and priorities for tomorrow."
++++
+
+# Daily Review — 2026-07-08
+
+## What Shipped (Last 24h)
+
+**1 commit** landed today — the daily review doc for 2026-07-07 (`7187962a`, #3390). No code changes shipped. The BillingCycleExhausted fix series (#3382–#3388) remains fully deployed in v0.80.43 and continues to perform well.
+
+---
+
+## Operational Health
+
+### Throughput
+
+`task_activity` comparison vs yesterday:
+
+| Event | Today | Yesterday (07-07) |
+|-------|-------|------------------|
+| `status_change` | 186 | 244 |
+| `dispatch` | 59 | 71 |
+| `push` | 56 | 70 |
+| `branch_delete` | 44 | — |
+| `review_start` | 31 | 48 |
+| `review_decision` | 27 | 34 |
+| `pr_create` | 27 | — |
+| `routed` | 26 | 29 |
+| `error` | 4 | 7 |
+| `timeout` | 3 | 11 |
+| `rerouted` | 1 | 1 |
+
+Volume continued its moderate decline (~17% on dispatches), but **quality improved materially**: errors fell 43% (7 → 4) and timeouts fell 73% (11 → 3). The timeout improvement is directly attributable to `north-mini-code-free` getting 2 successes today instead of 5 timeouts.
+
+### Agent / Model Outcomes (last 24h)
+
+| Agent | Model | Outcome | Count |
+|-------|-------|---------|-------|
+| claude | sonnet | success | 30 |
+| kimi | opus | success | 11 |
+| opencode | mimo-v2.5-free | success | 7 |
+| opencode | deepseek-v4-flash-free | success | 4 |
+| opencode | hy3-free | success | 2 |
+| opencode | north-mini-code-free | success | 2 |
+| opencode | north-mini-code-free | timeout | 2 |
+| opencode | nemotron-3-ultra-free | failed | 2 |
+| claude | sonnet | failed | 2 |
+| opencode | hy3-free | timeout | 1 |
+| claude | sonnet | — | 1 |
+
+Claude/sonnet leads (30 successes). Kimi/opus solid (11 successes, 0 failures — second consecutive clean day). `north-mini-code-free` had mixed results: 2 successes and 2 timeouts, suggesting the model is intermittently available rather than completely broken. It is **not** in active cooldown as of this review. `nemotron-3-ultra-free` repeated its two-failure pattern from yesterday, earning a fresh ~9h cooldown.
+
+### Active Cooldowns
+
+| Key | Remaining | Notes |
+|-----|-----------|-------|
+| codex | ~17h | persisted; expires late 2026-07-09 |
+| minimax:opus | ~11h | persisted; expires early 2026-07-09 |
+| opencode/nemotron-3-ultra-free | ~9h | new today; 2 failures triggered cooldown |
+
+`north-mini-code-free` is **not** in cooldown — its previous ~10h cooldown (from yesterday's 5 timeouts) expired and the model partly recovered. The 2 new timeouts today may trigger another cooldown if the failure count crosses threshold.
+
+### Blocked Inventory
+
+| Reason | Count |
+|--------|-------|
+| CI failure limit reached | ~43 |
+| No block reason recorded | ~4 |
+| GitHub Actions billing failure | ~2 |
+| Max review cycles exceeded | 1 |
+| **Total blocked** | **50** |
+
+Blocked count held roughly stable (50 vs ~54 yesterday). No new categories. **`orch task unblock all` remains the recommended drain** — tasks that re-block immediately warrant inspection.
+
+---
+
+## What Failed
+
+### 1. opencode/north-mini-code-free: intermittent (2 successes, 2 timeouts)
+
+After yesterday's 5-timeout post-cooldown dispatch, the model partially recovered: 2 successful completions interleaved with 2 timeouts. This inconsistency may indicate the model is capacity-constrained rather than fundamentally broken. If it accumulates more failures it will enter another exponential backoff cycle.
+
+### 2. opencode/nemotron-3-ultra-free: 2 failures → ~9h cooldown (second consecutive day)
+
+`nemotron-3-ultra-free` hit 2 failures again. The exponential backoff is now applying a ~9h cooldown. Consecutive daily failures suggest a persistent capacity or availability issue with this model. The generic cooldown system is handling it correctly.
+
+### 3. Routing sanity warning: minimax still selected for internal tasks
+
+The LLM router (via kimi/haiku) selected minimax for `internal:154836` (this task), which was immediately overridden by the cooldown fallback to claude. The routing sanity warning will fire on every internal task until the minimax:opus cooldown clears in ~11h.
+
+---
+
+## Routing Accuracy
+
+No wrong complexity tier observed. Claude/sonnet assignments for medium-complexity tasks are appropriate. The single rerouted event was the expected minimax→claude fallback. No silent agent failures detected in logs.
+
+---
+
+## Log Health
+
+Sync ticks are clean: 1.4–2.6s elapsed, no errors or HTTP failures in the 200-line tail. One transient HTTP send failure occurred at 22:54 UTC for a downstream API request — the retry loop recovered immediately, no task impact. The error log (`/opt/homebrew/var/log/orch.error.log`) is empty (0 bytes). Service running v0.80.43.
+
+---
+
+## Open Issues
+
+`gh issue list --state open` returned **no open issues** in `gabrielkoerich/orch`.
+
+No new issues filed. The `north-mini-code-free` inconsistency and `nemotron-3-ultra-free` pattern are handled by the existing exponential cooldown system. The minimax routing warning resolves on its own when the cooldown expires.
+
+---
+
+## Priorities for Tomorrow
+
+1. **minimax cooldown expires ~11h (~early 2026-07-09)** — routing sanity warnings on internal tasks will stop. Confirm the LLM router assigns minimax cleanly after cooldown clears.
+2. **nemotron-3-ultra-free cooldown expires ~9h (~early 2026-07-09)** — watch for a third consecutive failure cycle. If it fails again, the exponential backoff will extend to ~27h.
+3. **north-mini-code-free** — not in cooldown but intermittent. Monitor whether it accumulates more timeouts and enters another cooldown cycle.
+4. **CI-failure backlog at 50 tasks** — run `orch task unblock all` to drain stale entries; inspect any that re-block immediately.
+5. **kimi/opus trending positive** (11 successes, 0 failures for second day) — stability is holding.
+
+---
+
+*Prepared by Orch automation (internal:154836) at 2026-07-08 UTC.*


### PR DESCRIPTION
## Summary

Daily review for 2026-07-08 written and pushed. Key findings: volume down ~17% from yesterday but quality improved — errors fell 43% (7→4), timeouts fell 73% (11→3). claude/sonnet led with 30 successes; kimi/opus had a second clean day (11 successes, 0 failures). north-mini-code-free showed mixed results (2 successes, 2 timeouts) — not in cooldown but intermittent. nemotron-3-ultra-free failed twice again, earning a ~9h cooldown. Active cooldowns: codex (~17h), minimax:opus (~11h, routing sanity warning will stop after), nemotron-3-ultra-free (~9h). 50 tasks blocked (mostly CI failures). Service at v0.80.43, logs clean. No issues filed — all failure patterns handled generically. Post committed and pushed at docs/content/posts/daily-review-2026-07-08.md.

### Files changed

- `docs/content/posts/daily-review-2026-07-08.md`


---
*Task internal-154836 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*