### PR TITLE
bug(parser): normalize_status missing bare "pushed" alias causes false needs_review routing

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -188,6 +188,7 @@ fn normalize_status(mut resp: AgentResponse) -> AgentResponse {
         | "changes_made"
         | "change_made"
         | "changes_pushed"
+        | "pushed"
         | "acknowledged"
         | "flat"
         | "no_action"
@@ -1094,6 +1095,13 @@ Some output here.
     #[test]
     fn parse_normalizes_changes_pushed_alias_to_done() {
         let input = r#"{"status":"changes_pushed","summary":"changes pushed to branch","accomplished":[],"remaining":[],"files":[]}"#;
+        let resp = parse(input).unwrap();
+        assert_eq!(resp.status, "done");
+    }
+
+    #[test]
+    fn parse_normalizes_bare_pushed_alias_to_done() {
+        let input = r#"{"status":"pushed","summary":"changes pushed to branch","accomplished":[],"remaining":[],"files":[]}"#;
         let resp = parse(input).unwrap();
         assert_eq!(resp.status, "done");
     }


### PR DESCRIPTION
## Summary

Normalized bare `pushed` to `done` in the parser and added a regression test so pushed-but-bare agent responses no longer fall through to `needs_review`.

### What was done

- Added `"pushed"` to the done-status alias list in `src/parser.rs`.
- Added a parser regression test covering a bare `pushed` status.
- Verified formatting, clippy, and the full nextest suite all pass.
- Committed the fix as `082bc0da` (`fix(parser): normalize bare pushed status`).


### Files changed

- `src/parser.rs`


Closes #3447

---
*Task #3447 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.4-mini`*