### PR TITLE
bug(parser): normalize_status missing `changes_requested_addressed` alias — same class as changes_addressed

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -189,6 +189,7 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         | "no_action_needed"
         | "missed"
         | "changes_addressed"
+        | "changes_requested_addressed"
         | "review_addressed"
         | "already_finalized_in_attempt_1"
         | "alert"
@@ -1014,6 +1015,13 @@ Some output here.
     }
 
     #[test]
+    fn parse_normalizes_changes_requested_addressed_alias_to_done() {
+        let input = r#"{"status":"changes_requested_addressed","summary":"review feedback addressed","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "done");
+    }
+
+    #[test]
     fn parse_normalizes_review_addressed_alias_to_done() {
         let input = r#"{"status":"review_addressed","summary":"review feedback addressed","accomplished":[],"remaining":[],"files":[]}"#;
         let resp = parse(input).unwrap();
@@ -1235,6 +1243,7 @@ Some output here.
             ("changes_made", "done"),
             ("changes_pushed", "done"),
             ("changes_addressed", "done"),
+            ("changes_requested_addressed", "done"),
             ("fixed", "done"),
             ("running", "in_progress"),
             ("partial", "in_progress"),


### PR DESCRIPTION
## Summary

Added the missing `changes_requested_addressed` status alias to parser normalization and covered it with a regression test.

### What was done

- Normalized `changes_requested_addressed` to `done` in `src/parser.rs` alongside the existing review-completion aliases.
- Added a unit test for `changes_requested_addressed` -> `done`.
- Extended the alias regression table to include `changes_requested_addressed`.
- Verified `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings` passed.
- Verified the new parser regression with `cargo test parse_normalizes_changes_requested_addressed_alias_to_done --lib`.


### Remaining

- Investigate the unrelated failing integration test in `cargo nextest run` if you want the full suite green.
- Re-run the full suite after that unrelated tmux test failure is understood or fixed.


### Files changed

- `/Users/gb/.orch/worktrees/orch/gh-issue-3417-bug-parser-normalize-status-missing-chan/src/parser.rs`


Closes #3417

---
*Task #3417 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.4-mini`*