### PR TITLE
bug(router): agent missing from router.weights silently defaults to max weight (1.0), outranking every explicitly configured agent

### DIFF
--- a/src/engine/router/llm.rs
+++ b/src/engine/router/llm.rs
@@ -718,7 +718,9 @@ impl LlmRouter {
             available_agents
                 .iter()
                 .map(|a| {
-                    let w = configured_weights.get(a).copied().unwrap_or(1.0);
+                    let w = configured_weights.get(a).copied().unwrap_or_else(|| {
+                        super::weights::default_missing_weight(configured_weights)
+                    });
                     format!("{a}: {w}")
                 })
                 .collect::<Vec<_>>()

--- a/src/engine/router/mod.rs
+++ b/src/engine/router/mod.rs
@@ -2315,6 +2315,54 @@ Hope that helps!"#;
         assert_eq!(weights.get_weight("opencode"), DEFAULT_WEIGHT);
     }
 
+    #[test]
+    fn default_missing_weight_uses_minimum_of_configured() {
+        use super::weights::default_missing_weight;
+
+        let mut configured = std::collections::HashMap::new();
+        configured.insert("claude".to_string(), 0.2);
+        configured.insert("codex".to_string(), 0.2);
+        configured.insert("opencode".to_string(), 0.2);
+        configured.insert("kimi".to_string(), 0.2);
+
+        // minimax omitted from router.weights — must not silently outrank
+        // every explicitly configured agent (issue #3596).
+        assert_eq!(default_missing_weight(&configured), 0.2);
+    }
+
+    #[test]
+    fn default_missing_weight_falls_back_when_none_configured() {
+        use super::weights::default_missing_weight;
+
+        let configured = std::collections::HashMap::new();
+        assert_eq!(default_missing_weight(&configured), DEFAULT_WEIGHT);
+    }
+
+    #[serial(cooldown_state)]
+    #[test]
+    fn ensure_agents_with_weights_missing_agent_does_not_outrank_configured() {
+        let mut weights = AgentWeights::default();
+        let mut configured = std::collections::HashMap::new();
+        configured.insert("claude".to_string(), 0.2);
+        configured.insert("codex".to_string(), 0.2);
+        configured.insert("opencode".to_string(), 0.2);
+        configured.insert("kimi".to_string(), 0.2);
+
+        let agents = vec![
+            "claude".to_string(),
+            "codex".to_string(),
+            "opencode".to_string(),
+            "kimi".to_string(),
+            "minimax".to_string(),
+        ];
+        weights.ensure_agents_with_weights(&agents, &configured);
+
+        // minimax was omitted from router.weights but must not get the old
+        // DEFAULT_WEIGHT of 1.0, which would outrank every configured agent.
+        assert_eq!(weights.get_weight("minimax"), 0.2);
+        assert_eq!(weights.get_weight("claude"), 0.2);
+    }
+
     #[serial(cooldown_state)]
     #[test]
     fn agent_weights_record_rate_limit() {

--- a/src/engine/router/ollama.rs
+++ b/src/engine/router/ollama.rs
@@ -203,7 +203,10 @@ impl OllamaRouter {
                 .agents
                 .iter()
                 .map(|a| {
-                    let w = config.weights.get(a).copied().unwrap_or(1.0);
+                    let w =
+                        config.weights.get(a).copied().unwrap_or_else(|| {
+                            super::weights::default_missing_weight(&config.weights)
+                        });
                     format!("{a}: {w}")
                 })
                 .collect::<Vec<_>>()

--- a/src/engine/router/weights.rs
+++ b/src/engine/router/weights.rs
@@ -20,6 +20,20 @@ pub(super) const MIN_WEIGHT: f64 = 0.05;
 /// How much to reduce weight on each rate limit hit (multiplicative decay).
 pub(super) const RATE_LIMIT_DECAY: f64 = 0.3;
 
+/// Weight to use for an agent that is absent from a configured `router.weights`
+/// map. Rather than the constant `DEFAULT_WEIGHT` (1.0) — which would silently
+/// outrank every agent the operator *did* configure — an omitted agent falls
+/// back to the minimum of the explicitly configured weights. An empty map
+/// means no weights are configured at all, so `DEFAULT_WEIGHT` applies to
+/// everyone equally.
+pub(super) fn default_missing_weight(configured_weights: &HashMap<String, f64>) -> f64 {
+    configured_weights
+        .values()
+        .copied()
+        .fold(None, |min, w| Some(min.map_or(w, |m: f64| m.min(w))))
+        .unwrap_or(DEFAULT_WEIGHT)
+}
+
 /// Generate jitter duration for recovery delay based on agent name.
 /// Uses a simple hash to create deterministic but varied jitter per agent.
 fn generate_recovery_jitter(agent: &str) -> Duration {
@@ -126,7 +140,9 @@ impl AgentWeights {
     /// Ensure all available agents have an entry, applying configured base weights.
     ///
     /// Agents with an explicit weight in `config.yml` use that as their base.
-    /// Agents without a configured weight default to `DEFAULT_WEIGHT` (1.0).
+    /// Agents without a configured weight default to the minimum of the
+    /// explicitly configured weights (see `default_missing_weight`), so an
+    /// omission never outranks an agent the operator actually configured.
     pub fn ensure_agents_with_weights(
         &mut self,
         agents: &[String],
@@ -136,7 +152,7 @@ impl AgentWeights {
             let base = configured_weights
                 .get(agent)
                 .copied()
-                .unwrap_or(DEFAULT_WEIGHT);
+                .unwrap_or_else(|| default_missing_weight(configured_weights));
             let state = self
                 .states
                 .entry(agent.clone())
@@ -201,10 +217,12 @@ impl AgentWeights {
         let weights: Vec<f64> = agents
             .iter()
             .map(|a| {
-                self.states
-                    .get(a)
-                    .map(|s| s.weight)
-                    .unwrap_or_else(|| self.base_weights.get(a).copied().unwrap_or(DEFAULT_WEIGHT))
+                self.states.get(a).map(|s| s.weight).unwrap_or_else(|| {
+                    self.base_weights
+                        .get(a)
+                        .copied()
+                        .unwrap_or_else(|| default_missing_weight(&self.base_weights))
+                })
             })
             .collect();
 
@@ -237,7 +255,7 @@ impl AgentWeights {
             self.base_weights
                 .get(agent)
                 .copied()
-                .unwrap_or(DEFAULT_WEIGHT)
+                .unwrap_or_else(|| default_missing_weight(&self.base_weights))
         })
     }
 


### PR DESCRIPTION
## Summary

Ending this turn now to let the background test run finish — I'll pick back up when the completion notification arrives.

### Files changed

- `src/engine/router/llm.rs`
- `src/engine/router/mod.rs`
- `src/engine/router/ollama.rs`
- `src/engine/router/weights.rs`


Closes #3596

---
*Task #3596 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*