### PR TITLE
bug(runner): truncated/malformed claude NDJSON result line loses structured error classification, falls back to generic Unknown

### DIFF
--- a/src/engine/runner/agents/claude.rs
+++ b/src/engine/runner/agents/claude.rs
@@ -444,7 +444,23 @@ impl AgentRunner for ClaudeRunner {
             (None, Some(s)) => format!("{s}\n{stdout}\n{stderr}"),
             (None, None) => format!("{stdout}\n{stderr}"),
         };
-        super::patterns::classify_from_text(exit_code, &combined)
+        let classified = super::patterns::classify_from_text(exit_code, &combined);
+
+        // `classify_from_text`'s generic catch-all truncates to the last 300
+        // bytes of the combined text, which can cut a perfectly well-formed
+        // `error_result` line off mid-field-name (e.g. `is_error` becomes
+        // `i_error`) once enough NDJSON precedes it (issue #3577). When we
+        // already extracted a clean, complete error message from the result
+        // envelope but none of the specific pattern detectors matched it,
+        // prefer that clean message over the byte-truncated fallback.
+        if let (AgentError::Unknown { .. }, Some(message)) = (&classified, &error_result) {
+            if !message.is_empty() {
+                return AgentError::AgentFailed {
+                    message: message.clone(),
+                };
+            }
+        }
+        classified
     }
 
     fn router_command(
@@ -982,6 +998,45 @@ mod tests {
         assert!(
             msg.contains("session limit"),
             "error message should contain the rate limit reason, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn classify_error_prefers_clean_result_text_over_byte_truncated_tail() {
+        // Regression test for issue #3577: a well-formed `type:result`
+        // envelope with `is_error:true` was correctly extracted into
+        // `error_result`, but `classify_from_text`'s generic Unknown
+        // fallback then re-truncates the combined stdout+stderr to its last
+        // 300 bytes — which, once enough preceding NDJSON pushes the result
+        // line's start past that window, cuts it off mid-field-name (e.g.
+        // `"is_error"` becomes `"i_error"`). The stored error ends up a
+        // garbled JSON fragment instead of the clean message, and (in the
+        // fallback.rs non-zero-exit path) skips the model cooldown that the
+        // AgentFailed branch applies.
+        let padding = "{\"type\":\"system\",\"subtype\":\"init\"}\n".repeat(50);
+        let result_line = r#"{"is_error":true,"duration_api_ms":0,"num_turns":1,"stop_reason":"stop_sequence","session_id":"32a7c67c","total_cost_usd":0,"usage":{},"modelUsage":{},"permission_denials":[],"terminal_reason":"api_error","fast_mode_state":"off","fast_mode_disabled_reason":"sdk_opt_in_required","subtype":"success","api_error_status":null,"result":"Failed to authenticate: OAuth session expired and could not be refreshed","type":"result","duration_ms":141,"uuid":"fe0ccff2-54d3-47cd-b5ba-a82f99a72b45"}"#;
+        let stdout = format!("{padding}{result_line}\n");
+        // Sanity check: the message text itself is not caught by any of the
+        // specific keyword detectors (auth/rate_limit/context_overflow), so
+        // without the fix this must fall to the generic Unknown branch.
+        assert!(
+            stdout.len() > 300,
+            "test stdout must exceed the tail-truncation window"
+        );
+
+        let err = runner().classify_error(1, &stdout, "");
+        assert!(
+            matches!(err, AgentError::AgentFailed { .. }),
+            "expected AgentFailed with the clean message, got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert_eq!(
+            msg, "agent failed: Failed to authenticate: OAuth session expired and could not be refreshed",
+            "stored error must be the clean result text, not a byte-truncated JSON fragment"
+        );
+        assert!(
+            !msg.contains("i_error"),
+            "stored error must not contain the byte-truncated JSON fragment, got: {msg}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixed classify_error() in the claude runner so it no longer discards a cleanly-parsed error message behind a byte-truncated fallback string, closing the gap where truncated/malformed claude NDJSON result lines lost structured error classification.

### What was done

- Root-caused the bug by querying the live orch.db for task 162287's actual stdout (10613 bytes): the captured NDJSON was NOT corrupted in transit — it was a complete, valid `type:result`/`is_error:true` envelope
- Found that classify_error() in src/engine/runner/agents/claude.rs already extracts the clean `result` field text into `error_result`, but then re-scans the full combined stdout+stderr via classify_from_text(), whose generic Unknown catch-all truncates to the last 300 bytes (safe_tail) — cutting the well-formed JSON line off mid-field-name (`"is_error"` -> `"i_error"`) once enough preceding NDJSON pushed it past that window
- Fixed classify_error() to prefer the already-extracted clean error_result message (via AgentError::AgentFailed) over the byte-truncated Unknown fallback when no specific pattern detector (auth/rate_limit/context_overflow) matches
- Added a regression test (classify_error_prefers_clean_result_text_over_byte_truncated_tail) reproducing the exact scenario from the DB evidence, verifying the stored error is the clean message and never contains the truncated 'i_error' fragment
- Ran cargo fmt, cargo clippy --all-targets -- -D warnings, and the full test suite (cargo nextest run: 3964 passed, 0 failed) — all clean
- Verified AgentFailed already triggers record_model_failure/record_agent_failure_with_message in fallback.rs (main runner) and falls into record_review_agent_failure's cooldown-recording catch-all in review.rs, so this fix restores the missing cooldown signal for this failure class in both the main task runner and the review pipeline


### Files changed

- `src/engine/runner/agents/claude.rs`


Closes #3577

---
*Task #3577 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*