### PR TITLE
bug(engine): watchdog suspend-gap check races the main loop's checkpoint(), false WATCHDOG ERRORs still fire after #3491

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1979,8 +1979,14 @@ pub async fn serve() -> anyhow::Result<()> {
         tokio::spawn(async move {
             // Check every 30s whether the main loop is still ticking.
             let mut watchdog_interval = tokio::time::interval(std::time::Duration::from_secs(30));
+            // Own suspend baseline, independent of the main loop's checkpoint(). The
+            // watchdog's interval timer also freezes during a host suspend, so this
+            // detects the gap from its own wake-up instead of racing the main loop's
+            // checkpoint() for the same GAP_LOG entry (see #3544).
+            let mut suspend_detector = crate::engine::suspend::SuspendDetector::new();
             loop {
                 watchdog_interval.tick().await;
+                let own_gap = suspend_detector.check();
                 let last = last_tick_epoch.load(std::sync::atomic::Ordering::Relaxed);
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
@@ -1992,10 +1998,20 @@ pub async fn serve() -> anyhow::Result<()> {
                 if stale_secs > threshold {
                     // A host suspend/resume gap fully explains a stale window that
                     // isn't an actual stall — the process (and its timers) were
-                    // simply not scheduled while the host was asleep.
-                    if let Some(gap) = crate::engine::suspend::gap_detected_within(
+                    // simply not scheduled while the host was asleep. Prefer this
+                    // watchdog's own detector (immune to the checkpoint race above);
+                    // fall back to the shared log in case the main loop's checkpoint()
+                    // already ran and recorded a larger gap.
+                    let shared_gap = crate::engine::suspend::gap_detected_within(
                         std::time::Duration::from_secs(stale_secs),
-                    ) {
+                    );
+                    let gap = match (own_gap, shared_gap) {
+                        (Some(a), Some(b)) => Some(a.max(b)),
+                        (Some(a), None) => Some(a),
+                        (None, Some(b)) => Some(b),
+                        (None, None) => None,
+                    };
+                    if let Some(gap) = gap {
                         let gap_secs = gap.num_seconds() as u64;
                         if gap_secs >= stale_secs {
                             tracing::info!(

--- a/src/engine/suspend.rs
+++ b/src/engine/suspend.rs
@@ -6,9 +6,12 @@
 //! (the watchdog in `engine::mod`) or a hung agent (`stuck_task_timing_from_map` in
 //! `engine::tick`).
 //!
-//! `checkpoint()` is the single detection point, called once per main tick loop
-//! iteration. Both consumers pull from the resulting gap log instead of re-deriving
-//! suspend information from their own wall-clock deltas.
+//! `checkpoint()` is the primary detection point, called once per main tick loop
+//! iteration; `suspended_duration_since` pulls from its gap log instead of re-deriving
+//! suspend information from its own wall-clock deltas. Callers that run on an
+//! independent timer and can't wait for the main loop's checkpoint (e.g. the tick
+//! watchdog, which would otherwise race it on wake from suspend) should use their own
+//! `SuspendDetector` instance instead.
 
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use std::sync::Mutex;
@@ -33,6 +36,24 @@ struct Checkpoint {
     wall: DateTime<Utc>,
 }
 
+/// Compare a previous checkpoint against now and return the suspend gap, if the
+/// wall-clock-minus-monotonic delta clears `SUSPEND_GAP_THRESHOLD`. Shared by the
+/// global checkpoint log and by independent `SuspendDetector` instances so both use
+/// identical detection math.
+fn gap_since(
+    prev: &Checkpoint,
+    now_instant: Instant,
+    now_wall: DateTime<Utc>,
+) -> Option<ChronoDuration> {
+    let monotonic_elapsed = now_instant.saturating_duration_since(prev.instant);
+    let wall_elapsed = (now_wall - prev.wall).to_std().unwrap_or_default();
+    let gap = wall_elapsed.saturating_sub(monotonic_elapsed);
+    if gap < SUSPEND_GAP_THRESHOLD {
+        return None;
+    }
+    Some(ChronoDuration::from_std(gap).unwrap_or_else(|_| ChronoDuration::zero()))
+}
+
 static LAST_CHECKPOINT: Mutex<Option<Checkpoint>> = Mutex::new(None);
 static GAP_LOG: Mutex<Vec<GapRecord>> = Mutex::new(Vec::new());
 
@@ -50,15 +71,8 @@ pub fn checkpoint() -> Option<ChronoDuration> {
         })
     };
     let prev = prev?;
+    let gap = gap_since(&prev, now_instant, now_wall)?;
 
-    let monotonic_elapsed = now_instant.saturating_duration_since(prev.instant);
-    let wall_elapsed = (now_wall - prev.wall).to_std().unwrap_or_default();
-    let gap = wall_elapsed.saturating_sub(monotonic_elapsed);
-    if gap < SUSPEND_GAP_THRESHOLD {
-        return None;
-    }
-
-    let gap = ChronoDuration::from_std(gap).unwrap_or_else(|_| ChronoDuration::zero());
     let mut log = GAP_LOG.lock().unwrap_or_else(|e| e.into_inner());
     log.push(GapRecord {
         detected_at: now_wall,
@@ -69,6 +83,42 @@ pub fn checkpoint() -> Option<ChronoDuration> {
         log.drain(0..excess);
     }
     Some(gap)
+}
+
+/// Independent suspend detector for callers that run on their own timer and can't
+/// rely on the shared `checkpoint()`/`GAP_LOG` pair, which is only written by the
+/// main tick loop. Two independently-scheduled tokio tasks that both freeze during a
+/// host suspend become "due" at roughly the same instant on wake with no ordering
+/// guarantee between them — a caller reading `GAP_LOG` right after wake can race the
+/// main loop's own `checkpoint()` call and observe no gap yet. A `SuspendDetector`
+/// avoids the race by tracking its own Instant/wall-clock baseline, so it detects the
+/// gap from its own frozen timer instead of waiting on another task to record it.
+pub struct SuspendDetector {
+    last: Option<Checkpoint>,
+}
+
+impl SuspendDetector {
+    pub fn new() -> Self {
+        Self { last: None }
+    }
+
+    /// Record a checkpoint on this detector and return the suspend gap (if any)
+    /// detected since the previous call.
+    pub fn check(&mut self) -> Option<ChronoDuration> {
+        let now_instant = Instant::now();
+        let now_wall = Utc::now();
+        let prev = self.last.replace(Checkpoint {
+            instant: now_instant,
+            wall: now_wall,
+        })?;
+        gap_since(&prev, now_instant, now_wall)
+    }
+}
+
+impl Default for SuspendDetector {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Total suspend time detected since `since`. Subtract this from a wall-clock age
@@ -137,6 +187,20 @@ mod tests {
         assert_eq!(total, ChronoDuration::zero());
 
         clear_for_test();
+    }
+
+    #[test]
+    fn suspend_detector_first_check_has_no_baseline() {
+        let mut detector = SuspendDetector::new();
+        assert_eq!(detector.check(), None);
+    }
+
+    #[test]
+    fn suspend_detector_reports_no_gap_for_normal_elapsed_time() {
+        let mut detector = SuspendDetector::new();
+        detector.check();
+        std::thread::sleep(Duration::from_millis(10));
+        assert_eq!(detector.check(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix already committed and verified: watchdog now uses its own independent SuspendDetector baseline instead of racing the main loop's checkpoint()-written GAP_LOG, closing the false WATCHDOG ERROR gap from #3544.

### Files changed

- `src/engine/mod.rs`
- `src/engine/suspend.rs`


Closes #3544

---
*Task #3544 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*