### PR TITLE
bug(runner): codex is_error:true NDJSON path skips model-unavailable detection — ModelUnavailable downgrades to AgentFailed, triggers 24h agent-wide cooldown

### DIFF
--- a/src/engine/runner/mod.rs
+++ b/src/engine/runner/mod.rs
@@ -259,6 +259,9 @@ fn parse_success_output(
             if let Some(e) = agents::patterns::detect_auth_error(&agent_result.result_text) {
                 return Err(e);
             }
+            if let Some(e) = agents::patterns::detect_model_unavailable(&agent_result.result_text) {
+                return Err(e);
+            }
             return Err(agents::AgentError::AgentFailed {
                 message: agent_result.result_text,
             });
@@ -2761,6 +2764,28 @@ mod tests {
                 assert_eq!(message, "I failed because of reasons");
             }
             _ => panic!("expected AgentFailed, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_success_output_classifies_model_unavailable_from_is_error_result() {
+        // Regression test for issue #3607: the is_error=true NDJSON path
+        // (used by codex's find_codex_result, which stringifies its own
+        // classified AgentError into result_text) must re-classify a
+        // model-not-found message as ModelUnavailable so it gets
+        // model-scoped cooldown treatment instead of degrading to a
+        // generic AgentFailed, which triggers an agent-wide cooldown.
+        let ndjson = r#"{"type":"result","subtype":"success","is_error":true,"result":"model unavailable (gpt-5.5): Reconnecting... 2/5 (unexpected status 404 Not Found: The model `gpt-5.5` does not exist or you do not have access to it.)"}"#;
+
+        let runner = FailingMockRunner;
+        let result = parse_success_output("999", "claude", &runner, ndjson);
+
+        let err = result.expect_err("should return error");
+        match err {
+            agents::AgentError::ModelUnavailable { model, .. } => {
+                assert_eq!(model, "gpt-5.5");
+            }
+            _ => panic!("expected ModelUnavailable, got {err:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

Fixed the is_error:true NDJSON path in parse_success_output (src/engine/runner/mod.rs) to detect model-unavailable errors via agents::patterns::detect_model_unavailable, alongside the existing rate-limit/auth checks, before falling back to generic AgentFailed. This closes the gap where codex's structured NDJSON model-not-found errors were downgraded to AgentFailed, triggering a 24h agent-wide cooldown instead of a model-scoped cooldown.

### What was done

- Added detect_model_unavailable check to the is_error branch in parse_success_output (src/engine/runner/mod.rs)
- Added regression test parse_success_output_classifies_model_unavailable_from_is_error_result
- Verified with cargo fmt -- --check, cargo clippy --all-targets -- -D warnings, and cargo nextest run (3992 tests passed)
- Committed as ce55c270


### Files changed

- `src/engine/runner/mod.rs`


Closes #3607

---
*Task #3607 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `sonnet`*