### PR TITLE
fix(engine): internal-task stuck-review recovery uses 30min in_review override

### DIFF
--- a/src/engine/tick.rs
+++ b/src/engine/tick.rs
@@ -1434,12 +1434,16 @@ pub(crate) async fn tick_recover_stuck_tasks(
         }
 
         let review_task_id = format!("{}-review", task_id);
+        let in_review_config = crate::engine::EngineConfig {
+            no_session_stuck_timeout: config.in_review_no_session_stuck_timeout,
+            ..config.clone()
+        };
         let Some(timing) = stuck_task_timing_from_map(
             tmux,
             repo,
             &review_task_id,
             &task.updated_at,
-            config,
+            &in_review_config,
             "cannot parse updated_at, skipping stuck internal in_review check",
             session_map,
         ) else {


### PR DESCRIPTION
## Summary

The internal (SQLite) task stuck-review recovery in `tick_recover_stuck_tasks` was using the 10-minute `no_session_stuck_timeout` default instead of the 30-minute `in_review_no_session_stuck_timeout` override. This caused a race condition with review result delivery — the review agent exits its tmux session before delivering the result, so the 10-minute threshold fires the stuck recovery just before the result arrives, discarding the approval decision and forcing a second review.

## Changes

- Apply the same `in_review_config` override used in the external-task recovery loop to the internal-task loop
- Prevents premature stuck-task recovery on nearly every internal review (6/6 in last 7 days hit this race)
- Eliminates wasted review agent invocations and misleading error logs

## Evidence

The last 7 days' internal review tasks show the race firing in near 100% of cases — stuck recovery at ~10-12 minutes, followed by approval 1-5 seconds later from the review that had already completed.

See #3612 for full details and data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Task #3612 · Created by claude[bot] via [Orch](https://github.com/gabrielkoerich/orch) using `haiku`*