### PR TITLE
bug(tests): tick.rs tmux tests leak real orch-* sessions on early return — phantom sessions pollute stuck-task recovery and orch task live

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2674,6 +2674,7 @@ mod tests {
     async fn integration_channel_to_tmux_to_capture() {
         use crate::channels::capture::CaptureService;
         use crate::channels::transport::Transport;
+        use crate::tmux::SessionGuard;
         use std::sync::Arc;
 
         // Create transport and capture service
@@ -2691,14 +2692,6 @@ mod tests {
             .expect("failed to start tmux session");
 
         // Guard ensures session cleanup even on panic
-        struct SessionGuard(String);
-        impl Drop for SessionGuard {
-            fn drop(&mut self) {
-                let _ = std::process::Command::new("tmux")
-                    .args(["kill-session", "-t", &self.0])
-                    .output();
-            }
-        }
         let _guard = SessionGuard(session_name.clone());
 
         // Register session with capture service and transport binding

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -2483,7 +2483,7 @@ mod tests {
     use crate::channels::transport::Transport;
     use crate::engine::tasks::TaskManager;
     use crate::store::TaskStore;
-    use crate::tmux::TmuxManager;
+    use crate::tmux::{SessionGuard, TmuxManager};
     use async_trait::async_trait;
     use std::sync::{Arc, Mutex};
 
@@ -3354,13 +3354,14 @@ mod tests {
             }
         }
 
+        let _guard = SessionGuard(session_name.clone());
+
         let set_option_result = tokio::process::Command::new("tmux")
             .args(["set-option", "-t", &session_name, "remain-on-exit", "on"])
             .output()
             .await;
         if !matches!(set_option_result, Ok(ref o) if o.status.success()) {
             eprintln!("Skipping test: unable to set tmux remain-on-exit option");
-            let _ = tmux.kill_session(&session_name).await;
             return;
         }
 
@@ -3370,7 +3371,6 @@ mod tests {
             .await;
         if !matches!(send_exit_result, Ok(ref o) if o.status.success()) {
             eprintln!("Skipping test: unable to exit tmux pane");
-            let _ = tmux.kill_session(&session_name).await;
             return;
         }
 
@@ -3396,7 +3396,6 @@ mod tests {
         }
         if session_map.get(&session_name).copied().unwrap_or(false) {
             eprintln!("Skipping test: session still alive in batch_session_active after retries (CI tmux lag)");
-            let _ = tmux.kill_session(&session_name).await;
             return;
         }
 
@@ -3422,8 +3421,6 @@ mod tests {
 
         assert!(!timing.has_session);
         assert_eq!(timing.threshold, config.no_session_stuck_timeout);
-
-        let _ = tmux.kill_session(&session_name).await;
     }
 
     #[tokio::test]
@@ -3642,6 +3639,8 @@ mod tests {
                 return;
             }
         }
+        let _guard = SessionGuard(session_name.clone());
+
         // Ensure remain-on-exit so the session lingers as dead long enough to be snapshot
         let _ = tokio::process::Command::new("tmux")
             .args(["set-option", "-t", &session_name, "remain-on-exit", "on"])
@@ -3689,7 +3688,6 @@ mod tests {
                     "Skipping test: tick_check_session_completions did not update stored \
                      updated_at — session was not in snapshot (CI tmux environment issue)"
                 );
-                let _ = tmux.kill_session(&session_name).await;
                 return;
             }
         }
@@ -3716,8 +3714,6 @@ mod tests {
             crate::store::TaskStatus::InProgress,
             "task should not be reclaimed to New"
         );
-
-        let _ = tmux.kill_session(&session_name).await;
     }
 
     // ── tick_job_scheduler: resilience to bad project configs ────────────────

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -560,30 +560,32 @@ impl TmuxManager {
 }
 
 #[cfg(test)]
+pub(crate) fn test_session_name() -> String {
+    format!(
+        "orch-test-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or_else(|_| 0)
+    )
+}
+
+/// RAII guard that kills a tmux session on drop, even if the test panics.
+#[cfg(test)]
+pub(crate) struct SessionGuard(pub(crate) String);
+
+#[cfg(test)]
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("tmux")
+            .args(["kill-session", "-t", &self.0])
+            .output();
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Helper to get a test session name with unique ID
-    fn test_session_name() -> String {
-        format!(
-            "orch-test-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis())
-                .unwrap_or_else(|_| 0)
-        )
-    }
-
-    /// RAII guard that kills a tmux session on drop, even if the test panics.
-    struct SessionGuard(String);
-
-    impl Drop for SessionGuard {
-        fn drop(&mut self) {
-            let _ = std::process::Command::new("tmux")
-                .args(["kill-session", "-t", &self.0])
-                .output();
-        }
-    }
 
     #[test]
     fn session_name_internal_task_id_is_sanitized() {


### PR DESCRIPTION
## Summary

Fixed tmux session leak in tick.rs tests by adopting the RAII SessionGuard pattern

### Files changed

- `src/engine/mod.rs`
- `src/engine/tick.rs`
- `src/tmux.rs`


Closes #3480

---
*Task #3480 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*