### PR TITLE
bug(parser): agent status "failure" not recognized — unrecognized status: failure misclassifies explicit failure as parse error

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -206,7 +206,7 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         "in_review" | "reviewing" => "in_review".to_string(),
         "needs_review" | "pending_review" | "ready_for_review" => "needs_review".to_string(),
         // Canonical error statuses.
-        "blocked" | "error" | "failed" => "blocked".to_string(),
+        "blocked" | "error" | "failed" | "failure" => "blocked".to_string(),
         // Passthrough: known canonical statuses (already canonical, keep as-is).
         s if s == "new"
             || s == "routed"
@@ -1110,6 +1110,13 @@ Some output here.
     fn parse_normalizes_error_alias_to_blocked() {
         let input =
             r#"{"status":"error","summary":"failed","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "blocked");
+    }
+
+    #[test]
+    fn parse_normalizes_failure_alias_to_blocked() {
+        let input = r#"{"status":"failure","summary":"could not complete","accomplished":[],"remaining":[],"files":[]}"#;
         let resp = parse(input).unwrap();
         assert_eq!(resp.status, "blocked");
     }


### PR DESCRIPTION
## Summary

## Summary

I've successfully fixed the bug where the parser didn't recognize `"failure"` as a valid status. The fix includes:

1. **Main Fix**: Added `"failure"` to the error-status normalization arm in `src/parser.rs:209`, so it now maps to `"blocked"` alongside `"error"` and `"failed"`.

2. **Unit Test**: Added `parse_normalizes_failure_alias_to_blocked()` test to verify the normalization works correctly for this status.

3. **Quality Checks**:
   - ✅ All 3,771 tests pass
   - ✅ Formattin

### Files changed

- `src/parser.rs`


Closes #3399

---
*Task #3399 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*