### PR TITLE
bug(sync): open issue #3453 has no corresponding orch task after 4 days

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -2638,9 +2638,20 @@ pub(crate) async fn ingest_external_tasks(
     }
 
     // Record last ingest time for next incremental fetch.
-    let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
-    if let Err(e) = store.kv_set(&kv_key, &now).await {
-        tracing::error!(key = kv_key, err = %e, "ingest: failed to record last ingest time");
+    //
+    // Advance the cursor to the max `updated_at` actually observed in this fetch, not to
+    // wall-clock now(). Using now() creates a watermark race: an issue created or updated
+    // between the moment GitHub computed the `since` query results and the moment this line
+    // runs (API replication lag, or simply request latency) can be excluded from *this*
+    // fetch, and then the cursor jumps past its updated_at anyway. On every subsequent tick
+    // `since` is newer than that issue's updated_at, so it is silently skipped forever unless
+    // it receives a new comment/label to bump updated_at, or the engine restarts (which clears
+    // the cursor, see clear_issues_last_ingested). Deriving the cursor from observed data only
+    // is the same safe pattern used by the mentions cursor (see MentionCursor::advance above).
+    if let Some(latest) = all_tasks.iter().map(|(t, _)| t.updated_at.as_str()).max() {
+        if let Err(e) = store.kv_set(&kv_key, latest).await {
+            tracing::error!(key = kv_key, err = %e, "ingest: failed to record last ingest time");
+        }
     }
 
     Ok(())
@@ -2849,6 +2860,36 @@ mod tests {
             .unwrap();
         assert_eq!(task2.title, "Second issue");
         assert_eq!(task2.status, crate::store::TaskStatus::InProgress);
+    }
+
+    #[serial(cooldown_state)]
+    #[tokio::test]
+    async fn ingest_advances_cursor_to_max_observed_updated_at_not_wall_clock() {
+        // Regression test for the watermark race: the `issues_last_ingested` cursor must be
+        // derived from the max `updated_at` actually seen in the fetch, not from
+        // chrono::Utc::now(). Otherwise an issue whose updated_at lags real time (e.g. GitHub
+        // API replication lag between the `since` query and this line running) gets skipped by
+        // every subsequent `since` fetch forever, even though it was never actually ingested.
+        crate::engine::cooldown::reset_global_state().await;
+        let mut task = make_ext_task("1", "First issue");
+        task.updated_at = "2026-01-01T00:00:00Z".to_string();
+        let backend: Arc<dyn ExternalBackend> =
+            IngestMockBackend::with_tasks(vec![(Status::New, task)]);
+        let store = Arc::new(TaskStore::open_memory().await.unwrap());
+
+        ingest_external_tasks(&backend, "owner/repo", &store)
+            .await
+            .unwrap();
+
+        let cursor = store
+            .kv_get("issues_last_ingested:owner/repo")
+            .await
+            .unwrap();
+        assert_eq!(
+            cursor,
+            Some("2026-01-01T00:00:00Z".to_string()),
+            "cursor must match the max updated_at observed in the fetch, not wall-clock now()"
+        );
     }
 
     #[serial(cooldown_state)]


### PR DESCRIPTION
## Summary

Fixed the root cause of GitHub issues silently disappearing from orch's ingest pipeline: the issues_last_ingested cursor advanced to chrono::Utc::now() instead of the max updated_at actually observed in the fetch, creating a watermark race where an issue whose updated_at lags real time (API replication lag or request latency) gets excluded from the current fetch while the cursor still jumps past it, permanently hiding it from every future since query.

### What was done

- Traced ingest_external_tasks in src/engine/sync.rs and confirmed it advanced the issues_last_ingested KV cursor to wall-clock now() unconditionally after every fetch
- Identified the watermark race: an issue whose GitHub updated_at lags the cursor value (replication lag / request latency) is silently excluded from every subsequent since-filtered fetch forever, matching the reported symptom of issue #3453 never getting a task
- Fixed ingest_external_tasks to derive the cursor from the max updated_at actually observed in the fetched tasks instead of now(), matching the safer per-item cursor pattern already used by the mentions ingestion path (MentionCursor::advance)
- Added a regression test (ingest_advances_cursor_to_max_observed_updated_at_not_wall_clock) asserting the cursor equals the fetched task's updated_at, not wall-clock time
- Ran cargo fmt, cargo clippy --all-targets -D warnings, and the full test suite (cargo nextest run) — all pass except one pre-existing, environment-dependent tmux test failure (session_blocks_dispatch_cleans_dead_session) verified to fail identically on unmodified origin/main, unrelated to this change
- Committed the fix to a single commit on this branch


### Remaining

- Issue #3453 itself is still not ingested: its updated_at already predates the corrupted cursor value from the original bug, and the engine's 24h startup fallback window won't reach back far enough to recover it since it has had no activity in 4 days. Recovering that specific issue requires an operator action (e.g. bump its updated_at with a comment/label, or a manual DB nudge) — this is outside the scope of a code fix and is not something this agent should do by mutating the live production task store


### Files changed

- `src/engine/sync.rs`


Closes #3458

---
*Task #3458 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*