### PR TITLE
bug(store): task_metrics/task_runs/task_activity time-window queries over-count by up to ~2x due to RFC3339 vs SQLite datetime() string-comparison mismatch

### DIFF
--- a/prompts/jobs/agent-debugger.md
+++ b/prompts/jobs/agent-debugger.md
@@ -14,13 +14,13 @@ Read `./prompts/skills/orch/SKILL.md` first — it contains the repo-tracked ope
 
 1. Check recent task run logs for failures:
    ```
-    sqlite3 ~/.orch/orch.db "SELECT id, external_id, status, agent, model, last_error, block_reason, updated_at FROM tasks WHERE status IN ('blocked', 'needs_review') AND updated_at > datetime('now', '-12 hours') ORDER BY updated_at DESC LIMIT 20;"
+    sqlite3 ~/.orch/orch.db "SELECT id, external_id, status, agent, model, last_error, block_reason, updated_at FROM tasks WHERE status IN ('blocked', 'needs_review') AND datetime(updated_at) > datetime('now', '-12 hours') ORDER BY updated_at DESC LIMIT 20;"
    ```
 2. Check recent task run audit trails:
    ```
-   sqlite3 ~/.orch/orch.db "SELECT agent, model, outcome, COUNT(*) AS count FROM task_runs WHERE started_at > datetime('now', '-12 hours') AND outcome != 'success' GROUP BY agent, model, outcome ORDER BY count DESC;"
-   sqlite3 ~/.orch/orch.db "SELECT agent, started_at, error FROM task_runs WHERE outcome = 'rate_limit' AND started_at > datetime('now', '-24 hours') ORDER BY started_at;"
-   sqlite3 ~/.orch/orch.db "SELECT agent, outcome, SUM(total_cost_usd) AS total_cost, COUNT(*) AS runs FROM task_runs WHERE started_at > datetime('now', '-24 hours') GROUP BY agent, outcome;"
+   sqlite3 ~/.orch/orch.db "SELECT agent, model, outcome, COUNT(*) AS count FROM task_runs WHERE datetime(started_at) > datetime('now', '-12 hours') AND outcome != 'success' GROUP BY agent, model, outcome ORDER BY count DESC;"
+   sqlite3 ~/.orch/orch.db "SELECT agent, started_at, error FROM task_runs WHERE outcome = 'rate_limit' AND datetime(started_at) > datetime('now', '-24 hours') ORDER BY started_at;"
+   sqlite3 ~/.orch/orch.db "SELECT agent, outcome, SUM(total_cost_usd) AS total_cost, COUNT(*) AS runs FROM task_runs WHERE datetime(started_at) > datetime('now', '-24 hours') GROUP BY agent, outcome;"
    ```
 3. Read the service log for errors:
    ```

--- a/prompts/jobs/daily-review.md
+++ b/prompts/jobs/daily-review.md
@@ -19,8 +19,8 @@ End-of-day review covering the last 24 hours. Your ONLY output is a summary post
 
 1. Which tasks completed? What went well?
 2. Which tasks failed or needed retries? Why?
-3. Task/agent/model failure patterns: `sqlite3 ~/.orch/orch.db "SELECT agent, model, outcome, COUNT(*) FROM task_runs WHERE started_at > datetime('now', '-24 hours') GROUP BY agent, model, outcome ORDER BY COUNT(*) DESC;"`
-4. If `task_activity` exists: `sqlite3 ~/.orch/orch.db "SELECT event_type, COUNT(*) FROM task_activity WHERE timestamp > datetime('now', '-24 hours') GROUP BY event_type ORDER BY COUNT(*) DESC;" 2>/dev/null`
+3. Task/agent/model failure patterns: `sqlite3 ~/.orch/orch.db "SELECT agent, model, outcome, COUNT(*) FROM task_runs WHERE datetime(started_at) > datetime('now', '-24 hours') GROUP BY agent, model, outcome ORDER BY COUNT(*) DESC;"`
+4. If `task_activity` exists: `sqlite3 ~/.orch/orch.db "SELECT event_type, COUNT(*) FROM task_activity WHERE datetime(timestamp) > datetime('now', '-24 hours') GROUP BY event_type ORDER BY COUNT(*) DESC;" 2>/dev/null`
 5. Error patterns in `orch log 200`.
 6. Is routing accurate? Any models failing silently? Any agents repeatedly cooled?
 7. Are agent prompts effective or do they need tuning?

--- a/prompts/skills/orch/SKILL.md
+++ b/prompts/skills/orch/SKILL.md
@@ -23,7 +23,7 @@ Start with observation, not intervention:
 ```bash
 orch task list --global
 orch log 100
-sqlite3 ~/.orch/orch.db "SELECT agent, model, outcome, COUNT(*) FROM task_runs WHERE started_at > datetime('now', '-24 hours') GROUP BY agent, model, outcome ORDER BY COUNT(*) DESC;"
+sqlite3 ~/.orch/orch.db "SELECT agent, model, outcome, COUNT(*) FROM task_runs WHERE datetime(started_at) > datetime('now', '-24 hours') GROUP BY agent, model, outcome ORDER BY COUNT(*) DESC;"
 ```
 
 When a specific task needs inspection:

--- a/src/store/metrics.rs
+++ b/src/store/metrics.rs
@@ -161,9 +161,11 @@ impl TaskStore {
     pub async fn insert_task_metric(&self, metric: &InsertTaskMetric<'_>) -> anyhow::Result<i64> {
         let mut tx = self.pool.begin().await?;
 
-        sqlx::query("DELETE FROM task_metrics WHERE completed_at < datetime('now', '-90 days')")
-            .execute(&mut *tx)
-            .await?;
+        sqlx::query(
+            "DELETE FROM task_metrics WHERE datetime(completed_at) < datetime('now', '-90 days')",
+        )
+        .execute(&mut *tx)
+        .await?;
 
         let row = sqlx::query(
         "INSERT INTO task_metrics (repo, task_id, agent, model, complexity, outcome, duration_seconds,
@@ -211,7 +213,7 @@ impl TaskStore {
                 AVG(CASE WHEN complexity = 'medium' THEN duration_seconds END) AS avg_medium,
                 AVG(CASE WHEN complexity = 'complex' THEN duration_seconds END) AS avg_complex
              FROM task_metrics
-             WHERE completed_at >= datetime('now', ?)",
+             WHERE datetime(completed_at) >= datetime('now', ?)",
         )
         .bind(&interval)
         .fetch_one(&self.pool)
@@ -228,7 +230,7 @@ impl TaskStore {
             "SELECT agent, COUNT(*) as total,
                 COALESCE(SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END), 0) as success_count
              FROM task_metrics
-             WHERE completed_at >= datetime('now', ?)
+             WHERE datetime(completed_at) >= datetime('now', ?)
              GROUP BY agent",
         )
         .bind(&interval)
@@ -301,7 +303,7 @@ impl TaskStore {
                     OR (m.task_id = t.external_id AND NOT EXISTS (
                         SELECT 1 FROM tasks t2 WHERE t2.id = CAST(m.task_id AS INTEGER) AND t2.repo = t.repo
                     ))
-                WHERE m.completed_at >= datetime('now', ?)
+                WHERE datetime(m.completed_at) >= datetime('now', ?)
             )
             SELECT
                 COALESCE(SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END), 0) AS completed,
@@ -332,7 +334,7 @@ impl TaskStore {
                  OR (m.task_id = t.external_id AND NOT EXISTS (
                      SELECT 1 FROM tasks t2 WHERE t2.id = CAST(m.task_id AS INTEGER) AND t2.repo = t.repo
                  ))
-             WHERE m.completed_at >= datetime('now', ?)
+             WHERE datetime(m.completed_at) >= datetime('now', ?)
              AND COALESCE(NULLIF(m.repo, ''), t.repo) = ?
              GROUP BY m.agent",
         )
@@ -414,7 +416,7 @@ impl TaskStore {
              OR (m.task_id = t.external_id AND NOT EXISTS (
                  SELECT 1 FROM tasks t2 WHERE t2.id = CAST(m.task_id AS INTEGER) AND t2.repo = t.repo
              ))
-         WHERE m.completed_at >= datetime('now', ?)
+         WHERE datetime(m.completed_at) >= datetime('now', ?)
          AND COALESCE(NULLIF(m.repo, ''), t.repo) = ?",
         )
         .bind(&interval)
@@ -507,7 +509,7 @@ impl TaskStore {
         let rows = sqlx::query(
             "SELECT task_id, agent, complexity, duration_seconds
          FROM task_metrics
-         WHERE completed_at >= datetime('now', ?) AND outcome = 'success'
+         WHERE datetime(completed_at) >= datetime('now', ?) AND outcome = 'success'
          ORDER BY duration_seconds DESC
          LIMIT 10",
         )
@@ -535,7 +537,7 @@ impl TaskStore {
         let rows = sqlx::query(
             "SELECT task_id, agent, complexity, duration_seconds
          FROM task_metrics
-         WHERE completed_at >= datetime('now', '-7 days') AND outcome = 'success'
+         WHERE datetime(completed_at) >= datetime('now', '-7 days') AND outcome = 'success'
          ORDER BY duration_seconds DESC
          LIMIT 10",
         )
@@ -561,7 +563,7 @@ impl TaskStore {
         let rows = sqlx::query(
             "SELECT error_type, COUNT(*) as count
          FROM task_metrics
-         WHERE completed_at >= datetime('now', ?)
+         WHERE datetime(completed_at) >= datetime('now', ?)
            AND outcome != 'success'
            AND error_type IS NOT NULL
          GROUP BY error_type
@@ -597,7 +599,7 @@ impl TaskStore {
                     COALESCE(SUM(total_cost_usd), 0.0) as total_cost_usd,
                     COUNT(*) as task_count
              FROM task_metrics
-             WHERE completed_at >= datetime('now', '-24 hours')",
+             WHERE datetime(completed_at) >= datetime('now', '-24 hours')",
                 "24h",
             ),
             (
@@ -608,7 +610,7 @@ impl TaskStore {
                     COALESCE(SUM(total_cost_usd), 0.0) as total_cost_usd,
                     COUNT(*) as task_count
              FROM task_metrics
-             WHERE completed_at >= datetime('now', '-7 days')",
+             WHERE datetime(completed_at) >= datetime('now', '-7 days')",
                 "7d",
             ),
             (
@@ -619,7 +621,7 @@ impl TaskStore {
                     COALESCE(SUM(total_cost_usd), 0.0) as total_cost_usd,
                     COUNT(*) as task_count
              FROM task_metrics
-             WHERE completed_at >= datetime('now', '-30 days')",
+             WHERE datetime(completed_at) >= datetime('now', '-30 days')",
                 "30d",
             ),
         ];
@@ -729,7 +731,7 @@ impl TaskStore {
             "SELECT external_id, agent, review_cycles, title
          FROM tasks
          WHERE review_cycles >= 2
-           AND updated_at >= datetime('now', ?)
+           AND datetime(updated_at) >= datetime('now', ?)
          ORDER BY review_cycles DESC
          LIMIT 10",
         )
@@ -758,7 +760,7 @@ impl TaskStore {
             "SELECT external_id, agent, review_cycles, title
          FROM tasks
          WHERE review_cycles >= 2
-           AND updated_at >= datetime('now', '-7 days')
+           AND datetime(updated_at) >= datetime('now', '-7 days')
          ORDER BY review_cycles DESC
          LIMIT 10",
         )

--- a/src/store/tests.rs
+++ b/src/store/tests.rs
@@ -4503,6 +4503,60 @@ async fn metrics_summary_counts_success_and_failure() {
 }
 
 #[tokio::test]
+async fn metrics_summary_excludes_rows_before_cutoff_on_same_calendar_day() {
+    let store = TaskStore::open_memory().await.unwrap();
+
+    // `completed_at` is stored as RFC3339 ('T' separator) but SQLite's
+    // `datetime('now', '-24 hours')` produces a space-separated string. 'T' (0x54)
+    // sorts after ' ' (0x20), so a plain string `>=` comparison used to treat any
+    // row sharing the cutoff's calendar day as "within the window" regardless of
+    // its actual time-of-day. Midnight of the cutoff's own day is unambiguously
+    // >=24h in the past yet shares that day's date with the cutoff, so it
+    // reproduces the bug deterministically without depending on wall-clock timing.
+    let cutoff_str: String = sqlx::query_scalar("SELECT datetime('now', '-24 hours')")
+        .fetch_one(&store.pool)
+        .await
+        .unwrap();
+    let cutoff_date = &cutoff_str[..10];
+
+    let midnight = chrono::NaiveDateTime::parse_from_str(
+        &format!("{cutoff_date} 00:00:01"),
+        "%Y-%m-%d %H:%M:%S",
+    )
+    .unwrap()
+    .and_utc();
+
+    store
+        .insert_task_metric(&InsertTaskMetric {
+            repo: "",
+            task_id: "old",
+            agent: "claude",
+            model: None,
+            complexity: None,
+            outcome: "success",
+            duration_seconds: 10.0,
+            started_at: &midnight,
+            completed_at: &midnight,
+            attempts: 1,
+            files_changed: 0,
+            error_type: None,
+            input_tokens: None,
+            output_tokens: None,
+            input_cost_usd: None,
+            output_cost_usd: None,
+            total_cost_usd: None,
+        })
+        .await
+        .unwrap();
+
+    let summary = store.get_metrics_summary(24).await.unwrap();
+    assert_eq!(
+        summary.tasks_completed_24h, 0,
+        "a row from midnight of the cutoff's calendar day is >=24h old and must not be counted"
+    );
+}
+
+#[tokio::test]
 async fn cost_summary_returns_correct_periods() {
     let store = TaskStore::open_memory().await.unwrap();
     let summary = store.get_cost_summary().await.unwrap();


### PR DESCRIPTION
## Summary

Fixed the RFC3339-vs-SQLite datetime() string-comparison bug in src/store/metrics.rs that caused all 'last N hours/days' window queries against RFC3339-stored columns (task_metrics.completed_at, tasks.updated_at) to over-count by up to ~2x. Wrapped every affected column reference in datetime(...) so both sides of the comparison are normalized before comparing. Also fixed the same bug in the ad-hoc runbook queries used by prompts/jobs/agent-debugger.md, prompts/jobs/daily-review.md, and prompts/skills/orch/SKILL.md, and added a regression test.

### What was done

- Wrapped completed_at/updated_at column references in datetime(...) at all 13 affected call sites in src/store/metrics.rs (get_metrics_summary, get_metrics_summary_by_repo, insert_task_metric's 90-day retention delete, slow_tasks, get_cost_summary, error breakdown queries, high review-cycle queries)
- Confirmed rate_limits.occurred_at comparisons were correctly left unchanged since that column is written via SQLite-native datetime('now') and isn't affected by the bug
- Fixed matching ad-hoc SQL in prompts/jobs/agent-debugger.md, prompts/jobs/daily-review.md, and prompts/skills/orch/SKILL.md
- Added regression test metrics_summary_excludes_rows_before_cutoff_on_same_calendar_day in src/store/tests.rs that deterministically reproduces the bug using a midnight timestamp on the cutoff's calendar day
- Verified cargo fmt --check, cargo clippy --all-targets -- -D warnings, and cargo nextest run (store module, 247/247 tests) all pass
- Confirmed clean git status and commit a29eca23 present ahead of origin/main


### Files changed

- `src/store/metrics.rs`
- `src/store/tests.rs`
- `prompts/jobs/agent-debugger.md`
- `prompts/jobs/daily-review.md`
- `prompts/skills/orch/SKILL.md`


Closes #3548

---
*Task #3548 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*