### PR TITLE
bug(github): get_sub_issues still coerces internal task ids to issue 0

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -2099,18 +2099,20 @@ pub(crate) async fn tick_unblock_parents(
                     }
                 }
 
-                match backend_clone.get_sub_issues(task_id).await {
-                    Ok(ids) => {
-                        let mut seen: std::collections::HashSet<String> =
-                            children.iter().map(|child| child.0.clone()).collect();
-                        for id in ids {
-                            if seen.insert(id.0.clone()) {
-                                children.push(id);
+                if !is_internal_id(&task_id.0) {
+                    match backend_clone.get_sub_issues(task_id).await {
+                        Ok(ids) => {
+                            let mut seen: std::collections::HashSet<String> =
+                                children.iter().map(|child| child.0.clone()).collect();
+                            for id in ids {
+                                if seen.insert(id.0.clone()) {
+                                    children.push(id);
+                                }
                             }
                         }
-                    }
-                    Err(e) => {
-                        tracing::debug!(task_id = task_id.0, ?e, "failed to get sub-issues");
+                        Err(e) => {
+                            tracing::debug!(task_id = task_id.0, ?e, "failed to get sub-issues");
+                        }
                     }
                 }
 
@@ -2321,6 +2323,8 @@ mod tests {
         sub_issues: std::collections::HashMap<String, Vec<ExternalId>>,
         /// Tasks returned by `get_task`. Keyed by id.0.
         tasks_by_id: std::collections::HashMap<String, ExternalTask>,
+        /// Recorded `get_sub_issues` calls.
+        get_sub_issues_calls: Arc<Mutex<Vec<String>>>,
         /// Recorded `update_status` calls.
         status_updates: Arc<Mutex<Vec<(String, Status)>>>,
         /// Recorded `remove_label` calls.
@@ -2335,6 +2339,7 @@ mod tests {
                 blocked_tasks: vec![],
                 sub_issues: Default::default(),
                 tasks_by_id: Default::default(),
+                get_sub_issues_calls: Arc::new(Mutex::new(vec![])),
                 status_updates: Arc::new(Mutex::new(vec![])),
                 removed_labels: Arc::new(Mutex::new(vec![])),
                 posted_comments: Arc::new(Mutex::new(vec![])),
@@ -2403,6 +2408,7 @@ mod tests {
             Ok(())
         }
         async fn get_sub_issues(&self, id: &ExternalId) -> anyhow::Result<Vec<ExternalId>> {
+            self.get_sub_issues_calls.lock().unwrap().push(id.0.clone());
             Ok(self.sub_issues.get(&id.0).cloned().unwrap_or_default())
         }
         async fn create_sub_task(
@@ -2596,6 +2602,7 @@ mod tests {
     #[tokio::test]
     async fn unblock_parents_unblocks_internal_parent_from_store_children() {
         let mock = MockBackend::new();
+        let get_sub_issues_calls = mock.get_sub_issues_calls.clone();
         let status_updates = mock.status_updates.clone();
         let backend: Arc<dyn ExternalBackend> = Arc::new(mock);
         let store = Arc::new(TaskStore::open_memory().await.unwrap());
@@ -2643,6 +2650,10 @@ mod tests {
         assert!(
             status_updates.lock().unwrap().is_empty(),
             "internal parent should be updated in store without backend mirroring"
+        );
+        assert!(
+            get_sub_issues_calls.lock().unwrap().is_empty(),
+            "internal parent should not query backend sub-issues"
         );
     }
 

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -27,6 +27,16 @@ use urlencoding;
 
 const GITHUB_API: &str = "https://api.github.com";
 
+fn parse_positive_issue_number(number: &str) -> anyhow::Result<i64> {
+    let parsed = number
+        .parse::<i64>()
+        .with_context(|| format!("invalid issue number: {number}"))?;
+    if parsed <= 0 {
+        anyhow::bail!("invalid issue number: {number}");
+    }
+    Ok(parsed)
+}
+
 // ── Rate-limit state ─────────────────────────────────────────────────
 
 /// Proactive rate-limit state derived from `X-RateLimit-*` response headers.
@@ -2287,6 +2297,13 @@ impl GhHttp {
             anyhow::bail!("invalid repo format: expected 'owner/repo', got '{}'", repo);
         }
         let (owner, repo_name) = (parts[0], parts[1]);
+        let number = match parse_positive_issue_number(number) {
+            Ok(number) => number,
+            Err(e) => {
+                tracing::debug!(repo, issue = number, ?e, "skipping sub-issues lookup");
+                return Ok(Vec::new());
+            }
+        };
 
         let mut all_numbers: Vec<u64> = Vec::new();
         let mut cursor: Option<String> = None;
@@ -2320,7 +2337,7 @@ impl GhHttp {
                     serde_json::json!({
                         "owner": owner,
                         "name": repo_name,
-                        "number": number.parse::<i64>().unwrap_or(0),
+                        "number": number,
                         "first": page_size,
                         "after": c,
                     }),
@@ -2340,7 +2357,7 @@ impl GhHttp {
                     serde_json::json!({
                         "owner": owner,
                         "name": repo_name,
-                        "number": number.parse::<i64>().unwrap_or(0),
+                        "number": number,
                         "first": page_size,
                     }),
                 )
@@ -3145,6 +3162,25 @@ mod tests {
         assert!(query.contains("issue1: issue(number: 1)"));
         assert!(query.contains("issue3: issue(number: 3)"));
         assert!(query.contains("labels(first: 100)"));
+    }
+
+    #[test]
+    fn parse_positive_issue_number_accepts_positive_values() {
+        assert_eq!(parse_positive_issue_number("42").unwrap(), 42);
+    }
+
+    #[test]
+    fn parse_positive_issue_number_rejects_zero() {
+        let err = parse_positive_issue_number("0").unwrap_err().to_string();
+        assert!(err.contains("invalid issue number: 0"));
+    }
+
+    #[test]
+    fn parse_positive_issue_number_rejects_internal_ids() {
+        let err = parse_positive_issue_number("internal:5")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("invalid issue number: internal:5"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prevented internal task ids from reaching GitHub sub-issue GraphQL lookups and added regression coverage for invalid sub-issue numbers.

### What was done

- Updated Phase 4 parent-unblock logic in `src/engine/tick.rs` to skip backend `get_sub_issues` calls for internal task ids and rely on store-linked children only.
- Added a regression assertion in `src/engine/tick.rs` proving internal parents unblock without any backend sub-issue lookup.
- Hardened `src/github/http.rs` with explicit positive issue-number validation so nonnumeric or nonpositive ids return an empty sub-issue list instead of coercing to issue `0`.
- Added parser-level regression tests for valid numeric ids, `0`, and `internal:<id>` inputs in `src/github/http.rs`.
- Ran `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` successfully.
- Committed the fix as `ef92ce2d` (`fix(github): reject invalid sub-issue ids`).


### Files changed

- `src/engine/tick.rs`
- `src/github/http.rs`


Closes #3428

---
*Task #3428 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.4`*