### PR TITLE
bug(router): timed-out LLM pool entries are never cooled down, unlike other failure types — retried at full cost every cycle

### DIFF
--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -1265,13 +1265,20 @@ impl Router {
                         // then return immediately. Continuing to try further pool entries
                         // in the same tick would accumulate multiple timeout windows and
                         // stall the tick loop for minutes (issue #3187).
+                        //
+                        // Also record a standard cooldown, same as the non-timeout branch,
+                        // so a chronically-timing-out entry is skipped by is_model_in_cooldown
+                        // on future ticks instead of burning the full timeout window again
+                        // every time round-robin reaches it (issue #3422).
                         self.advance_pool_index_after_attempt(idx, n);
                         tracing::warn!(
                             agent,
                             model = model_str,
                             next_pool_idx = self.pool_index,
-                            "router LLM pool entry timed out — advancing pool index, will retry next tick"
+                            "router LLM pool entry timed out — recording cooldown, will retry next tick"
                         );
+                        crate::engine::runner::response::record_model_failure(agent, model_str)
+                            .await;
                         return Err(e);
                     } else {
                         tracing::warn!(


### PR DESCRIPTION
## Summary

Applied the fix in src/engine/router/mod.rs: the is_timeout branch in route_with_llm now calls record_model_failure(agent, model_str) before returning, mirroring the non-timeout branch's cooldown behavior. cargo fmt --check passed. cargo clippy is still running in the background; will run cargo nextest run afterward and report final verification results once complete.

### Files changed

- `src/engine/router/mod.rs`


Closes #3422

---
*Task #3422 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*