### PR TITLE
bug(telegram): getUpdates poll loop retries at a flat 5s with no backoff or escalation during outages

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -278,6 +278,10 @@ impl Channel for TelegramChannel {
         };
 
         tokio::spawn(async move {
+            const POLL_BACKOFF_BASE: Duration = Duration::from_secs(5);
+            const POLL_BACKOFF_CAP: Duration = Duration::from_secs(60);
+            let mut backoff = POLL_BACKOFF_BASE;
+
             loop {
                 let current_offset = {
                     let off = offset.lock().await;
@@ -287,11 +291,17 @@ impl Channel for TelegramChannel {
                 let updates = match channel.get_updates(current_offset).await {
                     Ok(u) => u,
                     Err(e) => {
-                        tracing::warn!(?e, "failed to get telegram updates");
-                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                        tracing::warn!(
+                            ?e,
+                            backoff_secs = backoff.as_secs(),
+                            "failed to get telegram updates"
+                        );
+                        tokio::time::sleep(backoff).await;
+                        backoff = (backoff * 2).min(POLL_BACKOFF_CAP);
                         continue;
                     }
                 };
+                backoff = POLL_BACKOFF_BASE;
 
                 let has_updates = !updates.is_empty();
 


### PR DESCRIPTION
## Summary

Fixed the Telegram getUpdates poll loop's flat 5s retry by applying the same doubling-backoff-with-cap pattern already used by the Discord gateway loop in this codebase (src/channels/discord_ws.rs). On failure, sleep now doubles from a 5s base up to a 60s cap, logs backoff_secs alongside the warning, and resets to the 5s base on the next successful poll. Verified with cargo fmt --check, cargo clippy --all-targets -D warnings, and cargo nextest run (34/34 telegram-related tests pass). Committed as 8041ee2a; not pushed since TASK_ID is set and the engine handles push/PR creation.

### Files changed

- `src/channels/telegram.rs`


Closes #3502

---
*Task #3502 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*