### PR TITLE
bug(capture): silence detection age check doesn't discount host suspend gaps — false-positive reroutes on wake

### DIFF
--- a/src/channels/capture.rs
+++ b/src/channels/capture.rs
@@ -231,7 +231,14 @@ impl CaptureService {
                 continue;
             }
 
-            let age = now.signed_duration_since(buf.registered_at);
+            let raw_age = now.signed_duration_since(buf.registered_at);
+            // Host suspend (laptop sleep) freezes the process just like it freezes
+            // the agent running inside it — suspended wall-clock time is not evidence
+            // of a hung agent. Discount any detected suspend/resume gaps that occurred
+            // since the session was registered, mirroring the watchdog fix in
+            // engine::tick (`stuck_task_timing_from_map`).
+            let suspended = crate::engine::suspend::suspended_duration_since(buf.registered_at);
+            let age = (raw_age - suspended).max(chrono::Duration::zero());
             if age.num_seconds() > grace_period.as_secs() as i64 {
                 silent.push((buf.task_id.clone(), buf.session.clone(), age.num_seconds()));
             }

--- a/tests/capture_diff.rs
+++ b/tests/capture_diff.rs
@@ -188,10 +188,15 @@ async fn silent_detection_discounts_host_suspend_gap() {
         chrono::Utc::now() - chrono::Duration::seconds(60),
         chrono::Duration::seconds(880),
     );
+    // `seen_alive=false` — the common false-positive case: the session was
+    // never confirmed alive (e.g. the agent's first output was still pending)
+    // when the host suspended. Using `seen_alive=true` would skip the buffer
+    // entirely in the live-session branch (`!is_session_dead` → continue)
+    // and never reach the suspend-discount age computation.
     svc.set_buffer_state_for_test(
         repo,
         "suspend-gap-task",
-        true,  // seen_alive
+        false, // seen_alive
         false, // has_output
         chrono::Utc::now() - chrono::Duration::seconds(900),
     )

--- a/tests/capture_diff.rs
+++ b/tests/capture_diff.rs
@@ -51,6 +51,34 @@ mod channels {
 }
 
 #[allow(dead_code)]
+mod engine {
+    pub mod suspend {
+        use chrono::{DateTime, Duration, Utc};
+        use std::sync::Mutex;
+
+        static GAPS: Mutex<Vec<(DateTime<Utc>, Duration)>> = Mutex::new(Vec::new());
+
+        pub fn suspended_duration_since(since: DateTime<Utc>) -> Duration {
+            GAPS.lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .iter()
+                .filter(|(detected_at, _)| *detected_at > since)
+                .fold(Duration::zero(), |acc, (_, gap)| acc + *gap)
+        }
+
+        pub fn inject_gap_for_test(detected_at: DateTime<Utc>, gap: Duration) {
+            GAPS.lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push((detected_at, gap));
+        }
+
+        pub fn clear_for_test() {
+            GAPS.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        }
+    }
+}
+
+#[allow(dead_code)]
 #[path = "../src/channels/capture.rs"]
 mod capture;
 
@@ -137,4 +165,44 @@ async fn seen_alive_with_live_session_not_silenced() {
         silent.is_empty(),
         "seen_alive=true + live session must NOT appear in silent list (issue #2318)"
     );
+}
+
+/// Regression test for issue #3496: a session registered long enough ago to
+/// trip the silence grace period must NOT be reported silent when a host
+/// suspend/resume gap fully explains the wall-clock age. Without discounting,
+/// any laptop sleep longer than `silence_grace_period` produces a burst of
+/// false-positive reroutes across every in-flight task at once.
+#[tokio::test]
+async fn silent_detection_discounts_host_suspend_gap() {
+    let transport = Arc::new(Transport::new());
+    let svc = CaptureService::new(transport);
+    let repo = "owner/repo";
+
+    // Register a session; then back its `registered_at` up by 900s (7.5× the
+    // 120s grace), with 880s of that being a suspend gap detected 1 minute ago.
+    // Real elapsed runtime = 900 - 880 = 20s, well under grace.
+    svc.register_session(repo, "suspend-gap-task", "orch-suspend-gap")
+        .await;
+    engine::suspend::clear_for_test();
+    engine::suspend::inject_gap_for_test(
+        chrono::Utc::now() - chrono::Duration::seconds(60),
+        chrono::Duration::seconds(880),
+    );
+    svc.set_buffer_state_for_test(
+        repo,
+        "suspend-gap-task",
+        true,  // seen_alive
+        false, // has_output
+        chrono::Utc::now() - chrono::Duration::seconds(900),
+    )
+    .await;
+
+    let grace = std::time::Duration::from_secs(120);
+    let silent = svc.get_silent_sessions_for_repo(repo, grace).await;
+    assert!(
+        silent.is_empty(),
+        "session must NOT be silenced when suspend gap explains the wall-clock age (issue #3496)"
+    );
+
+    engine::suspend::clear_for_test();
 }


### PR DESCRIPTION
## Summary

Fixed false-positive silence detection in CaptureService by discounting host suspend/resume gaps, mirroring the existing stuck-task-timing fix. Added a stub engine::suspend to the capture_diff test crate and a regression test.

### What was done

- Discounted suspend gap in get_silent_sessions_for_repo via suspended_duration_since(registered_at) before grace-period comparison
- Added engine::suspend stub module to tests/capture_diff.rs (test crate includes capture.rs via #[path])
- Added silent_detection_discounts_host_suspend_gap regression test verifying suspend discounting prevents false positives
- All checks pass: cargo fmt, cargo clippy, cargo nextest (3866 passed, 19 skipped)


### Files changed

- `src/channels/capture.rs`
- `tests/capture_diff.rs`


Closes #3496

---
*Task #3496 · Created by opencode[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opencode/laguna-s-2.1-free`*