### PR TITLE
bug(runner): Timeout errors never record model-specific cooldown in main task-runner path — same slow free model reselected repeatedly

### DIFF
--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -331,10 +331,19 @@ pub async fn handle_error(
             };
             (retryable, format!("{agent_name} auth error: {message}"))
         }
-        agents::AgentError::Timeout { elapsed } => (
-            response::RetryableError::Timeout,
-            format!("{agent_name} timed out after {}s", elapsed.as_secs()),
-        ),
+        agents::AgentError::Timeout { elapsed } => {
+            // Record model-specific cooldown so the same slow model isn't
+            // immediately reselected on the next attempt of this (or another)
+            // task — mirrors the InvalidResponse/AgentFailed arms above and the
+            // review-path fix in review.rs (issue #3307/#3310).
+            if let Some(model) = model_name {
+                response::record_model_failure(agent_name, model).await;
+            }
+            (
+                response::RetryableError::Timeout,
+                format!("{agent_name} timed out after {}s", elapsed.as_secs()),
+            )
+        }
         agents::AgentError::MissingTool { tool } => (
             response::RetryableError::MissingTooling,
             format!("missing tool: {tool}"),
@@ -922,6 +931,50 @@ mod tests {
         assert!(
             !crate::engine::cooldown::is_model_in_cooldown(agent, other_model),
             "other models should not be cooled by a single model's rate limit"
+        );
+    }
+
+    /// Regression test for issue #3576: a Timeout classification must record a
+    /// model-specific cooldown, not just clear the agent from the task. Without
+    /// this, the router's model_for_complexity() has no signal that this model
+    /// just burned a full timeout window and can immediately reselect it —
+    /// exactly what happened to task 162289 (same model timed out twice, 90
+    /// minutes apart). Mirrors the fix already applied to the review path in
+    /// review.rs (issue #3307/#3310).
+    #[serial(cooldown_state)]
+    #[tokio::test]
+    async fn timeout_sets_model_specific_cooldown() {
+        crate::engine::cooldown::reset_global_state().await;
+        let runner = MockRunner { free: vec![] };
+        let agent = "opencode";
+        let model = "opencode/nemotron-3-ultra-free";
+
+        assert!(
+            !crate::engine::cooldown::is_model_in_cooldown(agent, model),
+            "model should not be in cooldown before handle_error"
+        );
+
+        let err = AgentError::Timeout {
+            elapsed: std::time::Duration::from_secs(1800),
+        };
+
+        let _result = handle_error(
+            "test-3576-timeout",
+            &err,
+            agent,
+            &runner,
+            Some(model),
+            Some("simple"),
+            1,
+            &None,
+            "owner/repo",
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            crate::engine::cooldown::is_model_in_cooldown(agent, model),
+            "model should be in model-level cooldown after Timeout (fixes issue #3576)"
         );
     }
 


### PR DESCRIPTION
## Summary

Committed. The fix adds a `record_model_failure(agent_name, model)` call to the `Timeout` arm in `src/engine/runner/fallback.rs::handle_error()`, matching the pattern already used for `InvalidResponse`/`AgentFailed`/`ModelUnavailable` in the same match block, plus a regression test verifying the model-level cooldown is set after a timeout. All 3964 tests pass, along with `cargo fmt` and `cargo clippy -D warnings`. Since `TASK_ID` is set, I stopped at commit — the orch engine handles push/PR cr

### Files changed

- `src/engine/runner/fallback.rs`


Closes #3576

---
*Task #3576 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*