### PR TITLE
bug(sync): CI-failure-blocked tasks have no path to recovery when the CI failure cause is fixed upstream — polls PR state forever, never retriggers CI

### DIFF
--- a/src/engine/sync.rs
+++ b/src/engine/sync.rs
@@ -741,6 +741,29 @@ async fn try_unblock_ci_failure_task(
         return Ok(true);
     }
 
+    // Give the PR an active chance to recover instead of only re-polling its state:
+    // merge the base branch into the PR branch, which produces a new commit and
+    // re-triggers CI. This picks up any fix that landed on the base branch after
+    // the PR's last CI run failed (e.g. a transient toolchain/lint issue in
+    // pre-existing code that the PR never touched). Re-enable auto-merge so GitHub
+    // completes the merge on its own once the refreshed CI run passes — no further
+    // action needed from this sweep.
+    match gh.update_pr_branch(repo, pr_number as u64).await {
+        Ok(()) => {
+            tracing::info!(
+                task_id = task.id,
+                pr_number,
+                "updated CI-failure-blocked PR branch against base to retrigger CI"
+            );
+            if let Err(e) = gh.enable_auto_merge(repo, pr_number as u64).await {
+                tracing::debug!(task_id = task.id, pr_number, err = %e, "failed to re-enable auto-merge after branch update");
+            }
+        }
+        Err(e) => {
+            tracing::debug!(task_id = task.id, pr_number, err = %e, "failed to update CI-failure-blocked PR branch (may already be up to date)");
+        }
+    }
+
     let pr_state = pr.state.as_str();
     let new_reason = format!(
         "CI failure limit reached during auto-merge (PR #{} still open, state: {})",

--- a/src/github/http.rs
+++ b/src/github/http.rs
@@ -2250,6 +2250,35 @@ impl GhHttp {
         Ok(())
     }
 
+    /// Update a PR's branch by merging the latest base branch into it
+    /// (equivalent of the "Update branch" button on GitHub, or `gh pr
+    /// update-branch`). Produces a new merge commit on the head branch,
+    /// which re-triggers CI — used to give a PR a chance to pick up a fix
+    /// that landed on the base branch after the PR's last CI run failed.
+    pub async fn update_pr_branch(&self, repo: &str, pr_number: u64) -> anyhow::Result<()> {
+        Self::proactive_throttle_rest().await;
+        Self::check_backoff()?;
+        let url = format!("{GITHUB_API}/repos/{repo}/pulls/{pr_number}/update-branch");
+        let auth = self.auth_header().await?;
+        let make_req = || {
+            Ok(self
+                .client
+                .put(&url)
+                .header(header::AUTHORIZATION, auth.clone())
+                .header(header::ACCEPT, "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28"))
+        };
+        let resp = self.send_with_retries(make_req, false).await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            Self::maybe_record_rate_limit_from_body(status, &body);
+            anyhow::bail!("GitHub PR update-branch failed ({status}): {body}");
+        }
+        Self::record_success();
+        Ok(())
+    }
+
     /// Enable auto-merge on a PR via GraphQL.
     ///
     /// GitHub will automatically merge the PR once all required checks pass.


### PR DESCRIPTION
## Summary

Fixed the generic CI-failure-blocked recovery sweep so it gives blocked PRs a corrective action (update branch against base + re-enable auto-merge) instead of only re-polling PR state forever.

### What was done

- Added `GhHttp::update_pr_branch()` in src/github/http.rs, calling GitHub's PUT /repos/{repo}/pulls/{pr}/update-branch REST endpoint to merge the base branch into a PR's head branch, producing a new commit that re-triggers CI
- Updated `try_unblock_ci_failure_task()` in src/engine/sync.rs: when a CI-failure-blocked task's PR is still open, it now calls `update_pr_branch()` to pick up any fix that landed on the base branch since the PR's last (failing) CI run, then re-enables auto-merge so GitHub completes the merge on its own once CI passes — before falling back to the existing block_reason/cooldown bookkeeping
- Kept the fix fully generic (no clippy- or incident-specific special-casing) — it lives in the shared recovery sweep used by both the per-repo and cross-repo (global) CI-failure unblock paths
- Verified with cargo fmt --check, cargo clippy --all-targets -- -D warnings (no warnings), and cargo nextest run (all 3948 tests pass, including the existing ci_failure/global_ci_failure_sweep test suite)
- Committed the change locally (not pushed — orch handles push/PR)


### Files changed

- `src/engine/sync.rs`
- `src/github/http.rs`


Closes #3558

---
*Task #3558 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*