### PR TITLE
Daily review (last 24h)

### DIFF
--- a/docs/content/posts/daily-review-2026-08-13.md
+++ b/docs/content/posts/daily-review-2026-08-13.md
@@ -1,0 +1,110 @@
++++
+title = "Daily Review — 2026-08-13"
+date = 2026-08-13
+description = "Daily review: what shipped, what failed, operational health, and priorities for tomorrow."
++++
+
+# Daily Review — 2026-08-13
+
+## The headline: another same-day find-to-fix, this time on opencode's truncation classifier
+
+Quiet, healthy day. One commit shipped a routing fix already reported yesterday (#3509/#3511, `route_with_llm` cooled-agent filter), and a second bug was found, filed, and fixed within 17 minutes during today's window: opencode reasoning models that burn their entire token budget on hidden reasoning and emit **zero** output text were falling through to the harsh 4h→7d persistent-model cooldown instead of the standard-backoff `truncated` path, because the empty-`result_text` early return fired *before* the `truncated_by_length` check ran. Fixed same-day (#3512 → PR #3513, `2c22808c`). No WATCHDOG stalls, no DB-lock errors, `orch.error.log` still empty (stale since Aug 9).
+
+---
+
+## What Shipped (Last 24h)
+
+**3 commits landed** (window: 2026-08-12T23:05Z → 2026-08-13T23:05Z):
+
+| Commit | Issue | Summary |
+|--------|-------|---------|
+| `82e57208` | — | Yesterday's daily-review post (#3510), landed just inside this window |
+| `db6a9eb0` | #3509 | `route_with_llm()` cooled-agent filter fix (reported in detail in yesterday's review; merge timestamp falls in today's window) |
+| `2c22808c` | #3512 (PR #3513) | `find_opencode_result()` now computes `truncated_by_length` *before* the empty-`result_text` early return, and extends the signal to `step_finish reason="unknown"` when output tokens are exactly 0 — so a zero-output reasoning model gets standard exponential backoff instead of a persistent 4h→7d cooldown. 3 regression tests added; fmt/clippy/nextest (3878 tests) all clean. |
+
+**Closed today:** #3512 → #3513, filed at 21:05 UTC, merged at 21:22 UTC — 17-minute turnaround. Evidence was three same-24h `parse_error` review runs on `opencode/nemotron-3-ultra-free` (tasks 156428, 156347, 156415), one with a `step_finish` showing 40k reasoning tokens and 0 output tokens.
+
+**Still open:** #3453 (`bug(review-prompt): pending CI status prose still causes review parse errors`) — now 15 days old. Re-checked against current `HEAD`: `prompts/review_task.md` still has no explicit instruction covering an agent that pauses to report status instead of falling through to the local-checks fallback when `gh pr checks --watch` returns a genuinely pending (not backgrounded) result. Still reproducible, correctly left open, still the single fastest way to empty the tracker.
+
+---
+
+## Operational Health
+
+### Throughput and Activity
+
+`task_activity` in the last 24 hours:
+
+| Event | Count |
+|------|------:|
+| `status_change` | 104 |
+| `dispatch` | 35 |
+| `push` | 30 |
+| `branch_delete` | 30 |
+| `review_start` | 19 |
+| `routed` | 17 |
+| `pr_create` | 15 |
+| `review_decision` | 14 |
+| `error` | 5 |
+| `timeout` | 3 |
+| `rerouted` | 1 |
+
+Lower volume than yesterday's 181/53/50 day — a quieter throughput day, consistent with a healthy backlog rather than a stall (no WATCHDOG errors, no DB-lock errors in the window).
+
+### Task Run Outcomes
+
+| Agent | Model | Outcome | Count |
+|------|-------|---------|------:|
+| claude | `sonnet` | `success` | 20 |
+| opencode | `opencode/laguna-s-2.1-free` | `success` | 3 |
+| opencode | `opencode/ling-3.0-tiny-free` | `timeout` | 3 |
+| claude | `sonnet` | *(in progress)* | 2 |
+| opencode | `opencode/hy3-free` | `success` | 2 |
+| opencode | `opencode/mimo-v2.5-free` | `success` | 2 |
+| opencode | `opencode/nemotron-3-ultra-free` | `parse_error` | 2 |
+| claude | `sonnet` | `failed` | 1 |
+| minimax | `opus` | `rate_limit` | 1 |
+| opencode | `opencode/nemotron-3.5-lightning-free` | `success` | 1 |
+
+The two `nemotron-3-ultra-free` `parse_error` rows (tasks 156415, 156428) are exactly the evidence behind today's #3512 fix — genuinely misclassified at the time, will read as `truncated` going forward once the fix is live. The `claude:sonnet failed` row (task 156414) is `silence detection set task to new` — the generic silence-detection mechanism firing correctly on a single stalled session, self-recovered on retry, not a new pattern. `minimax:opus rate_limit` (task 156430) is the standard 429 → cooldown path, expected.
+
+### `opencode/ling-3.0-tiny-free`: 3 timeouts in the window, worth watching but not yet actionable
+
+All three timeouts (tasks 156385, 156384, 156411) are `run_type=review` and clustered right at the day boundary, 23:05–00:37 UTC. Checked this model's full run history: it has now timed out on 4 of its last 5 late-night (~23:00–00:07 UTC) runs going back to 2026-08-10, each hitting the review runner's 1800s ceiling almost exactly. All three tasks from tonight's cluster completed successfully on retry (standard timeout backoff → reroute, working as designed) — no task was left stuck. The time-of-day clustering is an interesting shape but the sample is still small (13 lifetime runs on this model) and every occurrence has self-recovered without operator or code intervention, so this doesn't clear the bar to file yet. Flagging as a watch item: if the late-night clustering repeats over the next few days, it'll be worth a root-cause pass on whether this specific free-tier model degrades under evening load.
+
+### GitHub transport errors: self-recovering, correctly not tripping the circuit breaker
+
+24 "GitHub not reached" transport-error WARNs scattered through the day, almost all resolved on retry within the same request. Two bursts around 18:21 UTC exhausted all 3 attempts and explicitly logged "not tripping the github:5xx circuit-breaker" — this is #3492's fix (transport-level failures don't open the circuit breaker) working exactly as designed. No polling-fallback-mode transitions, no sustained outage.
+
+### `orch.error.log` still empty
+
+0 bytes, mtime unchanged since Aug 9 — stale, unrelated to this window.
+
+### Routing accuracy
+
+The `route_with_llm` cooled-agent-filter fix (#3509/#3511) merged during yesterday's review window but the log still shows "LLM selected cooled agent/model; rerouting to available agent" for `minimax`/`complex` twice tonight (23:00–23:01 UTC, on this review's own two tasks). `minimax:opus` remains in persisted cooldown (~6d22h remaining). Every occurrence was still correctly caught by the existing sanity-check-and-reroute safety net with no functional harm — evaluate this against current `HEAD` once the fix is running.
+
+### Backlog and stuck work
+
+The two `review_cycles = 1` rebroadcast-blocked tasks flagged in the last three daily reviews are **still frozen** — same `block_reason`, `needs_review_refires = 6`, `updated_at` unchanged since 2026-08-09T22:44:38Z, now 4 days without reconciliation. #3507's new debug logging on the two silent early-return branches (merged yesterday) hasn't produced any log output yet for these two tasks — holding off on a new issue until that diagnostic signal actually shows up, since this bug class already has five dedicated fixes on record and another guess without new evidence would just restate what's tracked.
+
+The rest of the blocked backlog is unchanged in shape: `GitHub Actions billing failure` blocks at merge time (correct per-task policy) and a handful of `max review cycles exceeded` / long-idle items in other tracked projects. Nothing new or stuck in this repo's own queue.
+
+---
+
+## Issues Filed Today
+
+**New:** none filed by this review. #3512 (opencode zero-output truncation misclassification) was filed and fixed entirely within today's window by an earlier session before this review started — already covered above, not duplicated here.
+
+No other issue met the bar to file: the `ling-3.0-tiny-free` timeout clustering is a watch item, not yet a confirmed root cause; the GitHub transport WARNs and `minimax`/`complex` reroutes are existing mechanisms working as designed; the two rebroadcast-blocked tasks are being held for next-review diagnosis now that logging exists but hasn't fired yet.
+
+---
+
+## Priorities for Tomorrow
+
+1. **Check whether `opencode/ling-3.0-tiny-free`'s late-night timeout clustering continues** — 4 of 5 runs in the 23:00–00:07 UTC window have now timed out across 4 consecutive days. If it repeats again, this crosses from "watch item" to "root-cause it."
+2. **Check whether #3507's new debug logging has fired yet for the two frozen rebroadcast-blocked tasks** — still silent as of this review.
+3. **#3453 remains the single open issue, now 15 days old, still reproducible on `HEAD`.** Still a one-paragraph prompt edit away from an empty tracker.
+
+---
+
+*Prepared by Orch automation (internal:156452) on 2026-08-13.*


### PR DESCRIPTION
## Summary

Wrote and committed the daily review post for 2026-08-13 (docs/content/posts/daily-review-2026-08-13.md). Last 24h was quiet: one same-day find-to-fix (#3512, opencode zero-output truncation misclassified as parse_error, filed and merged in 17 minutes via PR #3513), plus the routing cooled-agent-filter fix from yesterday (#3509/#3511) whose merge commit fell inside this window. No WATCHDOG stalls, no DB-lock errors, orch.error.log still empty. Corrected a timestamp-format bug in my own SQL queries mid-review (ISO 'T' timestamps were comparing incorrectly against SQLite's space-separated datetime('now'), pulling in a stray extra day of data) before finalizing numbers. Flagged opencode/ling-3.0-tiny-free's late-night timeout clustering (4 of last 5 runs in the 23:00-00:07 UTC window timed out across 4 consecutive days, all self-recovered on retry) as a watch item, not yet filed since sample size is small and every occurrence self-recovered. No new GitHub issues filed — nothing else cleared the bar (GitHub transport WARNs and minimax/complex reroutes are existing mechanisms working as designed; the two frozen rebroadcast-blocked tasks are being held for next-review diagnosis since #3507's new debug logging hasn't fired yet). #3453 remains the sole open issue, now 15 days old, re-verified still reproducible on HEAD. Commit 11430fbf created; not pushed since TASK_ID env var is set and the orch engine handles push/PR per repo policy.

### Files changed

- `docs/content/posts/daily-review-2026-08-13.md`


---
*Task internal-156452 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*