### PR TITLE
bug(runner): resolve_project_dir() falls through to service CWD for inactive repos with no bare-clone — worktree creation fails, newly exposed by dispatch_routed_tasks_global

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -1608,8 +1608,22 @@ impl TaskRunner {
             }
         }
 
-        // Fall back to current directory
-        Ok(std::env::current_dir()?)
+        // No resolvable project directory: not in active config, no legacy
+        // project_dir, no bare clone. Falling back to the service's own CWD
+        // here would silently point worktree creation at an unrelated
+        // directory (see issue #3416) — surface a clear error instead.
+        anyhow::bail!(
+            "no resolvable project directory for repo {} — not in active config, no bare clone at {}, no legacy project_dir set",
+            self.repo,
+            self.orch_home
+                .join("projects")
+                .join(self.repo.split('/').next().unwrap_or_default())
+                .join(format!(
+                    "{}.git",
+                    self.repo.split('/').nth(1).unwrap_or_default()
+                ))
+                .display()
+        )
     }
 }
 
@@ -2185,8 +2199,18 @@ mod tests {
         let result = runner.resolve_project_dir().await;
         std::env::remove_var("PROJECT_DIR");
 
-        // Should succeed (falls back to current dir) without panicking.
-        assert!(result.is_ok());
+        // No active config entry, no legacy project_dir, no bare clone for this
+        // repo: should return an explicit error rather than falling back to the
+        // service's own CWD (see issue #3416).
+        assert!(
+            result.is_err(),
+            "resolve_project_dir should error when no project dir can be resolved"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("owner/testrepo-nonexistent"),
+            "error should name the unresolvable repo: {err}"
+        );
     }
 
     // ── mock backend for process_delegations ─────────────────────────────────


### PR DESCRIPTION
## Summary

Fixed resolve_project_dir() in src/engine/runner/mod.rs to return an explicit error instead of silently falling back to the orch service's own CWD when a repo has no active config entry, no legacy project_dir, and no bare clone.

### What was done

- Replaced the final fallback in TaskRunner::resolve_project_dir() (was `Ok(std::env::current_dir()?)`) with an anyhow::bail! that names the unresolvable repo and where it looked (active config, legacy project_dir, bare-clone path), matching the pattern already used in cleanup.rs::resolve_project_dir_for_repo
- Updated the existing test resolve_project_dir_empty_project_dir_env_falls_through to assert the new error behavior (previously asserted the old CWD-fallback succeeded)
- Verified cargo fmt, cargo clippy --all-targets -- -D warnings, and cargo nextest run all pass (3795 tests passed, 19 skipped)
- Committed the change with a conventional commit message


### Files changed

- `src/engine/runner/mod.rs`


Closes #3416

---
*Task #3416 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*