### PR TITLE
bug(sync): CI-failure unblock sweep rewrites updated_at on stale blocked tasks, polluting recent-failure triage

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -739,7 +739,10 @@ async fn try_unblock_ci_failure_task(
         ("auto_unblock_count", serde_json::json!(new_count)),
         ("auto_unblock_last_at", serde_json::json!(&now)),
     ];
-    store.set_fields(task.id, &fields).await?;
+    // Use set_fields_silent so the probe write does not bump updated_at on stale
+    // blocked tasks — triage queries keyed off updated_at must only see real
+    // status/result changes, not periodic re-checks of an open PR.
+    store.set_fields_silent(task.id, &fields).await?;
 
     Ok(false)
 }

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1176,6 +1176,54 @@ impl TaskStore {
         Ok(())
     }
 
+    /// Like `set_fields` but does NOT touch `updated_at`.
+    ///
+    /// Use this for internal bookkeeping writes (probe timestamps, counters) that
+    /// must not make a stale task appear recently-modified to triage queries.
+    pub async fn set_fields_silent(
+        &self,
+        id: i64,
+        updates: &[(&str, serde_json::Value)],
+    ) -> anyhow::Result<()> {
+        if updates.is_empty() {
+            return Ok(());
+        }
+
+        for (col, _) in updates {
+            anyhow::ensure!(
+                ALLOWED_FIELDS.contains(col),
+                "column {col} is not in the update allowlist"
+            );
+        }
+
+        let mut set_parts = Vec::new();
+        let mut values: Vec<Option<String>> = Vec::new();
+
+        for (col, val) in updates {
+            set_parts.push(format!("{col} = ?"));
+            match val {
+                serde_json::Value::String(s) => values.push(Some(s.clone())),
+                serde_json::Value::Number(n) => values.push(Some(n.to_string())),
+                serde_json::Value::Bool(b) => {
+                    values.push(Some(if *b { "1" } else { "0" }.to_string()));
+                }
+                serde_json::Value::Null => values.push(None),
+                other => values.push(Some(serde_json::to_string(other)?)),
+            }
+        }
+
+        let sql = format!("UPDATE tasks SET {} WHERE id = ?", set_parts.join(", "));
+
+        let mut query = sqlx::query(&sql);
+        for v in &values {
+            query = query.bind(v.as_deref());
+        }
+        query = query.bind(id);
+        query.execute(&self.pool).await?;
+
+        Ok(())
+    }
+
     /// Increment an integer field by 1, returning the new value.
     pub async fn increment(&self, id: i64, field: &str) -> anyhow::Result<i32> {
         anyhow::ensure!(

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -3727,6 +3727,46 @@ async fn set_fields_multiple_fields_at_once() {
 }
 
 #[tokio::test]
+async fn set_fields_silent_does_not_bump_updated_at() {
+    let store = TaskStore::open_memory().await.unwrap();
+    let id = store
+        .create(&NewTask {
+            external_id: Some("1".to_string()),
+            repo: "owner/repo".to_string(),
+            origin: "github".to_string(),
+            title: "Silent update".to_string(),
+            body: "".to_string(),
+            source: "".to_string(),
+            source_id: "".to_string(),
+            author: "".to_string(),
+            url: "".to_string(),
+            labels: vec![],
+            parent_id: None,
+        })
+        .await
+        .unwrap();
+
+    // Backdate updated_at to a known stale timestamp.
+    sqlx::query("UPDATE tasks SET updated_at = '2020-01-01T00:00:00Z' WHERE id = ?")
+        .bind(id)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+
+    store
+        .set_fields_silent(id, &[("agent", serde_json::json!("claude"))])
+        .await
+        .unwrap();
+
+    let task = store.get(id).await.unwrap();
+    assert_eq!(task.agent, Some("claude".to_string()));
+    assert_eq!(
+        task.updated_at, "2020-01-01T00:00:00Z",
+        "set_fields_silent must not touch updated_at"
+    );
+}
+
+#[tokio::test]
 async fn store_tokens_overwrites_previous_values() {
     let store = TaskStore::open_memory().await.unwrap();
     let id = store


### PR DESCRIPTION
## Summary

Fixed the CI-failure unblock sweep polluting updated_at on stale blocked tasks by adding a set_fields_silent() method to TaskStore that skips the updated_at touch, and routing the probe-only write through it.

### What was done

- Added TaskStore::set_fields_silent() in src/store/tasks.rs — identical to set_fields() but omits the updated_at = strftime(...) clause
- Updated try_unblock_ci_failure_task() in src/engine/sync.rs to call set_fields_silent() for the probe-only path (PR still open), preserving set_fields() for the unblock/done path which follows a real status transition
- Verified formatting (cargo fmt), lints (cargo clippy --all-targets -- -D warnings), and all 3759 tests pass (cargo nextest run)
- Committed: fix(sync): don't bump updated_at when CI-failure probe writes bookkeeping fields


### Files changed

- `src/store/tasks.rs`
- `src/engine/sync.rs`


Closes #3393

---
*Task #3393 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*