### PR TITLE
bug(review): Git CLI push connect failures consume review failure quota instead of transient reset

### DIFF
--- a/src/engine/runner/git_ops.rs
+++ b/src/engine/runner/git_ops.rs
@@ -1422,6 +1422,11 @@ pub(crate) fn is_transient_github_error(err_str: &str) -> bool {
         || lower.contains("connection refused")
         || lower.contains("connection closed")
         || lower.contains("transport error")
+        || lower.contains("failed to connect")
+        || lower.contains("failed to connect to github.com port")
+        || lower.contains("curl: (7) failed to connect")
+        || lower.contains("couldn't connect to server")
+        || lower.contains("could not connect to server")
     {
         return true;
     }
@@ -1803,6 +1808,23 @@ mod tests {
         assert!(is_transient_github_error(
             "transport error: connection lost"
         ));
+
+        // Git/Curl connect-failure patterns (review push failures)
+        assert!(is_transient_github_error(
+            "fatal: unable to access 'https://github.com/owner/repo.git/': Failed to connect to github.com port 443 after 20990 ms: Couldn't connect to server"
+        ));
+        assert!(is_transient_github_error(
+            "Failed to connect to github.com port 443: Connection timed out"
+        ));
+        assert!(is_transient_github_error(
+            "Failed to connect to github.com port 443: Connection refused"
+        ));
+        assert!(is_transient_github_error(
+            "curl: (7) Failed to connect to github.com port 443: Couldn't connect to server"
+        ));
+        assert!(is_transient_github_error(
+            "fatal: unable to access 'https://github.com/owner/repo.git/': Couldn't connect to server"
+        ));
     }
 
     #[test]
@@ -1872,8 +1894,14 @@ mod tests {
         assert!(is_transient_github_api_error(
             "gh error: transport error: connection reset by peer"
         ));
+        assert!(is_transient_github_api_error(
+            "push failed: fatal: unable to access 'https://github.com/owner/repo.git/': Failed to connect to github.com port 443 after 20990 ms: Couldn't connect to server"
+        ));
         assert!(!is_transient_github_api_error(
             "codex failed: Reconnecting... (stream disconnected before completion: Broken pipe)"
+        ));
+        assert!(!is_transient_github_api_error(
+            "agent stream failed: failed to connect to local relay"
         ));
     }
 


### PR DESCRIPTION
## Summary

Extended transient GitHub transport detection so review-phase git push connect failures are treated as retryable instead of consuming the review failure quota, and added regression coverage for the exact stderr shape from the incident.

### What was done

- Updated `src/engine/runner/git_ops.rs` so transient GitHub error detection now matches Git/Curl connect-failure wording including `failed to connect`, `couldn't connect to server`, and `could not connect to server`.
- Added regression tests covering the exact review push failure against both `is_transient_github_error()` and `is_transient_github_api_error()`.
- Added a negative regression test to keep generic non-GitHub relay/agent connect failures from being misclassified as GitHub API transients.
- Ran `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` successfully.
- Committed the fix as `ce516b92` (`fix(review): treat git push connect failures as transient`).


### Remaining

- Automated review pass and downstream PR handling by orch.


### Files changed

- `src/engine/runner/git_ops.rs`


Closes #3450

---
*Task #3450 · Created by codex[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `gpt-5.4`*