### PR TITLE
fix(runner): capture opencode models stderr for diagnostics

### DIFF
--- a/src/engine/runner/agents/opencode.rs
+++ b/src/engine/runner/agents/opencode.rs
@@ -917,7 +917,7 @@ async fn run_opencode_models_discovery_async() -> (Vec<String>, &'static str) {
     let mut child = match tokio::process::Command::new("opencode")
         .args(["models"])
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
         .spawn()
     {
         Ok(c) => c,
@@ -955,7 +955,22 @@ async fn run_opencode_models_discovery_async() -> (Vec<String>, &'static str) {
                 return (models, reason);
             }
             Ok(Some(status)) => {
-                tracing::warn!(?status, "opencode models command failed");
+                let stderr = match child.stderr.take() {
+                    Some(mut s) => {
+                        let mut buf = String::new();
+                        use tokio::io::AsyncReadExt;
+                        let _ = s.read_to_string(&mut buf).await.ok();
+                        buf
+                    }
+                    None => String::new(),
+                };
+                let stderr_trimmed = stderr.trim();
+                let stderr_display = if stderr_trimmed.len() > 500 {
+                    format!("{}...", &stderr_trimmed[..500])
+                } else {
+                    stderr_trimmed.to_string()
+                };
+                tracing::warn!(?status, stderr = %stderr_display, "opencode models command failed");
                 return (vec![], "exit_status_failure");
             }
             Ok(None) => {


### PR DESCRIPTION
## Summary

Captures stderr from the `opencode models` subprocess so when the process exits
non-zero, the error message is included in the warning log. Previously only the
exit status was logged, making it impossible to diagnose whether failures were
due to auth token expiry, network errors, CLI version mismatches, or other issues.

## Changes

- Changed `.stderr(std::process::Stdio::null())` to `.stderr(std::process::Stdio::piped())`
- In the error handling branch, read and include captured stderr (bounded to 500 chars) in the tracing::warn call
- Follows the same pattern already used for stdout reading

## Evidence

The issue manifests as recurring `exit_status_failure` reason codes in production logs (~4x/40h) with no diagnostic information:

```
2026-08-27T09:16:46.023109Z WARN opencode models command failed status=ExitStatus(unix_wait_status(256))
2026-08-27T17:20:07.847423Z WARN opencode models command failed status=ExitStatus(unix_wait_status(256))
```

With this fix, the actual CLI error message will be visible for future occurrences.

## Testing

- `cargo fmt -- --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- Code compiles successfully

---
*Task #3564 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*