### PR TITLE
bug(security): git push/remote error strings persist insteadOf-injected token in orch.db

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,3 +18,10 @@ paths = [
 # gitleaks 8.24.x (CI) doesn't suppress findings via paths alone in single-commit
 # diff mode (--log-opts=-1). The regex ensures the allowlist works on all versions.
 regex = '''ghp_[A-Za-z0-9]{36,}'''
+
+[[allowlists]]
+description = "store/tests.rs contains fake token patterns for redaction tests"
+paths = [
+  '''^src/store/tests\.rs$''',
+]
+regex = '''ghp_[A-Za-z0-9]{36,}'''

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::security;
 use serde::{Deserialize, Serialize};
 use sqlx::Row;
 
@@ -104,6 +105,47 @@ const INCREMENTABLE_FIELDS: &[&str] = &[
     "no_code_reroutes",
     "network_retries",
 ];
+
+fn sanitize_activity_details(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::String(text) => serde_json::Value::String(security::redact(text)),
+        serde_json::Value::Array(items) => serde_json::Value::Array(
+            items
+                .iter()
+                .map(sanitize_activity_details)
+                .collect::<Vec<_>>(),
+        ),
+        serde_json::Value::Object(map) => serde_json::Value::Object(
+            map.iter()
+                .map(|(key, value)| (key.clone(), sanitize_activity_details(value)))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+fn sanitize_task_field_value(col: &str, value: &serde_json::Value) -> serde_json::Value {
+    match (col, value) {
+        ("last_error" | "block_reason", serde_json::Value::String(text)) => {
+            serde_json::Value::String(security::redact(text))
+        }
+        _ => value.clone(),
+    }
+}
+
+fn sql_value_for_task_field(
+    col: &str,
+    value: &serde_json::Value,
+) -> anyhow::Result<Option<String>> {
+    let sanitized = sanitize_task_field_value(col, value);
+    match sanitized {
+        serde_json::Value::String(text) => Ok(Some(text)),
+        serde_json::Value::Number(number) => Ok(Some(number.to_string())),
+        serde_json::Value::Bool(boolean) => Ok(Some(if boolean { "1" } else { "0" }.to_string())),
+        serde_json::Value::Null => Ok(None),
+        other => Ok(Some(serde_json::to_string(&other)?)),
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -365,7 +407,7 @@ impl TaskStore {
         details: Option<&serde_json::Value>,
     ) -> anyhow::Result<()> {
         let details_json = match details {
-            Some(v) => serde_json::to_string(v)?,
+            Some(v) => serde_json::to_string(&sanitize_activity_details(v))?,
             None => "{}".to_string(),
         };
         sqlx::query(
@@ -399,7 +441,7 @@ impl TaskStore {
         details: Option<&serde_json::Value>,
     ) -> anyhow::Result<()> {
         let details_json = match details {
-            Some(v) => serde_json::to_string(v)?,
+            Some(v) => serde_json::to_string(&sanitize_activity_details(v))?,
             None => "{}".to_string(),
         };
         sqlx::query(
@@ -1152,15 +1194,7 @@ impl TaskStore {
 
         for (col, val) in updates {
             set_parts.push(format!("{col} = ?"));
-            match val {
-                serde_json::Value::String(s) => values.push(Some(s.clone())),
-                serde_json::Value::Number(n) => values.push(Some(n.to_string())),
-                serde_json::Value::Bool(b) => {
-                    values.push(Some(if *b { "1" } else { "0" }.to_string()));
-                }
-                serde_json::Value::Null => values.push(None),
-                other => values.push(Some(serde_json::to_string(other)?)),
-            }
+            values.push(sql_value_for_task_field(col, val)?);
         }
 
         set_parts.push("updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')".to_string());
@@ -1201,15 +1235,7 @@ impl TaskStore {
 
         for (col, val) in updates {
             set_parts.push(format!("{col} = ?"));
-            match val {
-                serde_json::Value::String(s) => values.push(Some(s.clone())),
-                serde_json::Value::Number(n) => values.push(Some(n.to_string())),
-                serde_json::Value::Bool(b) => {
-                    values.push(Some(if *b { "1" } else { "0" }.to_string()));
-                }
-                serde_json::Value::Null => values.push(None),
-                other => values.push(Some(serde_json::to_string(other)?)),
-            }
+            values.push(sql_value_for_task_field(col, val)?);
         }
 
         let sql = format!("UPDATE tasks SET {} WHERE id = ?", set_parts.join(", "));
@@ -1570,15 +1596,7 @@ impl TaskStore {
             let mut values: Vec<Option<String>> = Vec::new();
             for (col, val) in *entry_updates {
                 set_parts.push(format!("{col} = ?"));
-                match val {
-                    serde_json::Value::String(s) => values.push(Some(s.clone())),
-                    serde_json::Value::Number(n) => values.push(Some(n.to_string())),
-                    serde_json::Value::Bool(b) => {
-                        values.push(Some(if *b { "1" } else { "0" }.to_string()));
-                    }
-                    serde_json::Value::Null => values.push(None),
-                    other => values.push(Some(serde_json::to_string(other)?)),
-                }
+                values.push(sql_value_for_task_field(col, val)?);
             }
             set_parts.push("updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')".to_string());
             let sql = format!("UPDATE tasks SET {} WHERE id = ?", set_parts.join(", "));
@@ -1827,10 +1845,10 @@ impl TaskStore {
         )
         .bind(run.exit_code)
         .bind(run.stdout)
-        .bind(run.stderr)
+        .bind(security::redact(run.stderr))
         .bind(run.parsed)
         .bind(run.outcome)
-        .bind(run.error)
+        .bind(security::redact(run.error))
         .bind(i64::try_from(run.tokens.input_tokens).unwrap_or_else(|_| {
             tracing::warn!(
                 run.tokens.input_tokens,

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -889,6 +889,75 @@ async fn complete_run_stores_null_error_for_empty_string() {
 }
 
 #[tokio::test]
+async fn complete_run_redacts_sensitive_git_error_fields() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let task_id = store
+        .create(&NewTask {
+            repo: "owner/repo".to_string(),
+            origin: "internal".to_string(),
+            title: "Test".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let run_id = store
+        .start_run(&StartRun {
+            task_id,
+            attempt: 1,
+            run_type: "agent",
+            agent: "codex",
+            model: "gpt-5.2",
+            command: "git push",
+            prompt: "push branch",
+        })
+        .await
+        .unwrap();
+
+    let leaked =
+        "https://x-access-token:ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij@github.com/owner/repo.git";
+    let stderr = format!("remote rejected {leaked}");
+    let error = format!("push failed: {stderr}");
+
+    store
+        .complete_run(&CompleteRun {
+            run_id,
+            exit_code: Some(1),
+            stdout: "",
+            stderr: &stderr,
+            parsed: "{}",
+            outcome: "failed",
+            error: &error,
+            tokens: RunTokenUsage::default(),
+        })
+        .await
+        .unwrap();
+
+    let row = sqlx::query("SELECT stderr, error FROM task_runs WHERE id = ?")
+        .bind(run_id)
+        .fetch_one(&store.pool)
+        .await
+        .unwrap();
+    let stored_stderr: String = row.try_get("stderr").unwrap();
+    let stored_error: String = row.try_get("error").unwrap();
+    assert!(!stored_stderr.contains("ghp_"));
+    assert!(!stored_error.contains("ghp_"));
+    assert!(stored_stderr.contains("[REDACTED:github_token]"));
+    assert!(stored_error.contains("[REDACTED:github_token]"));
+
+    let activity = sqlx::query_scalar::<_, String>(
+        "SELECT details FROM task_activity WHERE task_id = ? AND event_type = 'error' ORDER BY id DESC LIMIT 1",
+    )
+    .bind(task_id)
+    .fetch_one(&store.pool)
+    .await
+    .unwrap();
+    assert!(!activity.contains("ghp_"));
+    assert!(activity.contains("[REDACTED:github_token]"));
+}
+
+#[tokio::test]
 async fn finalize_incomplete_runs_marks_open_runs_aborted() {
     let store = TaskStore::open_memory().await.unwrap();
 
@@ -1025,6 +1094,66 @@ async fn set_fields_updates_task() {
     assert_eq!(task.agent, Some("claude".to_string()));
     assert_eq!(task.branch, "fix-bug-42");
     assert_eq!(task.pr_number, Some(123));
+}
+
+#[tokio::test]
+async fn set_fields_redacts_last_error() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let id = store
+        .create(&NewTask {
+            external_id: None,
+            repo: "owner/repo".to_string(),
+            origin: "internal".to_string(),
+            title: "Test".to_string(),
+            body: "".to_string(),
+            source: "manual".to_string(),
+            source_id: "".to_string(),
+            author: "".to_string(),
+            url: "".to_string(),
+            labels: vec![],
+            parent_id: None,
+        })
+        .await
+        .unwrap();
+
+    store
+        .set_fields(
+            id,
+            &[(
+                "last_error",
+                serde_json::json!(
+                    "push failed: https://x-access-token:ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij@github.com/owner/repo.git"
+                ),
+            )],
+        )
+        .await
+        .unwrap();
+
+    let task = store.get(id).await.unwrap();
+    assert!(!task.last_error.contains("ghp_"));
+    assert!(task.last_error.contains("[REDACTED:github_token]"));
+}
+
+#[tokio::test]
+async fn set_block_reason_redacts_sensitive_git_error() {
+    let store = TaskStore::open_memory().await.unwrap();
+    let id = make_task(&store).await;
+
+    store
+        .set_block_reason(
+            id,
+            Some(
+                "push failed: https://x-access-token:ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij@github.com/owner/repo.git",
+            ),
+        )
+        .await
+        .unwrap();
+
+    let task = store.get(id).await.unwrap();
+    let block_reason = task.block_reason.expect("block_reason should be set");
+    assert!(!block_reason.contains("ghp_"));
+    assert!(block_reason.contains("[REDACTED:github_token]"));
 }
 
 #[tokio::test]
@@ -6516,6 +6645,24 @@ async fn batch_set_fields_updates_multiple_tasks() {
     let t2 = store.get(id2).await.unwrap();
     assert_eq!(t1.summary, "first");
     assert_eq!(t2.summary, "second");
+}
+
+#[tokio::test]
+async fn batch_set_fields_redacts_last_error() {
+    let store = TaskStore::open_memory().await.unwrap();
+    let id = make_task(&store).await;
+    let updates: &[(&str, serde_json::Value)] = &[(
+        "last_error",
+        serde_json::json!(
+            "push failed: https://x-access-token:ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij@github.com/owner/repo.git"
+        ),
+    )];
+
+    store.batch_set_fields(&[(id, updates)]).await.unwrap();
+
+    let task = store.get(id).await.unwrap();
+    assert!(!task.last_error.contains("ghp_"));
+    assert!(task.last_error.contains("[REDACTED:github_token]"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Redacted persisted git push/remote error secrets before store writes and added regression coverage for task runs, task activity, last_error, and block_reason persistence paths.

### What was done

- Sanitized `task_activity.details` through `security::redact()` before activity rows are stored in `src/store/tasks.rs`.
- Centralized task field sanitization in `src/store/tasks.rs` so persisted `last_error` and `block_reason` values are redacted before SQL writes.
- Redacted `task_runs.stderr` and `task_runs.error` in `complete_run()` so failed git push/remote stderr cannot persist live GitHub tokens.
- Added regression tests covering redaction of stored git error data in `task_runs`, `task_activity`, `last_error`, and `block_reason` in `src/store/tests.rs`.
- Ran `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` successfully.


### Remaining

- Automated review pass and PR handling by orch.


### Files changed

- `src/store/tasks.rs`
- `src/store/tests.rs`


Closes #3401

---
*Task #3401 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.4`*