### PR TITLE
bug(runner): opencode "not available in your country" misclassified as AgentFailed, not ModelUnavailable

### DIFF
--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -672,11 +672,14 @@ fn classify_opencode_message(message: &str) -> AgentError {
     //   "The free model has been deprecated. Transition to qwen/qwen3.6-plus for continued paid access."
     //   "No endpoints found for qwen/qwen3.6-plus:free."
     //   "This model is unavailable for free. The paid version is available now - use this slug instead: X"
+    //   "This model is not available in your country."
     let is_model_unavailable = (lower.contains("model")
         && (lower.contains("not found")
             || lower.contains("not supported")
             || lower.contains("deprecated")
-            || lower.contains("unavailable for free")))
+            || lower.contains("unavailable for free")
+            || lower.contains("not available in your country")
+            || lower.contains("not available in your region")))
         || lower.contains("no endpoints found");
 
     if is_model_unavailable {
@@ -1406,6 +1409,20 @@ mod tests {
                     "expected model extracted from 'use this slug instead: X', got: {model:?}"
                 );
             }
+            other => panic!("expected ModelUnavailable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_opencode_model_not_available_in_country() {
+        // Issue #3535: "This model is not available in your country." must classify as
+        // ModelUnavailable (persistent per-model cooldown), not fall through to the
+        // generic AgentFailed bucket which applies a weaker cooldown plus an
+        // unwarranted agent-wide penalty.
+        let err =
+            classify_opencode_message("agent failed: This model is not available in your country.");
+        match err {
+            AgentError::ModelUnavailable { .. } => {}
             other => panic!("expected ModelUnavailable, got: {other:?}"),
         }
     }


### PR DESCRIPTION
## Summary

Extended classify_opencode_message() to classify "not available in your country" / "not available in your region" as AgentError::ModelUnavailable instead of the generic AgentFailed fallback, so it gets the persistent per-model cooldown without penalizing the whole opencode agent.

### What was done

- Extended the is_model_unavailable check in src/engine/runner/agents/opencode.rs to also match "not available in your country" and "not available in your region" phrasing
- Added regression test classify_opencode_model_not_available_in_country using the exact message from the issue
- Verified cargo fmt -- --check and cargo clippy --all-targets -- -D warnings pass clean
- Ran cargo test --lib classify_opencode and cargo nextest run classify_opencode — all 10 tests pass, including the new one
- Committed the fix


### Files changed

- `src/engine/runner/agents/opencode.rs`


Closes #3535

---
*Task #3535 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*