### PR TITLE
bug(engine): host suspend/resume charged as agent hang — wall-clock stuck-task timing cools innocent models, watchdog reports false stalls

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1996,12 +1996,25 @@ pub async fn serve() -> anyhow::Result<()> {
                     if let Some(gap) = crate::engine::suspend::gap_detected_within(
                         std::time::Duration::from_secs(stale_secs),
                     ) {
-                        tracing::info!(
-                            stale_secs,
-                            threshold,
-                            suspend_gap_secs = gap.num_seconds(),
-                            "tick loop stale window explained by host suspend/resume, not a stall"
-                        );
+                        let gap_secs = gap.num_seconds() as u64;
+                        if gap_secs >= stale_secs {
+                            tracing::info!(
+                                stale_secs,
+                                threshold,
+                                suspend_gap_secs = gap_secs,
+                                "tick loop stale window explained by host suspend/resume, not a stall"
+                            );
+                        } else {
+                            tracing::error!(
+                                stale_secs,
+                                threshold,
+                                suspend_gap_secs = gap_secs,
+                                "WATCHDOG: tick loop has not completed a tick in {}s (threshold {}s) — suspend gap of {}s only partially explains the stall",
+                                stale_secs,
+                                threshold,
+                                gap_secs,
+                            );
+                        }
                     } else {
                         tracing::error!(
                             stale_secs,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -25,6 +25,7 @@ pub mod review_poll;
 pub mod router;
 pub mod runner;
 pub mod subscribers;
+pub mod suspend;
 pub mod sync;
 pub mod tasks;
 pub mod tick;
@@ -1989,13 +1990,27 @@ pub async fn serve() -> anyhow::Result<()> {
                 // Warn if the tick loop hasn't completed in > 6× the tick interval (at least 60s).
                 let threshold = (tick_interval_secs * 6).max(60);
                 if stale_secs > threshold {
-                    tracing::error!(
-                        stale_secs,
-                        threshold,
-                        "WATCHDOG: tick loop has not completed a tick in {}s (threshold {}s) — possible stall",
-                        stale_secs,
-                        threshold,
-                    );
+                    // A host suspend/resume gap fully explains a stale window that
+                    // isn't an actual stall — the process (and its timers) were
+                    // simply not scheduled while the host was asleep.
+                    if let Some(gap) = crate::engine::suspend::gap_detected_within(
+                        std::time::Duration::from_secs(stale_secs),
+                    ) {
+                        tracing::info!(
+                            stale_secs,
+                            threshold,
+                            suspend_gap_secs = gap.num_seconds(),
+                            "tick loop stale window explained by host suspend/resume, not a stall"
+                        );
+                    } else {
+                        tracing::error!(
+                            stale_secs,
+                            threshold,
+                            "WATCHDOG: tick loop has not completed a tick in {}s (threshold {}s) — possible stall",
+                            stale_secs,
+                            threshold,
+                        );
+                    }
                 }
             }
         });
@@ -2005,6 +2020,16 @@ pub async fn serve() -> anyhow::Result<()> {
         tokio::select! {
             _ = interval.tick() => {
                 let tick_start = std::time::Instant::now();
+
+                // Detect a host suspend/resume gap once per iteration, in one place.
+                // The watchdog and stuck-task recovery both read from this instead of
+                // re-deriving suspend information from their own wall-clock deltas.
+                if let Some(gap) = crate::engine::suspend::checkpoint() {
+                    tracing::info!(
+                        gap_secs = gap.num_seconds(),
+                        "host suspend/resume gap detected, discounting from stuck-task age checks"
+                    );
+                }
 
                 // Tick weight recovery for rate-limited agents
                 {

--- a/src/engine/suspend.rs
+++ b/src/engine/suspend.rs
@@ -1,0 +1,153 @@
+//! Host suspend/resume detection.
+//!
+//! `Instant` is monotonic and does not advance while the host is asleep; wall-clock
+//! time does. Comparing the two across a checkpoint reveals suspend/resume gaps that
+//! would otherwise be misread by wall-clock-only comparisons as a stalled tick loop
+//! (the watchdog in `engine::mod`) or a hung agent (`stuck_task_timing_from_map` in
+//! `engine::tick`).
+//!
+//! `checkpoint()` is the single detection point, called once per main tick loop
+//! iteration. Both consumers pull from the resulting gap log instead of re-deriving
+//! suspend information from their own wall-clock deltas.
+
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Wall-clock-minus-monotonic gap large enough to be a host suspend rather than
+/// scheduling jitter or a slow tick.
+const SUSPEND_GAP_THRESHOLD: Duration = Duration::from_secs(20);
+
+/// Bound on retained gap history so a long-running process doesn't grow this
+/// unboundedly; suspend events are rare so this comfortably covers any realistic
+/// task age window.
+const MAX_GAP_LOG: usize = 128;
+
+struct GapRecord {
+    detected_at: DateTime<Utc>,
+    gap: ChronoDuration,
+}
+
+struct Checkpoint {
+    instant: Instant,
+    wall: DateTime<Utc>,
+}
+
+static LAST_CHECKPOINT: Mutex<Option<Checkpoint>> = Mutex::new(None);
+static GAP_LOG: Mutex<Vec<GapRecord>> = Mutex::new(Vec::new());
+
+/// Record a checkpoint and return the suspend gap (if any) detected since the
+/// previous one. Call this once per main tick loop iteration.
+pub fn checkpoint() -> Option<ChronoDuration> {
+    let now_instant = Instant::now();
+    let now_wall = Utc::now();
+
+    let prev = {
+        let mut guard = LAST_CHECKPOINT.lock().unwrap_or_else(|e| e.into_inner());
+        guard.replace(Checkpoint {
+            instant: now_instant,
+            wall: now_wall,
+        })
+    };
+    let prev = prev?;
+
+    let monotonic_elapsed = now_instant.saturating_duration_since(prev.instant);
+    let wall_elapsed = (now_wall - prev.wall).to_std().unwrap_or_default();
+    let gap = wall_elapsed.saturating_sub(monotonic_elapsed);
+    if gap < SUSPEND_GAP_THRESHOLD {
+        return None;
+    }
+
+    let gap = ChronoDuration::from_std(gap).unwrap_or_else(|_| ChronoDuration::zero());
+    let mut log = GAP_LOG.lock().unwrap_or_else(|e| e.into_inner());
+    log.push(GapRecord {
+        detected_at: now_wall,
+        gap,
+    });
+    if log.len() > MAX_GAP_LOG {
+        let excess = log.len() - MAX_GAP_LOG;
+        log.drain(0..excess);
+    }
+    Some(gap)
+}
+
+/// Total suspend time detected since `since`. Subtract this from a wall-clock age
+/// computation to avoid mistaking suspend time for hung agent/tick runtime.
+pub fn suspended_duration_since(since: DateTime<Utc>) -> ChronoDuration {
+    let log = GAP_LOG.lock().unwrap_or_else(|e| e.into_inner());
+    log.iter()
+        .filter(|r| r.detected_at > since)
+        .fold(ChronoDuration::zero(), |acc, r| acc + r.gap)
+}
+
+/// Most recent suspend gap detected within the last `window`, if any. Lets the tick
+/// watchdog downgrade a stale-tick alert to informational when it is fully explained
+/// by a host suspend rather than an actual stall.
+pub fn gap_detected_within(window: Duration) -> Option<ChronoDuration> {
+    let window = ChronoDuration::from_std(window).unwrap_or_else(|_| ChronoDuration::zero());
+    let cutoff = Utc::now() - window;
+    let log = GAP_LOG.lock().unwrap_or_else(|e| e.into_inner());
+    log.iter()
+        .rev()
+        .find(|r| r.detected_at >= cutoff)
+        .map(|r| r.gap)
+}
+
+/// Test-only helper to inject a synthetic gap record without going through the real
+/// `Instant`/wall-clock comparison in `checkpoint()`, which can't be driven
+/// deterministically in tests.
+#[cfg(test)]
+pub(crate) fn inject_gap_for_test(detected_at: DateTime<Utc>, gap: ChronoDuration) {
+    let mut log = GAP_LOG.lock().unwrap_or_else(|e| e.into_inner());
+    log.push(GapRecord { detected_at, gap });
+}
+
+/// Test-only helper to reset shared gap state between tests. Callers must run
+/// `#[serial(suspend_state)]` since `GAP_LOG` is a process-wide static.
+#[cfg(test)]
+pub(crate) fn clear_for_test() {
+    let mut log = GAP_LOG.lock().unwrap_or_else(|e| e.into_inner());
+    log.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial(suspend_state)]
+    fn suspended_duration_since_sums_only_later_gaps() {
+        clear_for_test();
+        let t0 = Utc::now() - ChronoDuration::minutes(10);
+        let t1 = Utc::now() - ChronoDuration::minutes(5);
+        inject_gap_for_test(t0, ChronoDuration::minutes(3));
+        inject_gap_for_test(t1, ChronoDuration::minutes(2));
+
+        // Since before t0: both gaps count.
+        let total = suspended_duration_since(t0 - ChronoDuration::seconds(1));
+        assert_eq!(total, ChronoDuration::minutes(5));
+
+        // Since between t0 and t1: only the later gap counts.
+        let total = suspended_duration_since(t0 + ChronoDuration::seconds(1));
+        assert_eq!(total, ChronoDuration::minutes(2));
+
+        // Since after t1: no gaps count.
+        let total = suspended_duration_since(t1 + ChronoDuration::seconds(1));
+        assert_eq!(total, ChronoDuration::zero());
+
+        clear_for_test();
+    }
+
+    #[test]
+    #[serial(suspend_state)]
+    fn gap_detected_within_finds_recent_gap() {
+        clear_for_test();
+        inject_gap_for_test(Utc::now(), ChronoDuration::minutes(7));
+
+        let found = gap_detected_within(Duration::from_secs(60));
+        assert_eq!(found, Some(ChronoDuration::minutes(7)));
+
+        clear_for_test();
+    }
+}

--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -289,7 +289,12 @@ fn stuck_task_timing_from_map(
         }
     };
 
-    let age = chrono::Utc::now() - updated;
+    let raw_age = chrono::Utc::now() - updated;
+    // Host suspend (laptop sleep) freezes the process just like it freezes the agent
+    // running inside it — that frozen time is not evidence of a hang. Discount any
+    // detected suspend/resume gaps that occurred since this task was last touched.
+    let suspended = super::suspend::suspended_duration_since(updated);
+    let age = (raw_age - suspended).max(chrono::Duration::zero());
     if age.num_seconds() <= threshold as i64 {
         return None;
     }
@@ -3666,6 +3671,50 @@ mod tests {
 
         assert!(!timing.has_session);
         assert_eq!(timing.threshold, config.no_session_stuck_timeout);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(suspend_state)]
+    async fn stuck_task_timing_discounts_host_suspend_gap() {
+        super::super::suspend::clear_for_test();
+
+        let tmux = Arc::new(TmuxManager::new());
+        let repo = "owner/repo";
+        let task_id = "internal:99001";
+        let session_map = std::collections::HashMap::new();
+
+        let config = EngineConfig {
+            no_session_stuck_timeout: 1800,
+            stuck_timeout: 1800,
+            ..EngineConfig::default()
+        };
+
+        // Task was last touched 33 minutes ago (age_mins=33 matches the reported
+        // false-positive), but the host was suspended for 30 of those minutes —
+        // real elapsed runtime is only 3 minutes, well under the 30-minute threshold.
+        let updated_at = (chrono::Utc::now() - chrono::Duration::minutes(33)).to_rfc3339();
+        let suspend_gap_detected_at = chrono::Utc::now() - chrono::Duration::minutes(1);
+        super::super::suspend::inject_gap_for_test(
+            suspend_gap_detected_at,
+            chrono::Duration::minutes(30),
+        );
+
+        let timing = stuck_task_timing_from_map(
+            &tmux,
+            repo,
+            task_id,
+            &updated_at,
+            &config,
+            "parse failure",
+            &session_map,
+        );
+
+        assert!(
+            timing.is_none(),
+            "task age should be discounted below the stuck threshold once suspend time is subtracted, got {timing:?}"
+        );
+
+        super::super::suspend::clear_for_test();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Added engine::suspend as a single host suspend/resume detection point (Instant vs wall-clock comparison, once per tick loop iteration). The tick watchdog now downgrades its stale-tick alert to info when a detected suspend gap fully explains the staleness, instead of firing a false ERROR. stuck_task_timing_from_map() now subtracts detected suspend time since a task's updated_at from its age before comparing to the stuck threshold, so a laptop sleep is no longer charged to an agent/model as a hang (no more spurious 1h cooldowns + task_runs failure pollution).

### Files changed

- `src/engine/suspend.rs (new)`
- `src/engine/mod.rs`
- `src/engine/tick.rs`


Closes #3491

---
*Task #3491 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*