### PR TITLE
bug(runner): classify_from_text has no model-unavailable pattern — plain-text 'model not found' errors bump agent-wide cooldown instead of model-scoped

### DIFF
--- a/src/engine/runner/agents/mod.rs
+++ b/src/engine/runner/agents/mod.rs
@@ -1445,6 +1445,47 @@ pub(crate) mod patterns {
         None
     }
 
+    /// Check for a plain-text "model not found" / "model unavailable" error.
+    ///
+    /// Mirrors the model-unavailable detection already present in codex.rs's
+    /// and opencode.rs's structured NDJSON classifiers (`classify_message`,
+    /// `classify_opencode_message`), for the case where the same failure
+    /// surfaces as raw stdout/stderr text instead of a recognizable NDJSON
+    /// event. Without this, the message falls through to `AgentError::Unknown`,
+    /// which bumps the agent-wide failure cooldown instead of the
+    /// model-scoped one that `ModelUnavailable` is exempted into.
+    pub fn detect_model_unavailable(text: &str) -> Option<AgentError> {
+        let lower = text.to_lowercase();
+        let is_model_unavailable = lower.contains("model metadata")
+            || lower.contains("no endpoints found")
+            || (lower.contains("model")
+                && (lower.contains("not found")
+                    || lower.contains("not supported")
+                    || lower.contains("does not exist")
+                    || lower.contains("deprecated")
+                    || lower.contains("unavailable for free")
+                    || lower.contains("not available in your country")
+                    || lower.contains("not available in your region")));
+        if !is_model_unavailable {
+            return None;
+        }
+        let model = extract_quoted(text, '`')
+            .or_else(|| extract_quoted(text, '\''))
+            .unwrap_or_default();
+        Some(AgentError::ModelUnavailable {
+            message: safe_tail(text, 300).to_string(),
+            model,
+        })
+    }
+
+    /// Extract text between the first matching pair of `quote` characters.
+    fn extract_quoted(text: &str, quote: char) -> Option<String> {
+        let start = text.find(quote)?;
+        let rest = &text[start + quote.len_utf8()..];
+        let end = rest.find(quote)?;
+        Some(rest[..end].to_string())
+    }
+
     /// Check for missing worktree / working directory setup failures.
     pub fn detect_worktree_missing(text: &str) -> Option<AgentError> {
         let lower = text.to_lowercase();
@@ -1717,6 +1758,9 @@ pub(crate) mod patterns {
             return e;
         }
         if let Some(e) = detect_rate_limit(scan_tail) {
+            return e;
+        }
+        if let Some(e) = detect_model_unavailable(scan_tail) {
             return e;
         }
         if let Some(e) = detect_network_error(scan_tail) {
@@ -2227,6 +2271,32 @@ mod tests {
     fn classify_from_text_worktree_missing() {
         let err = patterns::classify_from_text(1, "worktree directory does not exist: /tmp/wt");
         assert!(matches!(err, AgentError::AgentFailed { .. }));
+    }
+
+    #[test]
+    fn classify_from_text_model_not_found_backtick() {
+        // Issue #3604: plain-text "model not found" errors (no structured
+        // NDJSON event) must classify as ModelUnavailable, not fall through to
+        // Unknown, so the agent-wide cooldown is not bumped for a bad model name.
+        let text = "codex failed: model unavailable (gpt-5.5): Reconnecting... 2/5 \
+            (unexpected status 404 Not Found: The model `gpt-5.5` does not exist \
+            or you do not have access to it.)";
+        let err = patterns::classify_from_text(1, text);
+        match err {
+            AgentError::ModelUnavailable { model, .. } => assert_eq!(model, "gpt-5.5"),
+            other => panic!("expected ModelUnavailable, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_from_text_model_metadata_not_found() {
+        let text = "Model metadata for `gpt-5.4` not found. Defaulting to fallback \
+            metadata; this can degrade performance and cause issues.";
+        let err = patterns::classify_from_text(1, text);
+        match err {
+            AgentError::ModelUnavailable { model, .. } => assert_eq!(model, "gpt-5.4"),
+            other => panic!("expected ModelUnavailable, got: {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Added a model-unavailable pattern to the shared plain-text classifier classify_from_text() so 'model not found' / 'model does not exist' errors that surface as raw stdout/stderr (not a structured NDJSON event) are classified as AgentError::ModelUnavailable instead of falling through to Unknown, which was bumping the agent-wide failure cooldown instead of the model-scoped one.

### What was done

- Added detect_model_unavailable() to the patterns module in src/engine/runner/agents/mod.rs, mirroring the phrase-based detection already present in codex.rs's classify_message() and opencode.rs's classify_opencode_message() (checks for 'model metadata', 'no endpoints found', and 'model' combined with 'not found'/'not supported'/'does not exist'/'deprecated'/'unavailable for free'/'not available in your country or region')
- Added a small extract_quoted() helper to pull the model name out of backtick- or single-quote-delimited text (e.g. 'The model `gpt-5.5` does not exist')
- Wired detect_model_unavailable() into classify_from_text()'s tail scan, between the tail rate-limit check and the network-error check, so it runs before the generic AgentError::Unknown fallback
- Added two unit tests reproducing the exact error text from the issue's evidence (gpt-5.5 'does not exist' 404 message and gpt-5.4 'Model metadata ... not found' message), both asserting AgentError::ModelUnavailable with the correct extracted model name
- Ran cargo fmt, cargo clippy --all-targets -- -D warnings (clean, no warnings), and the full cargo nextest run suite (3989/3990 passed; the one failure, tmux::tests::session_blocks_dispatch_cleans_dead_session, is unrelated to this change, lives in src/tmux.rs, and passes in isolation when run alone — confirmed as a pre-existing flaky/order-dependent test, not a regression)
- Committed the change


### Files changed

- `src/engine/runner/agents/mod.rs`


Closes #3604

---
*Task #3604 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*