### PR TITLE
bug(engine): internal-task parents that delegate subtasks never auto-unblock — Phase 4 requires the parent to be a real GitHub issue

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -2024,9 +2024,7 @@ pub(crate) async fn tick_unblock_parents(
     store: &Arc<TaskStore>,
     repo: &str,
 ) -> anyhow::Result<()> {
-    let blocked = task_manager
-        .list_external_by_status(Status::Blocked)
-        .await?;
+    let blocked = task_manager.list_all_by_status(Status::Blocked).await?;
 
     // Pre-filter: skip tasks that are blocked for a known reason (e.g. CI failure,
     // escalation). These are not waiting on children, so there is no point making
@@ -2063,13 +2061,58 @@ pub(crate) async fn tick_unblock_parents(
             let repo_owned = repo.to_string();
             tokio::spawn(async move {
                 let task_id = &task.id;
-                let children = match backend_clone.get_sub_issues(task_id).await {
-                    Ok(ids) => ids,
+
+                let mut children: Vec<ExternalId> = Vec::new();
+                let mut child_statuses: std::collections::HashMap<
+                    String,
+                    crate::store::TaskStatus,
+                > = std::collections::HashMap::new();
+
+                match store_clone.resolve_task_id(&repo_owned, &task_id.0).await {
+                    Ok(Some(parent_store_id)) => {
+                        match store_clone.list_children(&repo_owned, parent_store_id).await {
+                            Ok(store_children) => {
+                                for child in store_children {
+                                    let Some(child_external_id) = child.external_id else {
+                                        continue;
+                                    };
+                                    child_statuses.insert(child_external_id.clone(), child.status);
+                                    children.push(ExternalId(child_external_id));
+                                }
+                            }
+                            Err(e) => {
+                                tracing::debug!(
+                                    task_id = task_id.0,
+                                    ?e,
+                                    "failed to list store-linked children"
+                                );
+                            }
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        tracing::debug!(
+                            task_id = task_id.0,
+                            ?e,
+                            "failed to resolve blocked task in store for child lookup"
+                        );
+                    }
+                }
+
+                match backend_clone.get_sub_issues(task_id).await {
+                    Ok(ids) => {
+                        let mut seen: std::collections::HashSet<String> =
+                            children.iter().map(|child| child.0.clone()).collect();
+                        for id in ids {
+                            if seen.insert(id.0.clone()) {
+                                children.push(id);
+                            }
+                        }
+                    }
                     Err(e) => {
                         tracing::debug!(task_id = task_id.0, ?e, "failed to get sub-issues");
-                        return;
                     }
-                };
+                }
 
                 // No children means nothing to wait on — skip (may be blocked for other reasons)
                 if children.is_empty() {
@@ -2085,16 +2128,12 @@ pub(crate) async fn tick_unblock_parents(
                 let child_exts: Vec<&str> =
                     child_ext_strs.iter().map(|s| s.as_str()).collect();
                 // Query store for statuses of any children present locally
-                let mut store_status_map: std::collections::HashMap<
-                    String,
-                    crate::store::TaskStatus,
-                > = std::collections::HashMap::new();
                 if let Ok(map) = store_clone
                     .get_statuses_by_external_ids(&repo_owned, &child_exts)
                     .await
                 {
                     for (k, v) in map.into_iter() {
-                        store_status_map.insert(k, v);
+                        child_statuses.insert(k, v);
                     }
                 } else {
                     tracing::debug!(
@@ -2105,7 +2144,7 @@ pub(crate) async fn tick_unblock_parents(
 
                 for child_id in &children {
                     // Check store first
-                    if let Some(status) = store_status_map.get(&child_id.0) {
+                    if let Some(status) = child_statuses.get(&child_id.0) {
                         if *status != crate::store::TaskStatus::Done {
                             all_done = false;
                             break;
@@ -2551,6 +2590,59 @@ mod tests {
         assert!(
             updates.is_empty(),
             "task with block_reason should be skipped — no API call, no unblock"
+        );
+    }
+
+    #[tokio::test]
+    async fn unblock_parents_unblocks_internal_parent_from_store_children() {
+        let mock = MockBackend::new();
+        let status_updates = mock.status_updates.clone();
+        let backend: Arc<dyn ExternalBackend> = Arc::new(mock);
+        let store = Arc::new(TaskStore::open_memory().await.unwrap());
+        let task_manager = Arc::new(TaskManager::with_store(
+            backend.clone(),
+            store.clone(),
+            "test/repo".to_string(),
+        ));
+
+        let parent_id = store
+            .create_internal("test/repo", "Parent", "", "job", "daily", None)
+            .await
+            .unwrap();
+        store
+            .update_status(parent_id, crate::store::TaskStatus::Blocked)
+            .await
+            .unwrap();
+        let child_id = store
+            .create(&crate::store::NewTask {
+                external_id: Some("91".to_string()),
+                repo: "test/repo".to_string(),
+                origin: "github".to_string(),
+                title: "Child".to_string(),
+                body: String::new(),
+                source: String::new(),
+                source_id: String::new(),
+                author: String::new(),
+                url: String::new(),
+                labels: vec![],
+                parent_id: Some(parent_id),
+            })
+            .await
+            .unwrap();
+        store
+            .update_status(child_id, crate::store::TaskStatus::Done)
+            .await
+            .unwrap();
+
+        tick_unblock_parents(&backend, &task_manager, &store, "test/repo")
+            .await
+            .unwrap();
+
+        let parent = store.get(parent_id).await.unwrap();
+        assert_eq!(parent.status, crate::store::TaskStatus::New);
+        assert!(
+            status_updates.lock().unwrap().is_empty(),
+            "internal parent should be updated in store without backend mirroring"
         );
     }
 

--- a/src/store/tasks.rs
+++ b/src/store/tasks.rs
@@ -393,6 +393,13 @@ pub struct UpsertExternal<'a> {
     pub origin: &'a str,
 }
 
+fn parent_external_id_from_labels(labels: &[String]) -> Option<&str> {
+    labels
+        .iter()
+        .find_map(|label| label.strip_prefix("parent:"))
+        .filter(|parent| !parent.is_empty())
+}
+
 impl TaskStore {
     /// Append a lifecycle activity event for a task.
     #[allow(clippy::too_many_arguments)]
@@ -641,14 +648,19 @@ impl TaskStore {
     /// Upsert an external task — insert if new, update title/body/labels if exists.
     pub async fn upsert_external(&self, ext: &UpsertExternal<'_>) -> anyhow::Result<i64> {
         let labels_json = serde_json::to_string(ext.labels)?;
+        let parent_id = match parent_external_id_from_labels(ext.labels) {
+            Some(parent_external_id) => self.resolve_task_id(ext.repo, parent_external_id).await?,
+            None => None,
+        };
         let row = sqlx::query(
-            "INSERT INTO tasks (external_id, repo, origin, title, body, author, url, labels)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            "INSERT INTO tasks (external_id, repo, origin, title, body, author, url, labels, parent_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(repo, external_id) DO UPDATE SET
             title = excluded.title,
             body = excluded.body,
             labels = excluded.labels,
-            url = excluded.url
+            url = excluded.url,
+            parent_id = COALESCE(excluded.parent_id, tasks.parent_id)
          RETURNING id",
         )
         .bind(ext.ext_id)
@@ -659,6 +671,7 @@ impl TaskStore {
         .bind(ext.author)
         .bind(ext.url)
         .bind(&labels_json)
+        .bind(parent_id)
         .fetch_one(&self.pool)
         .await?;
 
@@ -931,6 +944,19 @@ impl TaskStore {
         ))
         .bind(repo)
         .bind(status.as_str())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(Self::row_to_task).collect()
+    }
+
+    /// List tasks that are linked to the given parent task.
+    pub async fn list_children(&self, repo: &str, parent_id: i64) -> anyhow::Result<Vec<Task>> {
+        let rows = sqlx::query(&format!(
+            "SELECT {TASK_COLS} FROM tasks WHERE repo = ? AND parent_id = ? ORDER BY created_at ASC"
+        ))
+        .bind(repo)
+        .bind(parent_id)
         .fetch_all(&self.pool)
         .await?;
 

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -1620,6 +1620,38 @@ async fn task_with_parent_id() {
 }
 
 #[tokio::test]
+async fn upsert_external_sets_parent_id_from_parent_label() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    let parent_id = store
+        .create_internal("owner/repo", "Parent", "", "manual", "", None)
+        .await
+        .unwrap();
+    let labels = vec![format!("parent:internal:{parent_id}")];
+
+    let child_id = store
+        .upsert_external(&UpsertExternal {
+            repo: "owner/repo",
+            ext_id: "42",
+            title: "Child",
+            body: "",
+            author: "bot",
+            url: "https://github.com/owner/repo/issues/42",
+            labels: &labels,
+            origin: "github",
+        })
+        .await
+        .unwrap();
+
+    let child = store.get(child_id).await.unwrap();
+    assert_eq!(child.parent_id, Some(parent_id));
+
+    let children = store.list_children("owner/repo", parent_id).await.unwrap();
+    assert_eq!(children.len(), 1);
+    assert_eq!(children[0].external_id.as_deref(), Some("42"));
+}
+
+#[tokio::test]
 async fn multiple_runs_per_task() {
     let store = TaskStore::open_memory().await.unwrap();
 


### PR DESCRIPTION
## Summary

Fixed Phase 4 parent unblocking for internal tasks that delegate GitHub subtasks. The fix is committed as bba0997d (fix: unblock internal parents with delegated children), and the worktree is clean.

### What was done

- Changed parent unblocking to consider both external and internal blocked tasks via TaskManager::list_all_by_status.
- Added store-side child discovery using tasks.parent_id before falling back to GitHub native sub-issues, so internal parents no longer depend on a numeric GitHub issue ID.
- Updated external task ingestion to populate parent_id from existing parent:{id} labels, preserving existing parent_id on later reingest when no parent label is present.
- Added regression coverage for ingesting parent labels and unblocking an internal parent whose store-linked child is done.
- Ran cargo fmt -- --check, cargo clippy --all-targets -- -D warnings, and cargo nextest run; all passed, with nextest reporting 3801 passed and 19 skipped.


### Files changed

- `src/engine/tick.rs`
- `src/store/tasks.rs`
- `src/store/tests.rs`


Closes #3421

---
*Task #3421 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.5`*