### PR TITLE
bug(review-prompt): review agent can background the CI-wait command and end its turn without the required JSON decision

### DIFF
--- a/prompts/review_task.md
+++ b/prompts/review_task.md
@@ -26,6 +26,8 @@ Check **required checks only**:
 timeout 300 gh pr checks {{PR_NUMBER}} --watch --fail-fast --required || true
 ```
 
+Run this command in the foreground and wait for it to complete — do NOT use a background/async task tool for this step. The review is not complete until this command has finished and you have interpreted its output.
+
 **Non-required checks** are informational — the `--required` flag filters to required checks only. The only non-required check orch installs is `review-gate`. Do NOT request changes based on non-required check failures.
 
 Follow this decision tree exactly:
@@ -108,6 +110,7 @@ Flag `request_changes` if the PR:
 
 You MUST output the JSON block below even if you already ran this review earlier.
 Do NOT respond with prose summaries.
+Your turn must not end with a background task still running. If you started any background command, wait for it to finish before producing your final answer.
 
 ```json
 {


### PR DESCRIPTION
## Summary

I'll tighten the review prompt to prevent the agent from backgrounding the CI-wait command.
Fixed the prompt gap in `prompts/review_task.md`:

- **Step 2** now explicitly says to run the CI-wait command in the foreground and forbids using a background/async task tool for it.
- **Output Format** now requires the turn not to end with a background task still running.

I also ran `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`; both passed. I committed the change but did not push

### What was done

- **Step 2** now explicitly says to run the CI-wait command in the foreground and forbids using a background/async task tool for it.
- **Output Format** now requires the turn not to end with a background task still running.


### Files changed

- `prompts/review_task.md`


Closes #3438

---
*Task #3438 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*