### PR TITLE
bug(review): fallback review-agent selection dispatches agents with no configured review model

### DIFF
--- a/src/engine/review.rs
+++ b/src/engine/review.rs
@@ -239,7 +239,7 @@ async fn select_review_agent(
     store_id: Option<i64>,
     router: &Arc<RwLock<Router>>,
     store: &Arc<TaskStore>,
-) -> (String, Option<String>) {
+) -> anyhow::Result<(String, Option<String>)> {
     let mut exclude_set: HashSet<String> = HashSet::new();
     if !task_agent.is_empty() {
         exclude_set.insert(task_agent.to_string());
@@ -284,7 +284,7 @@ async fn select_review_agent(
     }
 
     if let Some(agent) = chosen_agent {
-        (agent, chosen_model)
+        Ok((agent, chosen_model))
     } else {
         let final_exclude_refs: Vec<&str> = exclude_set.iter().map(|s| s.as_str()).collect();
         let fallback_agent = r
@@ -293,7 +293,13 @@ async fn select_review_agent(
         let fallback_model = r
             .config
             .model_for_complexity(&fallback_agent, "review", task_id);
-        (fallback_agent, fallback_model)
+        if fallback_model.is_none() {
+            anyhow::bail!(
+                "no review agent with a configured review model is available for task {}",
+                task_id
+            );
+        }
+        Ok((fallback_agent, fallback_model))
     }
 }
 
@@ -489,7 +495,13 @@ async fn build_review_context(
         .and_then(|t| t.agent.clone())
         .unwrap_or_default();
     let (review_agent, review_model) =
-        select_review_agent(&task.id.0, &task_agent, store_id, router, store).await;
+        select_review_agent(&task.id.0, &task_agent, store_id, router, store).await?;
+
+    anyhow::ensure!(
+        review_model.is_some(),
+        "review model missing for task {} after agent selection — refusing to dispatch",
+        task.id.0
+    );
 
     tracing::info!(
         task_id = task.id.0,

--- a/src/engine/subscribers/review.rs
+++ b/src/engine/subscribers/review.rs
@@ -703,6 +703,19 @@ async fn classify_review_failure(
         return ReviewOutcome::Reroute;
     }
 
+    // No configured review model for any available agent, or the selected agent
+    // has no review model. This is a configuration/cooldown gap, not a review
+    // failure. Defer without incrementing the failure counter so the task retries
+    // once a review model is available.
+    if lower_reason.contains("no review agent") || lower_reason.contains("review model missing") {
+        tracing::warn!(
+            task_id,
+            reason,
+            "{context}: no review model available — deferring retry until one is available"
+        );
+        return ReviewOutcome::RateLimited;
+    }
+
     if lower_reason.contains("rate limit") || lower_reason.contains("auth error") {
         tracing::warn!(
             task_id,
@@ -911,6 +924,51 @@ mod tests {
         assert_eq!(
             task.review_agent_failures, 0,
             "network errors must not count toward review_agent_failures"
+        );
+    }
+
+    /// When no agent has a configured review model (or the fallback agent has none),
+    /// the review must be deferred, not counted as a review failure. Counting it
+    /// would eventually block tasks for a configuration/cooldown gap (issue #3584).
+    #[tokio::test]
+    async fn classify_review_failure_missing_review_model_is_rate_limited() {
+        let store = Arc::new(TaskStore::open_memory().await.unwrap());
+        let repo = "owner/repo";
+        let store_id = store
+            .create_internal(
+                repo,
+                "Missing review model test",
+                "",
+                "review",
+                "review-3",
+                None,
+            )
+            .await
+            .unwrap();
+        let task_id = format!("internal:{store_id}");
+
+        let error_messages = [
+            "no review agent with a configured review model is available for task internal:123",
+            "review model missing for task internal:123 after agent selection — refusing to dispatch",
+        ];
+
+        for _ in 0..(MAX_REVIEW_AGENT_FAILURES + 1) {
+            for msg in &error_messages {
+                let outcome =
+                    classify_review_failure(&store, repo, &task_id, msg, "review_and_merge").await;
+                assert!(
+                    matches!(outcome, ReviewOutcome::RateLimited),
+                    "missing review model error '{msg}' must defer, not block"
+                );
+            }
+        }
+
+        let task = opt_store_get_task(&Some(store.clone()), repo, &task_id)
+            .await
+            .expect("task should exist");
+        assert_eq!(
+            task.review_agent_failures, 0,
+            "missing review model errors must not count toward review_agent_failures"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixed fallback review-agent selection so it bails when no available agent has a configured review model, instead of dispatching an agent with review_model=None. Added a defensive guard in build_review_context and classified the missing-model case as a deferred retry so it does not count toward MAX_REVIEW_AGENT_FAILURES.

### Files changed

- `src/engine/review.rs`
- `src/engine/subscribers/review.rs`


Closes #3584

---
*Task #3584 · Created by kimi[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `opus`*