### PR TITLE
bug(runner): claude/kimi mid-stream disconnect messages misclassified as AgentFailed, not NetworkError

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -1421,6 +1421,9 @@ pub(crate) mod patterns {
             "upstream idle timeout",
             "streaming response failed",
             "upstream request failed",
+            // Provider-side mid-stream disconnects (e.g. kimi/claude API errors)
+            "stalled mid-stream",
+            "connection closed mid-response",
         ];
         // Map the byte offset from `lower` back to `text` via char-count (same
         // rationale as detect_rate_limit: Unicode case-folding can change byte lengths).
@@ -2530,6 +2533,34 @@ mod tests {
         assert!(
             matches!(err, AgentError::NetworkError { .. }),
             "ECONNRESET must be NetworkError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_from_text_detects_stalled_mid_stream() {
+        // Regression test for issue #3541: kimi's "Response stalled mid-stream" must be
+        // classified as NetworkError, not Unknown/AgentFailed.
+        let err = patterns::classify_from_text(
+            1,
+            "API Error: Response stalled mid-stream. The response above may be incomplete.",
+        );
+        assert!(
+            matches!(err, AgentError::NetworkError { .. }),
+            "stalled mid-stream must be NetworkError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_from_text_detects_connection_closed_mid_response() {
+        // Regression test for issue #3541: claude's "Connection closed mid-response" must be
+        // classified as NetworkError, not Unknown/AgentFailed.
+        let err = patterns::classify_from_text(
+            1,
+            "API Error: Connection closed mid-response. The response above may be incomplete.",
+        );
+        assert!(
+            matches!(err, AgentError::NetworkError { .. }),
+            "connection closed mid-response must be NetworkError, got: {err:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Added "stalled mid-stream" and "connection closed mid-response" to detect_network_error() so kimi/claude mid-stream provider disconnects are classified as NetworkError (lighter same-agent retry) instead of falling through to AgentFailed/Unknown (full agent-wide exponential cooldown).

### What was done

- Added two new substring patterns to the patterns list in detect_network_error() (src/engine/runner/agents/mod.rs:1420-1423): "stalled mid-stream" and "connection closed mid-response", matching the exact wording from the kimi and claude API error messages reported in the issue
- Added regression test classify_from_text_detects_stalled_mid_stream covering the exact kimi message: "API Error: Response stalled mid-stream. The response above may be incomplete."
- Added regression test classify_from_text_detects_connection_closed_mid_response covering the exact claude message: "API Error: Connection closed mid-response. The response above may be incomplete."
- Verified cargo fmt -- --check passes with no diffs
- Verified cargo clippy --all-targets -- -D warnings passes with zero warnings
- Ran full cargo nextest run: 3928 tests passed, 19 skipped, including the 2 new regression tests and all 7 existing classify_from_text_detects_* tests


### Files changed

- `src/engine/runner/agents/mod.rs`


Closes #3541

---
*Task #3541 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*