### PR TITLE
Daily review (last 24h)

### DIFF
--- a/docs/content/posts/daily-review-2026-08-04.md
+++ b/docs/content/posts/daily-review-2026-08-04.md
@@ -14,19 +14,26 @@ Direct consequence: the `daily-review` cron job (`0 23 * * *`) never fired for 2
 
 Filed **#3463** — add duration-based escalation to the startup retry loop so a prolonged outage produces a visible signal instead of 316 identical `WARN` lines. The retry-forever design itself is correct (avoids a crash-loop) and is not being questioned — only the missing "this has gone on too long" alert.
 
+**Update, end of day: #3463 shipped the same day.** `9ed07be3` (PR #3465) adds `engine.startup_failure_escalation_secs` (default 3600s) — after an hour of continuous startup retry, the loop now emits a one-time `ERROR` log line and pushes a notification to configured channels (Telegram/Discord/Slack), closing the exact visibility gap this post opened with.
+
 ---
 
 ## What Shipped (Last 24h)
 
-**1 commit landed in the strict last-24h window:**
+**4 commits landed in the last 24h:**
 
 | Commit | PR | Summary |
 |--------|----|---------|
 | `824253e6` | #3462 | Fix: task permanently stuck in `routed` when a tmux session is pane-alive but the agent process inside it is dead — invisible to all prior recovery paths |
+| `9ed07be3` | #3465 | Add duration-based escalation (`startup_failure_escalation_secs`, default 3600s) to the startup GitHub-unreachable retry loop — closes #3463 |
+| `d5851ba7` | #3466 | Remove the unattended `auto_upgrade` path (`brew upgrade orch` + self-SIGTERM on new release) — the service now only notifies operators of new releases, never mutates its own install. Aligns the engine with the already-settled "upgrading is operator-only" policy |
+| `150b3f21` | #3467 | Add the `synthesize_response_from_text` plain-prose-completion fallback to opencode's and codex's `parse_response()`, mirroring the rescue path `claude.rs` already had (from #889/#1377/#1387) — prose-only agent completions on those backends no longer misclassify as `parse_error` and burn a wasted attempt + unwarranted model cooldown |
 
-That fix closed **#3461** (filed 2026-08-03, closed same day) — a real production incident where `internal:155568`-class tasks got stuck because none of the existing recovery mechanisms (stuck-task watchdog, silence detection, pane-liveness check) could distinguish a crashed agent from a working one inside an alive tmux pane.
+That first fix closed **#3461** (filed 2026-08-03, closed same day) — a real production incident where `internal:155568`-class tasks got stuck because none of the existing recovery mechanisms (stuck-task watchdog, silence detection, pane-liveness check) could distinguish a crashed agent from a working one inside an alive tmux pane.
 
-Given the 13h outage above, this is genuinely the only window in the last 24h where the pipeline was moving — the outage suppressed almost everything else.
+The `auto_upgrade` removal (#3466) is worth flagging on its own: it found and removed a genuine self-mutating-on-release code path that had been running unattended and directly contradicted this repo's own settled "brew is operator-only" policy. Good catch, good fix.
+
+Given the 13h outage above, most of today's real throughput happened in the second half of the day, after the service recovered at 11:08 UTC.
 
 ---
 
@@ -85,24 +92,28 @@ None of these are new patterns; all are already covered by existing generic cool
 
 ### Logs, Routing, and Cooldowns
 
-- Service running `orch/0.80.73`.
-- `/opt/homebrew/var/log/orch.error.log` is `0B` (freshly truncated) — no errors escaped to brew's stderr log, confirming the outage-retry demotion-to-WARN design worked as intended (see #3463 for why that's also the visibility gap).
+- Service running `orch/0.81.1` at time of writing (was `0.80.73` this morning — normal same-day version movement, not flagged as drift).
+- `/opt/homebrew/var/log/orch.error.log` is `0B`, last written ~18:27 UTC (well before this update) — no fresh errors escaped to brew's stderr log.
 - Router LLM pool (`claude/haiku`, `kimi/haiku`, `minimax/haiku`) exhausted simultaneously multiple times this morning right after the outage ended (11:08–11:09 UTC, tasks `155605`–`155610`, `155568`) — matches the well-documented, already-fixed router-LLM-pool-cooldown class (#3422, #3325, #3286, etc.); all routed successfully via weighted fallback within the same tick. Not a new issue.
+- A `codex:gpt-5.4` model cooldown appeared this evening (task `155657`, `21:18 UTC`: `"The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account"`) — correctly classified as `ModelUnavailable` and cooled at the model level via the generic persistent-cooldown mechanism, leaving other codex models unaffected. Working exactly as the settled per-model-cooldown architecture intends; no action needed.
+- Twice during this task's own dispatch (23:00–23:01 UTC), the LLM router selected `minimax` for a task even though `minimax` was cooled, and the routing-sanity fallback caught it and rerouted to `claude` within the same tick (`"LLM selected cooled agent/model; rerouting to available agent"`). This is expected, already-covered behavior (#1978/#2221 class) — the fallback did its job.
 
-Active cooldowns (`orch cooldown list`):
+Active cooldowns (`orch cooldown list`, as of 23:02 UTC):
 
 | Key | Remaining |
 |-----|----------:|
-| `claude:haiku` | 4h51m |
-| `kimi:haiku` | 2h34m |
-| `kimi:opus` | 1d11h |
-| `minimax:haiku` | 21h11m |
-| `minimax:opus` | 2d4h |
+| `codex:gpt-5.4` | 2h15m |
+| `kimi:haiku` | 1d16h |
+| `kimi:opus` | 1d |
+| `minimax:haiku` | 9h18m |
+| `minimax:opus` | 1d17h |
+
+(`claude:haiku`'s earlier cooldown expired between the morning and evening checks — expected decay, not an anomaly.)
 
 ### Backlog and Stuck Work
 
 - `56` tasks `blocked` (unchanged from yesterday) — `44` in one downstream repo (almost entirely `CI failure limit reached during auto-merge`, ~25 days old, PRs still open — the per-task block-at-merge-time behavior is working as designed; this is a downstream CI/billing problem, not an orch defect) and `12` in another downstream repo.
-- `2` tasks `needs_review` — external issues `#490` and `#493` in a downstream repo, still stuck, now **15 days old** (unchanged from yesterday's flag). Worth checking tomorrow whether the review agent is genuinely retrying or stuck behind a cooled model.
+- `2` tasks `needs_review` — external issues `#490` and `#493` in a downstream repo, still stuck at **15 days old**, unchanged. Traced this down today: both belong to a repo that has since been commented out of the active `projects:` config. The stale-`needs_review` refire/escalation sweep that would normally re-fire or escalate them to `Blocked` after 5 attempts only runs inside the per-project `sync_tick` loop, which never executes for repos outside the active project list — same "repo-scoped sweep, needs global scope" bug family as #3413/#3407/#3416/#3421/#3437. `needs_review_refires` is frozen at `0` for both, confirming the sweep has never touched them since the 2026-07-20 failure. Filed **#3469**.
 - `#3453` (`bug(review-prompt): pending CI status prose still causes review parse errors`) is still open, 6 days old, and **still has no corresponding orch task** — `#3458` fixed the underlying ingest-cursor race (`adbbddd1`, merged 2026-08-02) so this class of bug shouldn't recur going forward, but the fix doesn't backfill issues already missed by the old cursor logic. `#3453` itself needs a one-time manual task creation to get unstuck; not filing a new issue since this is already tracked.
 
 ---
@@ -111,23 +122,26 @@ Active cooldowns (`orch cooldown list`):
 
 **Filed today:**
 
-- **#3463** — `ops: startup GitHub-unreachable retry loop has no escalation — ~13h total service outage went silently undetected`. Root cause of the missing 2026-08-03 daily review post and the ~50% throughput drop in this window. See "headline" section above.
+- **#3463** — `ops: startup GitHub-unreachable retry loop has no escalation — ~13h total service outage went silently undetected`. Root cause of the missing 2026-08-03 daily review post and the ~50% throughput drop in this window. See "headline" section above. **Shipped same day** via #3465.
+- **#3469** — `bug(sync): stale-NeedsReview refire/escalation sweep is repo-scoped — tasks from inactive/removed repos never refire or escalate to Blocked`. Root cause of the `#490`/`#493` stuck-review-queue flag carried over from this morning's update — see "Backlog and Stuck Work" above.
 
 **Closed today:**
 
 - **#3461 → fixed by `824253e6`** — pane-alive-but-agent-dead tmux sessions now get caught by stuck-task recovery instead of remaining permanently invisible in `routed`.
+- **#3463 → fixed by `9ed07be3`** (#3465) — startup retry loop now escalates after 1h with an `ERROR` log and a push notification.
+- **#3467 → fixed by `150b3f21`** — opencode/codex now get the same plain-prose `synthesize_response_from_text` rescue path claude has had since #1377/#1387, closing a recurring `parse_error` class that was burning attempts and cooling innocent free-tier models.
 
-**Reasoning for not filing more:** every other non-success outcome this window (kimi billing-cycle rate limits, codex/opencode silence detections, one transient claude auth blip) is already handled by existing generic mechanisms and self-recovered without intervention. The 44-task backlog in one downstream repo is a known, correctly-classified CI/billing block at the per-task level, not a new orch defect.
+**Reasoning for not filing more:** every other non-success outcome this window (kimi billing-cycle rate limits, codex `gpt-5.4` model-unavailable cooldown, codex/opencode silence detections, one transient claude auth blip, two cooled-agent routing-sanity fallbacks) is already handled correctly by existing generic mechanisms and self-recovered without intervention. The 44-task backlog in one downstream repo is a known, correctly-classified CI/billing block at the per-task level, not a new orch defect.
 
 ---
 
 ## Priorities for Tomorrow
 
-1. **Watch for recurrence of the GitHub-unreachable outage.** If it happens again before #3463 ships, note the exact start/end timestamps — a second long outage would strengthen the case for the duration-based alert.
-2. **Get #3453 a task.** The ingest-cursor race that hid it is fixed, but the issue itself still needs a manual task so its review-prompt bug can actually be worked.
-3. **Check the `#490` / `#493` review queue** — 15 days stuck in `needs_review` now, one day past yesterday's flag with no change. Verify whether it's a genuinely stuck review agent or a cooled-model bottleneck.
-4. **Keep the signal-over-noise bar** — most of today's non-success outcomes are noise the system already handles; the outage was the one real signal.
+1. **Verify #3469 lands cleanly.** The fix needs the refire/escalation block extracted into a store-only, repo-agnostic function (mirroring `auto_unblock_ci_failure_blocked_tasks_global`) and wired into the global tick phase — check it doesn't reintroduce the double-trigger race #857 originally fixed.
+2. **Get #3453 a task.** The ingest-cursor race that hid it is fixed, but the issue itself still needs a manual task so its review-prompt bug can actually be worked. Two review cycles in a row without movement now.
+3. **Once #3469 ships, confirm `#490`/`#493` actually resolve** — either the refire sweep finally catches them and they progress, or they correctly escalate to `Blocked` with a clear reason instead of sitting silently.
+4. **Keep the signal-over-noise bar** — most of today's non-success outcomes are noise the system already handles; the outage and the repo-scoped-sweep gap were the two real signals.
 
 ---
 
-*Prepared by Orch automation (internal:155605) on 2026-08-04.*
+*Prepared by Orch automation (internal:155605, internal:155677) on 2026-08-04.*


### PR DESCRIPTION
## Summary

Updated the 2026-08-04 daily review post with the evening's developments (3 new commits/PRs, closed issues, refreshed cooldown/routing state) and filed one root-cause issue (#3469) for two review-queue tasks that have been silently stuck for 15 days due to a repo-scoped sweep gap. Committed locally.

### What was done

- Gathered 24h context: git log, task_activity/task_runs SQL, orch cooldown list, orch log, gh issue list (open/closed)
- Read the existing same-day post (daily-review-2026-08-04.md, written ~11:08 UTC) and identified what changed since: 3 new commits (#3465 startup-retry escalation shipping the fix for this morning's #3463, #3466 auto-upgrade removal, #3467 opencode/codex parse fallback)
- Verified codex:gpt-5.4 model-unavailable cooldown and two LLM-selected-cooled-agent routing fallbacks are expected, already-covered generic behavior — no new issue needed
- Traced the #490/#493 needs_review backlog flag to a concrete root cause: both tasks belong to a repo removed from the active `projects:` config, and the stale-NeedsReview refire/escalation sweep (sync.rs ~1500) only runs inside the per-project sync_tick loop, never for inactive-repo tasks — confirmed via needs_review_refires=0 frozen since 2026-07-20, same bug family as #3413/#3407/#3416/#3421/#3437
- Filed issue #3469 with full evidence and a suggested fix (extract to a global store-only sweep called from tick.rs, mirroring auto_unblock_ci_failure_blocked_tasks_global) — repo-agnostic per this repo's filing policy
- Updated docs/content/posts/daily-review-2026-08-04.md: headline update noting #3463 shipped same day, expanded 'What Shipped' to 4 commits, refreshed cooldown table and routing observations, updated backlog/issues/priorities sections
- Committed the change (TASK_ID is set, so per repo policy only committed — did not push; orch handles push/PR)


### Files changed

- `docs/content/posts/daily-review-2026-08-04.md`


---
*Task internal-155677 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*