### PR TITLE
Daily review (last 24h)

### DIFF
--- a/docs/content/posts/daily-review-2026-09-07.md
+++ b/docs/content/posts/daily-review-2026-09-07.md
@@ -1,0 +1,78 @@
++++
+title = "Daily Review — 2026-09-07"
+date = 2026-09-07
+description = "Daily review: what shipped, what failed, operational health, and priorities for tomorrow."
++++
+
+# Daily Review — 2026-09-07
+
+## The headline: a ~35-hour service gap, not a code problem
+
+Task activity in `orch.db` stops cold at `2026-09-06T00:32Z` (last event that hour: 32) and does not resume until `2026-09-07T11:xx Z` (6 events), picking back up fully at `12:xx Z` (104 events). The brew stdout log (`/opt/homebrew/var/log/orch.log`) begins with `starting orch serve` at `2026-09-07T12:02:19Z` — the earliest line in the file. For roughly 35 hours nothing dispatched, nothing routed, nothing reviewed, and the scheduled `2026-09-06T23:00Z` daily-review job never fired at all, so there is no `daily-review-2026-09-06.md` post. Zero commits, zero issues opened or closed, zero PRs in that window — not because of a workflow bug, but because the engine wasn't ticking.
+
+No root cause is visible from task/engine logs (no crash, no panic, no OOM signature) — consistent with the machine being powered off or asleep rather than a service fault. Nothing here indicates an orch defect, so no issue is filed for it.
+
+Since the restart at `12:02:19Z`, the engine picked up exactly where the graceful-shutdown design says it should: stale `in_progress` daily-job tasks reset to `routed` and re-dispatched normally, including this review.
+
+---
+
+## What Shipped (Last 24h)
+
+Nothing new to `gabrielkoerich/orch`. The most recent merge is still `#3591` (transient Git LFS locks/verify fix) from 2026-09-03, and `#3592`–`#3594` (daily-review posts through 2026-09-05) — all already covered in prior reviews. No commits landed in the strict last-24h window; the only activity was the current batch of internal jobs re-dispatching after the restart.
+
+---
+
+## What Failed
+
+**minimax `opus` hit `billing_cycle_exhausted` 6 times** in the first ~10 minutes after restart (`12:02–12:11Z`), across both `gabrielkoerich/orch` (this task, `internal:165379`, and the self-improvement job `internal:165378`) and `gabrielkoerich/bean` (4 jobs). Error: `Token Plan usage limit reached`. Every one of these was caught by the generic classifier, cooled `minimax:opus` persistently (now `6d23h` remaining, consistent with the 24h→7d billing-cycle-exhaustion cap), and rerouted `minimax → claude`. All rerouted runs completed or are progressing normally. This is the designed generic recovery path working correctly — no code action needed.
+
+**One `aborted` run** (`internal:165378`, self-improvement job) with `error: "superseded by a new run start before this one completed"`. This is an existing, intentional guard in `src/store/tasks.rs` that closes out a stale run record when a fresh dispatch starts for the same task before the old one finished — exactly what happens when a post-restart re-dispatch races a task that was still mid-run. Single occurrence, self-resolved, not a new pattern.
+
+---
+
+## Operational Health
+
+### Task run outcomes (last 24h, post-restart window)
+
+| Agent | Model | Outcome | Count |
+|------|-------|---------|------:|
+| minimax | `opus` | `billing_cycle_exhausted` | 6 |
+| claude | `sonnet` | (in progress) | 3 |
+| claude | `sonnet` | `success` | 2 |
+| opencode | `opencode/muse-spark-1.3-contributor-free` | `success` | 2 |
+| minimax | `opus` | (in progress) | 1 |
+| minimax | `opus` | `aborted` | 1 |
+
+`task_activity` (last 24h): `status_change` 64, `dispatch` 32, `routed` 19, `error` 7, `rerouted` 6, `push` 4, `branch_delete` 4, `review_start` 2, `review_decision` 2, `pr_create` 2 — all concentrated in the ~10 minutes after the `12:02Z` restart; nothing in the 35h gap before it.
+
+### Routing and cooldowns
+
+`orch cooldown list` shows 5 persisted cooldowns: `codex:gpt-5.4` (1d20h), `kimi:haiku` (23h46m), `kimi:opus` (3d19h), `minimax:haiku` (3h9m), `minimax:opus` (6d23h, new today from the exhaustion above). All model-scoped, all decaying on schedule, all consistent with the generic cooldown/backoff design — no mis-scoped or stuck cooldowns observed.
+
+### Backlog and stuck work
+
+Zero open issues in `gabrielkoerich/orch` — clean backlog. One long-standing blocked task remains outside this repo: a downstream task blocked on a GitHub Actions billing failure at merge time, now 71 days old. This is the correct per-task boundary per settled policy (work and review already done, only merging is blocked) — no action needed here.
+
+`orch.error.log` is 0 bytes (fresh since the `12:02Z` restart) — no crash recorded since then.
+
+### Policy alignment
+
+Current operational behavior matches `prompts/skills/orch/SKILL.md` — the billing-exhaustion → cooldown → reroute path and the stale-run supersede guard both worked exactly as designed. No drift detected, no manual intervention taken or recommended.
+
+---
+
+## Issues Filed Today
+
+None. The 35-hour activity gap has no evidence pointing to an orch code defect (most likely explanation is the host machine being off or asleep), and every task-level failure in the post-restart window was handled correctly by existing generic mechanisms.
+
+---
+
+## Priorities for Tomorrow
+
+1. **No regressions to chase.** `#3591` (LFS push fix) continues to hold; today's only failures were expected billing-cycle/rate-limit events.
+2. **Watch `minimax:opus`'s fresh 7-day-scale cooldown** (`6d23h` remaining) — confirm claude failover keeps covering minimax-routed work smoothly until it clears.
+3. **Confirm tomorrow's `23:00Z` daily-review job fires on schedule** — today's gap means it's worth a quiet check that the cadence is back to normal, not an intervention.
+
+---
+
+*Prepared by Orch automation (internal:165379) on 2026-09-07.*


### PR DESCRIPTION
## Summary

Wrote the daily review post for 2026-09-07, covering the last-24h gather (git log, GitHub issues/PRs, orch task list, task_runs/task_activity SQL, orch log, SKILL.md policy). Committed the post; no code changes and no new GitHub issues were needed.

### What was done

- Gathered git log, docs/content/posts history, gh issue list (open/closed), orch task list, and prompts/skills/orch/SKILL.md per the task checklist
- Queried task_runs and task_activity in ~/.orch/orch.db for the last 24h and 48h windows
- Identified the key operational fact: a ~35h gap in task_activity (2026-09-06T00:32Z to 2026-09-07T12:02Z) with the brew stdout log confirming a fresh 'starting orch serve' at 12:02:19Z — the scheduled 2026-09-06T23:00Z daily-review job never fired, so there's no daily-review-2026-09-06.md
- Confirmed post-restart minimax opus billing_cycle_exhausted (6 occurrences) was handled correctly by the generic cooldown/reroute-to-claude mechanism (now cooled 6d23h)
- Confirmed the single 'superseded by a new run start' abort (task internal:165378) is existing intentional guard logic in src/store/tasks.rs, not a bug, triggered by the post-restart re-dispatch race
- Verified zero open issues, one long-standing correctly-blocked task (GH Actions billing at merge time, out of scope), and no drift from SKILL.md policy
- Wrote and committed docs/content/posts/daily-review-2026-09-07.md with headline, what shipped, what failed, operational health, routing/cooldowns, backlog, policy alignment, and priorities for tomorrow
- Decided against filing new GitHub issues: the activity gap has no code-level root cause evidence (most likely explanation is the host machine being off/asleep), and all task-level failures were handled by existing generic mechanisms per settled policy


### Files changed

- `docs/content/posts/daily-review-2026-09-07.md`


---
*Task internal-165379 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*