### PR TITLE
bug(cooldown): persistent model failure counter is reset by every success, letting unreliable models re-enter rotation

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -115,6 +115,11 @@ const FAILURE_COUNT_PREFIX: &str = "failure_count:";
 /// cross-contamination of backoff escalation — credit exhaustion uses different base/max durations).
 const CREDIT_FAILURE_COUNT_PREFIX: &str = "credit_failure_count:";
 
+/// KV key prefix for persistent model failure counts (separate from [`FAILURE_COUNT_PREFIX`] so
+/// `record_agent_success()` resetting the generic counter on an intervening success doesn't erase
+/// escalation progress for structurally unreliable models — see `record_persistent_model_failure`).
+const PERSISTENT_FAILURE_COUNT_PREFIX: &str = "persistent_failure_count:";
+
 struct CooldownEntry {
     /// Unix timestamp when the cooldown expires.
     cooldown_until: i64,
@@ -623,10 +628,21 @@ pub async fn record_model_failure(agent_name: &str, model: &str) {
 /// Used for failure modes that are commonly broken for long periods (for example
 /// silent exit-0 or opaque provider errors). Starts at 4h and escalates with
 /// the generic backoff formula up to 7 days.
+///
+/// Uses [`PERSISTENT_FAILURE_COUNT_PREFIX`], a counter independent of the generic
+/// `failure_count:` key that `record_agent_success()` resets on every successful
+/// run. Otherwise a single intervening success between persistent failures would
+/// reset escalation back to the 4h base, letting structurally unreliable models
+/// (intermittent parse errors, truncated runs) stay in rotation indefinitely.
 pub async fn record_persistent_model_failure(agent_name: &str, model: &str) {
     let key = format!("{agent_name}:{model}");
     let store_opt = cooldown_store().lock().await.clone();
-    let count = read_and_increment_failure_count(&store_opt, &key).await;
+    let count = read_and_increment_failure_count_with_prefix(
+        &store_opt,
+        PERSISTENT_FAILURE_COUNT_PREFIX,
+        &key,
+    )
+    .await;
     let cooldown_secs = compute_backoff(
         count,
         PERSISTENT_MODEL_BACKOFF_BASE_SECS,
@@ -804,6 +820,11 @@ pub async fn clear_cooldown(key: &str, store: &Arc<crate::store::TaskStore>) {
             if let Err(e) = store.kv_set(&credit_fc_key, "0").await {
                 tracing::warn!(key = credit_fc_key, err = %e, "failed to reset credit failure count");
             }
+            // Also reset the persistent-model-failure counter.
+            let persistent_fc_key = format!("{PERSISTENT_FAILURE_COUNT_PREFIX}{k}");
+            if let Err(e) = store.kv_set(&persistent_fc_key, "0").await {
+                tracing::warn!(key = persistent_fc_key, err = %e, "failed to reset persistent failure count");
+            }
         }
         // Also reset any persisted failure_count keys that are not in the
         // in-memory map (e.g. survived a restart or were set without a
@@ -819,6 +840,13 @@ pub async fn clear_cooldown(key: &str, store: &Arc<crate::store::TaskStore>) {
             for (cfc_key, _) in cfc_entries {
                 if let Err(e) = store.kv_set(&cfc_key, "0").await {
                     tracing::warn!(key = cfc_key, err = %e, "failed to reset credit failure count");
+                }
+            }
+        }
+        if let Ok(pfc_entries) = store.kv_list_prefix(PERSISTENT_FAILURE_COUNT_PREFIX).await {
+            for (pfc_key, _) in pfc_entries {
+                if let Err(e) = store.kv_set(&pfc_key, "0").await {
+                    tracing::warn!(key = pfc_key, err = %e, "failed to reset persistent failure count");
                 }
             }
         }
@@ -844,6 +872,11 @@ pub async fn clear_cooldown(key: &str, store: &Arc<crate::store::TaskStore>) {
         let credit_fc_key = format!("{CREDIT_FAILURE_COUNT_PREFIX}{key}");
         if let Err(e) = store.kv_set(&credit_fc_key, "0").await {
             tracing::warn!(key = credit_fc_key, err = %e, "failed to reset credit failure count");
+        }
+        // Also reset the persistent-model-failure counter.
+        let persistent_fc_key = format!("{PERSISTENT_FAILURE_COUNT_PREFIX}{key}");
+        if let Err(e) = store.kv_set(&persistent_fc_key, "0").await {
+            tracing::warn!(key = persistent_fc_key, err = %e, "failed to reset persistent failure count");
         }
         tracing::info!(key, "cleared cooldown and failure count");
     }
@@ -1490,13 +1523,62 @@ mod tests {
             "second persistent model cooldown should be ~12h, got {second_remaining}s"
         );
 
-        let count_key = format!("{FAILURE_COUNT_PREFIX}{agent}:{model}");
+        let count_key = format!("{PERSISTENT_FAILURE_COUNT_PREFIX}{agent}:{model}");
         let stored_count = store
             .kv_get(&count_key)
             .await
             .expect("kv read should succeed")
             .expect("failure count should be written");
         assert_eq!(stored_count, "2");
+    }
+
+    #[serial(cooldown_state)]
+    #[tokio::test]
+    async fn record_agent_success_does_not_reset_persistent_failure_count() {
+        super::reset_global_state().await;
+        let store = test_store().await;
+        *cooldown_store().lock().await = Some(store.clone());
+
+        let agent = "testagent_persistent_success";
+        let model = "testmodel_persistent_success";
+        let key = format!("{agent}:{model}");
+
+        // Two persistent failures escalate the counter to 2 (~12h cooldown).
+        record_persistent_model_failure(agent, model).await;
+        record_persistent_model_failure(agent, model).await;
+
+        let count_key = format!("{PERSISTENT_FAILURE_COUNT_PREFIX}{agent}:{model}");
+        let stored_count = store
+            .kv_get(&count_key)
+            .await
+            .expect("kv read should succeed")
+            .expect("failure count should be written");
+        assert_eq!(stored_count, "2");
+
+        // A successful run resets the generic failure_count but must NOT touch
+        // the persistent counter — otherwise an intervening success would erase
+        // escalation progress for a structurally unreliable model.
+        record_agent_success(agent, model).await;
+
+        let stored_count_after_success = store
+            .kv_get(&count_key)
+            .await
+            .expect("kv read should succeed")
+            .expect("persistent failure count should still exist");
+        assert_eq!(
+            stored_count_after_success, "2",
+            "persistent failure count must survive an intervening success"
+        );
+
+        // The next persistent failure should escalate from 3 (~36h), not reset to base (4h).
+        record_persistent_model_failure(agent, model).await;
+        let now = chrono::Utc::now().timestamp();
+        let third_until = cooldown_until(&key).expect("third cooldown should exist");
+        let third_remaining = third_until.saturating_sub(now);
+        assert!(
+            third_remaining > PERSISTENT_MODEL_BACKOFF_BASE_SECS,
+            "third persistent model failure should escalate past the 4h base, got {third_remaining}s"
+        );
     }
 
     #[serial(cooldown_state)]

--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -3276,12 +3276,12 @@ mod tests {
 
     /// Regression test for issue #3478: a successful review run must reset
     /// `failure_count:{agent}:{model}`, mirroring the runner's task-agent
-    /// success path. Without this, review-only models ratchet through the
-    /// persistent-model backoff ladder from isolated failures that are
-    /// separated by many successful reviews.
+    /// success path, for generic/transient failures (not the persistent-model
+    /// path — see issue #3571, which deliberately gives persistent failures
+    /// their own counter that a success does NOT reset).
     #[serial_test::serial(cooldown_state)]
     #[tokio::test]
-    async fn finalize_review_run_success_resets_model_failure_count() {
+    async fn finalize_review_run_success_resets_generic_model_failure_count() {
         crate::engine::cooldown::reset_global_state().await;
         let store = Arc::new(TaskStore::open_memory().await.unwrap());
         crate::engine::cooldown::init_cooldown_store(store.clone()).await;
@@ -3290,8 +3290,11 @@ mod tests {
         let model = "test-3478-model";
         let failure_key = format!("failure_count:{agent}:{model}");
 
-        let err = runner::agents::AgentError::InvalidResponse {
-            raw: "empty review output".to_string(),
+        // AgentFailed is a generic/transient error, routed to record_model_failure
+        // (not record_persistent_model_failure), so it should still be reset by
+        // an intervening success.
+        let err = runner::agents::AgentError::AgentFailed {
+            message: "agent reported a generic failure".to_string(),
         };
         record_review_agent_failure("task-3478-a", agent, Some(model), &err).await;
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -3317,11 +3320,13 @@ mod tests {
     }
 
     /// Regression test for issue #3478: successful reviews interleaved between
-    /// isolated failures must keep each failure's backoff at the base duration
-    /// instead of escalating, since the previous success reset the counter.
+    /// isolated generic failures must keep each failure's backoff at the base
+    /// duration instead of escalating, since the previous success reset the
+    /// counter. Uses AgentFailed (generic/transient), not InvalidResponse
+    /// (persistent-model path — see issue #3571).
     #[serial_test::serial(cooldown_state)]
     #[tokio::test]
-    async fn finalize_review_run_interleaved_success_keeps_cooldown_at_base() {
+    async fn finalize_review_run_interleaved_success_keeps_generic_cooldown_at_base() {
         crate::engine::cooldown::reset_global_state().await;
         let store = Arc::new(TaskStore::open_memory().await.unwrap());
         crate::engine::cooldown::init_cooldown_store(store.clone()).await;
@@ -3335,8 +3340,8 @@ mod tests {
         let task = test_review_task("2");
 
         for i in 0..4 {
-            let err = runner::agents::AgentError::InvalidResponse {
-                raw: format!("failure {i}"),
+            let err = runner::agents::AgentError::AgentFailed {
+                message: format!("failure {i}"),
             };
             record_review_agent_failure("task-3478-b", agent, Some(model), &err).await;
 
@@ -3346,14 +3351,12 @@ mod tests {
             let remaining = until.saturating_sub(now);
 
             assert!(
-                (crate::engine::cooldown::PERSISTENT_MODEL_BACKOFF_BASE_SECS - 30
-                    ..crate::engine::cooldown::PERSISTENT_MODEL_BACKOFF_BASE_SECS + 60)
-                    .contains(&remaining),
+                remaining <= crate::engine::cooldown::BACKOFF_BASE_SECS + 60,
                 "failure #{} must stay at base backoff since the prior success reset the \
                  counter (issue #3478); got {remaining}s, base is {}s — an escalating value \
                  here means review successes are not resetting failure_count",
                 i + 1,
-                crate::engine::cooldown::PERSISTENT_MODEL_BACKOFF_BASE_SECS
+                crate::engine::cooldown::BACKOFF_BASE_SECS
             );
 
             // A successful review interleaves between each failure, mirroring the
@@ -3363,5 +3366,59 @@ mod tests {
             finalize_review_run(&task, &ctx, &parsed, &store).await;
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         }
+    }
+
+    /// Regression test for issue #3571: unlike generic failures, persistent
+    /// model failures (e.g. review parse errors, InvalidResponse) must NOT be
+    /// reset by an intervening successful review. Otherwise a model that fails
+    /// structurally every so often — but succeeds most of the time — never
+    /// escalates past the 4h base cooldown and stays in rotation indefinitely.
+    #[serial_test::serial(cooldown_state)]
+    #[tokio::test]
+    async fn finalize_review_run_success_does_not_reset_persistent_model_failure_count() {
+        crate::engine::cooldown::reset_global_state().await;
+        let store = Arc::new(TaskStore::open_memory().await.unwrap());
+        crate::engine::cooldown::init_cooldown_store(store.clone()).await;
+
+        let agent = "test-3571-agent";
+        let model = "test-3571-model";
+        let cooldown_key = format!("{agent}:{model}");
+
+        let work_dir = TempDir::new().unwrap();
+        let ctx = test_review_context(agent, model, work_dir.path());
+        let task = test_review_task("3");
+
+        // First structural (parse-error-equivalent) failure -> base 4h cooldown.
+        let err = runner::agents::AgentError::InvalidResponse {
+            raw: "empty review output".to_string(),
+        };
+        record_review_agent_failure("task-3571-a", agent, Some(model), &err).await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        // A successful review for the same model interleaves, exactly like the
+        // real-world pattern from issue #3571.
+        let parsed = test_parsed_review(ReviewDecision::Approve);
+        finalize_review_run(&task, &ctx, &parsed, &store).await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        // Second structural failure must escalate from count 2 (~12h), not
+        // reset back to the 4h base, despite the intervening success.
+        let err2 = runner::agents::AgentError::InvalidResponse {
+            raw: "empty review output again".to_string(),
+        };
+        record_review_agent_failure("task-3571-b", agent, Some(model), &err2).await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let now = chrono::Utc::now().timestamp();
+        let until = crate::engine::cooldown::cooldown_until(&cooldown_key)
+            .expect("second failure should set cooldown");
+        let remaining = until.saturating_sub(now);
+
+        assert!(
+            remaining > crate::engine::cooldown::PERSISTENT_MODEL_BACKOFF_BASE_SECS,
+            "second persistent model failure should escalate past the 4h base despite an \
+             intervening success (issue #3571); got {remaining}s, base is {}s",
+            crate::engine::cooldown::PERSISTENT_MODEL_BACKOFF_BASE_SECS
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixed the persistent-model-failure cooldown bug: record_persistent_model_failure() and record_model_failure() previously shared the same failure_count:{agent}:{model} KV key, which record_agent_success() zeroes out on every successful run. A single success between structural failures (parse errors, InvalidResponse, ModelUnavailable) reset escalation back to the 4h base, so unreliable models with intermittent successes never ratcheted toward the 7-day cap.

### What was done

- Added a new KV prefix persistent_failure_count:{agent}:{model} independent of the generic failure_count:{agent}:{model} key
- record_persistent_model_failure() now reads/increments/writes the new independent counter instead of sharing the generic one
- record_agent_success() unchanged — still resets the generic and credit-exhaustion counters (preserving issue #3478's fix for isolated transient failures), but no longer inadvertently erases persistent-failure escalation
- clear_cooldown() (both single-key and wildcard '*' paths) now also resets the new persistent counter so 'orch cooldown clear' still fully resets state
- Updated cooldown.rs unit test that asserted on the old shared key, and added a new test proving record_agent_success() no longer resets the persistent counter and that escalation continues across an intervening success
- Fixed two review.rs regression tests from issue #3478 that were asserting the old (now-buggy) shared-counter behavior on the InvalidResponse (persistent) path — repointed them to a generic AgentFailed error so they still validate #3478's real intent (isolated generic/transient failures reset on success)
- Added a new review.rs regression test for issue #3571 proving persistent model failures (e.g. parse errors) escalate past the 4h base despite an interleaved successful review


### Files changed

- `src/engine/cooldown.rs`
- `src/engine/review.rs`


Closes #3571

---
*Task #3571 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*