### PR TITLE
bug(skill): distributed orch skill still advertises forbidden brew upgrade and manual task-reset workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,6 @@ contexts/
 docs/public/
 lcov.info
 opencode.json
-skills/
+/skills/
 tasks.yml
 tasks.yml.lock*

--- a/prompts/jobs/agent-debugger.md
+++ b/prompts/jobs/agent-debugger.md
@@ -8,7 +8,7 @@ You are a self-improvement agent. Your job is to analyze recent agent failures, 
 
 ## Step 0: Read the orch skill
 
-Read `~/.claude/skills/orch/SKILL.md` first — it contains operational learnings, known patterns, common fixes, and agent/model notes accumulated from previous sessions. Use this context to avoid re-discovering known issues. If your analysis reveals new patterns or corrections, update the skill file at the end of your run.
+Read `./prompts/skills/orch/SKILL.md` first — it contains the repo-tracked operational guidance and known patterns for orch monitoring. Use this context to avoid re-discovering known issues. If you find drift between the skill and repo policy, file or update a dedicated issue instead of editing home-directory skill copies.
 
 ## Step 1: Gather failure data
 

--- a/prompts/jobs/daily-review.md
+++ b/prompts/jobs/daily-review.md
@@ -13,7 +13,7 @@ End-of-day review covering the last 24 hours. Your ONLY output is a summary post
 3. `gh issue list --state open` — what's still pending
 4. `gh issue list --state closed --limit 30` — what was resolved in the last 24h
 5. `orch task list` — stuck, blocked, or failing tasks
-6. Read `~/.claude/skills/orch/SKILL.md` — new learnings, patterns, and operational notes captured today
+6. Read `./prompts/skills/orch/SKILL.md` — repo-tracked monitoring guidance and settled operational policy
 
 ## Check operational health (last 24h)
 
@@ -25,7 +25,7 @@ End-of-day review covering the last 24 hours. Your ONLY output is a summary post
 6. Is routing accurate? Any models failing silently? Any agents repeatedly cooled?
 7. Are agent prompts effective or do they need tuning?
 8. Performance bottlenecks (slow syncs, lock contention, API rate limits, dead models)?
-9. Are learnings captured in the orch skill reflected in code/config changes?
+9. Does current operational behavior still match `./prompts/skills/orch/SKILL.md` and the settled repo policy?
 
 ## Write the summary
 

--- a/prompts/skills/orch/SKILL.md
+++ b/prompts/skills/orch/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: orch
+description: "Use when monitoring orch operations from this repository: daily reviews, retrospectives, agent-debugging, task health checks, blocked-task triage, routing/cooldown inspection, or global status reporting. Do not use this as a generic coding skill. Do not use it when the task is ordinary feature work unrelated to orch operations."
+---
+
+# Orch Operations Skill
+
+Use this skill for operational monitoring and triage in the `orch` repository. It is the repo-tracked source of truth for monitoring guidance used by the scheduled review/debug jobs.
+
+## Non-negotiable policy
+
+- Do not tell agents to run `brew` commands.
+- Do not recommend `brew upgrade`, `brew install`, `brew services restart`, or similar shared-state mutation as a normal remediation path.
+- Do not report CLI/service/main version drift as an issue, finding, or action item.
+- Do not suggest `orch -V` or version-parity checks as operational follow-up.
+- Do not recommend routine `orch task retry`, `orch task unblock`, or direct SQLite task-status edits as the default fix.
+- Do not suggest editing `~/.orch/config.yml`, `config.example.yml`, or project `.orch.yml` files. If config changes are truly required, describe them for the operator without editing them.
+
+## Monitoring workflow
+
+Start with observation, not intervention:
+
+```bash
+orch task list --global
+orch log 100
+sqlite3 ~/.orch/orch.db "SELECT agent, model, outcome, COUNT(*) FROM task_runs WHERE started_at > datetime('now', '-24 hours') GROUP BY agent, model, outcome ORDER BY COUNT(*) DESC;"
+```
+
+When a specific task needs inspection:
+
+```bash
+sqlite3 ~/.orch/orch.db "SELECT id, external_id, status, title, last_error, block_reason FROM tasks WHERE external_id = 'TASK_ID';"
+sqlite3 ~/.orch/orch.db "SELECT attempt, run_type, agent, model, outcome, error, completed_at FROM task_runs WHERE task_id = DB_ID ORDER BY attempt;"
+gh pr view PR_NUMBER --repo owner/repo --json state,mergeStateStatus
+```
+
+Use SQLite for diagnosis and evidence gathering. Do not use it as the normal way to mutate task state.
+
+## How to respond to problems
+
+Default posture:
+
+1. Identify the concrete failure mode.
+2. Check whether repo policy already says the behavior is expected.
+3. Check whether the bug was already fixed recently.
+4. File or update a root-cause issue only if the problem is still real on current `HEAD`.
+5. Recommend manual intervention only when policy explicitly allows it and only after the root cause or external dependency has been addressed.
+
+Prefer root-cause findings such as:
+
+- parser/classifier gaps
+- cooldown or routing bugs
+- stale tmux/session cleanup failures
+- PR/task state reconciliation bugs
+- external-system failures at the correct boundary, such as GitHub Actions billing blocks at merge time
+
+Avoid symptom-only recommendations such as "just retry everything" or "drain the blocked queue."
+
+## Manual intervention policy
+
+Manual intervention is exceptional operator action, not the default runbook.
+
+Allowed examples:
+
+- After GitHub Actions billing is fixed, the operator may unblock affected tasks.
+- After a stale tmux session is confirmed as the blocker, the operator may clear that session.
+- After a root cause is fixed in code, the operator may choose to re-run affected work.
+
+Not allowed as routine advice:
+
+- mass `orch task unblock all` as backlog drainage
+- `orch task retry` as a substitute for understanding the failure
+- direct SQLite `UPDATE tasks ...` resets
+- "upgrade and restart orch" to pick up a fix
+
+If you mention a manual action at all, make it explicit that it is an operator choice taken after the underlying cause is fixed or understood.
+
+## Version and deployment guidance
+
+Do not:
+
+- compare the running binary to `main`
+- flag "not deployed yet" as an operational bug
+- tell the operator to upgrade or restart orch
+- treat deployment lag as something agents should manage
+
+If a fix exists only on `HEAD`, say only that the bug is fixed in the repo and future runs should be evaluated against that code path. Stop there.
+
+## Reporting format
+
+For recurring status reports, use a table:
+
+```text
+# 22:30 UTC
+
+ID | Status | Agent | Model | PR | Age | Title
+-- | ------ | ----- | ----- | -- | --- | -----
+1082 | in_progress | claude | sonnet | — | 12m | investigate router timeout
+1037 | in_review | codex | gpt-5.2 | #1043 | 5m | fix parser alias
+
+---
+
+Changes: #1082 still running. #1037 awaiting review outcome.
+```
+
+Focus on:
+
+- stuck or aging tasks
+- repeated failure patterns
+- cooldown/routing anomalies
+- whether the current behavior matches settled policy
+
+## Checks before filing a new issue
+
+Always verify all three:
+
+```bash
+gh issue list --state open
+gh issue list --state closed --limit 50
+git log --since="48 hours ago" --oneline
+```
+
+Do not re-file:
+
+- version-drift complaints
+- expected cooldown behavior
+- expected per-task billing blocks at merge time
+- problems already fixed on recent `HEAD`
+
+## Common interpretations
+
+| Symptom | Interpretation |
+| --- | --- |
+| Task blocked on GitHub Actions billing | Correct per-task merge-time block; fix billing first, then operator may unblock |
+| Model repeatedly rate-limited with cooldowns | Usually expected generic cooldown behavior unless the classifier/cooldown scope is wrong |
+| PR merged but task status stale | Reconciliation/state bug worth investigating |
+| Review session vanished mid-flight | Session lifecycle or review rebroadcast bug worth investigating |
+| All agents cooled | Loud retry-on-next-tick behavior is expected; do not propose per-task defer timers |
+
+## Scope of edits from monitoring jobs
+
+The daily review and agent-debugger jobs should treat this file as reference material, not as something to rewrite opportunistically.
+
+- Daily review: summarize, diagnose, and file issues when warranted.
+- Agent debugger: analyze failures and file root-cause issues.
+- If you notice this skill has drifted from repo policy again, file or update a dedicated issue instead of patching random home-directory copies.


### PR DESCRIPTION
## Summary

Added a repo-tracked orch operations skill aligned with the settled operator policy, repointed the monitoring/debug job prompts to it, and fixed the overly broad ignore rule that blocked tracking `prompts/skills/...`.

### What was done

- Created `prompts/skills/orch/SKILL.md` as the repo-owned source of truth for orch monitoring guidance.
- Removed stale guidance from the tracked skill path by explicitly forbidding brew-based upgrade/restart advice, version-drift reporting, routine retry/unblock recommendations, and direct SQLite task resets as default remediation.
- Updated `prompts/jobs/daily-review.md` to read the repo-tracked skill instead of `~/.claude/skills/orch/SKILL.md` and to check policy alignment against that file.
- Updated `prompts/jobs/agent-debugger.md` to read the repo-tracked skill and stop telling agents to edit home-directory skill copies.
- Narrowed `.gitignore` from `skills/` to `/skills/` so `prompts/skills/...` can be tracked normally.
- Committed the fix as `d937e92d fix(skill): track orch operator guidance in repo`.


### Files changed

- `.gitignore`
- `prompts/jobs/agent-debugger.md`
- `prompts/jobs/daily-review.md`
- `prompts/skills/orch/SKILL.md`


Closes #3444

---
*Task #3444 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.4`*