### PR TITLE
bug(runner): opencode step_finish reason="length" truncation not distinguished from malformed-output parse_error

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -1108,6 +1108,46 @@ async fn parse_review_output(
                     )));
                 }
 
+                // The model was cut off for exceeding its output/reasoning
+                // token budget (opencode step_finish reason=length), not
+                // because it produced malformed prose. Keep this distinct
+                // from the generic parse_error path below: apply the
+                // standard exponential backoff instead of the 4h-7d
+                // persistent cooldown reserved for format-incapable models.
+                if agent_result
+                    .as_ref()
+                    .map(|r| r.truncated_by_length)
+                    .unwrap_or(false)
+                {
+                    tracing::warn!(
+                        task_id = task.id.0,
+                        agent = %ctx.review_agent,
+                        model = ?ctx.review_model,
+                        "review agent output truncated: step_finish reason=length \
+                         (token budget exceeded before completion)"
+                    );
+                    if let Some(model) = ctx.review_model.as_deref() {
+                        crate::engine::cooldown::record_model_failure(&ctx.review_agent, model)
+                            .await;
+                    }
+                    let stored_error = "truncated: review output was cut off before completion \
+                        (output/reasoning token budget exceeded)"
+                        .to_string();
+                    complete_review_run(
+                        store,
+                        run.run_id,
+                        Some(exit_code),
+                        &raw_output,
+                        &stderr,
+                        &text_for_review,
+                        "truncated",
+                        &stored_error,
+                        token_usage,
+                    )
+                    .await;
+                    return ReviewPhase::EarlyReturn(ReviewDecision::Failed(stored_error));
+                }
+
                 tracing::error!(
                     task_id = task.id.0,
                     error = %e,

--- a/src/engine/runner/agents/claude.rs
+++ b/src/engine/runner/agents/claude.rs
@@ -730,6 +730,7 @@ pub fn find_claude_result(ndjson: &str) -> Option<super::AgentResult> {
                     output_tokens,
                     cost_usd,
                     duration_ms,
+                    truncated_by_length: false,
                 });
             }
         }
@@ -786,6 +787,7 @@ pub fn find_claude_result(ndjson: &str) -> Option<super::AgentResult> {
         output_tokens,
         cost_usd: None,
         duration_ms: None,
+        truncated_by_length: false,
     })
 }
 

--- a/src/engine/runner/agents/codex.rs
+++ b/src/engine/runner/agents/codex.rs
@@ -435,6 +435,7 @@ pub fn find_codex_result(ndjson: &str) -> Option<super::AgentResult> {
         output_tokens: None,
         cost_usd: None,
         duration_ms: None,
+        truncated_by_length: false,
     })
 }
 

--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -169,6 +169,12 @@ pub struct AgentResult {
     pub cost_usd: Option<f64>,
     /// Wall-clock duration in milliseconds (if reported by the agent).
     pub duration_ms: Option<u64>,
+    /// True when the provider cut the response short by exceeding its
+    /// output/reasoning token budget (e.g. opencode's `step_finish` event
+    /// reporting `reason: "length"`), as opposed to producing malformed
+    /// output. Callers use this to distinguish a token-budget fluke from a
+    /// genuinely format-incapable model.
+    pub truncated_by_length: bool,
 }
 
 /// Concatenate text from all assistant-turn messages in the agent's NDJSON

--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -1098,18 +1098,9 @@ pub fn find_opencode_result(ndjson: &str) -> Option<super::AgentResult> {
     let truncated_by_length = events
         .iter()
         .rev()
-        .find_map(|event| {
-            if event.get("type").and_then(|v| v.as_str()) == Some("step_finish") {
-                event
-                    .get("part")
-                    .and_then(|p| p.get("reason"))
-                    .and_then(|v| v.as_str())
-                    .map(|reason| reason == "length")
-            } else {
-                None
-            }
-        })
-        .unwrap_or(false);
+        .find(|event| event.get("type").and_then(|v| v.as_str()) == Some("step_finish"))
+        .and_then(|event| event.get("part")?.get("reason")?.as_str())
+        .is_some_and(|reason| reason == "length");
 
     Some(super::AgentResult {
         is_error,

--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -1091,6 +1091,26 @@ pub fn find_opencode_result(ndjson: &str) -> Option<super::AgentResult> {
         }
     });
 
+    // The model was cut off for exceeding its output/reasoning token budget,
+    // not because it produced malformed prose. Distinguish this from a
+    // generic parse failure so callers don't apply the long
+    // format-incapable-model cooldown for a token-budget fluke.
+    let truncated_by_length = events
+        .iter()
+        .rev()
+        .find_map(|event| {
+            if event.get("type").and_then(|v| v.as_str()) == Some("step_finish") {
+                event
+                    .get("part")
+                    .and_then(|p| p.get("reason"))
+                    .and_then(|v| v.as_str())
+                    .map(|reason| reason == "length")
+            } else {
+                None
+            }
+        })
+        .unwrap_or(false);
+
     Some(super::AgentResult {
         is_error,
         result_text,
@@ -1098,6 +1118,7 @@ pub fn find_opencode_result(ndjson: &str) -> Option<super::AgentResult> {
         output_tokens,
         cost_usd,
         duration_ms: None,
+        truncated_by_length,
     })
 }
 
@@ -1704,6 +1725,7 @@ mod tests {
         assert_eq!(result.input_tokens, Some(5000));
         assert_eq!(result.output_tokens, Some(200));
         assert_eq!(result.cost_usd, Some(0.05));
+        assert!(!result.truncated_by_length);
     }
 
     #[test]
@@ -1712,6 +1734,24 @@ mod tests {
         let result = find_opencode_result(ndjson).expect("should find error result");
         assert!(result.is_error);
         assert!(result.result_text.contains("rate limit"));
+        assert!(!result.truncated_by_length);
+    }
+
+    /// step_finish reason=length signals the model was cut off by its
+    /// output/reasoning token budget, not malformed output — the flag must
+    /// be set so callers avoid the persistent-format-failure cooldown.
+    #[test]
+    fn find_opencode_result_length_truncation() {
+        let ndjson = concat!(
+            r#"{"type":"step_start","timestamp":1000,"part":{"type":"step-start"}}"#,
+            "\n",
+            r#"{"type":"text","timestamp":1001,"part":{"type":"text","text":"{\"decision\":"}}"#,
+            "\n",
+            r#"{"type":"step_finish","timestamp":1002,"part":{"type":"step-finish","reason":"length","tokens":{"input":5485,"output":759,"reasoning":31241}}}"#,
+        );
+        let result = find_opencode_result(ndjson).expect("should find result");
+        assert!(result.truncated_by_length);
+        assert!(!result.is_error, "length truncation is not a hard error");
     }
 
     #[test]

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -670,6 +670,18 @@ async fn classify_review_failure(
         return ReviewOutcome::Reset;
     }
 
+    // The review output was cut off by the model's output/reasoning token
+    // budget, not a genuine parse/format failure. Same treatment as a parse
+    // error: re-route without counting toward MAX_REVIEW_AGENT_FAILURES.
+    if lower_reason.contains("truncated") {
+        tracing::warn!(
+            task_id,
+            reason,
+            "{context} output truncated by token budget — re-routing for retry without counting as failure"
+        );
+        return ReviewOutcome::Reset;
+    }
+
     // Transient mergeability check: GitHub hasn't finished computing yet.
     // This is a normal, expected transient state for freshly-pushed PRs.
     // Return RetryMerge (not Reset) so the task stays in InReview — avoids
@@ -797,6 +809,57 @@ async fn post_review_failure_comment(
             pr_number,
             error = %e,
             "failed to post review failure comment"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A truncated review output (opencode step_finish reason=length) must be
+    /// treated like a parse error: reset for retry without counting toward
+    /// MAX_REVIEW_AGENT_FAILURES, so a run of token-budget flukes never
+    /// permanently blocks the task (issue #3473).
+    #[tokio::test]
+    async fn classify_review_failure_truncated_resets_without_counting() {
+        let store = Arc::new(TaskStore::open_memory().await.unwrap());
+        let repo = "owner/repo";
+        let store_id = store
+            .create_internal(
+                repo,
+                "Truncated review test",
+                "",
+                "review",
+                "review-1",
+                None,
+            )
+            .await
+            .unwrap();
+        let task_id = format!("internal:{store_id}");
+
+        for _ in 0..(MAX_REVIEW_AGENT_FAILURES + 1) {
+            let outcome = classify_review_failure(
+                &store,
+                repo,
+                &task_id,
+                "truncated: review output was cut off before completion \
+                 (output/reasoning token budget exceeded)",
+                "review agent",
+            )
+            .await;
+            assert!(
+                matches!(outcome, ReviewOutcome::Reset),
+                "truncated review failure must reset for retry, not block"
+            );
+        }
+
+        let task = opt_store_get_task(&Some(store.clone()), repo, &task_id)
+            .await
+            .expect("task should exist");
+        assert_eq!(
+            task.review_agent_failures, 0,
+            "truncated failures must not count toward review_agent_failures"
         );
     }
 }

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -293,8 +293,10 @@ fn classify_failure(error: &str, outcome: &str) -> FailureCategory {
     }
 
     if outcome == "parse_error"
+        || outcome == "truncated"
         || lower.contains("invalid response")
         || lower.contains("parse error")
+        || lower.contains("truncated")
     {
         return FailureCategory::ParseError;
     }
@@ -4747,6 +4749,31 @@ mod tests {
         let category = classify_failure("failed due to sparse index configuration", "error");
         assert_ne!(category, FailureCategory::ParseError);
         assert_eq!(category, FailureCategory::Unknown);
+    }
+
+    // ── classify_failure: truncated (issue #3473) ───────────────────────
+
+    /// A review output truncated by the model's token budget (opencode
+    /// step_finish reason=length) must classify as recoverable, so a task
+    /// blocked after repeated truncations can be auto-unblocked instead of
+    /// requiring manual intervention.
+    #[serial(cooldown_state)]
+    #[test]
+    fn classify_failure_truncated_is_recoverable() {
+        let category = classify_failure(
+            "truncated: review output was cut off before completion \
+             (output/reasoning token budget exceeded)",
+            "truncated",
+        );
+        assert_eq!(
+            category,
+            FailureCategory::ParseError,
+            "truncated outcome must classify as a recoverable parse-style failure"
+        );
+        assert!(
+            category.is_recoverable(),
+            "truncated failures must be recoverable so auto-unblock can retry"
+        );
     }
 
     #[serial(cooldown_state)]


### PR DESCRIPTION
## Summary

Fixed opencode step_finish reason="length" truncation being misclassified as a generic parse_error and hit with the 4h-7d persistent-model cooldown. Added AgentResult.truncated_by_length, set by find_opencode_result when the trailing step_finish event reports reason=="length". review.rs now checks this flag before the generic parse_error branch, recording a distinguishable "truncated" outcome and applying the standard exponential backoff (record_model_failure) instead of record_persistent_model_failure. Other agent extractors (claude, codex) set the new field to false. Added unit tests for both the truncated and non-truncated opencode NDJSON cases.

### Files changed

- `src/engine/review.rs`
- `src/engine/runner/agents/mod.rs`
- `src/engine/runner/agents/opencode.rs`
- `src/engine/runner/agents/claude.rs`
- `src/engine/runner/agents/codex.rs`


Closes #3473

---
*Task #3473 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*