### PR TITLE
bug(review-prompt): pending CI status prose still causes review parse errors

### DIFF
--- a/prompts/review_task.md
+++ b/prompts/review_task.md
@@ -58,6 +58,8 @@ IF required checks are NOT RUN or PENDING:
   → treat local results the same as "required checks PASS" or "FAIL" above
 ```
 
+Pending CI is never a terminal review state. Do not end your turn reporting that CI is still running or that you'll wait for a notification — the `--watch` command in this step already blocks in the foreground until CI settles or the timeout is hit. If it's still PENDING or NOT RUN after that, immediately run the local-checks fallback above and finish the review in this same turn.
+
 **Definition of auto-fixable**: ONLY the following commands qualify as auto-fixable:
 - `cargo fmt` / `cargo clippy --fix`
 - `npm run lint -- --fix` / `eslint --fix` / `prettier --write`
@@ -111,6 +113,7 @@ Flag `request_changes` if the PR:
 You MUST output the JSON block below even if you already ran this review earlier.
 Do NOT respond with prose summaries.
 Your turn must not end with a background task still running. If you started any background command, wait for it to finish before producing your final answer.
+Never end your turn with a CI-waiting status update. If CI is still PENDING or NOT RUN after the required `--watch` command completes, run the fallback local checks from Step 2 and output the JSON decision below using those results — in the same turn.
 
 ```json
 {

--- a/src/engine/runner/agent.rs
+++ b/src/engine/runner/agent.rs
@@ -727,6 +727,35 @@ mod tests {
     }
 
     #[test]
+    fn review_prompt_forbids_ending_turn_on_pending_ci_status() {
+        // Regression test for #3453: a review agent must not stop with a
+        // prose "CI is still running" status update and leave the turn
+        // without JSON. The prompt must explicitly route PENDING/NOT RUN CI
+        // through the local-checks fallback and into the same-turn JSON output.
+        let task = crate::backends::ExternalTask {
+            id: crate::backends::ExternalId("155460".to_string()),
+            title: "test task".to_string(),
+            body: "test body".to_string(),
+            state: "open".to_string(),
+            labels: vec![],
+            author: "tester".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            url: "https://example.com/1".to_string(),
+        };
+        let prompt = build_review_prompt(&task, "", "", "", "main", 1);
+
+        assert!(
+            prompt.contains("Pending CI is never a terminal review state"),
+            "prompt must state pending CI is not terminal: {prompt}"
+        );
+        assert!(
+            prompt.contains("Never end your turn with a CI-waiting status update"),
+            "prompt must forbid ending the turn on a CI-waiting status update: {prompt}"
+        );
+    }
+
+    #[test]
     fn shell_single_quote_escapes_embedded_quotes() {
         use crate::engine::runner::agents::shell_single_quote;
 


### PR DESCRIPTION
## Summary

Now I'll apply the two prompt fixes described in the issue.
Now let's check for any existing prompt tests/fixtures for this file to see if a regression test is warranted.
Now let's check ExternalId to build a fixture.
Now I'll add a regression test asserting the rendered review prompt includes the pending-CI instruction and never-end-with-status-update language.
Now let's run the required checks: fmt, clippy, and the new test.
Formatting's clean. Now clippy and the new test.
Clean. Now let's run

### What was done

- Summary of fix (task #3453):**
- `prompts/review_task.md`: added explicit instructions after the `PENDING`/`NOT RUN` CI branch and in the Output Format section stating pending CI is never a terminal review state — the review agent must run local fallback checks and emit the JSON decision in the same turn, never end with a CI-waiting status update.
- `src/engine/runner/agent.rs`: added a regression test (`review_prompt_forbids_ending_turn_on_pending_ci_status`) asserting the rendered review prompt contains both new instructions.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (3948 tests) all pass.


### Files changed

- `prompts/review_task.md`
- `src/engine/runner/agent.rs`


Closes #3453

---
*Task #3453 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*