### PR TITLE
bug(cli): orch task runs only resolves the current repo, breaking cross-project failure triage

### DIFF
--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -1610,13 +1610,29 @@ pub async fn logs(id: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Resolve a task ID, falling back to a global (cross-repo) lookup if the
+/// current-repo-scoped lookup finds nothing.  Emits a note on stderr when the
+/// task is found in a different repo so the operator can tell at a glance.
+async fn resolve_id(store: &TaskStore, id: &str) -> anyhow::Result<i64> {
+    let repo = config::get_current_repo().unwrap_or_default();
+    if let Some(task_id) = store.resolve_task_id(&repo, id).await? {
+        return Ok(task_id);
+    }
+    match store.resolve_task_id_globally(id).await? {
+        Some((task_id, found_repo)) => {
+            if found_repo != repo {
+                eprintln!("note: task {id} belongs to repo {found_repo:?}");
+            }
+            Ok(task_id)
+        }
+        None => anyhow::bail!("task not found: {id}"),
+    }
+}
+
 /// Show run history for a task.
 pub async fn runs(id: &str, verbose: bool) -> anyhow::Result<()> {
     let store = crate::cli::init_store().await?;
-    let repo = config::get_current_repo().unwrap_or_default();
-    let Some(task_id) = store.resolve_task_id(&repo, id).await? else {
-        anyhow::bail!("task not found: {id}");
-    };
+    let task_id = resolve_id(&store, id).await?;
 
     let runs = store.get_runs(task_id).await?;
     if runs.is_empty() {
@@ -1668,10 +1684,7 @@ pub async fn runs(id: &str, verbose: bool) -> anyhow::Result<()> {
 /// Show lifecycle activity timeline for a task.
 pub async fn activity_log(id: &str, limit: Option<usize>, json: bool) -> anyhow::Result<()> {
     let store = crate::cli::init_store().await?;
-    let repo = config::get_current_repo().unwrap_or_default();
-    let Some(task_id) = store.resolve_task_id(&repo, id).await? else {
-        anyhow::bail!("task not found: {id}");
-    };
+    let task_id = resolve_id(&store, id).await?;
 
     let events = store.get_activity(task_id, limit).await?;
     if events.is_empty() {
@@ -1713,10 +1726,7 @@ pub async fn activity_log(id: &str, limit: Option<usize>, json: bool) -> anyhow:
 /// Show task routing history with attempt timeline.
 pub async fn history(id: &str) -> anyhow::Result<()> {
     let store = crate::cli::init_store().await?;
-    let repo = config::get_current_repo().unwrap_or_default();
-    let Some(task_id) = store.resolve_task_id(&repo, id).await? else {
-        anyhow::bail!("task not found: {id}");
-    };
+    let task_id = resolve_id(&store, id).await?;
 
     let task = store.get(task_id).await?;
     let events = store.get_activity(task_id, None).await?;
@@ -1819,10 +1829,7 @@ pub async fn history(id: &str) -> anyhow::Result<()> {
 /// Unified diagnostic view for a task: status, agent, attempts, last error, PR, block reason.
 pub async fn inspect(id: &str) -> anyhow::Result<()> {
     let store = crate::cli::init_store().await?;
-    let repo = config::get_current_repo().unwrap_or_default();
-    let Some(task_id) = store.resolve_task_id(&repo, id).await? else {
-        anyhow::bail!("task not found: {id}");
-    };
+    let task_id = resolve_id(&store, id).await?;
 
     let task = store.get(task_id).await?;
 
@@ -1926,7 +1933,7 @@ pub async fn inspect(id: &str) -> anyhow::Result<()> {
         .clone()
         .unwrap_or_else(|| format!("internal:{}", task.id));
     let tmux = TmuxManager::new();
-    let session = tmux.session_name(&repo, &task_key);
+    let session = tmux.session_name(&task.repo, &task_key);
     if tmux.session_exists(&session).await {
         println!();
         println!(

--- a/src/engine/cleanup.rs
+++ b/src/engine/cleanup.rs
@@ -625,9 +625,7 @@ pub(crate) async fn cleanup_task_worktree_with_opts(
     // resolve the repo root. Resolving the repo root can fail for
     // projects not registered in config and that should not make
     // cleanup a hard error when there is nothing to do.
-    let branch_nonempty = branch
-        .as_ref()
-        .and_then(|b| if b.is_empty() { None } else { Some(b) });
+    let branch_nonempty = branch.as_ref().filter(|b| !b.is_empty());
     if worktree_to_remove.is_none() && branch_nonempty.is_none() {
         // If the stored worktree path is non-empty but doesn't exist on disk,
         // the worktree is already gone — mark it cleaned so we stop retrying.

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -2269,6 +2269,57 @@ impl TaskStore {
         self.resolve_id_by_external(repo, task_id).await
     }
 
+    /// Resolve a task_id globally (across all repos) when a repo-scoped lookup fails.
+    ///
+    /// Returns `(internal_id, repo)` if found unambiguously, `None` if not found,
+    /// or an error if the external_id matches tasks in multiple repos (GitHub issue
+    /// numbers are not globally unique).
+    pub async fn resolve_task_id_globally(
+        &self,
+        task_id: &str,
+    ) -> anyhow::Result<Option<(i64, String)>> {
+        if let Some(suffix) = task_id.strip_prefix("internal:") {
+            // internal:N — external_id is globally unique; primary key is also unique.
+            let row = sqlx::query("SELECT id, repo FROM tasks WHERE external_id = ?")
+                .bind(task_id)
+                .fetch_optional(&self.pool)
+                .await?;
+            if let Some(r) = row {
+                return Ok(Some((r.try_get("id")?, r.try_get("repo")?)));
+            }
+            if let Ok(id) = suffix.parse::<i64>() {
+                let row = sqlx::query("SELECT id, repo FROM tasks WHERE id = ?")
+                    .bind(id)
+                    .fetch_optional(&self.pool)
+                    .await?;
+                if let Some(r) = row {
+                    return Ok(Some((r.try_get("id")?, r.try_get("repo")?)));
+                }
+            }
+            return Ok(None);
+        }
+        // External IDs (e.g. GitHub issue numbers) may collide across repos.
+        let rows = sqlx::query("SELECT id, repo FROM tasks WHERE external_id = ?")
+            .bind(task_id)
+            .fetch_all(&self.pool)
+            .await?;
+        match rows.len() {
+            0 => Ok(None),
+            1 => Ok(Some((rows[0].try_get("id")?, rows[0].try_get("repo")?))),
+            _ => {
+                let repos: Vec<String> = rows
+                    .iter()
+                    .filter_map(|r| r.try_get::<String, _>("repo").ok())
+                    .collect();
+                anyhow::bail!(
+                    "task ID {task_id:?} is ambiguous — found in multiple repos: {}. \
+                     Run from the repo worktree so the current-repo lookup resolves it.",
+                    repos.join(", ")
+                )
+            }
+        }
+    }
+
     fn row_to_run(row: &sqlx::sqlite::SqliteRow) -> anyhow::Result<TaskRun> {
         Ok(TaskRun {
             id: row

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -3953,6 +3953,89 @@ async fn create_internal_resolvable_by_task_id() {
     assert_eq!(resolved, Some(id));
 }
 
+// ── resolve_task_id_globally ────────────────────────────────────────────
+
+#[tokio::test]
+async fn resolve_task_id_globally_finds_internal_across_repos() {
+    let store = TaskStore::open_memory().await.unwrap();
+    let id = store
+        .create_internal("other/repo", "Cross-repo task", "body", "cron", "j:1", None)
+        .await
+        .unwrap();
+
+    // Current-repo scoped lookup misses it.
+    let scoped = store
+        .resolve_task_id("my/repo", &format!("internal:{id}"))
+        .await
+        .unwrap();
+    assert_eq!(scoped, None);
+
+    // Global lookup finds it.
+    let global = store
+        .resolve_task_id_globally(&format!("internal:{id}"))
+        .await
+        .unwrap();
+    assert_eq!(global, Some((id, "other/repo".to_string())));
+}
+
+#[tokio::test]
+async fn resolve_task_id_globally_returns_none_for_unknown() {
+    let store = TaskStore::open_memory().await.unwrap();
+    let result = store
+        .resolve_task_id_globally("internal:999")
+        .await
+        .unwrap();
+    assert_eq!(result, None);
+}
+
+#[tokio::test]
+async fn resolve_task_id_globally_unique_external_resolves() {
+    let store = TaskStore::open_memory().await.unwrap();
+    let id = store
+        .create(&NewTask {
+            external_id: Some("77".to_string()),
+            repo: "owner/repo-a".to_string(),
+            origin: "github".to_string(),
+            title: "Issue 77".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let global = store.resolve_task_id_globally("77").await.unwrap();
+    assert_eq!(global, Some((id, "owner/repo-a".to_string())));
+}
+
+#[tokio::test]
+async fn resolve_task_id_globally_ambiguous_external_errors() {
+    let store = TaskStore::open_memory().await.unwrap();
+    store
+        .create(&NewTask {
+            external_id: Some("42".to_string()),
+            repo: "owner/repo-a".to_string(),
+            origin: "github".to_string(),
+            title: "Issue 42 in A".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    store
+        .create(&NewTask {
+            external_id: Some("42".to_string()),
+            repo: "owner/repo-b".to_string(),
+            origin: "github".to_string(),
+            title: "Issue 42 in B".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let result = store.resolve_task_id_globally("42").await;
+    assert!(result.is_err(), "ambiguous ID should return an error");
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("ambiguous"), "error should mention ambiguity");
+}
+
 #[tokio::test]
 async fn list_internal_by_status_filters_origin() {
     let store = TaskStore::open_memory().await.unwrap();


### PR DESCRIPTION
## Summary

Added cross-repo fallback resolution for `orch task runs`, `activity_log`, `history`, and `inspect`. The fix adds `TaskStore::resolve_task_id_globally` which does a repo-agnostic lookup when the current-repo-scoped lookup misses, emits a note on stderr when the task belongs to a different repo, and returns a clear error for ambiguous external IDs.

### What was done

- Added `resolve_task_id_globally` to `TaskStore` in `src/store/tasks.rs`: tries `external_id` match without repo filter; for `internal:N` always unique (primary key), for external IDs errors with helpful message if ambiguous across repos
- Added `resolve_id` helper in `src/cli/task.rs`: wraps current-repo lookup with global fallback and stderr note when found in different repo
- Updated `runs`, `activity_log`, `history`, and `inspect` to use `resolve_id` instead of inline repo-scoped lookup
- Fixed `inspect` to use `task.repo` for tmux session name (was using the now-removed `repo` local variable)
- Added 4 new tests covering: cross-repo internal lookup, not-found, unique external, ambiguous external
- All 24 `resolve_task_id*` tests pass; `cargo fmt` and `cargo clippy` clean


### Files changed

- `src/cli/task.rs`
- `src/store/tasks.rs`
- `src/store/tests.rs`


Closes #3394

---
*Task #3394 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*