### PR TITLE
bug(runner): failover rate-limit path bypasses relative-usage-window parser, undoing #3572/#3574 fix

### DIFF
--- a/src/engine/cooldown.rs
+++ b/src/engine/cooldown.rs
@@ -1444,7 +1444,11 @@ fn parse_retry_at(error_message: &str) -> Option<i64> {
 /// Returns the window length in seconds. Only matches in usage/quota/limit
 /// contexts ("usage limit", "quota", "window", "limit") to avoid interpreting
 /// unrelated numbers as cooldown durations.
-fn parse_relative_usage_window(error_message: &str) -> Option<u64> {
+///
+/// `pub(crate)` so `engine::runner::fallback::handle_error()` can apply the
+/// same window-detection the `needs_review` call site
+/// (`record_rate_limit()`, below) already uses — see issue #3580.
+pub(crate) fn parse_relative_usage_window(error_message: &str) -> Option<u64> {
     if error_message.is_empty() {
         return None;
     }

--- a/src/engine/runner/fallback.rs
+++ b/src/engine/runner/fallback.rs
@@ -262,6 +262,25 @@ pub async fn handle_error(
                 } else {
                     crate::engine::cooldown::record_credit_exhaustion(agent_name, reason).await;
                 }
+            } else if let (Some(model), Some(window_secs)) = (
+                model_name,
+                crate::engine::cooldown::parse_relative_usage_window(message),
+            ) {
+                // Vendor-advertised relative usage window (e.g. "weekly (7-day)
+                // usage limit") is authoritative — apply a model-specific cooldown
+                // for that exact duration instead of the generic exponential
+                // backoff. This is the same window-detection the `needs_review`
+                // call site (cooldown::record_rate_limit()) already applies; this
+                // in-task failover path bypassed it entirely, undoing the
+                // #3572/#3574 fix for the most common rate-limit path (issue #3580).
+                crate::engine::cooldown::set_model_cooldown(agent_name, model, window_secs).await;
+                tracing::info!(
+                    task_id,
+                    agent = agent_name,
+                    model,
+                    window_secs,
+                    "relative usage window detected: applying model-specific cooldown"
+                );
             } else {
                 crate::engine::cooldown::record_agent_failure_with_message(agent_name, message)
                     .await;
@@ -975,6 +994,56 @@ mod tests {
         assert!(
             crate::engine::cooldown::is_model_in_cooldown(agent, model),
             "model should be in model-level cooldown after Timeout (fixes issue #3576)"
+        );
+    }
+
+    /// Regression test for issue #3580: the in-task failover path (this
+    /// function) previously never called `parse_relative_usage_window()`, so a
+    /// vendor-advertised window like "weekly (7-day) usage limit" fell through
+    /// to the generic exponential backoff (5min base) instead of the ~7-day
+    /// window the vendor advertised. Only the `needs_review` call site in
+    /// `runner/mod.rs` applied the window fix from #3572/#3574 — this path did
+    /// not. Verify the model-specific cooldown now matches the parsed window
+    /// rather than the short exponential-backoff base.
+    ///
+    /// Note: `handle_failover()` still applies its own short agent-level
+    /// cooldown when switching to a fallback agent — that bookkeeping is
+    /// unrelated to and unaffected by this fix, so it isn't asserted here.
+    #[serial(cooldown_state)]
+    #[tokio::test]
+    async fn rate_limit_with_relative_window_sets_window_length_model_cooldown() {
+        crate::engine::cooldown::reset_global_state().await;
+        let runner = MockRunner { free: vec![] };
+        let agent = "test-agent-3580-kimi";
+        let model = "opus";
+        let key = format!("{agent}:{model}");
+
+        let err = AgentError::RateLimit {
+            message: "You've reached your weekly (7-day) usage limit. Your quota will reset when the current 7-day window expires.".to_string(),
+        };
+
+        let _result = handle_error(
+            "test-3580-a",
+            &err,
+            agent,
+            &runner,
+            Some(model),
+            Some("medium"),
+            1,
+            &None,
+            "owner/repo",
+        )
+        .await
+        .unwrap();
+
+        let now = chrono::Utc::now().timestamp();
+        let until = crate::engine::cooldown::cooldown_until(&key)
+            .expect("relative usage window should set model cooldown");
+        let remaining = until.saturating_sub(now);
+
+        assert!(
+            remaining >= 7 * 86400 - 30,
+            "expected ~7-day model cooldown from the parsed window, got {remaining}s"
         );
     }
 


### PR DESCRIPTION
## Summary

Wired the in-task failover rate-limit path (runner/fallback.rs::handle_error) through parse_relative_usage_window() so vendor-advertised relative usage windows (e.g. "weekly (7-day) usage limit") apply an authoritative model-specific cooldown instead of falling through to the generic 5min-base exponential backoff. This closes the gap left by #3572/#3574, which only fixed the secondary needs_review call site in runner/mod.rs.

### What was done

- Made cooldown::parse_relative_usage_window() pub(crate) so it's reachable from runner/fallback.rs
- Added a window-detection branch to the AgentError::RateLimit non-credit-exhaustion arm in fallback.rs::handle_error(): when a window is parsed, applies set_model_cooldown(agent, model, window_secs) instead of the generic backoff
- Preserved existing behavior unchanged when no window is detected, including the is_provider_returned_error persistent-cooldown distinction
- Added regression test rate_limit_with_relative_window_sets_window_length_model_cooldown using the exact 'weekly (7-day) usage limit' message from the issue, asserting a ~7-day model cooldown instead of the ~5min exponential-backoff base
- Verified cargo fmt, cargo clippy --all-targets -- -D warnings, and full cargo nextest run (3968 tests) all pass
- Committed the fix


### Files changed

- `src/engine/cooldown.rs`
- `src/engine/runner/fallback.rs`


Closes #3580

---
*Task #3580 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*