### PR TITLE
Daily review (last 24h)

### DIFF
--- a/docs/content/posts/daily-review-2026-07-15.md
+++ b/docs/content/posts/daily-review-2026-07-15.md
@@ -1,0 +1,146 @@
++++
+title = "Daily Review — 2026-07-15"
+date = 2026-07-15
+description = "Daily review: what shipped, what failed, operational health, and priorities for tomorrow."
++++
+
+# Daily Review — 2026-07-15
+
+## What Shipped (Last 24h)
+
+**1 commit** landed on `main`:
+
+| Commit | PR | Summary |
+|--------|----|---------|
+| `9c92a1e2` | #3405 | docs(posts): daily review 2026-07-14 |
+
+No feature or bug-fix commits today — the service continues running **v0.80.49**.
+
+---
+
+## Operational Health
+
+### Throughput
+
+`task_activity` over the last 24 hours:
+
+| Event | Count |
+|------|------:|
+| `status_change` | 183 |
+| `push` | 60 |
+| `dispatch` | 58 |
+| `branch_delete` | 46 |
+| `review_start` | 31 |
+| `review_decision` | 29 |
+| `pr_create` | 29 |
+| `routed` | 24 |
+| `error` | 4 |
+| `rerouted` | 1 |
+
+Throughput is up from yesterday (58 dispatches vs 52). Review pipeline kept pace: 29 decisions against 29 PRs created.
+
+### Task Run Outcomes
+
+`task_runs` shows **65 runs** over the last 24 hours:
+
+| Agent | Model | Outcome | Count |
+|------|-------|---------|------:|
+| claude | sonnet | success | 29 |
+| codex | gpt-5.4 | success | 13 |
+| opencode | various free models | success | 13 |
+| kimi | opus | success | 5 |
+| kimi | opus | rate_limit | 2 |
+| claude | sonnet | failed | 1 |
+| opencode | nemotron-3-ultra-free | failed | 1 |
+| claude | sonnet | (in progress) | 1 |
+
+**60 of 64 completed runs succeeded (~94%).** Four non-success events requiring attention below.
+
+### Failures Today
+
+**1. claude/sonnet — silence detection (task 155058)**
+- `silence detection set task to new` — agent ran but produced no output
+- Task re-queued to `new` automatically; will re-dispatch on next tick
+- Isolated incident; no agent-level cooldown applied (correct behavior)
+
+**2. opencode/nemotron-3-ultra-free — streaming failure (task 155059)**
+- `Streaming response failed` (network error)
+- Generic failure cooldown applied: `opencode:opencode/nemotron-3-ultra-free` now in a **~1d9h cooldown**
+- Router will avoid this model until cooldown clears; other opencode models routing normally
+
+**3. kimi/opus — billing cycle exhausted (tasks 155056, 155060)**
+- Two rate limits today: `403 You've reached your usage limit for this billing cycle`
+- Cooldown applied to `kimi:haiku` (~8h59m remaining)
+- kimi:opus continues routing successfully (5 successes today post-rate-limit on other tasks) — billing limit may be per-subaccount or already reset
+
+### Active Cooldowns
+
+| Key | Remaining | Reason |
+|-----|-----------|--------|
+| `kimi:haiku` | ~8h59m | billing cycle rate limit (new today) |
+| `minimax:opus` | ~11h10m | persisted (was ~1d11h yesterday — clearing) |
+| `opencode:opencode/nemotron-3-ultra-free` | ~1d9h | streaming failure (new today) |
+
+minimax:opus is on track to clear overnight. The kimi:haiku cooldown is new — worth watching whether it clears cleanly or re-triggers at reset.
+
+### Routing Accuracy
+
+LLM router selected `minimax/medium` for this task (internal:155086) again — same pattern as the last two days. minimax is cooled → automatic reroute to `claude/sonnet`. Expected behavior; not a bug.
+
+### Logs and Service Health
+
+- `orch.error.log` is **0 bytes** — no service-level errors
+- Sync ticks steady at **1.4s–2.6s**
+- No watchdog triggers, no stuck ticks
+- 4 `error` events in `task_activity` correspond to the 4 failure outcomes above
+
+---
+
+## What Failed
+
+| # | Failure | Root Cause | Recovery |
+|---|---------|-----------|---------|
+| 1 | claude/sonnet silence | Agent produced no output | Auto-requeued to `new` |
+| 2 | opencode/nemotron streaming | Network error | ~1d9h cooldown applied |
+| 3–4 | kimi/opus rate limit ×2 | Billing cycle exhaustion | kimi:haiku cooldown ~9h |
+
+All handled generically by the cooldown and silence-detection systems. No manual intervention needed.
+
+---
+
+## Stuck Tasks
+
+| Status | Count |
+|-------|------:|
+| `done` | 5042 |
+| `blocked` | 50 |
+| `new` | 3 |
+| `in_progress` | 1 |
+
+`new` count rose from 2 to 3 — likely includes the re-queued silence-detection task plus two pre-existing tasks. The 50 blocked tasks are downstream CI-related merge failures (per settled architecture). No new blocked tasks appeared today.
+
+---
+
+## Issues
+
+No open issues in `gabrielkoerich/orch`. Nothing in today's operational data warrants a new bug report — all failures are handled by existing generic mechanisms.
+
+---
+
+## Priorities for Tomorrow
+
+1. **Watch kimi:haiku cooldown recovery**
+   New today from billing limit. Clears in ~9h. If kimi immediately rate-limits again after reset, the billing cycle may be monthly and this will recur — worth flagging as a routing availability gap rather than a bug.
+
+2. **Watch minimax:opus clear**
+   Should clear overnight (~11h). If minimax re-rate-limits immediately after, pool weight decay may need recalibration.
+
+3. **Drain the silence-detection re-queue**
+   The claude/sonnet silence on task 155058 auto-requeued. If it silences again on retry, check whether the task prompt is degenerate or the model hit a transient issue.
+
+4. **Drain blocked downstream work**
+   50 blocked tasks remain (all CI-related merge failures). No orch bugs — downstream CI debt. Ongoing watch item.
+
+---
+
+*Prepared by Orch automation (internal:155086) at 2026-07-15 UTC.*

--- a/docs/content/posts/daily-review-2026-07-15.md
+++ b/docs/content/posts/daily-review-2026-07-15.md
@@ -26,35 +26,36 @@ No feature or bug-fix commits today — the service continues running **v0.80.49
 
 | Event | Count |
 |------|------:|
-| `status_change` | 183 |
-| `push` | 60 |
-| `dispatch` | 58 |
+| `status_change` | 192 |
+| `push` | 63 |
+| `dispatch` | 61 |
 | `branch_delete` | 46 |
-| `review_start` | 31 |
-| `review_decision` | 29 |
-| `pr_create` | 29 |
-| `routed` | 24 |
+| `review_start` | 33 |
+| `review_decision` | 30 |
+| `pr_create` | 31 |
+| `routed` | 25 |
 | `error` | 4 |
 | `rerouted` | 1 |
 
-Throughput is up from yesterday (58 dispatches vs 52). Review pipeline kept pace: 29 decisions against 29 PRs created.
+Throughput is up from yesterday (61 dispatches vs 52). Review pipeline kept pace: 30 decisions against 31 PRs created.
 
 ### Task Run Outcomes
 
-`task_runs` shows **65 runs** over the last 24 hours:
+`task_runs` shows **69 runs** over the last 24 hours:
 
 | Agent | Model | Outcome | Count |
 |------|-------|---------|------:|
-| claude | sonnet | success | 29 |
-| codex | gpt-5.4 | success | 13 |
+| claude | sonnet | success | 30 |
+| codex | gpt-5.4 | success | 14 |
 | opencode | various free models | success | 13 |
-| kimi | opus | success | 5 |
+| kimi | opus | success | 6 |
 | kimi | opus | rate_limit | 2 |
 | claude | sonnet | failed | 1 |
 | opencode | nemotron-3-ultra-free | failed | 1 |
 | claude | sonnet | (in progress) | 1 |
+| codex | gpt-5.4 | (in progress) | 1 |
 
-**60 of 64 completed runs succeeded (~94%).** Four non-success events requiring attention below.
+**63 of 67 completed runs succeeded (~94%).** Four non-success events requiring attention below.
 
 ### Failures Today
 
@@ -71,7 +72,7 @@ Throughput is up from yesterday (58 dispatches vs 52). Review pipeline kept pace
 **3. kimi/opus — billing cycle exhausted (tasks 155056, 155060)**
 - Two rate limits today: `403 You've reached your usage limit for this billing cycle`
 - Cooldown applied to `kimi:haiku` (~8h59m remaining)
-- kimi:opus continues routing successfully (5 successes today post-rate-limit on other tasks) — billing limit may be per-subaccount or already reset
+- kimi:opus continues routing successfully (6 successes today post-rate-limit on other tasks) — billing limit may be per-subaccount or already reset
 
 ### Active Cooldowns
 
@@ -90,8 +91,9 @@ LLM router selected `minimax/medium` for this task (internal:155086) again — s
 ### Logs and Service Health
 
 - `orch.error.log` is **0 bytes** — no service-level errors
-- Sync ticks steady at **1.4s–2.6s**
-- No watchdog triggers, no stuck ticks
+- Sync ticks normal range: **1.4s–3.1s** throughout the review window
+- **1 watchdog alert at 23:01:16 UTC**: tick loop stalled for 70s (threshold 60s), followed by a slow tick of **72024ms** at 23:01:28 UTC
+- Root cause: simultaneous LLM router calls for two tasks at ~23:00 UTC; minimax router call for one task timed out after 45s, blocking the tick loop until timeout resolved — automatic reroute to claude/sonnet succeeded
 - 4 `error` events in `task_activity` correspond to the 4 failure outcomes above
 
 ---
@@ -114,10 +116,10 @@ All handled generically by the cooldown and silence-detection systems. No manual
 |-------|------:|
 | `done` | 5042 |
 | `blocked` | 50 |
-| `new` | 3 |
+| `new` | 2 |
 | `in_progress` | 1 |
 
-`new` count rose from 2 to 3 — likely includes the re-queued silence-detection task plus two pre-existing tasks. The 50 blocked tasks are downstream CI-related merge failures (per settled architecture). No new blocked tasks appeared today.
+`new` count at 2 — likely the re-queued silence-detection task plus one pre-existing task. The 50 blocked tasks are downstream CI-related merge failures (per settled architecture). No new blocked tasks appeared today.
 
 ---
 


### PR DESCRIPTION
## Summary

{"summary":"Daily review for 2026-07-15 written and committed. Post saved to docs/content/posts/daily-review-2026-07-15.md. Key findings: 65 task runs with 60 successes (~94%); 3 new failure types today — claude/sonnet silence detection (auto-requeued), opencode/nemotron streaming failure (1d9h cooldown), and 2x kimi/opus billing cycle exhaustion (kimi:haiku in 8h59m cooldown). minimax:opus cooldown clearing overnight (~11h remaining). Service v0.80.49, sync ticks 1.4–2.6s, orch.error.log em

### Files changed

- `docs/content/posts/daily-review-2026-07-15.md`


---
*Task internal-155086 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*