### PR TITLE
bug(runner): kimi billing-cycle exhaustion is recorded as outcome=rate_limit instead of billing_cycle_exhausted

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -72,6 +72,19 @@ pub enum CreditExhaustionReason {
     BillingCycleExhausted,
 }
 
+impl CreditExhaustionReason {
+    /// Stable string for `task_runs.outcome`, distinct from the cooldown reason
+    /// string used by `record_credit_exhaustion`. Lets callers persist the actual
+    /// failure mode instead of collapsing it into a generic "rate_limit"/"failed".
+    pub fn outcome_str(self) -> &'static str {
+        match self {
+            CreditExhaustionReason::OutOfCredits => "credit_exhausted",
+            CreditExhaustionReason::OrgLevelDisabled => "org_level_disabled",
+            CreditExhaustionReason::BillingCycleExhausted => "billing_cycle_exhausted",
+        }
+    }
+}
+
 /// Short agent cooldown applied on silence detection (120 seconds).
 ///
 /// Forces the router to pick a different agent immediately on re-route,
@@ -448,6 +461,18 @@ pub async fn record_agent_failure_with_message(agent_name: &str, error_message: 
     let cooldown_until =
         chrono::Utc::now().timestamp() + compute_backoff(count, base, BACKOFF_MAX_SECS, true);
     set_cooldown_async(agent_name, cooldown_until, "agent_error").await;
+}
+
+/// Detect credit exhaustion from an error message and return the stable
+/// `task_runs.outcome` string for it (see `CreditExhaustionReason::outcome_str`).
+///
+/// Callers that classify `AgentError::RateLimit`/`AgentError::Auth` into an
+/// outcome string should consult this first — generic rate-limit patterns like
+/// "usage limit" also match billing-cycle exhaustion messages (e.g. Kimi's
+/// "You've reached your usage limit for this billing cycle"), which would
+/// otherwise be stored as a plain "rate_limit" outcome.
+pub fn detect_credit_exhaustion_outcome(error_message: &str) -> Option<&'static str> {
+    detect_credit_exhaustion(error_message).map(CreditExhaustionReason::outcome_str)
 }
 
 /// Detect credit exhaustion reasons from error message.
@@ -2414,6 +2439,47 @@ mod tests {
             ),
             Some(CreditExhaustionReason::BillingCycleExhausted)
         );
+    }
+
+    #[serial(cooldown_state)]
+    #[test]
+    fn detect_credit_exhaustion_outcome_kimi_billing_cycle() {
+        // Regression test for issue #3529: the exact Kimi billing-cycle exhaustion
+        // message from task_runs (tasks 156734/156678) must resolve to the
+        // "billing_cycle_exhausted" outcome string, not fall through to a generic
+        // rate-limit/auth classification.
+        let msg = "Failed to authenticate. API Error: 403 You've reached your usage limit for \
+                    this billing cycle. Your quota will be refreshed soon.";
+        assert_eq!(
+            detect_credit_exhaustion_outcome(msg),
+            Some("billing_cycle_exhausted")
+        );
+    }
+
+    #[serial(cooldown_state)]
+    #[test]
+    fn detect_credit_exhaustion_outcome_maps_all_reasons() {
+        assert_eq!(
+            detect_credit_exhaustion_outcome("out of credits"),
+            Some("credit_exhausted")
+        );
+        assert_eq!(
+            detect_credit_exhaustion_outcome("organization has been disabled"),
+            Some("org_level_disabled")
+        );
+        assert_eq!(
+            detect_credit_exhaustion_outcome("monthly quota exceeded"),
+            Some("billing_cycle_exhausted")
+        );
+    }
+
+    #[test]
+    fn detect_credit_exhaustion_outcome_returns_none_for_unrelated_errors() {
+        assert_eq!(
+            detect_credit_exhaustion_outcome("429 Too Many Requests"),
+            None
+        );
+        assert_eq!(detect_credit_exhaustion_outcome("connection reset"), None);
     }
 
     #[serial(cooldown_state)]

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -21,8 +21,18 @@ const MAX_PR_CREATE_FAILURES: u64 = 3;
 fn outcome_for_agent_error(err: &runner::agents::AgentError) -> &'static str {
     match err {
         runner::agents::AgentError::Timeout { .. } => "timeout",
-        runner::agents::AgentError::RateLimit { .. } => "rate_limit",
-        runner::agents::AgentError::Auth { .. } => "auth_error",
+        // Consult credit-exhaustion detection first — generic rate-limit patterns
+        // (e.g. "usage limit") also match billing-cycle exhaustion messages, so
+        // reviews on a billing-cycle-exhausted model must not be stored as a
+        // plain "rate_limit"/"auth_error" outcome (issue #3529).
+        runner::agents::AgentError::RateLimit { message } => {
+            crate::engine::cooldown::detect_credit_exhaustion_outcome(message)
+                .unwrap_or("rate_limit")
+        }
+        runner::agents::AgentError::Auth { message } => {
+            crate::engine::cooldown::detect_credit_exhaustion_outcome(message)
+                .unwrap_or("auth_error")
+        }
         runner::agents::AgentError::InvalidResponse { .. } => "parse_error",
         _ => "failed",
     }
@@ -2503,6 +2513,37 @@ mod tests {
     use crate::github::types::{GitHubReview, GitHubReviewComment, GitHubUser, PullRequestReview};
     use crate::store::TaskStore;
     use tempfile::TempDir;
+
+    // ── outcome_for_agent_error ─────────────────────────────────────────────
+
+    #[test]
+    fn outcome_for_agent_error_kimi_billing_cycle_is_not_rate_limit() {
+        // Regression test for issue #3529: a review run hitting Kimi's billing-cycle
+        // exhaustion (task 156734 in the bug report) must not be stored as a plain
+        // "rate_limit" outcome.
+        let err = runner::agents::AgentError::RateLimit {
+            message: "Failed to authenticate. API Error: 403 You've reached your usage limit \
+                      for this billing cycle. Your quota will be refreshed soon."
+                .to_string(),
+        };
+        assert_eq!(outcome_for_agent_error(&err), "billing_cycle_exhausted");
+    }
+
+    #[test]
+    fn outcome_for_agent_error_generic_rate_limit_unaffected() {
+        let err = runner::agents::AgentError::RateLimit {
+            message: "429 Too Many Requests".to_string(),
+        };
+        assert_eq!(outcome_for_agent_error(&err), "rate_limit");
+    }
+
+    #[test]
+    fn outcome_for_agent_error_generic_auth_unaffected() {
+        let err = runner::agents::AgentError::Auth {
+            message: "401 Unauthorized".to_string(),
+        };
+        assert_eq!(outcome_for_agent_error(&err), "auth_error");
+    }
 
     // ── parse_pr_number_from_url ────────────────────────────────────────────
 

--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -93,7 +93,17 @@ fn classify_run_outcome(
     }
     match parse_result {
         Err(agents::AgentError::Timeout { .. }) => "timeout",
-        Err(agents::AgentError::RateLimit { .. }) => "rate_limit",
+        // Generic rate-limit patterns (e.g. "usage limit") also match billing-cycle
+        // exhaustion messages, so consult the credit-exhaustion detector first —
+        // otherwise Kimi-style "usage limit for this billing cycle" errors are
+        // stored as a plain "rate_limit" outcome (issue #3529).
+        Err(agents::AgentError::RateLimit { message }) => {
+            crate::engine::cooldown::detect_credit_exhaustion_outcome(message)
+                .unwrap_or("rate_limit")
+        }
+        Err(agents::AgentError::Auth { message }) => {
+            crate::engine::cooldown::detect_credit_exhaustion_outcome(message).unwrap_or("failed")
+        }
         Err(agents::AgentError::InvalidResponse { .. }) => "parse_error",
         Err(_) => "failed",
         Ok(_)
@@ -1256,10 +1266,12 @@ impl TaskRunner {
             // to retry the same rate-limited agent immediately.
             //
             // Detection: classify_run_error_type() confirms "rate limit" in last_error.
-            // We detect rate limits from the last_error text (consistent with the
-            // classify_run_error_type() pattern used in record_metrics).
-            let has_rate_limit_error =
-                last_error.contains("rate limit") || last_error.contains("usage limit");
+            // Reuse the same classifier as `is_rate_limit_error` above rather than a raw
+            // substring check — billing-cycle exhaustion messages (e.g. Kimi's "usage
+            // limit for this billing cycle") also contain "usage limit"/"rate limit", so
+            // a bare substring check would record a rate-limit event into the router's
+            // health signal for a condition that isn't a genuine rate limit (issue #3529).
+            let has_rate_limit_error = classify_run_error_type(&last_error) == "rate_limit";
             if has_rate_limit_error {
                 // Record in the metrics store so the router's health check detects it.
                 if let Some(ref store) = self.store {
@@ -2001,6 +2013,65 @@ mod tests {
         let parse_result = ok_parse_result("fix_deployed");
         assert_eq!(
             classify_run_outcome("fix_deployed", &parse_result, false),
+            "failed"
+        );
+    }
+
+    #[test]
+    fn classify_run_outcome_kimi_billing_cycle_is_not_rate_limit() {
+        // Regression test for issue #3529: Kimi's exact billing-cycle exhaustion
+        // message was stored as outcome="rate_limit" because the generic "usage
+        // limit" pattern in detect_rate_limit() matched before credit-exhaustion
+        // detection ever ran. The outcome must reflect the actual failure mode.
+        let parse_result: Result<agents::ParsedResponse, agents::AgentError> =
+            Err(agents::AgentError::RateLimit {
+                message: "Failed to authenticate. API Error: 403 You've reached your usage \
+                          limit for this billing cycle. Your quota will be refreshed soon."
+                    .to_string(),
+            });
+        assert_eq!(
+            classify_run_outcome("needs_review", &parse_result, false),
+            "billing_cycle_exhausted"
+        );
+    }
+
+    #[test]
+    fn classify_run_outcome_generic_rate_limit_is_unaffected() {
+        // A genuine rate limit (no billing-cycle/credit-exhaustion markers) must
+        // still classify as "rate_limit".
+        let parse_result: Result<agents::ParsedResponse, agents::AgentError> =
+            Err(agents::AgentError::RateLimit {
+                message: "429 Too Many Requests".to_string(),
+            });
+        assert_eq!(
+            classify_run_outcome("needs_review", &parse_result, false),
+            "rate_limit"
+        );
+    }
+
+    #[test]
+    fn classify_run_outcome_auth_billing_cycle_is_not_failed() {
+        // Auth-classified billing-cycle exhaustion (e.g. "billing cycle exhausted"
+        // matches detect_auth_error's pattern list) must also be distinguished from
+        // a generic auth failure.
+        let parse_result: Result<agents::ParsedResponse, agents::AgentError> =
+            Err(agents::AgentError::Auth {
+                message: "billing cycle exhausted for this account".to_string(),
+            });
+        assert_eq!(
+            classify_run_outcome("needs_review", &parse_result, false),
+            "billing_cycle_exhausted"
+        );
+    }
+
+    #[test]
+    fn classify_run_outcome_generic_auth_error_is_unaffected() {
+        let parse_result: Result<agents::ParsedResponse, agents::AgentError> =
+            Err(agents::AgentError::Auth {
+                message: "401 Unauthorized".to_string(),
+            });
+        assert_eq!(
+            classify_run_outcome("needs_review", &parse_result, false),
             "failed"
         );
     }

--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -243,15 +243,26 @@ fn classify_failure(error: &str, outcome: &str) -> FailureCategory {
         return FailureCategory::Timeout;
     }
 
-    if outcome == "rate_limit" || lower.contains("rate limit") || lower.contains("usage limit") {
-        return FailureCategory::RateLimit;
-    }
-
     // Credit exhaustion is a transient condition (credits replenish, billing cycles
     // reset). Classifying it as recoverable allows auto-unblock to retry once the
     // credit-related cooldown expires, instead of permanently blocking the task.
-    if crate::engine::cooldown::detect_credit_exhaustion(&lower).is_some() {
+    //
+    // Checked before the generic rate-limit branch below: billing-cycle exhaustion
+    // messages (e.g. Kimi's "usage limit for this billing cycle") also contain
+    // "usage limit"/"rate limit" substrings, so checking outcome/content-based
+    // rate-limit patterns first would misclassify them as plain RateLimit (issue
+    // #3529). `outcome` also carries the specific string from `classify_run_outcome`
+    // when the task_run already recorded it.
+    if outcome == "billing_cycle_exhausted"
+        || outcome == "credit_exhausted"
+        || outcome == "org_level_disabled"
+        || crate::engine::cooldown::detect_credit_exhaustion(&lower).is_some()
+    {
         return FailureCategory::CreditExhausted;
+    }
+
+    if outcome == "rate_limit" || lower.contains("rate limit") || lower.contains("usage limit") {
+        return FailureCategory::RateLimit;
     }
 
     if error.trim().is_empty() {
@@ -4535,6 +4546,45 @@ mod tests {
             category.is_recoverable(),
             "ModelUnavailable must be recoverable so auto-unblock can re-route"
         );
+    }
+
+    // ── classify_failure: CreditExhausted (billing cycle) ──────────────
+    #[serial(cooldown_state)]
+    #[test]
+    fn classify_failure_kimi_billing_cycle_is_credit_exhausted_not_rate_limit() {
+        // Regression test for issue #3529: Kimi's billing-cycle exhaustion message
+        // contains "usage limit", which also matches the generic rate-limit content
+        // check. Credit exhaustion must be checked first so the failure is
+        // categorized as CreditExhausted, not RateLimit, even when the stored
+        // outcome is still "rate_limit" (e.g. from a task_run recorded before this
+        // fix landed).
+        let error = "kimi rate limit: Failed to authenticate. API Error: 403 You've reached \
+                      your usage limit for this billing cycle. Your quota will be refreshed soon.";
+        let category = classify_failure(error, "rate_limit");
+        assert_eq!(
+            category,
+            FailureCategory::CreditExhausted,
+            "billing-cycle exhaustion must classify as CreditExhausted, not RateLimit"
+        );
+        assert!(category.is_recoverable());
+    }
+
+    #[serial(cooldown_state)]
+    #[test]
+    fn classify_failure_billing_cycle_exhausted_outcome_is_credit_exhausted() {
+        // New task_runs store the specific "billing_cycle_exhausted" outcome
+        // (post-fix). classify_failure must recognize it directly too.
+        let category = classify_failure("some billing message", "billing_cycle_exhausted");
+        assert_eq!(category, FailureCategory::CreditExhausted);
+    }
+
+    #[serial(cooldown_state)]
+    #[test]
+    fn classify_failure_generic_rate_limit_is_still_rate_limit() {
+        // Genuine rate limits (no billing-cycle/credit-exhaustion markers) must
+        // remain RateLimit, not be swallowed by the reordered credit-exhaustion check.
+        let category = classify_failure("429 Too Many Requests", "rate_limit");
+        assert_eq!(category, FailureCategory::RateLimit);
     }
 
     // ── classify_failure: PrCreateFailed ──────────────────────────────


### PR DESCRIPTION
## Summary

Fixed Kimi (and other agents') billing-cycle exhaustion being misclassified as a plain rate_limit outcome. classify_run_outcome (runner) and outcome_for_agent_error (review) now consult the existing generic detect_credit_exhaustion detector before falling back to rate_limit/failed/auth_error, and sync.rs::classify_failure checks credit exhaustion before its generic rate-limit content match. Also fixed a duplicate raw substring check in runner/mod.rs that fed the router's rate-limit health signal, replacing it with the already-correct classify_run_error_type() classifier used just above it.

### What was done

- Added CreditExhaustionReason::outcome_str() and detect_credit_exhaustion_outcome() helper in cooldown.rs mapping credit-exhaustion reasons to task_runs.outcome strings (billing_cycle_exhausted, credit_exhausted, org_level_disabled)
- Updated classify_run_outcome() in runner/mod.rs to consult credit-exhaustion detection for RateLimit/Auth variants before falling back to rate_limit/failed
- Updated outcome_for_agent_error() in review.rs (review-run analog of classify_run_outcome) with the same fix
- Reordered sync.rs::classify_failure() to check credit exhaustion (via outcome string or message content) before the generic rate_limit/usage_limit substring match
- Fixed has_rate_limit_error in runner/mod.rs's needs_review branch to reuse classify_run_error_type() instead of a raw substring check, so billing-cycle exhaustion no longer pollutes the router's rate-limit health signal (recent_rate_limit_counts)
- Added regression tests using the exact Kimi error message shape from the bug report, plus tests confirming genuine rate_limit/auth errors are unaffected
- Ran cargo fmt, cargo clippy --all-targets -D warnings, and the full cargo nextest suite (3914 tests) — all pass


### Files changed

- `src/engine/cooldown.rs`
- `src/engine/review.rs`
- `src/engine/runner/mod.rs`
- `src/engine/sync.rs`


Closes #3529

---
*Task #3529 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*