### PR TITLE
bug(parser): opencode/codex parse_response skip synthesize_response_from_text fallback that claude.rs has

### DIFF
--- a/src/engine/runner/agents/codex.rs
+++ b/src/engine/runner/agents/codex.rs
@@ -329,9 +329,18 @@ impl AgentRunner for CodexRunner {
                 })?;
 
         // Parse the agent text through our standard parser
-        let response = parser::parse(&agent_text).map_err(|_| AgentError::InvalidResponse {
-            raw: agent_text.clone(),
-        })?;
+        let response = match parser::parse(&agent_text) {
+            Ok(r) => r,
+            Err(_) => {
+                // Structured parse failed — try plain-text synthesis before
+                // giving up, same rescue path claude.rs uses (issue #3467).
+                super::synthesize_response_from_text(&agent_text).ok_or_else(|| {
+                    AgentError::InvalidResponse {
+                        raw: agent_text.clone(),
+                    }
+                })?
+            }
+        };
 
         Ok(ParsedResponse {
             response,
@@ -466,6 +475,23 @@ mod tests {
 
         let err = runner().parse_response(raw).unwrap_err();
         assert!(matches!(err, AgentError::ModelUnavailable { .. }));
+    }
+
+    /// Regression test for issue #3467: when codex's agent_message text is a
+    /// plain-prose completion summary (not JSON), parser::parse fails but
+    /// synthesize_response_from_text must rescue it instead of returning
+    /// InvalidResponse, mirroring the fallback claude.rs already has.
+    #[test]
+    fn parse_codex_plain_prose_completion_synthesizes_response() {
+        let raw = r#"{"type":"thread.started","thread_id":"t1"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"type":"agent_message","text":"Fixed the typo and corrected the deadline reference in the review."}}
+{"type":"turn.completed"}"#;
+
+        let parsed = runner()
+            .parse_response(raw)
+            .expect("plain-prose completion text must synthesize successfully");
+        assert_eq!(parsed.response.status, "done");
     }
 
     #[test]

--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -555,8 +555,15 @@ impl AgentRunner for OpenCodeRunner {
         };
 
         // Parse the text through standard parser
-        let response =
-            parser::parse(&text).map_err(|_| AgentError::InvalidResponse { raw: text.clone() })?;
+        let response = match parser::parse(&text) {
+            Ok(r) => r,
+            Err(_) => {
+                // Structured parse failed — try plain-text synthesis before
+                // giving up, same rescue path claude.rs uses (issue #3467).
+                super::synthesize_response_from_text(&text)
+                    .ok_or_else(|| AgentError::InvalidResponse { raw: text.clone() })?
+            }
+        };
 
         Ok(ParsedResponse {
             response,
@@ -1196,6 +1203,24 @@ mod tests {
         // Tokens from step_finish must still be propagated.
         assert_eq!(parsed.input_tokens, Some(500));
         assert_eq!(parsed.output_tokens, Some(0));
+    }
+
+    /// Regression test for issue #3467: when opencode's `text` event contains
+    /// a plain-prose completion summary (not JSON), parser::parse fails but
+    /// synthesize_response_from_text must rescue it instead of returning
+    /// InvalidResponse, mirroring the fallback claude.rs already has.
+    #[test]
+    fn parse_opencode_plain_prose_completion_synthesizes_response() {
+        let raw = r#"{"type":"step_start","timestamp":1000,"part":{"type":"step-start"}}
+{"type":"text","timestamp":1001,"part":{"type":"text","text":"Fixed the typo and corrected the deadline reference in the review."}}
+{"type":"step_finish","timestamp":1002,"part":{"type":"step-finish","reason":"stop","tokens":{"input":300,"output":40}}}"#;
+
+        let parsed = runner()
+            .parse_response(raw)
+            .expect("plain-prose completion text must synthesize successfully");
+        assert_eq!(parsed.response.status, "done");
+        assert_eq!(parsed.input_tokens, Some(300));
+        assert_eq!(parsed.output_tokens, Some(40));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Now let's look at codex.rs around the parse_response function.
Codex doesn't track tokens at all, so no token-preservation concern there — just apply the same fallback pattern.
Now let's check `synthesize_response_from_text`'s visibility and signature to ensure `super::` works from both files.
Good, it's `pub fn` in `mod.rs`, so `super::synthesize_response_from_text` works from both `opencode.rs` and `codex.rs` (both are submodules of `agents`). Let's verify it builds.
Build is clean. Now let'

### What was done

- Summary**: Fixed `src/engine/runner/agents/opencode.rs` and `src/engine/runner/agents/codex.rs` so `parse_response()` falls back to `synthesize_response_from_text()` when `parser::parse()` fails on plain-prose text, mirroring the existing rescue path in `claude.rs`. Added regression tests for both backends covering the plain-prose-completion case, and verified `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and the full `cargo nextest run` (3831 tests) all pass.


### Files changed

- `src/engine/runner/agents/codex.rs`
- `src/engine/runner/agents/opencode.rs`


Closes #3467

---
*Task #3467 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*