### PR TITLE
bug(runner): opencode model-discovery cache timestamp isn't updated on failed refresh — no backoff, list frozen at startup snapshot

### DIFF
--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -69,9 +69,18 @@ fn update_discovered_models_cache(
             cached_models = guard.1.len(),
             "opencode model discovery returned empty; preserving previous cache contents"
         );
+        // Still advance the timestamp so a persistently-failing discovery
+        // backs off for the full TTL window instead of being retried on
+        // every subsequent call.
+        guard.0 = now;
         return;
     }
 
+    tracing::debug!(
+        cache = cache_name,
+        discovered_models = discovered.len(),
+        "opencode model discovery refreshed cache"
+    );
     *guard = (now, discovered);
 }
 
@@ -1535,7 +1544,9 @@ mod tests {
         update_discovered_models_cache(cache, Vec::new(), "free");
 
         let guard = cache.lock().unwrap_or_else(|e| e.into_inner());
-        assert_eq!(guard.0, 123);
+        // Timestamp must advance on a failed refresh so the TTL provides a
+        // real backoff window instead of retrying on every subsequent call.
+        assert!(guard.0 > 123);
         assert_eq!(guard.1, vec!["opencode/model-free".to_string()]);
     }
 
@@ -1557,7 +1568,7 @@ mod tests {
         update_discovered_models_cache(cache, Vec::new(), "all");
 
         let guard = cache.lock().unwrap_or_else(|e| e.into_inner());
-        assert_eq!(guard.0, 456);
+        assert!(guard.0 > 456);
         assert_eq!(
             guard.1,
             vec![


### PR DESCRIPTION
## Summary

Fixed the opencode model-discovery cache bug: update_discovered_models_cache() now advances the cache timestamp even when preserving stale contents on a failed refresh, so a persistently-failing discovery genuinely backs off for the full 1h TTL instead of retrying on nearly every call. Also added a debug log line on the successful-refresh path so future log analysis can distinguish real successes from the empty-preserve warning.

### What was done

- Updated update_discovered_models_cache() in src/engine/runner/agents/opencode.rs to set guard.0 = now on the preserve-stale-contents path (previously only guard.1 was implicitly kept and guard.0 was never touched)
- Added a tracing::debug! log line on the success path (cache name + discovered model count) so background-refresh success vs. 100%-failure is now distinguishable in logs
- Updated the two existing unit tests (empty_free_discovery_preserves_existing_cache_contents, empty_all_models_discovery_preserves_existing_cache_contents) to assert the timestamp advances past the seeded value while cache contents are still preserved
- Ran cargo fmt -- --check, cargo clippy --all-targets -- -D warnings, and cargo nextest run (full suite, 3868 tests) — all clean


### Remaining

- Item 3 from the issue (comparing the background-refresh subprocess path against prime_free_model_cache's dedicated-thread approach, e.g. capturing stderr instead of Stdio::null()) was intentionally left for a follow-up once the new debug log line confirms whether background refreshes are failing or simply never running


### Files changed

- `src/engine/runner/agents/opencode.rs`


Closes #3506

---
*Task #3506 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*